### PR TITLE
Add moist radiative equilibrium example

### DIFF
--- a/examples/common_spaces.jl
+++ b/examples/common_spaces.jl
@@ -64,13 +64,13 @@ function make_distributed_horizontal_space(
     return space, comms_ctx
 end
 
-function make_hybrid_spaces(h_space, z_max, z_elem)
+function make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
     z_domain = Domains.IntervalDomain(
         Geometry.ZPoint(zero(z_max)),
         Geometry.ZPoint(z_max);
         boundary_tags = (:bottom, :top),
     )
-    z_mesh = Meshes.IntervalMesh(z_domain, nelems = z_elem)
+    z_mesh = Meshes.IntervalMesh(z_domain, z_stretch; nelems = z_elem)
     z_topology = Topologies.IntervalTopology(z_mesh)
     z_space = Spaces.CenterFiniteDifferenceSpace(z_topology)
     center_space = Spaces.ExtrudedFiniteDifferenceSpace(h_space, z_space)


### PR DESCRIPTION
This PR adds moisture to `single_column_radiative_equilibrium.jl`. Specifically, it adds an `idealized_h2o` flag to the `rrtmgp_model_cache`, which computes a volume mixing ratio at every point such that the relative humidity is at most 0.6 and the specific humidity decreases monotonically with height. Due to our unrealistic initial condition (300 K throughout the domain), the relative humidity is slowly increased from 0 to 0.6 to prevent RRTMGP from giving absurd values at the top of the domain at the start of the simulation.

Also, this PR adds grid stretching to the radiative equilibrium example (so that `dz = 100` at the bottom and `dz = 10000` at the top), and it makes grid stretching available for other examples that use `driver.jl`.

In addition, this PR allows non-idealized insolation to work for flat spaces, and it fixes a bug in non-idealized insolation that occurs when `FT = Float32`, though the radiative equilibrium example will continue to use idealized insolation by default.

Closes #349 