### PR TITLE
Updated workflow to reflect registration of ClimaCore

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         JULIA_PROJECT: "@."
       run: |
-        julia --project=@. -e 'using Pkg; Pkg.add(url = "https://github.com/CliMA/ClimaCore.jl.git"); Pkg.instantiate()'
+        julia --project=@. -e 'using Pkg; Pkg.instantiate()'
         julia --project=@. -e 'using Pkg; Pkg.test(coverage=true)'
 
     - name: Generate coverage file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - run: |
-          julia --project=@. -e 'using Pkg; Pkg.add(url = "https://github.com/CliMA/ClimaCore.jl.git")'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: 1.6
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.add(url = "https://github.com/CliMA/ClimaCore.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: 1.6
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token


### PR DESCRIPTION
Since ClimaCore.jl is now registered, we should be able to treat it like any other package in our GH workflows.