### PR TITLE
Update function_space build to include surface topography modification

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -2,7 +2,8 @@ module Domains
 
 using IntervalSets
 using Printf
-using ClimaCore: ClimaCore, Geometry, Meshes, Topologies, Spaces
+using ClimaCore:
+    ClimaCore, Geometry, Meshes, Topologies, Spaces, Fields, Hypsography
 
 export make_function_space,
     AbstractDomain,
@@ -11,13 +12,17 @@ export make_function_space,
     Column,
     HybridPlane,
     HybridBox,
-    SphericalShell
+    SphericalShell,
+    WarpedSurface,
+    CanonicalSurface
 
 import ClimaCore.Meshes:
     StretchingRule,
     Uniform,
     ExponentialStretching,
     GeneralizedExponentialStretching
+
+import ClimaCore.Hypsography: TerrainAdaption, LinearAdaption
 
 """
     make_function_space(domain)
@@ -34,6 +39,7 @@ abstract type AbstractDomain{FT} end
 abstract type AbstractVerticalDomain{FT} <: AbstractDomain{FT} end
 abstract type AbstractHybridDomain{FT} <: AbstractDomain{FT} end
 
+include("topography.jl")
 include("domain.jl")
 include("make_function_space.jl")
 

--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -77,7 +77,7 @@ function HybridPlane(
     npolynomial,
     xperiodic = true,
     stretching = Uniform(),
-    topography = NoTopography(),
+    topography = CanonicalSurface(),
 ) where {FT}
     @assert xlim[1] < xlim[2]
     @assert zlim[1] < zlim[2]
@@ -131,7 +131,7 @@ Domain set-up:
 \txyz-box:\t[0.0, 3.1) × [0.0, 3.1) × [0.0, 1.0]
 \t# of elements:\t(5, 5, 10)
 \tpoly order:\t5
-\tVertical stretching rule:\tUniform
+\tVertical stretching rule:\tUniform()
 \tTopography:\tCanonicalSurface
 ```
 """
@@ -145,7 +145,7 @@ function HybridBox(
     xperiodic = true,
     yperiodic = true,
     stretching = Uniform(),
-    topography = NoTopography(),
+    topography = CanonicalSurface(),
 ) where {FT}
     @assert xlim[1] < xlim[2]
     @assert ylim[1] < ylim[2]
@@ -199,7 +199,7 @@ function SphericalShell(
     nelements,
     npolynomial,
     stretching = Uniform(),
-    topography = NoTopography(),
+    topography = CanonicalSurface(),
 ) where {FT}
     @assert 0 < radius
     @assert 0 < height
@@ -240,7 +240,7 @@ function Base.show(io::IO, domain::HybridPlane)
         "\n\tVertical stretching rule:\t",
         "$(typeof(domain.stretching).name.name)",
     )
-    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
+    print(io, "\n\tTopography:\t","$(typeof(domain.topography).name.name)")
 end
 
 function Base.show(io::IO, domain::HybridBox)
@@ -259,7 +259,7 @@ function Base.show(io::IO, domain::HybridBox)
         "\n\tVertical stretching rule:\t",
         "$(typeof(domain.stretching).name.name)",
     )
-    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
+    print(io, "\n\tTopography:\t","$(typeof(domain.topography).name.name)")
 end
 
 function Base.show(io::IO, domain::SphericalShell)
@@ -274,5 +274,5 @@ function Base.show(io::IO, domain::SphericalShell)
         "\n\tVertical stretching rule:\t",
         "$(typeof(domain.stretching).name.name)",
     )
-    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
+    print(io, "\n\tTopography:\t","$(typeof(domain.topography).name.name)")
 end

--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -17,7 +17,7 @@ julia> Column(zlim = (0, 1), nelements = 10)
 Domain set-up:
 \tz-column:\t[0.0, 1.0]
 \t# of elements:\t10
-\tVertical stretching rule:\tUniform()
+\tVertical stretching rule:\tUniform
 ```
 """
 function Column(
@@ -38,6 +38,7 @@ struct HybridPlane{FT} <: AbstractHybridDomain{FT}
     npolynomial::Int
     xperiodic::Bool
     stretching::StretchingRule
+    topography::AbstractTopography
 end
 
 """
@@ -64,7 +65,8 @@ Domain set-up:
 \txz-plane:\t[0.0, 3.1) × [0.0, 1.0]
 \t# of elements:\t(5, 10)
 \tpoly order:\t5
-\tVertical stretching rule:\tUniform()
+\tVertical stretching rule:\tUniform
+\tTopography:\tCanonicalSurface
 ```
 """
 function HybridPlane(
@@ -75,6 +77,7 @@ function HybridPlane(
     npolynomial,
     xperiodic = true,
     stretching = Uniform(),
+    topography = NoTopography(),
 ) where {FT}
     @assert xlim[1] < xlim[2]
     @assert zlim[1] < zlim[2]
@@ -86,6 +89,7 @@ function HybridPlane(
         npolynomial,
         xperiodic,
         stretching,
+        topography,
     )
 end
 
@@ -98,6 +102,7 @@ struct HybridBox{FT} <: AbstractHybridDomain{FT}
     xperiodic::Bool
     yperiodic::Bool
     stretching::StretchingRule
+    topography::AbstractTopography
 end
 
 """
@@ -126,7 +131,8 @@ Domain set-up:
 \txyz-box:\t[0.0, 3.1) × [0.0, 3.1) × [0.0, 1.0]
 \t# of elements:\t(5, 5, 10)
 \tpoly order:\t5
-\tVertical stretching rule:\tUniform()
+\tVertical stretching rule:\tUniform
+\tTopography:\tCanonicalSurface
 ```
 """
 function HybridBox(
@@ -139,6 +145,7 @@ function HybridBox(
     xperiodic = true,
     yperiodic = true,
     stretching = Uniform(),
+    topography = NoTopography(),
 ) where {FT}
     @assert xlim[1] < xlim[2]
     @assert ylim[1] < ylim[2]
@@ -153,6 +160,7 @@ function HybridBox(
         xperiodic,
         yperiodic,
         stretching,
+        topography,
     )
 end
 
@@ -162,6 +170,7 @@ struct SphericalShell{FT} <: AbstractHybridDomain{FT}
     nelements::Tuple{Int, Int}
     npolynomial::Int
     stretching::StretchingRule
+    topography::AbstractTopography
 end
 
 """
@@ -179,7 +188,8 @@ Domain set-up:
 \tsphere height:\t1.0
 \t# of elements:\t(6, 10)
 \tpoly order:\t5
-\tVertical stretching rule:\tUniform()
+\tVertical stretching rule:\tUniform
+\tTopography:\tCanonicalSurface
 ```
 """
 function SphericalShell(
@@ -189,6 +199,7 @@ function SphericalShell(
     nelements,
     npolynomial,
     stretching = Uniform(),
+    topography = NoTopography(),
 ) where {FT}
     @assert 0 < radius
     @assert 0 < height
@@ -198,6 +209,7 @@ function SphericalShell(
         nelements,
         npolynomial,
         stretching,
+        topography,
     )
 end
 
@@ -207,7 +219,11 @@ function Base.show(io::IO, domain::Column)
     printstyled(io, @sprintf("%#.2g, %#.2g", domain.zlim...), color = 7)
     printstyled(io, "]", color = 226)
     print(io, "\n\t# of elements:\t", domain.nelements)
-    print(io, "\n\tVertical stretching rule:\t", "$(domain.stretching)")
+    print(
+        io,
+        "\n\tVertical stretching rule:\t",
+        "$(typeof(domain.stretching).name.name)",
+    )
 end
 
 function Base.show(io::IO, domain::HybridPlane)
@@ -219,7 +235,12 @@ function Base.show(io::IO, domain::HybridPlane)
     printstyled(io, "]", color = 226)
     @printf(io, "\n\t# of elements:\t(%d, %d)", domain.nelements...)
     print(io, "\n\tpoly order:\t", domain.npolynomial)
-    print(io, "\n\tVertical stretching rule:\t", "$(domain.stretching)")
+    print(
+        io,
+        "\n\tVertical stretching rule:\t",
+        "$(typeof(domain.stretching).name.name)",
+    )
+    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
 end
 
 function Base.show(io::IO, domain::HybridBox)
@@ -233,7 +254,12 @@ function Base.show(io::IO, domain::HybridBox)
     printstyled(io, "]", color = 226)
     @printf(io, "\n\t# of elements:\t(%d, %d, %d)", domain.nelements...)
     print(io, "\n\tpoly order:\t", domain.npolynomial)
-    print(io, "\n\tVertical stretching rule:\t", "$(domain.stretching)")
+    print(
+        io,
+        "\n\tVertical stretching rule:\t",
+        "$(typeof(domain.stretching).name.name)",
+    )
+    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
 end
 
 function Base.show(io::IO, domain::SphericalShell)
@@ -243,5 +269,10 @@ function Base.show(io::IO, domain::SphericalShell)
     printstyled(io, @sprintf("%#.2g", domain.height), color = 7)
     @printf(io, "\n\t# of elements:\t(%d, %d)", domain.nelements...)
     print(io, "\n\tpoly order:\t", domain.npolynomial)
-    print(io, "\n\tVertical stretching rule:\t", "$(domain.stretching)")
+    print(
+        io,
+        "\n\tVertical stretching rule:\t",
+        "$(typeof(domain.stretching).name.name)",
+    )
+    print(io, "\n\tTopography:\t", "$(typeof(domain.topography).name.name)")
 end

--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -131,7 +131,7 @@ Domain set-up:
 \txyz-box:\t[0.0, 3.1) × [0.0, 3.1) × [0.0, 1.0]
 \t# of elements:\t(5, 5, 10)
 \tpoly order:\t5
-\tVertical stretching rule:\tUniform()
+\tVertical stretching rule:\tUniform
 \tTopography:\tCanonicalSurface
 ```
 """

--- a/src/Domains/make_function_space.jl
+++ b/src/Domains/make_function_space.jl
@@ -25,6 +25,7 @@ function make_function_space(domain::HybridPlane)
         nelems = domain.nelements[2],
     )
     vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    vert_face_space = Spaces.FaceFiniteDifferenceSpace(vertmesh)
 
     horzdomain = ClimaCore.Domains.IntervalDomain(
         Geometry.XPoint(domain.xlim[1])..Geometry.XPoint(domain.xlim[2]);
@@ -36,9 +37,26 @@ function make_function_space(domain::HybridPlane)
     quad = Spaces.Quadratures.GLL{domain.npolynomial + 1}()
     horzspace = Spaces.SpectralElementSpace1D(horztopology, quad)
 
-    hv_center_space =
-        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-    hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
+    if domain.topography isa WarpedSurface
+        surface_function = domain.topography.surface_function
+        z_surface =
+            surface_function.(ClimaCore.Fields.coordinate_field(horzspace))
+        hv_face_space = ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
+            horzspace,
+            vert_face_space,
+            domain.topography.interior_warping,
+            z_surface,
+        )
+        hv_center_space =
+            Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
+    else
+        hv_face_space = ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
+            horzspace,
+            vert_face_space,
+        )
+        hv_center_space =
+            Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
+    end
 
     return hv_center_space, hv_face_space
 end
@@ -54,6 +72,7 @@ function make_function_space(domain::HybridBox)
         nelems = domain.nelements[3],
     )
     vert_center_space = Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    vert_face_space = Spaces.FaceFiniteDifferenceSpace(vertmesh)
 
     horzdomain = ClimaCore.Domains.RectangleDomain(
         Geometry.XPoint(domain.xlim[1])..Geometry.XPoint(domain.xlim[2]),
@@ -70,10 +89,26 @@ function make_function_space(domain::HybridBox)
     quad = Spaces.Quadratures.GLL{domain.npolynomial + 1}()
     horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
 
-    hv_center_space =
-        Spaces.ExtrudedFiniteDifferenceSpace(horzspace, vert_center_space)
-    hv_face_space = Spaces.FaceExtrudedFiniteDifferenceSpace(hv_center_space)
-
+    if domain.topography isa WarpedSurface
+        surface_function = domain.topography.surface_function
+        z_surface =
+            surface_function.(ClimaCore.Fields.coordinate_field(horzspace))
+        hv_face_space = ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
+            horzspace,
+            vert_face_space,
+            domain.topography.interior_warping,
+            z_surface,
+        )
+        hv_center_space =
+            Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
+    else
+        hv_face_space = ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
+            horzspace,
+            vert_face_space,
+        )
+        hv_center_space =
+            Spaces.CenterExtrudedFiniteDifferenceSpace(hv_face_space)
+    end
     return hv_center_space, hv_face_space
 end
 

--- a/src/Domains/topography.jl
+++ b/src/Domains/topography.jl
@@ -7,9 +7,6 @@ Returns input coordinate (canonical surface for plane/box/sphere).
 (e.g. canonical box, sphere)
 """
 struct CanonicalSurface <: AbstractTopography end
-function NoTopography()
-    return CanonicalSurface()
-end
 
 """
   WarpedSurface <: AbstractTopography

--- a/src/Domains/topography.jl
+++ b/src/Domains/topography.jl
@@ -1,0 +1,29 @@
+abstract type AbstractTopography end
+
+"""
+  CanonicalSurface <: AbstractTopography
+Specification when simple surfaces are assembled 
+Returns input coordinate (canonical surface for plane/box/sphere).
+(e.g. canonical box, sphere)
+"""
+struct CanonicalSurface <: AbstractTopography end
+function NoTopography()
+    return CanonicalSurface()
+end
+
+"""
+  WarpedSurface <: AbstractTopography
+Specification when surface warp is defined by analytical function 
+Returns object with new warped coordinate surface and appropriate
+interior adapted mesh.
+(e.g. Gaussian mountains)
+"""
+struct WarpedSurface <: AbstractTopography
+    surface_function::Function
+    interior_warping::LinearAdaption
+end
+function AnalyticalTopography(f::Function; interior_warping = LinearAdaption())
+    # Assumes user prescribes functions that "morphs" bottom surface
+    # based on a smooth, analytical profile. 
+    return WarpedSurface(f, interior_warping)
+end


### PR DESCRIPTION
Summary : Updates function space construction to allow inclusion of topography. 
Initial commits that replicate test cases for topo construction in ClimaCore.
PRs with additional examples and demonstrations in "running" cases will
follow. 
Changes:
- [x] Update make_function_space flags to allow cases with warped surfaces to be built
- [x] Include containers for "canonical" or "warped" surfaces
- [x] Update show functions for topography characteristics
- [x] Link to ClimaCore Hypsography packages for future extensions.  
- [x] Track 0.9.0 version ; Update Project.toml 
- [ ] Add demo plots + Documentation


Status: 
Pending bug-fixes in `ClimaCore.jl`