### PR TITLE
Add modules for DG backend and bring back bickley jet on sphere

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: 1.6
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.add(url = "https://github.com/CliMA/ClimaCore.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.add(url = "https://github.com/CliMA/ClimaCore.jl.git"); Pkg.add(url = "https://github.com/CliMA/ClimateMachine.jl.git#tb/refactoring_ans_sphere"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+ClimateMachine = "777c4786-024f-11e9-21a3-85d5d4106250"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
-ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"

--- a/examples/WIP_bickley_jet_dg.jl
+++ b/examples/WIP_bickley_jet_dg.jl
@@ -6,13 +6,17 @@ ClimateMachine.init()
 
 # set up parameters
 parameters = (
-    ϵ  = 0.1,  # perturbation size for initial condition
-    l  = 0.5,  # Gaussian width
-    k  = 0.5,  # Sinusoidal wavenumber
-    ρ₀ = 1.0,  # reference density
-    c  = 2,
-    g  = 10,   # gravitation constant
-    D₄ = 1e-4, # hyperdiffusion coefficient
+    g  = 0.0,
+    ρₒ = 1.0,  # reference density
+    cₛ = 1e-2, # sound speed
+    ℓᵐ = 10,   # jet thickness, (larger is thinner)
+    ℓ  = 20,   # perturbation thickness, (larger is thinner)
+    m  = 2,    # number of sign changes on equator for perturbation
+    ϕᵖ = π/2 * 0.05, # of centerdness of perturbation
+    ϵ  = 0.3,  # perturbation amplitude
+    vˢ = 5e-4, # velocity scale
+    α  = 2e-4,
+    Ω  = 1e-3,
 )
 
 # set up grid
@@ -77,6 +81,7 @@ timestepper = TimeStepper(
     progress_message = (dt, u, p, t) -> t,
 )
 
+# set up simulation
 simulation = Simulation(
     DiscontinuousGalerkinBackend(numerics = (flux = :lmars,),),
     model = model,
@@ -88,10 +93,7 @@ simulation = Simulation(
     ), 
 )
 
-#=
-# set up simulation
 # run the simulation
 evolve(simulation)
 
 nothing
-=#

--- a/examples/WIP_bickley_jet_dg.jl
+++ b/examples/WIP_bickley_jet_dg.jl
@@ -1,0 +1,97 @@
+using ClimaAtmos
+using ClimateMachine
+ClimateMachine.init()
+
+@boilerplate
+
+# set up parameters
+parameters = (
+    ϵ  = 0.1,  # perturbation size for initial condition
+    l  = 0.5,  # Gaussian width
+    k  = 0.5,  # Sinusoidal wavenumber
+    ρ₀ = 1.0,  # reference density
+    c  = 2,
+    g  = 10,   # gravitation constant
+    D₄ = 1e-4, # hyperdiffusion coefficient
+)
+
+# set up grid
+domain = SphericalShell(
+    radius = 1.0,
+    height = 0.2,
+    nelements = (8, 1),
+    npolynomial = 3,
+    vertical_discretization = VerticalDiscontinousGalerkin(vpolynomial=1),
+)
+
+# set up inital condition
+uᵐ(p, λ, ϕ, r) =  p.ℓᵐ * sech(p.ℓᵐ * ϕ)^2 
+vᵐ(p, λ, ϕ, r) =  0.0
+hᵐ(p, λ, ϕ, r) =  0.0
+
+u1(p, λ, ϕ, r) =  p.ℓ * 2 * (ϕ - p.ϕᵖ)* exp(-p.ℓ * (ϕ - p.ϕᵖ)^2) * cos(ϕ) * cos(2 * (ϕ - p.ϕᵖ)) * sin(p.m * λ)
+u2(p, λ, ϕ, r) =  exp(-p.ℓ * (ϕ - p.ϕᵖ)^2) * sin(ϕ) * cos(2 * (ϕ - p.ϕᵖ)) * sin(p.m * λ)
+u3(p, λ, ϕ, r) =  2*exp(-p.ℓ * (ϕ - p.ϕᵖ)^2) * cos(ϕ) * sin(2 * (ϕ - p.ϕᵖ)) * sin(p.m * λ)
+uᵖ(p, λ, ϕ, r) =  u1(p, λ, ϕ, r) + u2(p, λ, ϕ, r) + u3(p, λ, ϕ, r)
+vᵖ(p, λ, ϕ, r) =  p.m * exp(-p.ℓ * (ϕ - p.ϕᵖ)^2) * cos(2 * (ϕ - p.ϕᵖ)) * cos(p.m * λ)
+hᵖ(p, λ, ϕ, r) =  0.0
+
+ρ₀(p, λ, ϕ, r)    = p.ρₒ 
+ρuʳᵃᵈ(p, λ, ϕ, r) = 0
+ρuˡᵃᵗ(p, λ, ϕ, r) = p.vˢ * ρ₀(p, λ, ϕ, r) * (p.ϵ * vᵖ(p, λ, ϕ, r))
+ρuˡᵒⁿ(p, λ, ϕ, r) = p.vˢ * ρ₀(p, λ, ϕ, r) * (uᵐ(p, λ, ϕ, r) + p.ϵ * uᵖ(p, λ, ϕ, r))
+ρθ₀(p, λ, ϕ, r) = ρ₀(p, λ, ϕ, r) * tanh(p.ℓᵐ * ϕ)
+
+# Cartesian Representation for initialization (boiler plate really)
+ρ₀ᶜᵃʳᵗ(p, x...)  = ρ₀(p, lon(x...), lat(x...), rad(x...))
+ρu⃗₀ᶜᵃʳᵗ(p, x...) = (   ρuʳᵃᵈ(p, lon(x...), lat(x...), rad(x...)) * r̂(x...) 
+                     + ρuˡᵃᵗ(p, lon(x...), lat(x...), rad(x...)) * ϕ̂(x...)
+                     + ρuˡᵒⁿ(p, lon(x...), lat(x...), rad(x...)) * λ̂(x...) ) 
+ρθ₀ᶜᵃʳᵗ(p, x...) = ρθ₀(p, lon(x...), lat(x...), rad(x...))
+
+# set up model
+model = BarotropicFluidModel(
+    domain = domain,
+    physics = ModelPhysics(
+        equation_of_state = BarotropicFluid(),
+        ref_state = NoReferenceState(),
+        sources = ( 
+            coriolis = DeepShellCoriolis(), 
+        ),
+    ),
+    boundary_conditions = (DefaultBC(), DefaultBC()),
+    initial_conditions = (
+        ρ = ρ₀ᶜᵃʳᵗ, ρu = ρu⃗₀ᶜᵃʳᵗ, ρθ = ρθ₀ᶜᵃʳᵗ,
+    ),
+    parameters = parameters,
+)
+
+# set up timestepper
+timestepper = TimeStepper(
+    method = SSPRK22Heuns,
+    dt = 1.0,
+    tspan = (0.0, 8*1600.0),
+    splitting = NoSplitting(),
+    saveat = 1.0,
+    progress = true,
+    progress_message = (dt, u, p, t) -> t,
+)
+
+simulation = Simulation(
+    DiscontinuousGalerkinBackend(numerics = (flux = :lmars,),),
+    model = model,
+    timestepper = timestepper,
+    callbacks = (
+        # Info(),
+        # VTKState(iteration = Int(floor(100.0/1.0)), filepath = "./out/"),
+        # CFL(), 
+    ), 
+)
+
+#=
+# set up simulation
+# run the simulation
+evolve(simulation)
+
+nothing
+=#

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -30,15 +30,22 @@ macro boilerplate()
         using OrdinaryDiffEq: SSPRK33;
 
         # explicit imports from Interface
-        import ClimaAtmos.Interface: PeriodicRectangle, SingleColumn;
+        import ClimaAtmos.Interface: PeriodicRectangle, SingleColumn, SphericalShell;
+        import ClimaAtmos.Interface: VerticalDiscontinousGalerkin, VerticalFiniteDifference;
         import ClimaAtmos.Interface: BarotropicFluidModel, HydrostaticModel;
-        import ClimaAtmos.Interface: TimeStepper;
-        import ClimaAtmos.Interface: DirichletBC, Simulation;
+        import ClimaAtmos.Interface: ModelPhysics, BarotropicFluid, DeepShellCoriolis;
+        import ClimaAtmos.Interface: TimeStepper, NoSplitting;
+        import ClimaAtmos.Interface: DirichletBC, DefaultBC, Simulation;
         import ClimaAtmos.Backends: create_ode_problem, evolve;
 
         # imports from Clima Core
         using ClimaCore.Geometry;
-        import ClimaCore: Fields, Domains, Topologies, Meshes, Spaces
+        import ClimaCore: Fields, Domains, Topologies, Meshes, Spaces;
+
+        # imports from ClimateMachine
+        using ClimateMachine;
+        using ClimateMachine.ODESolvers;
+        using ClimateMachine.Atmos: NoReferenceState
         )
     return boiler_block
 end

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -32,11 +32,11 @@ macro boilerplate()
         # explicit imports from Interface
         import ClimaAtmos.Interface: PeriodicRectangle, SingleColumn, SphericalShell;
         import ClimaAtmos.Interface: VerticalDiscontinousGalerkin, VerticalFiniteDifference;
-        import ClimaAtmos.Interface: BarotropicFluidModel, HydrostaticModel;
+        import ClimaAtmos.Interface: BarotropicFluidModel, HydrostaticModel, AbstractModel;
         import ClimaAtmos.Interface: ModelPhysics, BarotropicFluid, DeepShellCoriolis;
         import ClimaAtmos.Interface: TimeStepper, NoSplitting;
         import ClimaAtmos.Interface: DirichletBC, DefaultBC, Simulation;
-        import ClimaAtmos.Backends: create_ode_problem, evolve;
+        import ClimaAtmos.Backends: create_ode_problem, evolve, construct_odesolver;
 
         # imports from Clima Core
         using ClimaCore.Geometry;

--- a/src/backends/backends.jl
+++ b/src/backends/backends.jl
@@ -1,9 +1,12 @@
 module Backends
 
+export rad, lon, lat, r̂ⁿᵒʳᵐ, ϕ̂ⁿᵒʳᵐ, λ̂ⁿᵒʳᵐ, r̂, ϕ̂, λ̂, rfunc, ϕfunc, λfunc, ρu⃗
+
 import ..Interface: AbstractModel, AbstractDomain, Rectangle, PeriodicRectangle, SphericalShell, ClimaCoreBackend, DiscontinuousGalerkinBackend, SingleColumn
-import ClimaAtmos.Interface: TimeStepper, AbstractTimestepper, NoSplitting, Simulation
+import ClimaAtmos.Interface: TimeStepper, AbstractTimestepper, NoSplitting, DefaultBC, Simulation
 
 import ClimaAtmos.Interface: BarotropicFluidModel, HydrostaticModel, AbstractBackend
+import ClimaAtmos.Interface: BarotropicFluid, DeepShellCoriolis
 
 @info "error / warning comes from ClimaCore"
 using UnPack
@@ -55,6 +58,49 @@ using ClimateMachine.SystemSolvers
 using ClimateMachine.Orientations
 using ClimateMachine.VTK
 
+# for balance laws and bcs
+import ClimateMachine.BalanceLaws:
+    # declaration
+    vars_state,
+    # initialization
+    nodal_init_state_auxiliary!,
+    init_state_prognostic!,
+    init_state_auxiliary!,
+    # rhs computation
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    flux_first_order!,
+    flux_second_order!,
+    source!,
+    # boundary conditions
+    boundary_conditions,
+    boundary_state!
+import ClimateMachine.NumericalFluxes:
+    numerical_boundary_flux_first_order!,
+    numerical_boundary_flux_second_order!
+# to be removed: needed for updating ref state
+import ClimateMachine.ODESolvers: update_backward_Euler_solver!
+import ClimateMachine.DGMethods: update_auxiliary_state!
+
+# for numerical fluxes
+using ClimateMachine.NumericalFluxes
+using ClimateMachine.DGMethods.NumericalFluxes: NumericalFluxFirstOrder
+import ClimateMachine.DGMethods.NumericalFluxes:
+    numerical_volume_conservative_flux_first_order!,
+    numerical_volume_fluctuation_flux_first_order!,
+    ave,
+    numerical_flux_first_order!,
+    numerical_flux_second_order!,
+    numerical_boundary_flux_second_order!
+import ClimateMachine.BalanceLaws:
+    wavespeed
+
+# for callbacks
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.Thermodynamics: soundspeed_air
+using ClimateMachine.VariableTemplates: flattenednames
+
 # include
 include("climacore/function_spaces.jl")
 include("climacore/initial_conditions.jl")
@@ -65,10 +111,15 @@ include("discontinuous_galerkin/WIP_ode_problem.jl")
 include("discontinuous_galerkin/WIP_grids.jl")
 include("discontinuous_galerkin/WIP_balance_laws.jl")
 include("discontinuous_galerkin/WIP_backend_hook.jl")
+include("discontinuous_galerkin/sphere_utils.jl")
 
+include("discontinuous_galerkin/barotropic_fluid/balance_law_interface.jl")
+include("discontinuous_galerkin/barotropic_fluid/boundary_conditions_interface.jl")
 include("discontinuous_galerkin/barotropic_fluid/numerical_fluxes_interface.jl")
+include("discontinuous_galerkin/barotropic_fluid/sources_interface.jl")
+include("discontinuous_galerkin/barotropic_fluid/thermodynamics.jl")
 
-# Simulation for ClimaCore
+# Simulation 
 function Simulation(
     backend::AbstractBackend;
     model,
@@ -90,6 +141,7 @@ function Simulation(
     )
 end
 
+# time integration for ClimaCore
 function evolve(simulation::Simulation{<:ClimaCoreBackend})
     return solve(
         simulation.ode_problem,
@@ -99,6 +151,40 @@ function evolve(simulation::Simulation{<:ClimaCoreBackend})
         progress = simulation.timestepper.progress, 
         progress_message = simulation.timestepper.progress_message,
     )
+end
+
+# time integration for DG end in ClimateMachine
+function evolve(simulation::Simulation{<:DiscontinuousGalerkinBackend})
+    method        = simulation.timestepper.method
+    start         = simulation.timestepper.tspan[1]
+    finish        = simulation.timestepper.tspan[2]
+    timestep      = simulation.timestepper.dt
+    splitting     = simulation.timestepper.splitting
+    rhs           = simulation.ode_problem.rhs
+    state         = simulation.ode_problem.state
+
+    ode_solver = construct_odesolver(splitting, simulation)
+
+    # TODO: add back in callbacks
+    cb_vector = () #create_callbacks(simulation, ode_solver)
+
+    # Perform evolution of simulations
+    if isempty(cb_vector)
+        solve!(
+            state, 
+            ode_solver; 
+            timeend = finish, 
+            adjustfinalstep = false,
+        )
+    else
+        solve!(
+            state,
+            ode_solver;
+            timeend = finish,
+            callbacks = cb_vector,
+            adjustfinalstep = false,
+        )
+    end
 end
 
 end # end of module

--- a/src/backends/backends.jl
+++ b/src/backends/backends.jl
@@ -1,7 +1,7 @@
 module Backends
 
-import ..Interface: AbstractModel, AbstractDomain, Rectangle, PeriodicRectangle, ClimaCoreBackend, SingleColumn
-import ClimaAtmos.Interface: TimeStepper, AbstractTimestepper, Simulation
+import ..Interface: AbstractModel, AbstractDomain, Rectangle, PeriodicRectangle, SphericalShell, ClimaCoreBackend, DiscontinuousGalerkinBackend, SingleColumn
+import ClimaAtmos.Interface: TimeStepper, AbstractTimestepper, NoSplitting, Simulation
 
 import ClimaAtmos.Interface: BarotropicFluidModel, HydrostaticModel, AbstractBackend
 
@@ -29,11 +29,44 @@ import ClimaCore:
 
 using ClimaCore.Spaces: SpectralElementSpace2D, CenterFiniteDifferenceSpace, FaceFiniteDifferenceSpace
 import LinearAlgebra: norm, ×
+
+using Dates
+using GaussQuadrature
+using JLD2
+using LinearAlgebra
+using Logging
+using MPI
+using Printf
+using StaticArrays
+using Test
+
+using ClimateMachine
+using ClimateMachine.Atmos: NoReferenceState
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Geometry
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.BalanceLaws
+using ClimateMachine.ODESolvers
+using ClimateMachine.SystemSolvers
+using ClimateMachine.Orientations
+using ClimateMachine.VTK
+
 # include
 include("climacore/function_spaces.jl")
 include("climacore/initial_conditions.jl")
 include("climacore/ode_problems.jl")
 include("climacore/tendencies.jl")
+
+include("discontinuous_galerkin/WIP_ode_problem.jl")
+include("discontinuous_galerkin/WIP_grids.jl")
+include("discontinuous_galerkin/WIP_balance_laws.jl")
+include("discontinuous_galerkin/WIP_backend_hook.jl")
+
+include("discontinuous_galerkin/barotropic_fluid/numerical_fluxes_interface.jl")
 
 # Simulation for ClimaCore
 function Simulation(

--- a/src/backends/discontinuous_galerkin/WIP_backend_hook.jl
+++ b/src/backends/discontinuous_galerkin/WIP_backend_hook.jl
@@ -24,61 +24,13 @@ function create_esdg_rhs(model::AbstractModel, backend::DiscontinuousGalerkinBac
     return rhs
 end
 
-#=
-function create_linear_rhs(model::AbstractModel, splitting::IMEXSplitting; domain, grid)
-    balance_law = create_balance_law(model, domain)
-    if splitting.linear_model == :linear
-        linear_balance_law = linearize_balance_law(balance_law)
-        volume_flux = LinearKGVolumeFlux()
-        @info "linear model created"
-    elseif splitting.linear_model == :verylinear
-        linear_balance_law = verylinearize_balance_law(balance_law)
-        volume_flux = VeryLinearKGVolumeFlux()
-        @info "verylinear model created"
-    else
-        @warn "invalid linear model specification for IMEXSplitting, set to :linear"
-        linear_balance_law = linearize_balance_law(balance_law)
-        volume_flux = LinearKGVolumeFlux()
-    end 
-
-    rhs = VESDGModel(
-        linear_balance_law,
-        grid,
-        surface_numerical_flux_first_order = RefanovFlux(),
-        volume_numerical_flux_first_order = volume_flux,
-    )
-
-    return rhs
-end
-=#
-
 function create_rhs(::NoSplitting, model::AbstractModel, backend::DiscontinuousGalerkinBackend; grid)
     rhs = create_esdg_rhs(model, backend, grid = grid)
     return rhs 
 end
 
-#=
-function create_rhs(splitting::IMEXSplitting, model::AbstractModel, backend::DiscontinuousGalerkinBackend; domain, grid)
-    rhs = []
-    # create explicit model and push to rhs
-    tmp = #Explicit(
-        create_esdg_rhs(model, backend, domain = domain, grid = grid)
-    #)
-    push!(rhs, tmp)
-    # create implicit model and push to rhs
-    tmp = #Implicit(
-        create_linear_rhs(model, splitting, domain = domain, grid = grid)
-    # )
-    push!(rhs, tmp)
-    return Tuple(rhs)
-end
-=#
 
-function create_init_state(model::AbstractModel, backend::DiscontinuousGalerkinBackend; rhs = nothing)
-    if rhs === nothing
-        # TODO: this looks wrong
-        rhs = create_rhs(model, backend)
-    end
+function create_init_state(::AbstractModel, ::DiscontinuousGalerkinBackend; rhs)
     FT = eltype(rhs.grid.vgeo)
     state_init = init_ode_state(rhs, FT(0); init_on_cpu = true)
 
@@ -98,24 +50,3 @@ function get_polynomial_order(domain::SphericalShell)
     return (vertical = vertical_poly_order, horizontal = horizontal_poly_order)
 end
 
-#=
-function get_elements(discretized_domain::DiscretizedDomain{<:ProductDomain})
-    return discretized_domain.discretization.elements
-end
-
-function get_elements(discretized_domain::DiscretizedDomain{<:SphericalShell})
-    horizontal_elements =discretized_domain.discretization.horizontal.elements
-    vertical_elements = discretized_domain.discretization.vertical.elements
-    return (vertical = vertical_elements, horizontal = horizontal_elements)
-end
-
-function get_polynomial_order(discretized_domain::DiscretizedDomain{<:ProductDomain})
-    return discretized_domain.discretization.polynomial_order
-end
-
-function get_polynomial_order(discretized_domain::DiscretizedDomain{<:SphericalShell})
-    horizontal_poly_order = discretized_domain.discretization.horizontal.polynomial_order
-    vertical_poly_order = discretized_domain.discretization.vertical.polynomial_order
-    return (vertical = vertical_poly_order, horizontal = horizontal_poly_order)
-end
-=#

--- a/src/backends/discontinuous_galerkin/WIP_balance_laws.jl
+++ b/src/backends/discontinuous_galerkin/WIP_balance_laws.jl
@@ -143,5 +143,5 @@ function create_numerical_flux(surface_flux)
     end
 end
 
-create_orientation(::ProductDomain) = FlatOrientation()
+# create_orientation(::ProductDomain) = FlatOrientation()
 create_orientation(::SphericalShell) = SphericalOrientation()

--- a/src/backends/discontinuous_galerkin/WIP_boilerplate.jl
+++ b/src/backends/discontinuous_galerkin/WIP_boilerplate.jl
@@ -70,14 +70,14 @@ using ClimateMachine.Thermodynamics: soundspeed_air
 using ClimateMachine.VariableTemplates: flattenednames
 
 # interface includes
-include("grids.jl")
+include("WIP_grids.jl")
 include("temperature_profiles.jl")
 include("WIP_ode_problem.jl")
 # include("balance_laws.jl")
 include("WIP_balance_laws.jl")
 # include("callbacks.jl")
-include("WIP_callbacks.jl")
-include("../../utils/operations.jl")
+# include("WIP_callbacks.jl")
+# include("../../utils/operations.jl")
 
 # # TODO! Remove this.
 # dirs = ["three_dimensional_dry_compressible_euler_with_total_energy/", 

--- a/src/backends/discontinuous_galerkin/WIP_grids.jl
+++ b/src/backends/discontinuous_galerkin/WIP_grids.jl
@@ -1,0 +1,68 @@
+function create_dg_grid(
+    domain::SphericalShell;
+    elements = nothing,
+    polynomial_order = nothing,
+    grid_stretching = nothing,
+    FT = Float64,
+    mpicomm = MPI.COMM_WORLD,
+    array = ClimateMachine.array_type()
+)
+
+    new_polynomial_order = convention(polynomial_order, Val(2))
+    # new_polynomial_order = new_polynomial_order .+ convention(overintegration_order, Val(2))
+    horizontal, vertical = new_polynomial_order
+
+    Rrange = grid1d(
+        domain.radius, 
+        domain.radius + domain.height, 
+        grid_stretching,
+        nelem = elements.vertical,
+    )
+
+    topl = StackedCubedSphereTopology(
+        mpicomm,
+        elements.horizontal,
+        Rrange,
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = array,
+        polynomialorder = (horizontal, vertical),
+        meshwarp = equiangular_cubed_sphere_warp,
+    )
+
+    return grid
+
+end
+
+"""
+    Conventions for polynomial order and overintegration order 
+"""
+function convention(
+    a::NamedTuple{(:vertical, :horizontal), T},
+    ::Val{3},
+) where {T}
+    return (a.horizontal, a.horizontal, a.vertical)
+end
+
+function convention(a::Number, ::Val{3})
+    return (a, a, a)
+end
+
+function convention(
+    a::NamedTuple{(:vertical, :horizontal), T},
+    ::Val{2},
+) where {T}
+    return (a.horizontal, a.vertical)
+end
+
+function convention(a::Number, ::Val{2})
+    return (a, a)
+end
+
+function convention(a::Tuple, b)
+    return a
+end
+

--- a/src/backends/discontinuous_galerkin/WIP_ode_problem.jl
+++ b/src/backends/discontinuous_galerkin/WIP_ode_problem.jl
@@ -6,7 +6,7 @@ end
 
 function create_ode_problem(backend::DiscontinuousGalerkinBackend, model, timestepper)
     grid = create_grid(backend, model.domain)
-    rhs = create_rhs(timestepper.splitting, model, backend, domain = model.domain.domain, grid = grid)
+    rhs = create_rhs(timestepper.splitting, model, backend, grid = grid)
     if rhs isa SpaceDiscretization
         state = create_init_state(model, backend, rhs = rhs)
     elseif rhs isa Tuple 
@@ -38,6 +38,7 @@ function construct_odesolver(::NoSplitting, simulation)
     return ode_solver
 end
 
+#=
 function construct_odesolver(splitting::IMEXSplitting, simulation; t0 = 0, split_explicit_implicit = false)
     method       = simulation.timestepper.method.method
     start        = simulation.timestepper.tspan[1]
@@ -62,3 +63,4 @@ function construct_odesolver(splitting::IMEXSplitting, simulation; t0 = 0, split
 
     return odesolver
 end
+=#

--- a/src/backends/discontinuous_galerkin/WIP_ode_problem.jl
+++ b/src/backends/discontinuous_galerkin/WIP_ode_problem.jl
@@ -10,7 +10,7 @@ function create_ode_problem(backend::DiscontinuousGalerkinBackend, model, timest
     if rhs isa SpaceDiscretization
         state = create_init_state(model, backend, rhs = rhs)
     elseif rhs isa Tuple 
-        state = create_init_state(model, backend, rhs = rhs[1]) # what if rhs is not array??
+        state = create_init_state(model, backend, rhs = rhs[1]) 
     else
         println("rhs error => fail to initialize state")
     end
@@ -37,30 +37,3 @@ function construct_odesolver(::NoSplitting, simulation)
 
     return ode_solver
 end
-
-#=
-function construct_odesolver(splitting::IMEXSplitting, simulation; t0 = 0, split_explicit_implicit = false)
-    method       = simulation.timestepper.method.method
-    start        = simulation.timestepper.tspan[1]
-    timestep     = simulation.timestepper.dt
-    state        = simulation.ode_problem.state 
-
-    explicit_rhs    = simulation.ode_problem.rhs[1]
-    implicit_rhs    = simulation.ode_problem.rhs[2]
-
-    implicit_method         = splitting.implicit_method
-    split_explicit_implicit = splitting.split_explicit_implicit
-
-    odesolver = method(
-        explicit_rhs,
-        implicit_rhs,
-        implicit_method,
-        state;
-        dt = timestep,
-        t0 = start,
-        split_explicit_implicit = split_explicit_implicit,
-    )
-
-    return odesolver
-end
-=#

--- a/src/backends/discontinuous_galerkin/sphere_utils.jl
+++ b/src/backends/discontinuous_galerkin/sphere_utils.jl
@@ -1,0 +1,17 @@
+rad(x,y,z) = sqrt(x^2 + y^2 + z^2)
+lat(x,y,z) = asin(z/rad(x,y,z)) # ϕ ∈ [-π/2, π/2] 
+lon(x,y,z) = atan(y,x) # λ ∈ [-π, π) 
+
+r̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,z]) ≈ 0 ? 1 : norm([x, y, z])^(-1)
+ϕ̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,0]) ≈ 0 ? 1 : (norm([x, y, z]) * norm([x, y, 0]))^(-1)
+λ̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,0]) ≈ 0 ? 1 : norm([x, y, 0])^(-1)
+
+r̂(x,y,z) = r̂ⁿᵒʳᵐ(x,y,z) * @SVector([x, y, z])
+ϕ̂(x,y,z) = ϕ̂ⁿᵒʳᵐ(x,y,z) * @SVector [x*z, y*z, -(x^2 + y^2)]
+λ̂(x,y,z) = λ̂ⁿᵒʳᵐ(x,y,z) * @SVector [-y, x, 0] 
+
+rfunc(p, x...) = ρuʳᵃᵈ(p, lon(x...), lat(x...), rad(x...)) * r̂(x...)
+ϕfunc(p, x...) = ρuˡᵃᵗ(p, lon(x...), lat(x...), rad(x...)) * ϕ̂(x...)
+λfunc(p, x...) = ρuˡᵒⁿ(p, lon(x...), lat(x...), rad(x...)) * λ̂(x...)
+
+ρu⃗(p, x...) = rfunc(p, x...) + ϕfunc(p, x...) + λfunc(p, x...)

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -18,6 +18,7 @@ end
 # WIP includes
 include("domains.jl")
 include("models.jl")
+include("physicsl.jl")
 include("timesteppers.jl")
 include("boundary_conditions.jl")
 include("simulations.jl")

--- a/src/interface/boundary_conditions.jl
+++ b/src/interface/boundary_conditions.jl
@@ -3,3 +3,6 @@ abstract type AbstractBoundaryCondition end
 struct DirichletBC <: AbstractBoundaryCondition end
 struct NeumannBC <: AbstractBoundaryCondition end
 struct FluxBC <: AbstractBoundaryCondition end
+
+# impenetrable freeslip
+struct DefaultBC <: AbstractBoundaryCondition end

--- a/src/interface/domains.jl
+++ b/src/interface/domains.jl
@@ -1,4 +1,12 @@
 abstract type AbstractDomain end
+abstract type AbstractVerticalDiscretization end
+Base.@kwdef struct VerticalFiniteDifference{T} <: AbstractVerticalDiscretization 
+    warping::T = nothing
+end
+Base.@kwdef struct VerticalDiscontinousGalerkin{T} <: AbstractVerticalDiscretization
+    vpolynomial::Int
+    warping::T = nothing
+end
 
 struct Rectangle <: AbstractDomain
     xlim::Interval  
@@ -35,3 +43,52 @@ function SingleColumn(; zlim, nelements)
     @assert zlim.left < zlim.right
     return SingleColumn(zlim, nelements)
 end
+
+struct SphericalShell{A,B} <: AbstractDomain
+    radius::A
+    height::A
+    nelements::NamedTuple{(:horizontal, :vertical), Tuple{Int, Int}}
+    npolynomial::NamedTuple{(:horizontal,), Tuple{Int}}
+    vertical_discretization::B # default to FD 
+end
+
+function SphericalShell(; radius, height, nelements, npolynomial, vertical_discretization = VerticalFiniteDifference())
+    if nelements isa Tuple
+        nelements = (horizontal=nelements[1],vertical=nelements[2])
+    elseif nelements isa Int
+        nelements = (horizontal=nelements,vertical=nelements)
+    end
+    if npolynomial isa Int
+        npolynomial = (horizontal = npolynomial, )
+    end
+    return SphericalShell(radius, height, nelements, npolynomial, vertical_discretization)
+end
+
+#= old domain interface for DG
+struct SphericalShell{T} <: AbstractDomain
+    radius::T
+    height::T
+end
+
+function SphericalShell(; radius, height)
+    @assert radius > 0 && height > 0
+    return SphericalShell(radius, height)
+end
+
+Base.@kwdef struct DiscretizedDomain{𝒜, ℬ} <: AbstractDomain
+    domain::𝒜
+    discretization::ℬ
+end
+
+abstract type AbstractGrid end
+
+Base.@kwdef struct SpectralElementGrid{𝒜,ℬ,𝒞} <: AbstractGrid 
+    elements::𝒜
+    polynomial_order::ℬ
+    warping::𝒞
+end
+
+function SpectralElementGrid(; elements, polynomial_order)
+    return SpectralElementGrid(elements, polynomial_order, nothing)
+end
+=#

--- a/src/interface/models.jl
+++ b/src/interface/models.jl
@@ -3,11 +3,12 @@ abstract type AbstractModel end
 """
     BarotropicFluidModel <: AbstractModel
 """
-Base.@kwdef struct BarotropicFluidModel{A,B,C,D} <: AbstractModel
+Base.@kwdef struct BarotropicFluidModel{A,B,C,D,E} <: AbstractModel
     domain::A
-    boundary_conditions::B
-    initial_conditions::C
-    parameters::D
+    physics::B = ModelPhysics()
+    boundary_conditions::C
+    initial_conditions::D
+    parameters::E
 end
 
 """

--- a/src/interface/physicsl.jl
+++ b/src/interface/physicsl.jl
@@ -1,0 +1,19 @@
+abstract type AbstractPhysics end
+abstract type AbstractEquationOfState end
+
+# equation of state
+struct BarotropicFluid <: AbstractEquationOfState end
+struct DryIdealGas <: AbstractEquationOfState end
+struct MoistIdealGas <: AbstractEquationOfState end
+
+# coriolis force
+struct DeepShellCoriolis <: AbstractPhysics end
+
+# gravity
+struct Gravity <: AbstractPhysics end
+
+Base.@kwdef struct ModelPhysics{𝒜,ℬ,𝒞} 
+    equation_of_state::𝒜 = nothing
+    ref_state::ℬ = nothing
+    sources::𝒞 = nothing
+end

--- a/test/unit_tests_dg.jl
+++ b/test/unit_tests_dg.jl
@@ -1,0 +1,58 @@
+using ClimaAtmos
+using ClimaAtmos.Utils
+using ClimaAtmos.Interface
+using ClimaAtmos.Backends
+
+# explicit imports from Interface
+import ClimaAtmos.Interface: SphericalShell, VerticalDiscontinousGalerkin
+import ClimaAtmos.Interface: BarotropicFluidModel
+import ClimaAtmos.Interface: ModelPhysics, BarotropicFluid, DeepShellCoriolis
+import ClimaAtmos.Interface: TimeStepper, NoSplitting
+import ClimaAtmos.Interface: DefaultBC #, Simulation
+
+# from ClimateMachine
+using ClimateMachine
+using ClimateMachine.Atmos: NoReferenceState
+using ClimateMachine.ODESolvers
+
+# # explicit imports from Backends
+# import ClimaAtmos.Backends: create_ode_problem
+
+# # External Stuff
+# using IntervalSets
+# using OrdinaryDiffEq: ODEProblem, solve, SSPRK33
+
+# Domains
+domain = SphericalShell(
+    radius = 1.0,
+    height = 0.2,
+    nelements = (8, 1),
+    npolynomial = 3,
+    vertical_discretization = VerticalDiscontinousGalerkin(vpolynomial=1),
+)
+
+# Model
+model = BarotropicFluidModel(
+    domain = domain,
+    physics = ModelPhysics(
+        equation_of_state = BarotropicFluid(),
+        ref_state = NoReferenceState(),
+        sources = ( 
+            coriolis = DeepShellCoriolis(), 
+        ),
+    ),
+    boundary_conditions = (DefaultBC(), DefaultBC()),
+    initial_conditions = nothing,
+    parameters = nothing,
+)
+
+# Timestepper
+timestepper = TimeStepper(
+    method = SSPRK22Heuns,
+    dt = 1.0,
+    tspan = (0.0, 8*1600.0),
+    splitting = NoSplitting(),
+    saveat = 1.0,
+    progress = true,
+    progress_message = (dt, u, p, t) -> t,
+)


### PR DESCRIPTION
This PR is a first step towards a functioning DG backend interface, a follow-up effort of #13 . It adds modules for the DG core and brings back the bickley jet experiment on the sphere.

To bring back running benchmarks for the DG backend, the following will be added thru small PRs:
- To separate boilerplate for ClimaCore and ClimateMachine:  We would like to get rid of the boilerplate in the end (#17), but for the current convenience, we should keep them separate so that there is no need to import all ClimateMachine functions nor init it when running with ClimaCore;
- To add callbacks:  Abstract place holder in Interface, and ClimateMachine dependent functionality in backends;
- To optimize/simplify model physics struct;
- To add back IMEX splitting;
- To add back benchmarking tests.