### PR TITLE
bring back external boundary conditons

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 CLIMAParameters = "0.4"
-ClimaCore = "0.9"
+ClimaCore = "0.9, 0.10"
 ClimaCorePlots = "0.2"
 ClimaCoreVTK = "0.6, 0.7"
 CloudMicrophysics = "0.3"

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -5,11 +5,8 @@ using ClimaCore: Geometry, Fields, Operators
 using ClimaCore.Geometry: ⊗
 
 export get_boundary_flux,
-    AbstractBoundaryCondition,
-    CustomFluxCondition,
-    NoFluxCondition,
-    DragLawCondition,
-    BulkFormulaCondition
+    AbstractBoundary, NoFlux, NoVectorFlux, DragLaw, BulkFormula
+
 
 """
     get_boundary_flux(model, bc, var, Ym, Ya)
@@ -22,7 +19,7 @@ function get_boundary_flux end
 """
 Supertype for all boundary conditions.
 """
-abstract type AbstractBoundaryCondition end
+abstract type AbstractBoundary end
 
 include("flux_conditions.jl")
 include("flux_calculations.jl")

--- a/src/BoundaryConditions/flux_calculations.jl
+++ b/src/BoundaryConditions/flux_calculations.jl
@@ -1,61 +1,21 @@
 """
-    get_boundary_flux(model, ::NoFluxCondition, var::Fields.Field, Y, Ya)
+    get_boundary_flux(model, ::NoFlux, var::Fields.Field, Y, Ya)
 
-    Vertical flux assignment for no-flux conditions (i.e. free-slip wall)
+    Vertical flux assignment for no-flux conditions (e.g., insulating wall)
 """
-function get_boundary_flux(model, ::NoFluxCondition, var::Fields.Field, Y, Ya)
+function get_boundary_flux(model, ::NoFlux, var::Fields.Field, Y, Ya)
     FT = eltype(Y)
     flux = Geometry.WVector(FT(0))
 end
 
 """
-    get_boundary_flux(model, bc::DragLawCondition, uv, Y, Ya)
+    get_boundary_flux(model, ::NoVectorFlux, var::Fields.Field, Y, Ya)
 
-    Vertical momentum fluxes for a bulk-formulation drag law, given momentum exchange coefficients
+    Vertical flux assignment for an AxisTensor with CovariantAxis{(1,2)} in no-flux conditions (e.g., free-slip wall)
 """
-function get_boundary_flux(model, bc::DragLawCondition, uv, Y, Ya)
+function get_boundary_flux(model, ::NoVectorFlux, var::Fields.Field, Y, Ya)
     FT = eltype(Y)
-    coefficients =
-        eltype(bc.coefficients) == FT ? bc.coefficients : bc.coefficients(Y, Ya)
-
-    uv_1 = first_interior(uv)
-    u_wind = norm(uv_1)
-
-    flux = Geometry.WVector(coefficients.Cd * u_wind) ⊗ uv_1
-end
-
-"""
-    get_boundary_flux(
-        model,
-        bc::BulkFormulaCondition,
-        ρc::Fields.Field,
-        Y,
-        Ya,
-    )
-
-    Vertical fluxes for arbitrary variables with a bulk-formulation drag law, 
-    given variable exchange coefficients. (e.g. for energy, or tracers)
-"""
-function get_boundary_flux(
-    model,
-    bc::BulkFormulaCondition,
-    ρc::Fields.Field,
-    Y,
-    Ya,
-)
-    FT = eltype(Y.base)
-    coefficients =
-        eltype(bc.coefficients) == FT ? bc.coefficients : bc.coefficients(Y, Ya)
-    c_sfc = bc.surface_field
-
-    ρ_1 = first_interior(Y.base.ρ)
-    ρc_1 = first_interior(ρc)
-    uv_1 = first_interior(Y.base.uv)
-    u_wind = norm(uv_1)
-
     flux =
-        Geometry.WVector(coefficients.Ch * u_wind * ρ_1 * (ρc_1 / ρ_1 - c_sfc))
+        Geometry.Covariant3Vector(FT(0)) ⊗
+        Geometry.Covariant12Vector(FT(0), FT(0))
 end
-
-# Obtain the first interior datapoint of variable `v`
-first_interior(v) = Operators.getidx(v, Operators.Interior(), 1)

--- a/src/BoundaryConditions/flux_conditions.jl
+++ b/src/BoundaryConditions/flux_conditions.jl
@@ -1,27 +1,34 @@
 """
-    NoFluxCondition <: AbstractBoundaryCondition
+    NoFlux <: AbstractBoundary
 
 Computes a fixed boundary flux of 0.
 """
-struct NoFluxCondition <: AbstractBoundaryCondition end
+struct NoFlux <: AbstractBoundary end
 
 """
-    DragLawCondition{C} <: AbstractBoundaryCondition
+    NoVectorFlux <: AbstractBoundary
+
+Computes a fixed boundary vector flux of 0
+"""
+struct NoVectorFlux <: AbstractBoundary end
+
+"""
+    DragLaw{C} <: AbstractBoundary
 
 Computes the boundary flux using the bulk formula and constant or
 Mohnin-Obukhov-based drag coefficient `Cd`. Specific to momentum density.
 """
-struct DragLawCondition{C} <: AbstractBoundaryCondition
-    coefficients::C
+struct DragLaw{C} <: AbstractBoundary
+    coefficient::C
 end
 
 """
-    BulkFormulaCondition{C, T} <: AbstractBoundaryCondition
+    BulkFormula{C, T} <: AbstractBoundary
 
 Computes the boundary flux using the bulk formula and constant or
 Mohnin-Obukhov-based heat transfer coefficient `Ch`.
 """
-struct BulkFormulaCondition{C, T} <: AbstractBoundaryCondition
+struct BulkFormula{C, T} <: AbstractBoundary
     coefficients::C
     surface_field::T
 end

--- a/src/Models/Nonhydrostatic3DModels/Nonhydrostatic3DModels.jl
+++ b/src/Models/Nonhydrostatic3DModels/Nonhydrostatic3DModels.jl
@@ -8,6 +8,7 @@ using Thermodynamics
 using ClimaCore: Geometry, Spaces, Fields, Operators
 using ClimaCore.Geometry: ⊗
 using ...Domains, ...Models
+using ClimaAtmos.BoundaryConditions
 
 export Nonhydrostatic3DModel
 

--- a/src/Models/Nonhydrostatic3DModels/nonhydrostatic_3d_model.jl
+++ b/src/Models/Nonhydrostatic3DModels/nonhydrostatic_3d_model.jl
@@ -92,6 +92,8 @@ function Models.make_ode_function(model::Nonhydrostatic3DModel)
     flux_correction = model.flux_corr
     vert_diffusion_style = model.vertical_diffusion
 
+    bc = model.boundary_conditions
+
     # this is the complete explicit right-hand side function
     # assembled here to be delivered to the time stepper.
     function rhs!(dY, Y, Ya, t)
@@ -158,6 +160,7 @@ function Models.make_ode_function(model::Nonhydrostatic3DModel)
             Ya,
             t,
             p,
+            model,
             base_style,
             thermo_style,
             moisture_style,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -25,7 +25,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 CLIMAParameters = "0.4"
-ClimaCore = "0.9"
+ClimaCore = "0.9, 0.10"
 ClimaCorePlots = "0.2"
 ClimaCoreVTK = "0.6, 0.7"
 DiffEqCallbacks = "2"

--- a/test/test_cases/run_3d_baroclinic_wave.jl
+++ b/test/test_cases/run_3d_baroclinic_wave.jl
@@ -39,17 +39,22 @@ function run_3d_baroclinic_wave(
         npolynomial = npolynomial,
     )
 
+    boundary_conditions = (;
+        ρe_tot = (top = NoFlux(), bottom = NoFlux()),
+        uh = (top = NoVectorFlux(), bottom = NoVectorFlux()),
+    )
+
     model = Nonhydrostatic3DModel(
         domain = domain,
-        boundary_conditions = nothing,
+        boundary_conditions = boundary_conditions,
         parameters = params,
         hyperdiffusivity = FT(1e16),
-        vertical_diffusion = ConstantViscosity(ν = FT(1)),
+        vertical_diffusion = ConstantViscosity(ν = FT(5)), #default: 5 [m^2/s]
     )
 
     # execute differently depending on testing mode
     if test_mode == :regression
-        simulation = Simulation(model, stepper, dt = dt, tspan = (0.0, 1.0))
+        simulation = Simulation(model, stepper, dt = dt, tspan = (0.0, 100.0))
         @test simulation isa Simulation
 
         # test set function
@@ -59,6 +64,7 @@ function run_3d_baroclinic_wave(
 
         # test successful integration
         @test step!(simulation) isa Nothing # either error or integration runs
+
     # TODO!: Implement meaningful(!) regression test
 
     elseif test_mode == :validation
@@ -69,7 +75,7 @@ function run_3d_baroclinic_wave(
         throw(ArgumentError("$test_mode incompatible with test case."))
     end
 
-    nothing
+    simulation
 end
 
 @testset "3D baroclinic wave" begin


### PR DESCRIPTION
This reintroduces `boundary_conditions`, which can be specified outside of the `rhs!` from the driver file, essential for coupled simulations. Fluxes are applied via the `vertical_diffusion` rhs!, so this needs to be enabled in `model`.

This PR is primarily for prototyping interfaces for coupling, and only includes:
- total energy (`BulkFormula`) and horizontal momentum (`DragLaw`), following chapter 5 of the DesignDoc
- spatially constant boundary fluxes

Follow-up PRs:
- extend to use spatially variable boundary fluxes (ClimaCore PR #325)
- extend to other thermodynamic variables in the `vertical_diffusion` rhs! (pending upcoming interface changes)
- add moisture 
- use `SurfaceFluxes.jl` and apply in the form of sensible/latent heat flux
