### PR TITLE
Hook in regression tests

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -313,16 +313,8 @@ if !is_distributed || (is_distributed && ClimaComms.iamroot(Context))
         varname(pc::Tuple) = process_name(join(pc, "_"))
 
         export_nc(Y_last; nc_filename = ds_filename_computed, varname)
-        computed_mse = regression_test(;
-            job_id,
-            best_mse,
-            ds_filename_computed,
-            # TODO: we temporarily pass ds_filename_computed
-            #       as ds_filename_reference since no results exist
-            #       yet on central.
-            ds_filename_reference = ds_filename_computed,
-            varname,
-        )
+        computed_mse =
+            regression_test(; job_id, best_mse, ds_filename_computed, varname)
 
         computed_mse_filename = joinpath(job_id, "computed_mse.json")
 

--- a/post_processing/compute_mse.jl
+++ b/post_processing/compute_mse.jl
@@ -1,6 +1,7 @@
 include("NCRegressionTests.jl")
 import .NCRegressionTests
 import NCDatasets
+import Dates
 import ClimaCoreTempestRemap
 const CCTR = ClimaCoreTempestRemap
 
@@ -51,13 +52,21 @@ function regression_test(;
     if haskey(ENV, "BUILDKITE_COMMIT") && isnothing(ds_filename_reference)
         cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
         path = find_latest_dataset_folder(; dir = cluster_data_prefix)
+
+        # To fix the reference dataset, use, for example:
+        #     path = joinpath(cluster_data_prefix, "992d070")
+        # where `992d070` is the commit sha to fix our reference to.
+
         # TODO: make this more robust in case folder/file changes
         main_files = readdir(path)
-        if any(x -> basename(x) == ds_filename_computed, main_files)
-            ds_filename_reference = joinpath(path, ds_filename_computed)
+        @info "Files on main:"
+        for file_on_main in main_files
+            println("   file:$file_on_main, basename: $(basename(file_on_main))")
         end
+        println("ds_filename_computed: $ds_filename_computed")
+        ds_filename_reference = joinpath(path, ds_filename_computed)
     end
-    @info "ClimaAtmos.jl main dataset: $ds_filename_reference"
+    println("ClimaAtmos.jl main dataset: $ds_filename_reference")
 
     computed_mse = NCRegressionTests.compute_mse(;
         job_name = string(job_id),


### PR DESCRIPTION
Now that results have been saved on central, we can remove `ds_filename_reference = ds_filename_computed` in the driver so that we're comparing with a reference on main.

This is a follow-up to #312. This is a first attempt at `#4` in #301.