### PR TITLE
update jld2 filename

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -193,9 +193,10 @@ end
 function make_save_to_disk_func(output_dir, is_distributed)
     function save_to_disk_func(integrator)
         day = floor(Int, integrator.t / (60 * 60 * 24))
-        @info "Saving prognostic variables to JLD2 file on day $day"
+        sec = Int(mod(integrator.t, 3600 * 24))
+        @info "Saving prognostic variables to JLD2 file on day $day second $sec"
         suffix = is_distributed ? "_pid$pid.jld2" : ".jld2"
-        output_file = joinpath(output_dir, "day$day$suffix")
+        output_file = joinpath(output_dir, "day$day.$sec$suffix")
         jldsave(output_file; t = integrator.t, Y = integrator.u)
         return nothing
     end


### PR DESCRIPTION
Currently, the jld2 data is saved in the format of `dayX.jld2` which contains which day the data is. However, I found it useful to add seconds of the day into the filename when debugging. Usually, I save the data step-by-step on the day the simulation crashes and it overwrites if the filename contains only day info.