### PR TITLE
Add some cli args, unify additional_cache

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -39,25 +39,25 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --t_end 103680000 --job_id longrun_hs_rhoe --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoe --dt_save_to_sol 8640000" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --t_end 103680000 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoe_largerdt/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --t_end 103680000 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoeint_largerdt/*"
         agents:
           slurm_cpus_per_task: 8

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -159,26 +159,26 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_held_suarez_rhotheta_Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --forcing held_suarez --FLOAT_TYPE Float64 --job_id sphere_held_suarez_rhotheta_Float64"
         artifact_paths: "sphere_held_suarez_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --job_id sphere_held_suarez_rhotheta --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --forcing held_suarez --job_id sphere_held_suarez_rhotheta --regression_test true"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_equilmoist --moist equil --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_equilmoist --turbconv const_diffusivity --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 300"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int_equilmoist --energy_name rhoe_int --moist equil --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int_equilmoist --turbconv const_diffusivity --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: single column radiative equilibrium"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --rad clearsky --job_id sphere_single_column_radiative_equilibrium"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --rad clearsky --idealized_h2o true --job_id sphere_single_column_radiative_equilibrium"
         artifact_paths: "sphere_single_column_radiative_equilibrium/*"
 
       - label: ":computer: baroclinic wave (ρe)"
@@ -186,19 +186,19 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist --moist equil --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist radiation"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist_radiation --moist equil --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_radiation --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist_radiation --moist equil --microphy 0M --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_radiation --dt 300"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_radiation/*"
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --job_id sphere_held_suarez_rhoe --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --job_id sphere_held_suarez_rhoe --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --energy_name rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --energy_name rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
   - group: "Performance"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -24,6 +24,19 @@ function parse_commandline()
         help = "Moisture model [`dry` (default), `equil`, `non_equil`]"
         arg_type = String
         default = "dry"
+        "--microphy"
+        help = "Microphysics model [`nothing` (default), `0M`]"
+        arg_type = String
+        "--forcing"
+        help = "Forcing [`nothing` (default), `held_suarez`]"
+        arg_type = String
+        "--turbconv"
+        help = "Turbulence Convection model [`nothing` (default), `const_diffusivity`]"
+        arg_type = String
+        "--idealized_h2o"
+        help = "Use idealized H2O in radiation model [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--rad"
         help = "Radiation model [`clearsky`, `gray`, `allsky`] (default: no radiation)"
         arg_type = String

--- a/examples/hybrid/sphere/README.md
+++ b/examples/hybrid/sphere/README.md
@@ -41,7 +41,10 @@ Commonly used command line arguements for experiment setps:
 * `--enable_threading`: a boolean var to enable multi-threading; defaults to true; Note that Julia must be launched with, for example, `--threads=8`.
 * `--job_id`: a uniquely defined id for a job; is default based on the parsed args of the experiment if not specified;
 * `--output_dir`: specifies the output directory that saves all the jld2 outputs; is default to `job_id` if not specified.
-* `--dt_save_to_disk`: specifies specifies the frequency in seconds to save the data into jld2 files. Defaults to `dt_save_to_disk = 0`, which means no jld2 outputs.
+* `--dt_save_to_disk`: specifies the frequency in seconds to save the data into jld2 files. Defaults to `dt_save_to_disk = 0`, which means no jld2 outputs.
+* `--forcing`: specifies the forcing used. Options: [`nothing` (default), `held_suarez`]
+* `--microphy`: specifies the microphysics scheme used. Options: [`nothing` (default), `0M`]
+* `--turbconv`: specifies the turbulence scheme used. Options: [`nothing` (default), `const_diff`]
 
 To use `held_suarez_rhoe` as an example, one needs to modify [this driver](https://github.com/CliMA/ClimaAtmos.jl/blob/main/examples/hybrid/driver.jl) into the specific setup.
 

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe.jl
@@ -1,7 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist.jl
@@ -1,8 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    zero_moment_microphysics_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist_radiation.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhoe_equilmoist_radiation.jl
@@ -1,9 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    zero_moment_microphysics_cache(Y),
-    rrtmgp_model_cache(Y, params),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_rhotheta.jl
@@ -1,7 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/held_suarez_rhoe.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe.jl
@@ -1,8 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    held_suarez_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_equilmoist.jl
@@ -1,10 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    held_suarez_cache(Y),
-    vertical_diffusion_boundary_layer_cache(Y),
-    zero_moment_microphysics_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int.jl
@@ -1,8 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    held_suarez_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
+++ b/examples/hybrid/sphere/held_suarez_rhoe_int_equilmoist.jl
@@ -1,10 +1,3 @@
-additional_cache(Y, params, dt) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17)),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    held_suarez_cache(Y),
-    vertical_diffusion_boundary_layer_cache(Y),
-    zero_moment_microphysics_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/held_suarez_rhotheta.jl
+++ b/examples/hybrid/sphere/held_suarez_rhotheta.jl
@@ -1,9 +1,3 @@
-additional_cache(Y, params, dt; use_tempest_mode = false) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(2e17),
-        use_tempest_mode = use_tempest_mode),
-    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
-    held_suarez_cache(Y),
-)
 function additional_tendency!(Yₜ, Y, p, t)
     hyperdiffusion_tendency!(Yₜ, Y, p, t)
     sponge && rayleigh_sponge_tendency!(Yₜ, Y, p, t)

--- a/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
+++ b/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
@@ -16,8 +16,6 @@ dt = FT(60 * 60 * 3)
 dt_save_to_sol = 10 * dt
 ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 
-additional_cache(Y, params, dt) =
-    rrtmgp_model_cache(Y, params; idealized_h2o = true)
 additional_tendency!(Yₜ, Y, p, t) = rrtmgp_model_tendency!(Yₜ, Y, p, t)
 additional_callbacks = (PeriodicCallback(
     rrtmgp_model_callback!,

--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -22,7 +22,7 @@ dirs_to_monitor = [
 
 cli_options = [
     ("--TEST_NAME baroclinic_wave_rhoe --job_id alloc_sphere_baroclinic_wave_rhoe"),
-    ("--TEST_NAME held_suarez_rhoe_equilmoist --moist equil --job_id alloc_sphere_held_suarez_rhoe_equilmoist"),
+    ("--TEST_NAME held_suarez_rhoe_equilmoist --turbconv const_diffusivity --moist equil --forcing held_suarez --microphy 0M"),
 ]
 #! format: on
 


### PR DESCRIPTION
I think this proposed pattern is a bit of a balance:

```
additional_cache(Y, params, dt; use_tempest_mode) = merge(
    hyperdiffusion_cache(Y; κ₄ = FT(2e17), use_tempest_mode),
    sponge ? rayleigh_sponge_cache(Y, dt) : NamedTuple(),
    isnothing(micro) ? NamedTuple() : zero_moment_microphysics_cache(Y),
    isnothing(HSF) ? NamedTuple() : held_suarez_cache(Y),
    isnothing(rad) ? NamedTuple() : rrtmgp_model_cache(Y, params; idealized_h2o),
    isnothing(turbconv) ? NamedTuple() : vertical_diffusion_boundary_layer_cache(Y),
)
```
We still use a closure, but everything that's included is kind of directly visible at the top level. Thoughts, @dennisYatunin, @jiahe23 ?

I haven't updated the cli options, yet, since they were being updated in #397.