### PR TITLE
Don't capture thermodynamic states

### DIFF
--- a/src/Models/Nonhydrostatic2DModels/equations_pressure.jl
+++ b/src/Models/Nonhydrostatic2DModels/equations_pressure.jl
@@ -13,8 +13,11 @@ end
     ρ = Y.base.ρ
     ρθ = Y.thermodynamics.ρθ
 
-    ts = @. Thermodynamics.PhaseDry_ρθ(params, ρ, ρθ / ρ)
-    p = @. Thermodynamics.air_pressure(ts)
+    p = @. Thermodynamics.air_pressure(Thermodynamics.PhaseDry_ρθ(
+        params,
+        ρ,
+        ρθ / ρ,
+    ))
 
     return p
 end

--- a/src/Models/Nonhydrostatic3DModels/equations_pressure.jl
+++ b/src/Models/Nonhydrostatic3DModels/equations_pressure.jl
@@ -14,8 +14,11 @@ end
     ρ = Y.base.ρ
     ρθ = Y.thermodynamics.ρθ
 
-    thermo_state = @. Thermodynamics.PhaseDry_ρθ(params, ρ, ρθ / ρ)
-    p = @. Thermodynamics.air_pressure(thermo_state)
+    p = @. Thermodynamics.air_pressure(Thermodynamics.PhaseDry_ρθ(
+        params,
+        ρ,
+        ρθ / ρ,
+    ))
 
     return p
 end
@@ -42,8 +45,7 @@ end
     Φ = calculate_gravitational_potential(Y, Ya, params, FT)
 
     e_int = @. ρe_tot / ρ - Φ - norm(uvw)^2 / 2
-    thermo_state = Thermodynamics.PhaseDry.(params, e_int, ρ)
-    p = Thermodynamics.air_pressure.(thermo_state)
+    p = Thermodynamics.air_pressure.(Thermodynamics.PhaseDry.(params, e_int, ρ))
 
     return p
 end
@@ -73,8 +75,13 @@ end
     q_tot = @. ρq_tot / ρ
 
     # saturation adjustment
-    thermo_state = Thermodynamics.PhaseEquil_ρeq.(Ref(params), ρ, e_int, q_tot)
-    p = Thermodynamics.air_pressure.(thermo_state)
+    p =
+        Thermodynamics.air_pressure.(Thermodynamics.PhaseEquil_ρeq.(
+            Ref(params),
+            ρ,
+            e_int,
+            q_tot,
+        ))
 
     return p
 end


### PR DESCRIPTION
Thermodynamic states are not currently designed to be captured (i.e., we should not make fields of them) as that will duplicate the parameter set.

We can change this by removing parameter sets from the thermodynamic states, but for now this is a better design (will be more performant) and doesn't seem problematic.