### PR TITLE
Try higher frequency io in longer runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -51,13 +51,13 @@ steps:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --dt 600 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --t_end 103680000 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 21600 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoe_largerdt/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --dt 600 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 8640000 --enable_threading true" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 21600 --enable_threading true" # 1200 days
         artifact_paths: "longrun_hs_rhoeint_largerdt/*"
         agents:
           slurm_cpus_per_task: 8


### PR DESCRIPTION
@bischtob suggested trying to export solutions 4 times per day. The larger timestep case broke where we compute `log(~pressure)`, so I'm reverting that change.

This will give us some idea of how expensive IO is.