### PR TITLE
Add Base.show for Simulation and Domain

### DIFF
--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -70,11 +70,13 @@ Base.size(domain::Plane) =
 function Base.show(io::IO, domain::Column)
     min = domain.zlim[1]
     max = domain.zlim[2]
+    print("Domain set-up:\n\tSingle colume z-range:\t")
     printstyled(io, "[", color = 226)
     astring = @sprintf("%0.1f", min)
     bstring = @sprintf("%0.1f", max)
     printstyled(astring, ", ", bstring, color = 7)
     printstyled(io, "]", color = 226)
+    @printf("\n\tvert elem:\t\t%d\n", domain.nelements)
 end
 
 function Base.show(io::IO, domain::Plane)
@@ -82,6 +84,7 @@ function Base.show(io::IO, domain::Plane)
     maxx = domain.xlim[2]
     miny = domain.ylim[1]
     maxy = domain.ylim[2]
+    print("Domain set-up:\n\tHorizontal plane:\t")
     printstyled(io, "[", color = 226)
     astring = @sprintf("%0.1f", minx)
     bstring = @sprintf("%0.1f", maxx)
@@ -94,4 +97,10 @@ function Base.show(io::IO, domain::Plane)
     printstyled(astring, ", ", bstring, color = 7)
     domain.periodic[2] ? printstyled(io, ")", color = 226) :
     printstyled(io, "]", color = 226)
+    @printf(
+        "\n\thorz elem:\t\t(%d, %d)",
+        domain.nelements[1],
+        domain.nelements[2]
+    )
+    @printf("\n\tpoly order:\t\t%d\n", domain.npolynomial)
 end

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -2,6 +2,7 @@ module Simulations
 
 using DiffEqBase
 using UnPack: @unpack
+using Printf
 
 using ClimaAtmos.Models:
     AbstractModel, default_initial_conditions, make_ode_function

--- a/src/Simulations/simulation.jl
+++ b/src/Simulations/simulation.jl
@@ -45,6 +45,7 @@ function set!(
     submodel_name = nothing;
     kwargs...,
 )
+    show(simulation)
     for (varname, f) in kwargs
         if varname ∉ simulation.model.varnames
             throw(ArgumentError("$varname not in model variables."))
@@ -101,3 +102,19 @@ step!(sim::AbstractSimulation, args...; kwargs...) =
 
 run!(sim::AbstractSimulation, args...; kwargs...) =
     DiffEqBase.solve!(sim.integrator, args...; kwargs...)
+
+function Base.show(io::IO, s::Simulation)
+    println(io, "Simulation set-up:")
+    @printf(io, "\tmodel type:\t%s\n", typeof(s.model).name.name)
+    @printf(io, "\tmodel vars:\t%s\n\n", s.model.varnames)
+    show(io, s.model.domain)
+    println(io, "\nTimestepper set-up:")
+    @printf(io, "\tmethod:\t%s\n", typeof(s.integrator.alg).name.name)
+    @printf(io, "\tdt:\t%f\n", s.integrator.dt)
+    @printf(
+        io,
+        "\ttspan:\t(%f, %f)\n",
+        s.integrator.sol.prob.tspan[1],
+        s.integrator.sol.prob.tspan[2],
+    )
+end


### PR DESCRIPTION
This PR closes #76 . 

An example of experiment configuration displayed on Julia REPL
```
julia> include("test/runtests.jl")
[ Info: Testing ClimaAtmos.Simulations...
[ Info: Bickley jet 2D plane test does not run for Float32.
Simulation set-up:
        model type:     ShallowWaterModel
        model vars:     (:h, :u, :c)

Domain set-up:
        Horizontal plane:       [-6.3, 6.3) × [-6.3, 6.3)
        horz elem:              (16, 16)
        poly order:             4

Timestepper set-up:
        method: SSPRK33
        dt:     0.040000
        tspan:  (0.000000, 1.000000)
```