### PR TITLE
Make enable_threading a cli option, and use for long runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -39,10 +39,10 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --job_id longrun_hs --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --job_id longrun_hs_rhoe --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -16,6 +16,10 @@ ArgParse.@add_arg_table s begin
     help = "(Bool) perform regression test"
     arg_type = Bool
     default = true
+    "--enable_threading"
+    help = "Enable multi-threading. Note: Julia must be launched with (e.g.,) `--threads=8`"
+    arg_type = Bool
+    default = false
     "--TEST_NAME"
     help = "Job name"
     arg_type = String

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -59,7 +59,7 @@ atexit() do
 end
 
 import ClimaCore: enable_threading
-enable_threading() = false
+enable_threading() = parsed_args["enable_threading"]
 
 using OrdinaryDiffEq
 using DiffEqCallbacks

--- a/examples/hybrid/sphere/README.md
+++ b/examples/hybrid/sphere/README.md
@@ -38,10 +38,9 @@ Commonly used command line arguements for experiment setps:
 * `--t_end`: specifies the simulation time in seconds;
 * `--FLOAT_TYPE`: can be Float32 or Float64; is default to Float32 if not specified;
 * `--regression_test`: a boolean var to specify whether the regression test is performed; is default to true if not specified;
+* `--enable_threading`: a boolean var to enable multi-threading; defaults to false; Note that Julia must be launched with, for example, `--threads=8`.
 * `--job_id`: a uniquely defined id for a job; is default based on the parsed args of the experiment if not specified;
 * `--output_dir`: specifies the output directory that saves all the jld2 outputs; is default to `job_id` if not specified.
-
-Meanwhile, to enable multithreads, one needs to change [here](https://github.com/CliMA/ClimaAtmos.jl/blob/main/examples/hybrid/driver.jl#L62) in `driver.jl` to be `enable_threading() = true`.
 
 To use `sphere/held_suarez_rhoe` as an example, one needs to modify [these lines](https://github.com/CliMA/ClimaAtmos.jl/blob/main/examples/hybrid/sphere/held_suarez_rhoe.jl#L6-L16) into the specific setup. In particular, `dt_save_to_disk=FT(0)` means no jld2 outputs. A non-zero value specifies the frequency in seconds to save the data into jld2 files. 
 


### PR DESCRIPTION
This PR:
 - Makes `enable_threading` a cli option
 - Makes the long runs use multi-threading
 - Fixes the `job_id` for HS rho-e to match the artifact path.