### PR TITLE
Unify initial condition functions

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -48,8 +48,6 @@ additional_solver_kwargs = () # e.g., abstol and reltol
 test_implicit_solver = false # makes solver extremely slow when set to `true`
 additional_cache(Y, params, dt) = NamedTuple()
 additional_tendency!(Yₜ, Y, p, t) = nothing
-center_initial_condition(local_geometry, params) = NamedTuple()
-face_initial_condition(local_geometry, params) = NamedTuple()
 postprocessing(sol, output_dir) = nothing
 
 ################################################################################
@@ -137,7 +135,12 @@ else
     ᶜlocal_geometry = Fields.local_geometry_field(center_space)
     ᶠlocal_geometry = Fields.local_geometry_field(face_space)
     Y = Fields.FieldVector(
-        c = center_initial_condition.(ᶜlocal_geometry, params),
+        c = center_initial_condition.(
+            ᶜlocal_geometry,
+            params,
+            Val(energy_name()),
+            Val(moisture_mode()),
+        ),
         f = face_initial_condition.(ᶠlocal_geometry, params),
     )
 end

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -8,6 +8,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe))

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
@@ -10,10 +10,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist_radiation.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist_radiation.jl
@@ -19,10 +19,3 @@ additional_callbacks = (PeriodicCallback(
     FT(6 * 60 * 60); # update RRTMGPModel every 6 hours
     initial_affect = true,
 ),)
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -8,6 +8,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρθ))

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -27,12 +27,18 @@ baroclinic_wave_mesh(; params, h_elem) =
 ## Initial conditions
 ##
 
+function face_initial_condition(local_geometry, params)
+    z = local_geometry.coordinates.z
+    FT = eltype(z)
+    (; w = Geometry.Covariant3Vector(FT(0)))
+end
+
 function center_initial_condition(
     local_geometry,
     params,
-    ᶜ𝔼_name;
+    ᶜ𝔼_name,
+    moisture_mode;
     is_balanced_flow = false,
-    moisture_mode = Val(:dry),
 )
     # Constants from CLIMAParameters
     R_d = FT(Planet.R_d(params))
@@ -148,9 +154,6 @@ function center_initial_condition(
 
     return (; ρ, ᶜ𝔼_kwarg..., uₕ, moisture_kwargs...)
 end
-
-face_initial_condition(local_geometry, params) =
-    (; w = Geometry.Covariant3Vector(FT(0)))
 
 ##
 ## Additional tendencies

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -10,6 +10,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe))

--- a/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
@@ -14,10 +14,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -10,6 +10,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρe_int))

--- a/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
@@ -14,10 +14,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     zero_moment_microphysics_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) = center_initial_condition(
-    local_geometry,
-    params,
-    Val(:ρe_int);
-    moisture_mode = Val(:equil),
-)

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -11,6 +11,3 @@ function additional_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)
     held_suarez_tendency!(Yₜ, Y, p, t)
 end
-
-center_initial_condition(local_geometry, params) =
-    center_initial_condition(local_geometry, params, Val(:ρθ))

--- a/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
+++ b/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
@@ -33,29 +33,34 @@ additional_callbacks = (PeriodicCallback(
     save_positions = (false, false), # do not save Y before and after callback
 ),)
 
-function center_initial_condition(local_geometry, params)
+# TODO: dispatch into this method
+function center_initial_condition(
+    local_geometry,
+    params,
+    ᶜ𝔼_name,
+    moisture_mode,
+)
+    z = local_geometry.coordinates.z
+    FT = eltype(z)
+
     R_d = FT(Planet.R_d(params))
     MSLP = FT(Planet.MSLP(params))
     grav = FT(Planet.grav(params))
-
-    z = local_geometry.coordinates.z
 
     T = FT(300)
     p = MSLP * exp(-z * grav / (R_d * T))
     ρ = p / (R_d * T)
     ts = TD.PhaseDry_ρp(params, ρ, p)
 
-    if 𝔼_name == :ρθ
+    if ᶜ𝔼_name === Val(:ρθ)
         𝔼_kwarg = (; ρθ = ρ * TD.liquid_ice_pottemp(params, ts))
-    elseif 𝔼_name == :ρe
+    elseif ᶜ𝔼_name === Val(:ρe)
         𝔼_kwarg = (; ρe = ρ * (TD.internal_energy(params, ts) + grav * z))
-    elseif 𝔼_name == :ρe_int
+    elseif ᶜ𝔼_name === Val(:ρe_int)
         𝔼_kwarg = (; ρe_int = ρ * TD.internal_energy(params, ts))
     end
     return (; ρ, 𝔼_kwarg..., uₕ = Geometry.Covariant12Vector(FT(0), FT(0)))
 end
-face_initial_condition(local_geometry, params) =
-    (; w = Geometry.Covariant3Vector(FT(0)))
 
 function custom_postprocessing(sol, output_dir)
     get_var(i, var) = Fields.single_field(sol.u[i], var)


### PR DESCRIPTION
This PR unifies IC functions, and removes a closure over `FT`.

This peels a part off from #346.