### PR TITLE
Reorganize pipeline groups, add more long runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -34,6 +34,13 @@ steps:
 
     steps:
 
-      - label: ":computer: dry held-suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float32 --t_end 103680000 --output_dir longrun_hs" # 1200 days
-        artifact_paths: "longrun_hs/*"
+      # TODO: Add all milestone long simulation runs
+
+      - label: ":computer: held suarez (ρe) Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe  --FLOAT_TYPE Float32 --t_end 103680000 --output_dir longrun_hs" # 1200 days
+        artifact_paths: "longrun_hs_rhoe/*"
+
+      - label: ":computer: held suarez (ρe_int) Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int  --FLOAT_TYPE Float32 --t_end 103680000 --output_dir longrun_hs_rhoeint" # 1200 days
+        artifact_paths: "longrun_hs_rhoeint/*"
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,38 +150,42 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
-      - label: ":computer: baroclinic wave (ρe)  Float32"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe  --FLOAT_TYPE Float32"
-        artifact_paths: "sphere_baroclinic_wave_rhoe_Float32/*"
-
       - label: ":computer: baroclinic wave (ρθ)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta"
         artifact_paths: "sphere_baroclinic_wave_rhotheta/*"
-
-      - label: ":computer: baroclinic wave (ρe) equilmoist  Float32"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist  --FLOAT_TYPE Float32"
-        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_Float32/*"
-
-      - label: ":computer: held suarez (ρe)  Float32"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe  --FLOAT_TYPE Float32"
-        artifact_paths: "sphere_held_suarez_rhoe_Float32/*"
 
       - label: ":computer: held suarez (ρθ)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
-      - label: ":computer: held suarez (ρθ)  Float32"
+      - label: ":computer: held suarez (ρθ) Float32"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta  --FLOAT_TYPE Float32"
         artifact_paths: "sphere_held_suarez_rhotheta_Float32/*"
 
-      - label: ":computer: held suarez (ρe) int  Float32"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int  --FLOAT_TYPE Float32"
-        artifact_paths: "sphere_held_suarez_rhoe_int_Float32/*"
-
-      - label: ":computer: held suarez (ρe) equilmoist  Float32"
+      - label: ":computer: held suarez (ρe) equilmoist Float32"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist  --FLOAT_TYPE Float32"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_Float32/*"
 
-      - label: ":computer: held suarez (ρe) int equilmoist  Float32"
+      - label: ":computer: held suarez (ρe_int) equilmoist Float32"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist  --FLOAT_TYPE Float32"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist_Float32/*"
+
+  - group: "Milestones"
+    steps:
+
+      - label: ":computer: baroclinic wave (ρe) Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_Float32/*"
+
+      - label: ":computer: baroclinic wave (ρe) equilmoist Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_Float32/*"
+
+      - label: ":computer: held suarez (ρe) Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_Float32/*"
+
+      - label: ":computer: held suarez (ρe) int Float32"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int  --FLOAT_TYPE Float32"
+        artifact_paths: "sphere_held_suarez_rhoe_int_Float32/*"
+


### PR DESCRIPTION
This PR splits off some of the examples into a new separate group, "milestones", which will contain a finite set of concrete substeps towards AMIP. This PR also adds job(s) to the long-run pipeline.