### PR TITLE
Update pipeline, use output dir from cli options

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -35,5 +35,5 @@ steps:
     steps:
 
       - label: ":computer: dry held-suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32 --t_end 103680000" # 1200 days
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhotheta/Float32/*"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32 --t_end 103680000 --output_dir longrun_hs" # 1200 days
+        artifact_paths: "longrun_hs/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,7 +90,7 @@ steps:
         command: "julia --color=yes --project=test test/test_cases/run_3d_baroclinic_wave.jl"
         artifact_paths: "test/test_cases/run_3d_baroclinic_wave/*"
 
-  - group: "Examples"
+  - group: "Box Examples"
     steps:
 
       - label: ":package: Single column physics - EDMF"
@@ -109,6 +109,9 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhoe.jl"
         artifact_paths: "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
 
+  - group: "Plane Examples"
+    steps:
+
       - label: ":computer: Density current 2D hybrid invariant total energy"
         command: "julia --color=yes --project=examples examples/hybrid/plane/density_current_2dinvariant_rhoe.jl"
         artifact_paths: "examples/hybrid/plane/output/dc_invariant_etot/*"
@@ -121,6 +124,9 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/plane/density_current_2d_flux_form.jl"
         artifact_paths: "examples/hybrid/plane/output/dc_fluxform/*"
 
+  - group: "MPI Examples"
+    steps:
+
       - label: ":computer: MPI Rising Bubble 3D hybrid invariant (ρe)"
         command: "mpiexec julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhoe.jl"
         artifact_paths: "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
@@ -128,14 +134,6 @@ steps:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 2
-
-      - label: ":computer: Float64 baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhoe/Float64/*"
-
-      - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhoe/Float32/*"
 
       - label: ":computer: MPI baroclinic wave (ρe)"
         command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32"
@@ -145,38 +143,49 @@ steps:
         agents:
           slurm_ntasks: 2
 
+  - group: "Sphere Examples"
+    steps:
+
+      - label: ":computer: baroclinic wave (ρe)"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe"
+        artifact_paths: "sphere_baroclinic_wave_rhoe/*"
+
+      - label: ":computer: baroclinic wave (ρe)  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_Float32/*"
+
       - label: ":computer: baroclinic wave (ρθ)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhotheta/Float64/*"
+        artifact_paths: "sphere_baroclinic_wave_rhotheta/*"
 
-      - label: ":computer: equilibrium moisture baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhoe_equilmoist/Float32/*"
+      - label: ":computer: baroclinic wave (ρe) equilmoist  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_Float32/*"
 
-      - label: ":computer: equilibrium moisture baroclinic wave (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta_equilmoist --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhotheta_equilmoist/Float32/*"
+      - label: ":computer: baroclinic wave (ρθ) equilmoist  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta_equilmoist  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_baroclinic_wave_rhotheta_equilmoist_Float32/*"
 
-      - label: ":computer: dry held-suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhoe/Float32/*"
+      - label: ":computer: held suarez (ρe)  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_Float32/*"
 
-      - label: ":computer: Float64 dry held-suarez (ρθ)"
+      - label: ":computer: held suarez (ρθ)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhotheta/Float64/*"
+        artifact_paths: "sphere_held_suarez_rhotheta/*"
 
-      - label: ":computer: dry held-suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhotheta/Float32/*"
+      - label: ":computer: held suarez (ρθ)  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhotheta_Float32/*"
 
-      - label: ":computer: dry held-suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhoe_int/Float32/*"
+      - label: ":computer: held suarez (ρe) int  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_int_Float32/*"
 
-      - label: ":computer: equilibrium moisture held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhoe_equilmoist/Float32/*"
+      - label: ":computer: held suarez (ρe) equilmoist  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_equilmoist_Float32/*"
 
-      - label: ":computer: equilibrium moisture held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/held_suarez_rhoe_int_equilmoist/Float32/*"
+      - label: ":computer: held suarez (ρe) int equilmoist  Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist_Float32/*"

--- a/.dev/pipeline_examples_generator.jl
+++ b/.dev/pipeline_examples_generator.jl
@@ -1,7 +1,6 @@
 flattened_cli_options = (
     "--TEST_NAME sphere/baroclinic_wave_rhoe",
     "--TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32",
-    "--TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32",
     "--TEST_NAME sphere/baroclinic_wave_rhotheta",
     "--TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --FLOAT_TYPE Float32",
     "--TEST_NAME sphere/baroclinic_wave_rhotheta_equilmoist --FLOAT_TYPE Float32",
@@ -10,6 +9,7 @@ flattened_cli_options = (
     "--TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32",
     "--TEST_NAME sphere/held_suarez_rhoe_int --FLOAT_TYPE Float32",
     "--TEST_NAME sphere/held_suarez_rhoe_equilmoist --FLOAT_TYPE Float32",
+    "--TEST_NAME sphere/held_suarez_rhoe_int_equilmoist --FLOAT_TYPE Float32",
 )
 
 # Convert to tuples:

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -15,6 +15,9 @@ ArgParse.@add_arg_table s begin
     "--TEST_NAME" # TODO: change to "JobName"?
     help = "Job name"
     arg_type = String
+    "--output_dir"
+    help = "Output directory"
+    arg_type = String
 end
 
 parsed_args = ArgParse.parse_args(ARGS, s)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -149,12 +149,12 @@ else
     jac_kwargs = alg_kwargs = ()
 end
 
-if haskey(ENV, "OUTPUT_DIR")
-    output_dir = ENV["OUTPUT_DIR"]
+output_dir = if isnothing(parsed_args["output_dir"])
+    output_directory(s, parsed_args)
 else
-    output_dir =
-        joinpath(@__DIR__, test_dir, "output", test_file_name, string(FT))
+    parsed_args["output_dir"]
 end
+@info "Output directory: $output_dir"
 mkpath(output_dir)
 
 function make_dss_func(comms_ctx)

--- a/examples/hybrid/sphere/README.md
+++ b/examples/hybrid/sphere/README.md
@@ -19,20 +19,18 @@ export JULIA_MPI_BINARY=system
 export JULIA_CUDA_USE_BINARYBUILDER=false
 export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
 
-export OUTPUT_DIR=$YOUR_SIMULATION_OUTPUT_DIR
 #export RESTART_FILE=$YOUR_JLD2_RESTART_FILE
 
 CC_EXAMPLE=$HOME'/ClimaCore.jl/examples/'
-TESTCASE=$CC_EXAMPLE'hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe'
+TESTCASE=$CC_EXAMPLE'hybrid/driver.jl'
 
 julia --project=$CC_EXAMPLE -e 'using Pkg; Pkg.instantiate()'
 julia --project=$CC_EXAMPLE -e 'using Pkg; Pkg.API.precompile()'
 
-julia --project=$CC_EXAMPLE --threads=8 $TESTCASE
+julia --project=$CC_EXAMPLE --threads=8 $TESTCASE --TEST_NAME sphere/held_suarez_rhoe --output_dir=$YOUR_SIMULATION_OUTPUT_DIR
 
 ```
 In the runscript, one needs to specify the following environmant variable:
-* `OUTPUT_DIR`: the directory for jld2 data being saved at;
 * `RESTART_FILE`: if run from a pre-existing jld2 data saved from a previous simulation.
 
 Meanwhile, to enable multithreads, one needs to change [here](https://github.com/CliMA/ClimaCore.jl/blob/main/examples/hybrid/driver.jl#L51) in `driver.jl` to be `enable_threading() = true`.


### PR DESCRIPTION
This PR rearranges the pipeline by
 - grouping the examples a bit differently and
 - changing the output folders based on the cli options (this can be retrieved by `julia .dev/pipeline_examples_generator.jl`).

This is a sub-step towards adding regression tests since we need to have a job ID for the regression tables.

We should review the buildkite results to make sure that everything is still showing up correctly.