### PR TITLE
Add job_id to cli opts, use instead of output_dir

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -37,10 +37,10 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --output_dir longrun_hs" # 1200 days
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --job_id longrun_hs" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --output_dir longrun_hs_rhoeint" # 1200 days
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,7 @@ steps:
   - group: "MPI Examples"
     steps:
 
+      # TODO: fix non-unique artifact path: "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
       - label: ":computer: MPI Rising Bubble 3D hybrid invariant (ρe)"
         command: "mpiexec julia --color=yes --project=examples examples/hybrid/box/bubble_3d_invariant_rhoe.jl"
         artifact_paths: "examples/hybrid/box/output/bubble_3d_invariant_rhoe/*"
@@ -136,8 +137,8 @@ steps:
           slurm_ntasks: 2
 
       - label: ":computer: MPI baroclinic wave (ρe)"
-        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float32"
-        artifact_paths: "examples/hybrid/sphere/output/baroclinic_wave_rhoe/Float32/*"
+        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --job_id mpi_baroclinic_wave_rhoe"
+        artifact_paths: "mpi_baroclinic_wave_rhoe/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
@@ -147,45 +148,45 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhoe_Float64"
         artifact_paths: "sphere_baroclinic_wave_rhoe_Float64/*"
 
       - label: ":computer: baroclinic wave (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta --FLOAT_TYPE Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64"
         artifact_paths: "sphere_baroclinic_wave_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --FLOAT_TYPE Float64 --job_id sphere_held_suarez_rhotheta_Float64"
         artifact_paths: "sphere_held_suarez_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --job_id sphere_held_suarez_rhotheta"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist --job_id sphere_held_suarez_rhoe_equilmoist"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist --job_id sphere_held_suarez_rhoe_int_equilmoist"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --job_id sphere_baroclinic_wave_rhoe_equilmoist"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --job_id sphere_held_suarez_rhoe"
         artifact_paths: "sphere_held_suarez_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --job_id sphere_held_suarez_rhoe_int"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -18,6 +18,9 @@ ArgParse.@add_arg_table s begin
     "--output_dir"
     help = "Output directory"
     arg_type = String
+    "--job_id"
+    help = "Uniquely identifying string for a particular job"
+    arg_type = String
 end
 
 parsed_args = ArgParse.parse_args(ARGS, s)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -149,8 +149,13 @@ else
     jac_kwargs = alg_kwargs = ()
 end
 
+job_id = if isnothing(parsed_args["job_id"])
+    job_id_from_parsed_args(s, parsed_args)
+else
+    parsed_args["job_id"]
+end
 output_dir = if isnothing(parsed_args["output_dir"])
-    output_directory(s, parsed_args)
+    job_id
 else
     parsed_args["output_dir"]
 end


### PR DESCRIPTION
This PR:
 - Adds `job_id` as a CLI argument and the output directory defaults to this.
 - Fixes the artifact path for `MPI baroclinic wave (ρe)`

Deriving a unique ID from the CLI arguments was too complicated due to generating good simple names with floats (e.g., consider something like `held_suarez_rhoe_int_t_end_20000000.235239873509`. We could round it, but we'll have similar issues with viscosity (<1) or something becomes a CLI argument.

Therefore, providing a unique ID per job seems most reasonable. I'm still falling back on `job_id_from_parsed_args` if unspecified, but perhaps we can / should remove that in the future.

This is a step towards enabling regression tests (with this we'll be able to extract regression tables for all of the jobs).