### PR TITLE
Add long run job to buildkite

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,0 +1,39 @@
+env:
+  JULIA_VERSION: "1.7.1"
+  MPICH_VERSION: "4.0.0"
+  OPENMPI_VERSION: "4.1.1"
+  CUDA_VERSION: "11.2"
+  OPENBLAS_NUM_THREADS: 1
+  BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
+  BUILDKITE_BRANCH: "${BUILDKITE_BRANCH}"
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/cpu"
+
+agents:
+  config: cpu
+  queue: central
+  slurm_ntasks: 1
+
+steps:
+  - label: "init :computer:"
+    key: "init_cpu_env"
+    command:
+      - "echo $$JULIA_DEPOT_PATH"
+      - "julia --project=examples -e 'using Pkg; Pkg.develop(path = \".\")'"
+      - "julia --project=examples -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=examples -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=examples -e 'using Pkg; Pkg.status()'"
+
+    agents:
+      slurm_cpus_per_task: 8
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+
+  - wait
+
+  - group: "Long runs"
+
+    steps:
+
+      - label: ":computer: dry held-suarez (ρθ)"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32 --t_end 103680000" # 1200 days
+        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhotheta/Float32/*"


### PR DESCRIPTION
This PR adds a new pipeline file: `.buildkite/longruns/pipeline.yml`, which runs long-run Held-Suarez simulations. I've added the ClimaAtmos-LongRuns pipeline which monitors this new pipeline yaml, where I've set up a scheduled builds (`@midnight` to start with), we can change to `@weekly` if it seems unnecessary.

