### PR TITLE
First iteration of simulation restart option

### DIFF
--- a/src/Callbacks/callback.jl
+++ b/src/Callbacks/callback.jl
@@ -13,7 +13,8 @@ function (F::JLD2Output)(integrator)
     # Create directory
     mkpath(F.filedir)
     # Save data
-    jldsave(joinpath(F.filedir, F.filename * ".jld2"), integrator = integrator)
+    savefile = joinpath(F.filedir, F.filename * "_$(integrator.t)" * ".jld2")
+    jldsave(savefile, integrator = integrator, model = F.model)
     return nothing
 end
 
@@ -24,5 +25,5 @@ end
     variables from the integrator and stores them in a jld2 file. 
 """
 function generate_callback(F::JLD2Output; kwargs...)
-    return PeriodicCallback(F, F.interval; initial_affect = false, kwargs...)
+    return PeriodicCallback(F, F.interval; initial_affect = true, kwargs...)
 end

--- a/src/Simulations/Simulations.jl
+++ b/src/Simulations/Simulations.jl
@@ -1,6 +1,7 @@
 module Simulations
 
 using DiffEqBase
+using JLD2
 using UnPack: @unpack
 using Printf
 
@@ -16,9 +17,16 @@ import DiffEqBase: step!
 """
 abstract type AbstractSimulation end
 
+"""
+    AbstractRestart
+"""
+abstract type AbstractRestart end
+
 include("simulation.jl")
+include("restart.jl")
 
 export Simulation
+export AbstractRestart, Restart
 export step!
 export run!
 export set!

--- a/src/Simulations/restart.jl
+++ b/src/Simulations/restart.jl
@@ -1,0 +1,28 @@
+
+"""
+    NoRestart <: AbstractRestart
+Empty container, default method for no restarts, begin
+simulation from model initial conditions. 
+"""
+struct NoRestart <: AbstractRestart end
+
+"""
+    Restart <: AbstractRestart
+Container for restart file parameters and updated
+simulation end time. Restart file must be a .jld2
+file containing the `simulation.integrator` and 
+`simulation.model` objects. User must `set!` simulation
+prior to restart.
+"""
+struct Restart <: AbstractRestart
+    restartfile::String
+    end_time::Real
+end
+
+function Restart(; restartfile = nothing, end_time = nothing)
+    # Check valid filename input for restarts
+    @assert restartfile isa String
+    # Check new end time (tspan[2]) is positive
+    @assert end_time > 0.0
+    return Restart(restartfile, end_time)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ using ClimaAtmos.Domains: Plane, PeriodicPlane, Column, HybridPlane
 using ClimaAtmos.Models.ShallowWaterModels: ShallowWaterModel
 using ClimaAtmos.Models.SingleColumnModels: SingleColumnModel
 using ClimaAtmos.Models.Nonhydrostatic2DModels: Nonhydrostatic2DModel
-using ClimaAtmos.Simulations: Simulation, set!, step!, run!
+using ClimaAtmos.Simulations:
+    Simulation, set!, step!, run!, AbstractRestart, NoRestart, Restart
 using ClimaAtmos.Callbacks
 using ClimaCore: Geometry, Fields
 

--- a/test/test_cases/run_bickley_jet_2d_plane.jl
+++ b/test/test_cases/run_bickley_jet_2d_plane.jl
@@ -42,6 +42,7 @@ function run_bickley_jet_2d_plane(
         show(simulation)
         println()
         @test simulation isa Simulation
+        @test simulation.restart isa NoRestart
 
         # test set function
         @unpack h, u, c = init_bickley_jet_2d_plane(params)
@@ -57,6 +58,7 @@ function run_bickley_jet_2d_plane(
         simulation = Simulation(model, stepper, dt = dt, tspan = (0.0, 1.0))
         @unpack h, u, c = init_bickley_jet_2d_plane(params)
 
+        @test simulation.restart isa NoRestart
         # here we set the initial condition with an array for testing
         space = axes(simulation.integrator.u.swm.c) # get tracer field
         local_geometry = Fields.local_geometry_field(space)
@@ -74,6 +76,7 @@ function run_bickley_jet_2d_plane(
     elseif mode == :validation
         # TODO!: run with callbacks = ...
         simulation = Simulation(model, stepper, dt = dt, tspan = (0.0, 80.0))
+        @test simulation.restart isa NoRestart
         @unpack h, u, c = init_bickley_jet_2d_plane(params)
         set!(simulation, :swm, h = h, u = u, c = c)
         run!(simulation)


### PR DESCRIPTION
Extends JLD2 output callback to save at user-defined time intervals (previous output was at simulation final time) 

Extends `simulation` to allow users to define a restart file-path and new simulation end-time to pick-up simulation at some intermediate timestep for which model+integrator data (via jld2 files) is available. Requires model types (including domains) to be consistent across simulation model and restart model. (Currently does not include automated directory look-up/ scan for latest checkpoint files)