### PR TITLE
Update to add Adaptive CFL option Callback

### DIFF
--- a/src/Callbacks/Callbacks.jl
+++ b/src/Callbacks/Callbacks.jl
@@ -3,9 +3,10 @@ module Callbacks
 using DiffEqCallbacks
 using JLD2
 using UnPack
+using ClimaCore: ClimaCore, Fields, Spaces
 using ..Models
 
-export generate_callback, AbstractCallback, JLD2Output
+export generate_callback, AbstractCallback, JLD2Output, CFLAdaptive
 
 """
     generate_callback(callback; kwargs...)

--- a/src/Callbacks/callback.jl
+++ b/src/Callbacks/callback.jl
@@ -23,3 +23,121 @@ end
 function generate_callback(F::JLD2Output; kwargs...)
     return PeriodicCallback(F, F.interval; initial_affect = true, kwargs...)
 end
+
+"""
+    CFLAdaptive <: AbstractCallback
+    
+Container for CFL information callback.
+"""
+mutable struct CFLAdaptive <: AbstractCallback
+    model::AbstractModel
+    interval::Real
+    cfl_target::Real
+    update::Bool
+end
+
+"""
+    get_nodal_distance(space::Space)
+    
+Return a tuple of local spacing for a ClimaCore Space object.
+Dispatched over AbstractSpace subtypes.
+"""
+function get_nodal_distance(space::ClimaCore.Spaces.AbstractSpace)
+    return nothing
+end
+function get_nodal_distance(
+    space::ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace,
+)
+    Δh_local = space.horizontal_space.local_geometry.WJ
+    vertspace = Spaces.CenterFiniteDifferenceSpace(space.vertical_topology.mesh)
+    Δv_local = ClimaCore.Spaces.coordinates_data(vertspace).z[1]
+    return (Δh_local, Δv_local)
+end
+function get_nodal_distance(
+    space::Union{
+        ClimaCore.Spaces.SpectralElementSpace1D,
+        ClimaCore.Spaces.SpectralElementSpace2D,
+    },
+)
+    # Assumes uniform polynomial order in horizontal and vertical direction
+    Δh_local = space.local_geometry.WJ
+    return (Δh_local)
+end
+function get_nodal_distance(space::ClimaCore.Spaces.FiniteDifferenceSpace)
+    Δv_local = ClimaCore.Spaces.coordinates_data(space).z[1]
+    return (Δv_local)
+end
+
+abstract type CFLDirection end
+struct HorizontalCFL <: CFLDirection end
+struct VerticalCFL <: CFLDirection end
+
+function get_local_courant(uh, Δx, Δt, ::HorizontalCFL)
+    return abs.(ClimaCore.Fields.field_values(uh.components.data.:1)) ./ Δx .*
+           eltype(Δx)(Δt)
+end
+function get_local_courant(w, Δz, Δt, ::VerticalCFL)
+    return maximum(abs.(w.components.data.:1)) ./ Δz .* eltype(Δz)(Δt)
+end
+
+"""
+    (F::CFLAdaptive)(integrator)
+For the given model and function space, gets the nodal distances 
+(local=> horizontal), (minimum=> vertical) and model velocities
+from which the CFL number is calculated at the user specified
+time interval. If the update flag is true, sets new timestep size.
+"""
+function domain_max_cfl(
+    space::ClimaCore.Spaces.AbstractSpace,
+    integrator,
+    model,
+)
+    return nothing
+end
+function domain_max_cfl(
+    space::ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace,
+    integrator,
+    model,
+)
+    Δx, Δz = get_nodal_distance(space)
+    Δt = integrator.dt
+    uh, w = Models.get_velocities(integrator.u, model)
+    cfl_local_x = get_local_courant(uh, Δx, Δt, HorizontalCFL())
+    cfl_local_z = get_local_courant(w, Δz, Δt, VerticalCFL())
+    cfl_domain_x = maximum(cfl_local_x)
+    cfl_domain_z = maximum(cfl_local_z)
+    return max(cfl_domain_x, cfl_domain_z)
+end
+function domain_max_cfl(
+    space::ClimaCore.Spaces.FiniteDifferenceSpace,
+    integrator,
+    model,
+)
+    w = Models.get_velocities(integrator.u, model)
+    Δz = get_nodal_distance(space)
+    cfl_local_z = get_local_courant(w, Δz, integrator.dt, VerticalCFL())
+    return max(cfl_local_z)
+end
+function (F::CFLAdaptive)(integrator)
+    model = F.model
+    # Assumes mass conservation equation is included in model.
+    space = ClimaCore.Fields.axes(integrator.u.base.ρ)
+    cfl_current = domain_max_cfl(space, integrator, model)
+    if F.update == true
+        dt_updated = F.cfl_target / cfl_current * integrator.dt
+        isinf(dt_updated) ? nothing : integrator.dtcache = dt_updated
+    else
+        nothing
+    end
+    return nothing
+end
+
+"""
+    generate_callback(F::CFLAdaptive; kwargs...)
+
+    Creates a PeriodicCallback object that computes the 
+    maximum CFL number in the domain. 
+"""
+function generate_callback(F::CFLAdaptive; kwargs...)
+    return DiffEqCallbacks.PeriodicCallback(F, F.interval; kwargs...)
+end

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -23,7 +23,8 @@ export AbstractModelStyle,
     TotalEnergy,
     Dry,
     EquilibriumMoisture,
-    NonEquilibriumMoisture
+    NonEquilibriumMoisture,
+    get_velocities
 
 export SingleColumnModel, Nonhydrostatic2DModel, Nonhydrostatic3DModel
 
@@ -100,6 +101,14 @@ Construct the ordinary differential equations for `model`.
 """
 make_ode_function(model::AbstractModel) =
     error("make_ode_function not implemented for given model type")
+
+"""
+    get_velocities(Y, model)
+
+Construct the initial conditions for `model`.
+"""
+get_velocities(Y, model::AbstractModel) =
+    error("No method to get velocities implemented for given model type")
 
 # model styles
 include("style_base_model.jl")

--- a/src/Models/Nonhydrostatic2DModels/nonhydrostatic_2d_model.jl
+++ b/src/Models/Nonhydrostatic2DModels/nonhydrostatic_2d_model.jl
@@ -83,3 +83,13 @@ function Models.make_ode_function(model::Nonhydrostatic2DModel)
 
     return rhs!
 end
+
+using ClimaCore: ClimaCore
+IF2C = ClimaCore.Operators.InterpolateF2C()
+function Models.get_velocities(Y, model::Nonhydrostatic2DModel)
+    uh = Y.base.ρuh ./ Y.base.ρ
+    w = @. IF2C(Y.base.ρw) / Y.base.ρ
+    # Returns tuple with horizontal and vertical velocities for 2D model
+    # Cell centered variables are returned (interpolated vertical velocity)
+    return (uh, w)
+end

--- a/src/Models/SingleColumnModels/single_column_model.jl
+++ b/src/Models/SingleColumnModels/single_column_model.jl
@@ -145,3 +145,8 @@ function Models.make_ode_function(model::SingleColumnModel)
 
     return rhs!
 end
+
+function Models.get_velocities(Y, model::SingleColumnModel)
+    w = Y.base.w
+    return w
+end

--- a/test/test_cases/run_1d_ekman_column.jl
+++ b/test/test_cases/run_1d_ekman_column.jl
@@ -62,9 +62,14 @@ function run_1d_ekman_column(
         mkpath(temp_filepath)
         cb_1 = JLD2Output(model, temp_filepath, "TestFilename1", 0.01)
         cb_2 = JLD2Output(model, temp_filepath, "TestFilename2", 0.02)
+        cb_3 = CFLAdaptive(model, 0.01, 0.90, true)
 
         # Generate CallbackSet 
-        cb_set = CallbackSet(generate_callback(cb_1), generate_callback(cb_2))
+        cb_set = CallbackSet(
+            generate_callback(cb_1),
+            generate_callback(cb_2),
+            generate_callback(cb_3),
+        )
 
         # Type Checks
         @test generate_callback(cb_1) isa DiscreteCallback

--- a/test/test_cases/run_2d_rising_bubble.jl
+++ b/test/test_cases/run_2d_rising_bubble.jl
@@ -44,7 +44,15 @@ function run_2d_rising_bubble(
     # execute differently depending on testing mode
     if test_mode == :regression
         # TODO!: run with input callbacks = ...
-        simulation = Simulation(model, stepper, dt = dt, tspan = (0.0, 1.0))
+        cb_cfl = CFLAdaptive(model, 0.01, 1.0, false)
+        cb = CallbackSet(generate_callback(cb_cfl))
+        simulation = Simulation(
+            model,
+            stepper,
+            dt = dt,
+            tspan = (0.0, 1.0),
+            callbacks = cb,
+        )
         @test simulation isa Simulation
 
         # test error handling


### PR DESCRIPTION
Periodic Callback with user specified frequency.
Adds VerticalCFL, HorizontalCFL option.
Adds methods for get_nodal_distance [Move to ClimaCore] for Spaces
Adds methods for get_local_courant for combinations of models/ spaces
Adds method for get_velocities based on model types.

 Changes to be committed:
	modified:   src/Callbacks/Callbacks.jl
	modified:   src/Callbacks/callback.jl
	modified:   src/Models/Models.jl
	modified:   src/Models/Nonhydrostatic2DModels/equations_base_model.jl
	modified:   src/Models/Nonhydrostatic2DModels/nonhydrostatic_2d_model.jl
	modified:   src/Models/SingleColumnModels/single_column_model.jl
	modified:   test/test_cases/run_1d_ekman_column.jl
	modified:   test/test_cases/run_2d_rising_bubble.jl