### PR TITLE
Add regression infrastructure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,7 +193,6 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --job_id sphere_held_suarez_rhoe_int"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
-
   - group: "Performance"
     steps:
 
@@ -213,3 +212,13 @@ steps:
         env:
           CI_PERF_CPUPROFILE: "true"
 
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":robot_face: Print new mse tables"
+    command: "julia --color=yes --project=examples post_processing/print_new_mse.jl"
+
+  - wait
+
+  - label: ":robot_face: Move main results"
+    command: "julia --color=yes --project=examples post_processing/move_output.jl"

--- a/post_processing/NCRegressionTests.jl
+++ b/post_processing/NCRegressionTests.jl
@@ -1,0 +1,151 @@
+# TODO: call from NCRegressionTests once its registered
+#! format: off
+module NCRegressionTests
+
+using Test
+import OrderedCollections
+import NCDatasets
+const NC = NCDatasets
+import PrettyTables
+
+function get_nc_data(ds, var::String)
+    if haskey(ds, var)
+        return ds[var]
+    else
+        for key in keys(ds.group)
+            if haskey(ds.group[key], var)
+                return ds.group[key][var]
+            end
+        end
+    end
+    error("No key $var for mse computation.")
+    return nothing
+end
+
+"""
+    compute_mse(;
+        job_name::String,
+        best_mse::OrderedCollections.OrderedDict,
+        ds_filename_computed::String,
+        ds_filename_reference::String,
+        varname::Function = s -> s,
+    )
+
+Returns a `Dict` of mean-squared errors between
+`NCDataset`s `ds_filename_computed` and
+`ds_filename_reference` for all keys in `best_mse`.
+Keys in `best_mse` may directly map to keys in
+the `NCDataset`s, or they may be mapped to the keys
+via `varname`.
+"""
+function compute_mse(;
+    job_name::String,
+    best_mse::OrderedCollections.OrderedDict,
+    ds_filename_computed::String,
+    ds_filename_reference::String,
+    varname::Function = s -> s,
+)
+    @assert isfile(ds_filename_computed)
+    @assert isfile(ds_filename_reference)
+
+    computed_mse = NC.Dataset(ds_filename_computed, "r") do ds_computed
+        NC.Dataset(ds_filename_reference, "r") do ds_reference
+            _compute_mse(job_name, best_mse, ds_computed, ds_reference, varname)
+        end
+    end
+end
+
+function _compute_mse(job_name, best_mse, ds_computed, ds_reference, varname)
+
+    mse = OrderedCollections.OrderedDict()
+    # Ensure z_tcc and fields are consistent lengths:
+    best_keys = keys(best_mse)
+    n_keys = length(best_keys)
+    variables = Vector{String}(undef, n_keys)
+    variables .= varname.(best_keys)
+    computed_mse = zeros(n_keys)
+    table_best_mse = zeros(n_keys)
+    mse_reductions = zeros(n_keys)
+    data_scales_now = zeros(n_keys)
+    data_scales_ref = zeros(n_keys)
+
+    for (i, key) in enumerate(best_keys)
+        str_key = varname(key)
+        @info "Computing mse for $key, $str_key"
+        data_computed_arr = vec(get_nc_data(ds_computed, str_key))
+        data_reference_arr = vec(get_nc_data(ds_reference, str_key))
+
+        # Interpolate data
+        # Compute data scale
+        data_scale_now = sum(abs.(data_computed_arr)) / length(data_computed_arr)
+        data_scale_ref = sum(abs.(data_reference_arr)) / length(data_reference_arr)
+        data_scales_now[i] = data_scale_now
+        data_scales_ref[i] = data_scale_ref
+
+        # Compute mean squared error (mse)
+        mse_single_var = sum((data_computed_arr .- data_reference_arr) .^ 2)
+        scaled_mse = mse_single_var / data_scale_ref^2 # Normalize by data scale
+
+        mse[key] = scaled_mse
+        mse_reductions[i] = (best_mse[key] - mse[key]) / best_mse[key] * 100
+        table_best_mse[i] = best_mse[key]
+        computed_mse[i] = mse[key]
+    end
+
+    # Tabulate output
+    header = (
+        ["Variable", "Data scale", "Data scale", "MSE", "MSE", "MSE"],
+        ["", "Computed", "Reference", "Computed", "Best", "Reduction (%)"],
+    )
+
+    table_data = hcat(variables, data_scales_now, data_scales_ref, computed_mse, table_best_mse, mse_reductions)
+
+    hl_worsened_mse = PrettyTables.Highlighter(
+        (data, i, j) -> !sufficient_mse(data[i, 4], data[i, 5]) && j == 4,
+        PrettyTables.crayon"red bold",
+    )
+    hl_worsened_mse_reduction = PrettyTables.Highlighter(
+        (data, i, j) -> !sufficient_mse(data[i, 4], data[i, 5]) && j == 6,
+        PrettyTables.crayon"red bold",
+    )
+    hl_improved_mse = PrettyTables.Highlighter(
+        (data, i, j) -> sufficient_mse(data[i, 4], data[i, 5]) && j == 6,
+        PrettyTables.crayon"green bold",
+    )
+    @info "Regression tables for $job_name"
+    PrettyTables.pretty_table(
+        table_data;
+        header,
+        formatters = PrettyTables.ft_printf("%.16e", 4:5),
+        header_crayon = PrettyTables.crayon"yellow bold",
+        subheader_crayon = PrettyTables.crayon"green bold",
+        highlighters = (hl_worsened_mse, hl_improved_mse, hl_worsened_mse_reduction),
+        crop = :none,
+    )
+
+    return mse
+end
+
+sufficient_mse(computed_mse::Real, best_mse::Real) = computed_mse <= best_mse + sqrt(eps())
+
+# Sometimes we don't have variables to compare against, so
+# we have default behavior for handling these cases.
+# Users may want to overload these methods for their own use-case.
+sufficient_mse(computed_mse::String, best_mse::String) = true
+sufficient_mse(computed_mse::Real, best_mse::String) = true
+sufficient_mse(computed_mse::String, best_mse::Real) = true
+
+function test_mse(computed_mse, best_mse)
+    @testset "Regression tests" begin
+        for key in keys(best_mse)
+            mse_not_regressed = sufficient_mse(computed_mse[key], best_mse[key])
+            if !mse_not_regressed
+                @info "Regression failed for $key. (computed | best) mse: $(computed_mse[key]) | $(best_mse[key])"
+            end
+            @test mse_not_regressed
+        end
+    end
+end
+
+end # module
+#! format: on

--- a/post_processing/compute_mse.jl
+++ b/post_processing/compute_mse.jl
@@ -1,0 +1,130 @@
+include("NCRegressionTests.jl")
+import .NCRegressionTests
+import NCDatasets
+import ClimaCoreTempestRemap
+const CCTR = ClimaCoreTempestRemap
+
+function find_latest_dataset_folder(; dir = pwd())
+    matching_paths = String[]
+    for file in readdir(dir)
+        !ispath(joinpath(dir, file)) && continue
+        push!(matching_paths, joinpath(dir, file))
+    end
+    isempty(matching_paths) && return ""
+    # sort by timestamp
+    sorted_paths =
+        sort(matching_paths; by = f -> Dates.unix2datetime(stat(f).mtime))
+    return pop!(sorted_paths)
+end
+
+"""
+    regression_test(;
+        job_id,
+        best_mse,
+        ds_filename_computed,
+        ds_filename_reference = nothing,
+        varname,
+    )
+
+Returns a `Dict` of mean-squared errors between
+`NCDataset`s `ds_filename_computed` and
+`ds_filename_reference` for all keys in `best_mse`.
+Keys in `best_mse` may directly map to keys in
+the `NCDataset`s, or they may be mapped to the keys
+via `varname`.
+
+If running on buildkite, we get `ds_filename_reference`
+from the latest merged dataset on Caltech central.
+"""
+function regression_test(;
+    job_id,
+    best_mse,
+    ds_filename_computed,
+    ds_filename_reference = nothing,
+    varname,
+)
+
+    # # Kickstart CI: do not uncomment.
+    # return best_mse
+
+    # Note: cluster_data_prefix is also defined in move_output.jl
+    if haskey(ENV, "BUILDKITE_COMMIT") && isnothing(ds_filename_reference)
+        cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
+        path = find_latest_dataset_folder(; dir = cluster_data_prefix)
+        # TODO: make this more robust in case folder/file changes
+        main_files = readdir(path)
+        if any(x -> basename(x) == ds_filename_computed, main_files)
+            ds_filename_reference = joinpath(path, ds_filename_computed)
+        end
+    end
+    @info "ClimaAtmos.jl main dataset: $ds_filename_reference"
+
+    computed_mse = NCRegressionTests.compute_mse(;
+        job_name = string(job_id),
+        best_mse = best_mse,
+        ds_filename_computed = ds_filename_computed,
+        ds_filename_reference = ds_filename_reference,
+        varname = varname,
+    )
+    return computed_mse
+
+end
+
+
+##### TODO: move below functions to ClimaCore
+
+function first_center_space(fv::Fields.FieldVector)
+    for prop_chain in Fields.property_chains(fv)
+        f = Fields.single_field(fv, prop_chain)
+        space = axes(f)
+        if space isa Spaces.CenterExtrudedFiniteDifferenceSpace
+            return space
+        end
+    end
+    error("Unfound space")
+end
+
+function first_face_space(fv::Fields.FieldVector)
+    for prop_chain in Fields.property_chains(fv)
+        f = Fields.single_field(fv, prop_chain)
+        space = axes(f)
+        if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
+            return space
+        end
+    end
+    error("Unfound space")
+end
+
+function export_nc(
+    Y::Fields.FieldVector;
+    nc_filename,
+    t_now = 0.0,
+    center_space = first_center_space,
+    face_space = first_face_space,
+    filter_prop_chain = pn -> true, # use all fields
+    varname::Function,
+)
+    prop_chains = Fields.property_chains(Y)
+    filter!(filter_prop_chain, prop_chains)
+    cspace = center_space(Y)
+    fspace = face_space(Y)
+    # create a temporary dir for intermediate data
+    FT = eltype(Y)
+    NCDatasets.NCDataset(nc_filename, "c") do nc
+        # defines the appropriate dimensions and variables for a space coordinate
+        # defines the appropriate dimensions and variables for a time coordinate (by default, unlimited size)
+        nc_time = CCTR.def_time_coord(nc)
+        CCTR.def_space_coord(nc, cspace, type = "cgll")
+        CCTR.def_space_coord(nc, fspace, type = "cgll")
+        # define variables for the prognostic states
+        for prop_chain in Fields.property_chains(Y)
+            f = Fields.single_field(Y, prop_chain)
+            space = axes(f)
+            nc_var = CCTR.defVar(nc, varname(prop_chain), FT, space, ("time",))
+            nc_var[:, 1] = f
+        end
+        # TODO: interpolate w onto center space and save it the same way as the other vars
+        nc_time[1] = t_now
+    end
+    return nothing
+end

--- a/post_processing/move_output.jl
+++ b/post_processing/move_output.jl
@@ -1,0 +1,35 @@
+all_lines = readlines(joinpath(@__DIR__, "mse_tables.jl"))
+lines = deepcopy(all_lines)
+filter!(x -> occursin("] = OrderedCollections", x), lines)
+job_ids = getindex.(split.(lines, "\""), 2)
+@assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
+@assert length(job_ids) ≠ 0 # safety net
+
+if haskey(ENV, "BUILDKITE_COMMIT") && haskey(ENV, "BUILDKITE_BRANCH")
+    commit = ENV["BUILDKITE_COMMIT"]
+    branch = ENV["BUILDKITE_BRANCH"]
+    # Note: cluster_data_prefix is also defined in compute_mse.jl
+    cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
+
+    @info "pwd() = $(pwd())"
+    @info "branch = $(branch)"
+    @info "commit = $(commit)"
+
+    using Glob
+    @show readdir(joinpath(@__DIR__, ".."))
+    if branch == "staging"
+        commit_sha = commit[1:7]
+        mkpath(cluster_data_prefix)
+        path = joinpath(cluster_data_prefix, commit_sha)
+        mkpath(path)
+        for folder_name in job_ids
+            src = folder_name
+            dst = joinpath(path, folder_name)
+            @info "Moving $src to $dst"
+            mv(src, dst; force = true)
+        end
+        @info "readdir(): $(readdir(path))"
+    end
+else
+    @info "ENV keys: $(keys(ENV))"
+end

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -1,0 +1,70 @@
+#################################
+################################# MSE tables
+#################################
+#! format: off
+#
+all_best_mse = OrderedCollections.OrderedDict()
+#
+all_best_mse["mpi_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
+all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.0
+all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :ρe)] = 0.0
+all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["mpi_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_held_suarez_rhotheta"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.0
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρe_int)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρq_tot)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_held_suarez_rhoe"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+#
+all_best_mse["sphere_held_suarez_rhoe_int"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 0.0
+#
+#! format: on
+#################################
+#################################
+#################################

--- a/post_processing/print_new_mse.jl
+++ b/post_processing/print_new_mse.jl
@@ -1,0 +1,91 @@
+import OrderedCollections
+import JSON
+
+# Get cases from JobIDs in mse_tables file:
+all_lines = readlines(joinpath(@__DIR__, "mse_tables.jl"))
+lines = deepcopy(all_lines)
+filter!(x -> occursin("] = OrderedCollections", x), lines)
+job_ids = getindex.(split.(lines, "\""), 2)
+@assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
+@assert length(job_ids) ≠ 0 # safety net
+
+include(joinpath(@__DIR__, "mse_tables.jl"))
+
+percent_reduction_mse = Dict()
+
+computed_mse = OrderedCollections.OrderedDict()
+files_skipped = OrderedCollections.OrderedDict()
+for job_id in job_ids
+    filename = joinpath(job_id, "computed_mse.json")
+    if !isfile(filename)
+        @warn "File $filename skipped"
+        files_skipped[job_id] = true
+        continue
+    end
+    jsonfile =
+        JSON.parsefile(filename; dicttype = OrderedCollections.OrderedDict)
+    files_skipped[job_id] = false
+    computed_mse[job_id] = jsonfile
+end
+
+println("#################################")
+println("################################# MSE tables")
+println("#################################")
+println("#! format: off")
+println("#")
+
+println("all_best_mse = OrderedCollections.OrderedDict()\n#")
+for job_id in keys(computed_mse)
+    println("all_best_mse[\"$job_id\"] = OrderedCollections.OrderedDict()")
+    for var in keys(computed_mse[job_id])
+        if computed_mse[job_id][var] == "NA"
+            println("all_best_mse[\"$job_id\"][\"$var\"] = \"$(computed_mse[job_id][var])\"")
+        else
+            println("all_best_mse[\"$job_id\"][\"$var\"] = $(computed_mse[job_id][var])")
+        end
+    end
+    println("#")
+end
+println("#! format: on")
+
+println("#################################")
+println("#################################")
+println("#################################")
+
+# Cleanup
+for job_id in job_ids
+    rm(joinpath(job_id, "computed_mse.json"); force = true)
+end
+
+#####
+##### min percentage reduction of mse across cases
+#####
+
+println("-- DO NOT COPY --")
+
+for job_id in keys(computed_mse)
+    percent_reduction_mse[job_id] = 0
+    for var in keys(computed_mse[job_id])
+        if haskey(all_best_mse[job_id], var)
+            all_best_mse[job_id][var] isa Real || continue # skip if "NA"
+            computed_mse[job_id][var] isa Real || continue # skip if "NA"
+            percent_reduction_mse[job_id] = min(
+                percent_reduction_mse[job_id],
+                (all_best_mse[job_id][var] - computed_mse[job_id][var]) /
+                all_best_mse[job_id][var] * 100,
+            )
+        else
+            percent_reduction_mse[job_id] = "NA"
+        end
+    end
+end
+
+for job_id in keys(percent_reduction_mse)
+    @info "percent_reduction_mse[$job_id] = $(percent_reduction_mse[job_id])"
+end
+@info "min mse reduction (%) over all cases = $(min(values(percent_reduction_mse)...))"
+
+if any(values(files_skipped))
+    @show files_skipped
+    error("Some MSE files where skipped due to missing files")
+end


### PR DESCRIPTION
This PR adds regression tests, which involves adding the following code and logic:

New code at end of driver.jl:

1) Simulate case with `job_id`
2) load `all_best_mse` (from `mse_tables.jl`), which contains errors for each reference, and extract errors for the specific case (`best_mse` for the given `job_id`).
3) export `FieldVector` at last timestep to NC file
4) call `regression_test` which:
   - Grabs:
       - The last NC file on central that was merged into main. or
       - A specific NC file on central that was merged into main.
   - Returns a `computed_mse_dict` from computed NC (step 3) against the NC file on main
5) Export `computed_mse_dict` to a `.json`
6) Test that `computed_mse_dict` is no worse than the `best_mse` (determines if CI passes or not)

Additional jobs after all job_ids:

1) Print `computed_mse_dict` for all jobs to make updating `mse_tables.jl` easy
2) If on staging branch (all tests have passed, and the PR is effectively merging)
  - move NC files and `computed_mse_dict` for all `job_ids` into folder on central
  - folder has a commit sha prefix, and we can look this up based on when created

Docs are needed, both for functions and general workflow. I'll open an issue to document this to document the code a bit more. I'd rather delay it a bit because some of this code (e.g., `NCRegressionTests.jl` can be moved to an entirely separate repo with its own docs), and other functionality is likely to be moved into ClimaCore.

Being that things are moving quickly, and this testing infrastructure makes our CI stateful, I'm inclined to get this merged earlier than later so that we can build confidence with it.

I'm more than happy to answer questions, and I know that this is a large PR, but most of what's been added was transferred from TC.jl (which was built incrementally).