### PR TITLE
Add a pipeline example generator script

### DIFF
--- a/.dev/pipeline_examples_generator.jl
+++ b/.dev/pipeline_examples_generator.jl
@@ -1,0 +1,68 @@
+flattened_cli_options = (
+    "--TEST_NAME sphere/baroclinic_wave_rhoe",
+    "--TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/baroclinic_wave_rhotheta",
+    "--TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/baroclinic_wave_rhotheta_equilmoist --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/held_suarez_rhoe --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/held_suarez_rhotheta",
+    "--TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/held_suarez_rhoe_int --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/held_suarez_rhoe_equilmoist --FLOAT_TYPE Float32",
+)
+
+# Convert to tuples:
+flattened_cli_options = map(flattened_cli_options) do clio
+    tup = split(clio, " --")
+    length(tup) > 1 && (tup[2:end] = map(x -> " --" * x, tup[2:end]))
+    tup
+end
+
+include(joinpath("..", "examples", "hybrid", "cli_options.jl"))
+
+#= A string for the buildkite "label" field =#
+function label_name(cli_options)
+    s = join(cli_options)
+    s = replace(s, "--FLOAT_TYPE Float32" => " Float32")
+    s = replace(s, "--TEST_NAME" => "")
+    s = replace(s, "sphere/" => "")
+    s = replace(s, "_" => " ")
+    s = replace(s, "rhoe" => "(ρe)")
+    s = replace(s, "rhotheta" => "(ρθ)")
+end
+
+#= A string for the buildkite "artifact_path" field =#
+function artifact_path(s, cli_options)
+    parsed_args = parsed_args_from_cli_options(s, cli_options)
+    return job_id_from_parsed_args(s, parsed_args)
+end
+
+"""
+    parsed_args_from_cli_options(cli_options)
+
+`parsed_args` given a string of all command line
+interface options.
+"""
+function parsed_args_from_cli_options(s, cli_options)
+    tup = split.(cli_options, " ")
+    args = vcat(tup...)
+    filter!(x -> !isempty(x), args)
+    ArgParse.parse_args(args, s)
+end
+
+spaces = "      "
+println("----------- Pipeline for examples:")
+for cli_options in flattened_cli_options
+    println("$(spaces)- label: \":computer:$(label_name(cli_options))\"")
+    print("$(spaces)  command: \"julia --color=yes --project=examples ")
+    print("examples/hybrid/driver.jl ")
+    print(join(cli_options, " ") * "\"\n")
+    println("$(spaces)  artifact_paths: \"$(artifact_path(s, cli_options))/*\"\n")
+end
+
+println("----------- Print JobIDs")
+for cli_options in flattened_cli_options
+    _parsed_args = parsed_args_from_cli_options(s, cli_options)
+    @show job_id_from_parsed_args(s, _parsed_args)
+end

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -18,3 +18,57 @@ ArgParse.@add_arg_table s begin
 end
 
 parsed_args = ArgParse.parse_args(ARGS, s)
+
+function cli_defaults(s::ArgParse.ArgParseSettings)
+    defaults = Dict()
+    # TODO: Don't use ArgParse internals
+    for arg in s.args_table.fields
+        defaults[arg.dest_name] = arg.default
+    end
+    return defaults
+end
+
+#= Use the job ID for the output folder =#
+function output_directory(
+    s::ArgParse.ArgParseSettings,
+    parsed_args = ArgParse.parse_args(ARGS, s),
+)
+    return job_id_from_parsed_args(s, parsed_args)
+end
+
+"""
+    job_id_from_parsed_args(
+        s::ArgParseSettings,
+        parsed_args = ArgParse.parse_args(ARGS, s)
+    )
+
+Returns a unique name (`String`) given
+ - `s::ArgParse.ArgParseSettings` The arg parse settings
+ - `parsed_args` The parse arguments
+
+The `ArgParseSettings` are used for truncating
+this string based on the default values.
+"""
+job_id_from_parsed_args(s, parsed_args = ArgParse.parse_args(ARGS, s)) =
+    job_id_from_parsed_args(cli_defaults(s), parsed_args)
+
+function job_id_from_parsed_args(defaults::Dict, parsed_args)
+    _parsed_args = deepcopy(parsed_args)
+    s = ""
+    for k in keys(_parsed_args)
+        # Skip defaults to alleviate verbose names
+        defaults[k] == _parsed_args[k] && continue
+
+        if _parsed_args[k] isa String
+            # We don't need keys if the value is a string
+            # (alleviate verbose names)
+            s *= _parsed_args[k]
+        else
+            s *= k * "=" * string(_parsed_args[k])
+        end
+        s *= "_"
+    end
+    s = replace(s, "/" => "_")
+    s = strip(s, '_')
+    return s
+end


### PR DESCRIPTION
This PR adds `.dev/pipeline_examples_generator.jl`, which is a _development tool_ for maintaining the pipeline yaml file-- it's not necessary to use, so that users can still edit the pipeline in a simple manually way.

The parts that are intended to be (optionally) used for convenience (`output_directory`) are part of the cli options, and have been added to `cli_options.jl`. I think that this will strike a nice balance between manual simplicity while also allowing us to maintain things in an automated way.

To avoid git conflicts, we can apply this in a separate PR.