### PR TITLE
Try to fix long runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -12,6 +12,9 @@ agents:
   config: cpu
   queue: central
   slurm_ntasks: 1
+  slurm_time: 10:00:00
+
+timeout_in_minutes: 600
 
 steps:
   - label: "init :computer:"

--- a/bors.toml
+++ b/bors.toml
@@ -4,6 +4,6 @@ status = [
   "format",
 ]
 delete_merged_branches = true
-timeout_sec = 10800
+timeout_sec = 36000
 block_labels = [ "do-not-merge-yet" ]
 cut_body_after = "<!--"


### PR DESCRIPTION
Does `timeout_in_minutes` need to be at the top-level of the yaml? cc @simonbyrne 