### PR TITLE
Re-introducing model.boundary_conditions

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -1,18 +1,26 @@
 module BoundaryConditions
 
+using ClimaCore: Geometry, Fields, Operators, Spaces
+using ClimaCore.Geometry: ⊗
+using LinearAlgebra
+using LinearAlgebra: norm, ×
+
 """
     AbstractFluxBoundaryCondition
-
+    
     Abstract supertype for boundary conditions that imply fluxes
     at the boundaries they are attached to.
 """
 abstract type AbstractBoundaryCondition end
 
 include("flux_conditions.jl")
+include("flux_calculations.jl")
 
 export AbstractBoundaryCondition
 export CustomFluxCondition
 export DragLawCondition
 export NoFluxCondition
+export BulkFormulaCondition
+export get_boundary_flux
 
 end # module

--- a/src/BoundaryConditions/flux_calculations.jl
+++ b/src/BoundaryConditions/flux_calculations.jl
@@ -1,0 +1,63 @@
+# General
+"""
+    get_boundary_flux(model, ::NoFluxCondition, _...)
+
+Construct zero boundary fluxes for a scalar or 2-element vector(x,y)
+"""
+function get_boundary_flux(model, ::NoFluxCondition, var::Fields.Field, Ym, Ya)
+    FT = eltype(Ym)
+    flux = Geometry.Cartesian3Vector(FT(0))
+end
+
+# Momentum-specific
+"""
+    get_boundary_flux(model, ::DragLawCondition, _...)
+
+Construct non-zero boundary fluxes using the bulk formula and constant or Mohnin-Obukhov-based drag coefficient, Cd
+"""
+function get_boundary_flux(model, bc::DragLawCondition, uv, Ym, Ya)
+    FT = eltype(Ym)
+    coefficients = eltype(bc.coefficients) == FT ? bc.coefficients :
+        bc.coefficients(Ym, Ya)
+
+    uv_1 = first_interior(Ym.uv)
+    u_wind = LinearAlgebra.norm(uv_1)
+
+    flux = Geometry.Cartesian3Vector(coefficients.Cd * u_wind) ⊗ uv_1
+end
+
+
+# Potential temperature density-specific
+"""
+    get_boundary_flux(model, ::BulkFormulaCondition, _...)
+
+    Construct non-zero boundary fluxes using the bulk formula and constant or Mohnin-Obukhov-based heat transfer coefficient, Ch
+"""
+function get_boundary_flux(
+    model,
+    bc::BulkFormulaCondition,
+    ρθ::Fields.Field,
+    Ym,
+    Ya,
+)
+    FT = eltype(Ym)
+    coefficients = eltype(bc.coefficients) == FT ? bc.coefficients :
+        bc.coefficients(Ym, Ya)
+    θ_sfc = bc.θ_sfc
+
+    ρ_1 = first_interior(Ym.ρ)
+    ρθ_1 = first_interior(Ym.ρθ)
+    uv_1 = first_interior(Ym.uv)
+    u_wind = LinearAlgebra.norm(uv_1)
+
+    flux = Geometry.Cartesian3Vector(
+        coefficients.Ch * u_wind * ρ_1 * (ρθ_1 / ρ_1 - θ_sfc),
+    )
+end
+
+# helpers
+"""
+    first_interior(f)
+- obtains the first interior datapoint of variable `v`
+"""
+first_interior(v) = Operators.getidx(v, Operators.Interior(), 1)

--- a/src/BoundaryConditions/flux_conditions.jl
+++ b/src/BoundaryConditions/flux_conditions.jl
@@ -19,6 +19,16 @@ struct CustomFluxCondition <: AbstractBoundaryCondition
 end
 
 """
-    DragLawCondition <: AbstractFluxBoundaryCondition
+    DragLawCondition{C} <: AbstractFluxBoundaryCondition
 """
-struct DragLawCondition <: AbstractBoundaryCondition end
+struct DragLawCondition{C} <: AbstractBoundaryCondition
+    coefficients::C
+end
+
+"""
+    BulkFormulaCondition{C, T}
+"""
+struct BulkFormulaCondition{C, T} <: AbstractBoundaryCondition
+    coefficients::C
+    θ_sfc::T
+end

--- a/src/Models/SingleColumnModels/SingleColumnModels.jl
+++ b/src/Models/SingleColumnModels/SingleColumnModels.jl
@@ -6,7 +6,7 @@ using UnPack: @unpack
 
 # clima ecosystem
 using ClimaAtmos.BoundaryConditions:
-    NoFluxCondition, CustomFluxCondition, DragLawCondition
+    NoFluxCondition, CustomFluxCondition, DragLawCondition, get_boundary_flux
 using ClimaAtmos.Domains: AbstractVerticalDomain, make_function_space
 using ClimaAtmos.Models: AbstractModel, get_boundary_flux
 using ClimaCore: Fields, Geometry, Operators, Spaces

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,8 @@ using Plots
 
 # Clima ecosystem
 using ClimaAtmos
-using ClimaAtmos.BoundaryConditions: NoFluxCondition, DragLawCondition
+using ClimaAtmos.BoundaryConditions:
+    NoFluxCondition, DragLawCondition, BulkFormulaCondition, get_boundary_flux
 using ClimaAtmos.Domains: Plane, PeriodicPlane, Column, HybridPlane
 using ClimaAtmos.Models.ShallowWaterModels: ShallowWaterModel
 using ClimaAtmos.Models.SingleColumnModels: SingleColumnModel

--- a/test/test_cases/run_ekman_column_1d.jl
+++ b/test/test_cases/run_ekman_column_1d.jl
@@ -23,6 +23,7 @@ function run_ekman_column_1d(
         f = FT(5e-5), # Coriolis parameters
         ν = FT(0.01),
         Cd = FT(0.01 / (2e2 / 30.0)),
+        Ch = FT(0.01 / (2e2 / 30.0)),
         uvg = Geometry.Cartesian12Vector(FT(1.0), FT(0.0)),
         T_surf = FT(300.0),
         T_min_ref = FT(230.0),
@@ -33,17 +34,20 @@ function run_ekman_column_1d(
 
     domain = Column(FT, zlim = (0.0, 2e2), nelements = nelements)
 
-    # boundary_conditions = (
-    #     ρ = (top = NoFluxCondition(), bottom = NoFluxCondition()),
-    #     u = (top = nothing, bottom = DragLawCondition()),
-    #     v = (top = nothing, bottom = DragLawCondition()),
-    #     w = (top = NoFluxCondition(), bottom = NoFluxCondition()),
-    #     ρθ = (top = NoFluxCondition(), bottom = NoFluxCondition()),
-    # )
+    coefficients = (Cd = params.Cd, Ch = params.Ch)
+    boundary_conditions = (
+        ρ = (top = NoFluxCondition(), bottom = NoFluxCondition()),
+        uv = (top = nothing, bottom = DragLawCondition(coefficients)),
+        w = (top = NoFluxCondition(), bottom = NoFluxCondition()),
+        ρθ = (
+            top = NoFluxCondition(),
+            bottom = BulkFormulaCondition(coefficients, params.T_surf),
+        ),
+    )
 
     model = SingleColumnModel(
         domain = domain,
-        boundary_conditions = nothing,
+        boundary_conditions = boundary_conditions,
         parameters = params,
     )
 


### PR DESCRIPTION
This addresses issue #122, and allows boundary fluxes to be prescribed externally. 

The next iteration / PR should 
- abstract the currently hard-coded top BC for `uv`
- generalist `get_boundary_flux` for any boundary. Currently all surface fluxes are applied at the bottom boundary via `first_interior(v)` 
- add a more general interface, such as that in Land's [rhs](https://github.com/CliMA/LandHydrology.jl/blob/c2e3fc1fd2b29d2381a5edfabd292ce1de6df3b3/src/SoilModel/right_hand_side.jl#L179) with their BCs specified [here](https://github.com/CliMA/LandHydrology.jl/blob/c2e3fc1fd2b29d2381a5edfabd292ce1de6df3b3/src/SoilModel/boundary_conditions.jl#L376). However, `ClimaSimulations` will most likely introduce a new way of prescribing BCs, so this point may depend on the interim needs of developers. 
 - decide if `get_boundary_flux` is better than `set_boundary_flux!` (see discussion below)