### PR TITLE
Add radiative equilibrium example

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -177,6 +177,10 @@ steps:
   - group: "Milestones"
     steps:
 
+      - label: ":computer: single column radiative equilibrium"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --job_id sphere_single_column_radiative_equilibrium"
+        artifact_paths: "sphere_single_column_radiative_equilibrium/*"
+
       - label: ":computer: baroclinic wave (ρe)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe --regression_test true"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"

--- a/examples/common_spaces.jl
+++ b/examples/common_spaces.jl
@@ -30,8 +30,7 @@ function cubed_sphere_mesh(; radius, h_elem)
     return Meshes.EquiangularCubedSphere(domain, h_elem)
 end
 
-function make_horizontal_space(mesh, npoly)
-    quad = Spaces.Quadratures.GLL{npoly + 1}()
+function make_horizontal_space(mesh, quad)
     if mesh isa Meshes.AbstractMesh1D
         topology = Topologies.IntervalTopology(mesh)
         space = Spaces.SpectralElementSpace1D(topology, quad)
@@ -44,12 +43,11 @@ end
 
 function make_distributed_horizontal_space(
     mesh,
-    npoly,
+    quad,
     Context,
     nlevels,
     max_field_element_size,
 )
-    quad = Spaces.Quadratures.GLL{npoly + 1}()
     if mesh isa Meshes.AbstractMesh1D
         error("Distributed mode does not work with 1D horizontal spaces.")
     elseif mesh isa Meshes.AbstractMesh2D

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -16,7 +16,7 @@ using ClimaCore
 # TODO: Allow some of these to be environment variables or command line arguments
 params = nothing
 horizontal_mesh = nothing # must be object of type AbstractMesh
-npoly = 0
+quad = nothing # must be object of type QuadratureStyle
 z_max = 0
 z_elem = 0
 t_end = if isnothing(parsed_args["t_end"])
@@ -34,7 +34,7 @@ dt_save_to_disk = 0 # 0 means don't save to disk
 ode_algorithm = nothing # must be object of type OrdinaryDiffEqAlgorithm
 jacobian_flags = () # only required by implicit ODE algorithms
 max_newton_iters = 10 # only required by ODE algorithms that use Newton's method
-show_progress_bar = true
+show_progress_bar = isinteractive()
 additional_callbacks = () # e.g., printing diagnostic information
 additional_solver_kwargs = () # e.g., abstol and reltol
 test_implicit_solver = false # makes solver extremely slow when set to `true`
@@ -84,7 +84,7 @@ const sponge = false
 # Variables required for driver.jl (modify as needed)
 params = BaroclinicWaveParameterSet()
 horizontal_mesh = baroclinic_wave_mesh(; params, h_elem = 4)
-npoly = 4
+quad = Spaces.Quadratures.GLL{5}()
 z_max = FT(30e3)
 z_elem = 10
 dt_save_to_disk = FT(0) # 0 means don't save to disk
@@ -117,7 +117,7 @@ if haskey(ENV, "RESTART_FILE")
         comms_ctx = Spaces.setup_comms(
             Context,
             axes(Y.c).horizontal_space.topology,
-            Spaces.Quadratures.GLL{npoly + 1}(),
+            quad,
             z_elem + 1,
             max_field_element_size,
         )
@@ -129,13 +129,13 @@ else
     if is_distributed
         h_space, comms_ctx = make_distributed_horizontal_space(
             horizontal_mesh,
-            npoly,
+            quad,
             Context,
             z_elem + 1,
             max_field_element_size,
         )
     else
-        h_space = make_horizontal_space(horizontal_mesh, npoly)
+        h_space = make_horizontal_space(horizontal_mesh, quad)
         comms_ctx = nothing
     end
     center_space, face_space = make_hybrid_spaces(h_space, z_max, z_elem)
@@ -235,7 +235,7 @@ integrator = OrdinaryDiffEq.init(
     dt = dt,
     adaptive = false,
     progress = show_progress_bar,
-    progress_steps = 1000,
+    progress_steps = isinteractive() ? 1 : 1000,
     additional_solver_kwargs...,
 )
 
@@ -248,7 +248,7 @@ sol = @timev OrdinaryDiffEq.solve!(integrator)
 
 if is_distributed # replace sol.u on the root processor with the global sol.u
     if ClimaComms.iamroot(Context)
-        global_h_space = make_horizontal_space(horizontal_mesh, npoly)
+        global_h_space = make_horizontal_space(horizontal_mesh, quad)
         global_center_space, global_face_space =
             make_hybrid_spaces(global_h_space, z_max, z_elem)
         global_Y_c_type = Fields.Field{
@@ -292,6 +292,8 @@ if !is_distributed
         paperplots_baro_wave_ρe(sol, output_dir, p, FT(90), FT(180))
     elseif TEST_NAME == "baroclinic_wave_rhotheta"
         paperplots_baro_wave_ρθ(sol, output_dir, p, FT(90), FT(180))
+    elseif TEST_NAME == "single_column_radiative_equilibrium"
+        custom_postprocessing(sol, output_dir)
     else
         postprocessing(sol, output_dir)
     end

--- a/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
+++ b/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
@@ -1,0 +1,98 @@
+using PrettyTables
+
+include("../radiation_utilities.jl")
+
+const 𝔼_name = :ρe
+
+struct EarthParameterSet <: AbstractEarthParameterSet end
+
+Δx = FT(1) # Note: This value shouldn't matter, since we only have 1 column.
+
+params = EarthParameterSet()
+horizontal_mesh =
+    periodic_rectangle_mesh(; x_max = Δx, y_max = Δx, x_elem = 1, y_elem = 1)
+quad = Spaces.Quadratures.GL{1}()
+z_max = FT(100e3)
+z_elem = 100
+t_end = FT(60 * 60 * 24 * 365.25 * 5)
+dt = FT(60 * 60 * 3)
+dt_save_to_sol = 100 * dt
+ode_algorithm = OrdinaryDiffEq.Rosenbrock23
+jacobian_flags = (;
+    ∂ᶜ𝔼ₜ∂ᶠ𝕄_mode = 𝔼_name == :ρe ? :no_∂ᶜp∂ᶜK : :exact, ∂ᶠ𝕄ₜ∂ᶜρ_mode = :exact,
+)
+
+additional_cache(Y, params, dt) = rrtmgp_model_cache(Y, params)
+additional_tendency!(Yₜ, Y, p, t) = rrtmgp_model_tendency!(Yₜ, Y, p, t)
+additional_callbacks = (PeriodicCallback(
+    rrtmgp_model_callback!,
+    dt; # this will usually be bigger than dt, but for this example it can be dt
+    initial_affect = true, # run callback at t = 0
+    save_positions = (false, false), # do not save Y before and after callback
+),)
+
+function center_initial_condition(local_geometry, params)
+    R_d = FT(Planet.R_d(params))
+    MSLP = FT(Planet.MSLP(params))
+    grav = FT(Planet.grav(params))
+
+    T₀ = FT(300)
+
+    z = local_geometry.coordinates.z
+    p = MSLP * exp(-z * grav / (R_d * T₀))
+    ρ = p / (R_d * T₀)
+    ts = TD.PhaseDry_ρp(params, ρ, p)
+
+    if 𝔼_name == :ρθ
+        𝔼_kwarg = (; ρθ = ρ * TD.liquid_ice_pottemp(params, ts))
+    elseif 𝔼_name == :ρe
+        𝔼_kwarg = (; ρe = ρ * (TD.internal_energy(params, ts) + grav * z))
+    elseif 𝔼_name == :ρe_int
+        𝔼_kwarg = (; ρe_int = ρ * TD.internal_energy(params, ts))
+    end
+    return (; ρ, 𝔼_kwarg..., uₕ = Geometry.Covariant12Vector(FT(0), FT(0)))
+end
+face_initial_condition(local_geometry, params) =
+    (; w = Geometry.Covariant3Vector(FT(0)))
+
+function custom_postprocessing(sol, output_dir)
+    get_var(i, var) = Fields.single_field(sol.u[i], var)
+    n = length(sol.u)
+    #! format: off
+    get_row(var) = [
+        "Y.$(join(var, '.'))";;
+        "$(norm(get_var(1, var), 2)) → $(norm(get_var(n, var), 2))";;
+        "$(mean(get_var(1, var))) → $(mean(get_var(n, var)))";;
+        "$(maximum(abs, get_var(1, var))) → $(maximum(abs, get_var(n, var)))";;
+        "$(minimum(abs, get_var(1, var))) → $(minimum(abs, get_var(n, var)))";;
+    ]
+    #! format: on
+    pretty_table(
+        vcat(map(get_row, Fields.property_chains(sol.u[1]))...);
+        title = "Change in Y from t = $(sol.t[1]) to t = $(sol.t[n]):",
+        header = ["var", "‖var‖₂", "mean(var)", "max(∣var∣)", "min(∣var∣)"],
+        alignment = :c,
+    )
+
+    anim = @animate for Y in sol.u
+        if :ρθ in propertynames(Y.c)
+            ᶜts = @. thermo_state_ρθ(Y.c.ρθ, Y.c, params)
+        elseif :ρe in propertynames(Y.c)
+            grav = FT(Planet.grav(params))
+            ᶜK = @. norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+            ᶜΦ = grav .* Fields.coordinate_field(Y.c).z
+            ᶜts = @. thermo_state_ρe(Y.c.ρe, Y.c, ᶜK, ᶜΦ, params)
+        elseif :ρe_int in propertynames(Y.c)
+            ᶜts = @. thermo_state_ρe_int(Y.c.ρe_int, Y.c, params)
+        end
+        plot(
+            vec(TD.air_temperature.(params, ᶜts)),
+            vec(Fields.coordinate_field(Y.c).z ./ 1000);
+            xlabel = "T [K]",
+            ylabel = "z [km]",
+            xlims = (100, 300),
+            legend = false,
+        )
+    end
+    Plots.mp4(anim, joinpath(output_dir, "T.mp4"), fps = 10)
+end

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -106,7 +106,8 @@ function default_cache(Y, params, comms_ctx)
         Ω = FT(Planet.Omega(params))
         ᶜf = @. 2 * Ω * sind(ᶜcoord.lat)
     else
-        ᶜf = map(_ -> f_plane_coriolis_frequency(params), ᶜcoord)
+        f = FT(f_plane_coriolis_frequency(params))
+        ᶜf = map(_ -> f, ᶜcoord)
     end
     ᶜf = @. Geometry.Contravariant3Vector(Geometry.WVector(ᶜf))
     if (


### PR DESCRIPTION
This PR adds a single column radiative equilibrium example. With the way the driver is currently set up, I had to put the example in the `sphere` subfolder, and I had to add a workaround to avoid the default post-processing, but we can fix this when we next reorganize the driver.

This example starts with a column of air at 300 K, then runs RRTMGP using clear-sky optics every 3 hours to update the radiation flux until an equilibrium is reached. The concentration of water vapor in this example is 0, and the concentrations of all other gases required for clear-sky optics are read in from a dataset that comes with RRTMGP.

The resulting equilibrium temperature profile has some grid imprinting at around 80 km, but this might not be a significant issue.