### PR TITLE
Unify driver more

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -155,42 +155,42 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhoe_Float64/*"
 
       - label: ":computer: baroclinic wave (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhotheta --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64"
         artifact_paths: "sphere_baroclinic_wave_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --FLOAT_TYPE Float64 --job_id sphere_held_suarez_rhotheta_Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_held_suarez_rhotheta_Float64 --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --job_id sphere_held_suarez_rhotheta --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --job_id sphere_held_suarez_rhotheta --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_equilmoist --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_equilmoist --moist equil --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int_equilmoist --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int_equilmoist --energy_name rhoe_int --moist equil --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist --moist equil --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --job_id sphere_held_suarez_rhoe --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --job_id sphere_held_suarez_rhoe --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --energy_name rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true --trunc_stack_traces true"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
   - group: "Performance"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -11,6 +11,14 @@ ArgParse.@add_arg_table s begin
     "--dt"
     help = "Simulation time step"
     arg_type = Float64
+    "--moist"
+    help = "Moisture model [`dry` (default), `equil`, `non_equil`]"
+    arg_type = String
+    default = "dry"
+    "--energy_name"
+    help = "Energy variable name [`rhoe` (default), `rhoe_int` , `rhotheta`]"
+    arg_type = String
+    default = "rhoe"
     "--dt_save_to_sol" # TODO: should we default to Inf?
     help = "Time between saving solution, 0 means do not save"
     arg_type = Float64
@@ -26,12 +34,17 @@ ArgParse.@add_arg_table s begin
     "--TEST_NAME"
     help = "Job name"
     arg_type = String
+    default = "baroclinic_wave_rhoe"
     "--output_dir"
     help = "Output directory"
     arg_type = String
     "--job_id"
     help = "Uniquely identifying string for a particular job"
     arg_type = String
+    "--trunc_stack_traces"
+    help = "Truncate stack traces by truncating printing of fields and fieldvectors"
+    arg_type = Bool
+    default = false
 end
 
 parsed_args = ArgParse.parse_args(ARGS, s)

--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -117,7 +117,7 @@ function postprocessing(sol, output_dir)
 end
 
 # plots in the Ullrish et al 2014 paper: surface pressure, 850 temperature and vorticity at day 8 and day 10
-function paperplots_baro_wave_ρθ(sol, output_dir, p, nlat, nlon)
+function paperplots_baro_wave(sol, output_dir, p, nlat, nlon, ::Val{:ρθ})
     (; comms_ctx, ᶜts, ᶜp, params) = p
     days = [8, 10]
 
@@ -242,7 +242,7 @@ function paperplots_baro_wave_ρθ(sol, output_dir, p, nlat, nlon)
 
 end
 
-function paperplots_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
+function paperplots_baro_wave(sol, output_dir, p, nlat, nlon, ::Val{:ρe})
     (; comms_ctx, ᶜts, ᶜp, params, ᶜK, ᶜΦ) = p
     days = [8, 10]
 

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -8,6 +6,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe))

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -10,10 +8,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -8,6 +6,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρθ))

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -23,9 +23,9 @@ baroclinic_wave_mesh(; params, h_elem) =
 function center_initial_condition(
     local_geometry,
     params,
-    ᶜ𝔼_name;
+    ᶜ𝔼_name = Val(:ρe),
+    moisture_mode = Val(:dry);
     is_balanced_flow = false,
-    moisture_mode = Val(:dry),
 )
     # Constants from CLIMAParameters
     R_d = FT(Planet.R_d(params))
@@ -142,7 +142,7 @@ function center_initial_condition(
     return (; ρ, ᶜ𝔼_kwarg..., uₕ, moisture_kwargs...)
 end
 
-face_initial_condition(local_geometry, params) =
+face_initial_condition(local_geometry, params; kwargs...) =
     (; w = Geometry.Covariant3Vector(FT(0)))
 
 ##

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -10,6 +8,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe))

--- a/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :no_∂ᶜp∂ᶜK, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -14,10 +12,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -10,6 +8,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe_int))

--- a/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
     sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
@@ -14,10 +12,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe_int);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -1,5 +1,3 @@
-jacobian_flags = (; ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact)
-
 additional_cache(Y, params, dt; use_tempest_mode = false) = merge(
     hyperdiffusion_cache(Y; κ₄ = FT(2e17),
         use_tempest_mode = use_tempest_mode),
@@ -11,6 +9,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρθ))


### PR DESCRIPTION
This PR:
 - Adds more cli options for moisture model and energy variable name
 - Uses the added cli options for dispatching to generalized methods in `driver.jl` (and post-processing)
 - Changes a kwarg in `center_initial_condition` to args (so that we can dispatch)
 - Adds a convenience `parse_arg` method to help trim some dynamically parsed arguments
 - Makes `params` constant

This is another step towards #339 and #301.