### PR TITLE
Specify slurm_cpus_per_task env, try larger dt, for long runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -41,8 +41,24 @@ steps:
       - label: ":computer: held suarez (ρe)"
         command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --job_id longrun_hs_rhoe --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
+        agents:
+          slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
         command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
+        agents:
+          slurm_cpus_per_task: 8
+
+      - label: ":computer: held suarez (ρe)"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --dt 600 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
+        artifact_paths: "longrun_hs_rhoe_largerdt/*"
+        agents:
+          slurm_cpus_per_task: 8
+
+      - label: ":computer: held suarez (ρe_int)"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --dt 600 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
+        artifact_paths: "longrun_hs_rhoeint_largerdt/*"
+        agents:
+          slurm_cpus_per_task: 8
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -8,6 +8,9 @@ ArgParse.@add_arg_table s begin
     "--t_end"
     help = "Simulation end time"
     arg_type = Float64
+    "--dt"
+    help = "Simulation time step"
+    arg_type = Float64
     "--dt_save_to_sol" # TODO: should we default to Inf?
     help = "Time between saving solution, 0 means do not save"
     arg_type = Float64

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -16,7 +16,11 @@ t_end = if isnothing(parsed_args["t_end"])
 else
     parsed_args["t_end"]
 end
-dt = 0
+dt = if isnothing(parsed_args["dt"])
+    FT(400)
+else
+    parsed_args["dt"]
+end
 dt_save_to_sol = parsed_args["dt_save_to_sol"]
 dt_save_to_disk = 0 # 0 means don't save to disk
 ode_algorithm = nothing # must be object of type OrdinaryDiffEqAlgorithm

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -12,7 +12,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)

--- a/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta_tempest.jl
@@ -11,7 +11,6 @@ horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
 npoly = 4
 z_max = FT(30e3)
 z_elem = 10
-dt = FT(400)
 dt_save_to_disk = FT(0) # 0 means don't save to disk
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)


### PR DESCRIPTION
Yesterday's long run (with multi-threading enabled) is taking much longer than the single thread case. This PR:
 - specifies the `slurm_cpus_per_task` env for the long runs.
 - Tries out additional long run jobs with `dt = 600`