### PR TITLE
Opt out of regression tests by default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -163,34 +163,34 @@ steps:
         artifact_paths: "sphere_held_suarez_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --job_id sphere_held_suarez_rhotheta"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhotheta --job_id sphere_held_suarez_rhotheta --regression_test true"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist --job_id sphere_held_suarez_rhoe_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_equilmoist --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist --job_id sphere_held_suarez_rhoe_int_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int_equilmoist --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe --regression_test true"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --job_id sphere_baroclinic_wave_rhoe_equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/baroclinic_wave_rhoe_equilmoist --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --job_id sphere_held_suarez_rhoe"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe --job_id sphere_held_suarez_rhoe --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --job_id sphere_held_suarez_rhoe_int"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME sphere/held_suarez_rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
   - group: "Performance"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -18,7 +18,7 @@ ArgParse.@add_arg_table s begin
     "--regression_test"
     help = "(Bool) perform regression test"
     arg_type = Bool
-    default = true
+    default = false
     "--enable_threading"
     help = "Enable multi-threading. Note: Julia must be launched with (e.g.,) `--threads=8`"
     arg_type = Bool

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -276,7 +276,7 @@ if !is_distributed || (is_distributed && ClimaComms.iamroot(Context))
 
     include(joinpath(@__DIR__, "..", "..", "post_processing", "mse_tables.jl"))
 
-    if !occursin("Float64", job_id) # only do regression tests on Float32 jobs
+    if parsed_args["regression_test"]
 
         Y_last = sol.u[end]
         # This is helpful for starting up new tables

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -5,13 +5,6 @@
 #
 all_best_mse = OrderedCollections.OrderedDict()
 #
-all_best_mse["mpi_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.0
-all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :ρe)] = 0.0
-all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["mpi_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["mpi_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
-#
 all_best_mse["sphere_held_suarez_rhotheta"] = OrderedCollections.OrderedDict()
 all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.0
 all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.0


### PR DESCRIPTION
This PR:
 - Peels a small piece off of #322
 - Changes regression tests to use the cli option `--regression_test`
 - Sets `regression_test = false` by default
 - Drops regression tests for `mpi_baroclinic_wave_rhoe`

This probably just makes more sense. This PR ties up some loose ends in #301.