### PR TITLE
Add allocation analysis to equil held suarez

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -22,6 +22,7 @@ dirs_to_monitor = [
 
 cli_options = [
     ("--TEST_NAME baroclinic_wave_rhoe --job_id alloc_sphere_baroclinic_wave_rhoe"),
+    ("--TEST_NAME held_suarez_rhoe_equilmoist --moist equil --job_id alloc_sphere_held_suarez_rhoe_equilmoist"),
 ]
 #! format: on
 


### PR DESCRIPTION
The moist baro wave and held suarez cases are allocating nearly 2x compared to the dry versions. This PR adds allocation monitoring for the moist held suarez.