### PR TITLE
Add upwinding to Jacobian

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -44,6 +44,10 @@ function parse_commandline()
         help = "Energy variable name [`rhoe` (default), `rhoe_int` , `rhotheta`]"
         arg_type = String
         default = "rhoe"
+        "--upwinding"
+        help = "Upwinding mode [`none`, `first_order` , `third_order` (default)]"
+        arg_type = String
+        default = "third_order"
         "--regression_test"
         help = "(Bool) perform regression test"
         arg_type = Bool

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -30,6 +30,9 @@ energy_name() =
     energy_variable(Val(Symbol(parse_arg(parsed_args, "energy_name", "rhoe")))) # e.g., :ρθ
 @assert energy_name() in (:ρe, :ρe_int, :ρθ)
 
+upwinding_mode() = Symbol(parse_arg(parsed_args, "upwinding", "third_order"))
+@assert upwinding_mode() in (:none, :first_order, :third_order)
+
 # Test-specific definitions (may be overwritten in each test case file)
 # TODO: Allow some of these to be environment variables or command line arguments
 params = nothing
@@ -168,7 +171,7 @@ else
         f = face_initial_condition.(ᶠlocal_geometry, params),
     )
 end
-p = get_cache(Y, params, dt)
+p = get_cache(Y, params, upwinding_mode(), dt)
 
 if ode_algorithm <: Union{
     OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -6,56 +6,56 @@
 all_best_mse = OrderedCollections.OrderedDict()
 #
 all_best_mse["sphere_held_suarez_rhotheta"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.40319557163955005
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.1853519893990248
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 34266.015821027475
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 36065.46033531932
-all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 39035.86901596442
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.4775594337002111
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.19759905652893225
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 34266.015811724246
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 36065.46036982125
+all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 39038.11272905916
 #
 all_best_mse["sphere_held_suarez_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 5.661394027557731
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe)] = 2617.2288641597675
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 35664.58211879597
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 37815.87682311461
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 1.1235221924739871e6
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 37993.16760837382
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 5.577394561047046
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe)] = 2598.4997861700767
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 35664.582231018016
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 37815.87681815437
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 1.120439432983028e6
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 37991.58333627958
 #
 all_best_mse["sphere_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.7473069093787298
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe)] = 6.741451164479781
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 34068.54772506208
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 35670.67757385232
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 45070.130284660016
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.8627451542604228
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe)] = 7.444508533309317
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 34068.54772711041
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 35670.67752342032
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 45067.812083412704
 #
 all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 1.3045295908999257
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe)] = 2196.851655624807
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 32812.21765996959
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 34290.33585538467
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 1.1148473639743039e8
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 51282.91249443253
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 1.0766377376116971
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe)] = 2178.5586836993148
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 32812.21765209773
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 34290.33583812611
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 1.1037792237572859e8
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 51281.75337869067
 #
 all_best_mse["sphere_held_suarez_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 0.4104666901341939
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe)] = 3.731295586299375
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 36072.79321907828
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 38080.091893890814
-all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 37320.94000389826
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 0.5033393662110333
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe)] = 4.421547448586976
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 36072.7932431925
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 38080.0918722839
+all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 37321.12152981984
 #
 all_best_mse["sphere_held_suarez_rhoe_int"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 0.5835797388425713
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 52.98741504759665
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 34340.82083296806
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 36547.61116014529
-all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 44942.453449183566
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 0.6522877308438431
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 58.79965486750936
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 34340.8208803665
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 36547.61117144068
+all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 44945.62015018725
 #
 all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρ)] = 67.4123689710185
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρe_int)] = 37819.63404478892
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 30725.327392883373
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 32458.15018194053
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρq_tot)] = 1.2230006290442871e6
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:f, :w, :components, :data, 1)] = 51690.489076879916
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρ)] = 67.18872931688702
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρe_int)] = 37586.953746244944
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 30725.327405077183
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 32458.150161943526
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρq_tot)] = 1.2150500120713473e6
+all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:f, :w, :components, :data, 1)] = 51690.31526278284
 #
 #! format: on
 #################################


### PR DESCRIPTION
This PR adds a flag for upwinding, which is used in the implicit tendency and the Jacobian computation for the vertical advection of energy and tracer variables. The flag is set just like the energy variable flag (through a command-line argument and a function that returns a symbol). The possible values for this flag are

- `:none`, which uses central differencing for vertical advection; i.e., `ᶜvariableₜ = -ᶜdivᵥ(ᶠinterp(ᶜvariable) * ᶠw)`
- `:first_order`, which uses first-order upwinding; i.e., `ᶜvariableₜ = -ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind_product(ᶠw, ᶜvariable / ᶜρ))`, where `ᶠupwind_product = Operators.UpwindBiasedProductC2F()`
- `:third_order`, which is the same as `:first_order`, but with `ᶠupwind_product = Operators.Upwind3rdOrderBiasedProductC2F(bottom = Operators.FirstOrderOneSided(), top = Operators.FirstOrderOneSided())`

Note that we could also use `Operators.ThirdOrderOneSided()` instead of `Operators.FirstOrderOneSided()` for `:third_order`. I don't think this makes too much of a difference, so I've just hardcoded `Operators.FirstOrderOneSided()` as the default.