### PR TITLE
fix bug

### DIFF
--- a/src/Models/Nonhydrostatic3DModels/equations_moisture.jl
+++ b/src/Models/Nonhydrostatic3DModels/equations_moisture.jl
@@ -56,7 +56,7 @@
        Geometry.Covariant123Vector(interp_f2c(w))
 
     # hyperdiffusion
-    χq = @. hwdiv(hgrad(ρq_tot / ρ))
+    χq = @. dρq_tot = hwdiv(hgrad(ρq_tot / ρ))
     Spaces.weighted_dss!(dρq_tot)
     @. dρq_tot = -κ₄ * hwdiv(ρ * hgrad(χq))
 


### PR DESCRIPTION
dss is applied to the incorrect fields in the moist equation. Current way of fix is only to be in an computationally efficient way and stays consistent with all other vars, but definitely not the most elegant way. @dennisYatunin  has better idea for his new interface.