### PR TITLE
Truncate stack traces

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -61,6 +61,10 @@ function parse_commandline()
         "--job_id"
         help = "Uniquely identifying string for a particular job"
         arg_type = String
+        "--trunc_stack_traces"
+        help = "Set to `true` to truncate printing of ClimaCore `Field`s"
+        arg_type = Bool
+        default = true
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -103,6 +103,7 @@ using OrdinaryDiffEq
 using DiffEqCallbacks
 using JLD2
 
+parsed_args["trunc_stack_traces"] && include("truncate_stack_traces.jl")
 include("../implicit_solver_debugging_tools.jl")
 include("../ordinary_diff_eq_bug_fixes.jl")
 include("../common_spaces.jl")

--- a/examples/hybrid/truncate_stack_traces.jl
+++ b/examples/hybrid/truncate_stack_traces.jl
@@ -1,0 +1,32 @@
+
+function Base.show(io::IO, ::Type{T}) where {T <: ClimaCore.Fields.Field}
+    values_type(::Type{T}) where {V, T <: ClimaCore.Fields.Field{V}} = V
+    V = values_type(T)
+
+    _apply!(f, ::T, match_list) where {T} = nothing # sometimes we need this...
+    function _apply!(f, ::Type{T}, match_list) where {T}
+        if f(T)
+            push!(match_list, T)
+        end
+        for p in T.parameters
+            _apply!(f, p, match_list)
+        end
+    end
+    #=
+        apply(::T) where {T <: Any}
+    Recursively traverse type `T` and apply
+    `f` to the types (and type parameters).
+    Returns a list of matches where `f(T)` is true.
+    =#
+    apply(f, ::T) where {T} = apply(f, T)
+    function apply(f, ::Type{T}) where {T}
+        match_list = []
+        _apply!(f, T, match_list)
+        return match_list
+    end
+
+    nts = apply(x -> x <: NamedTuple, eltype(V))
+    syms = unique(map(nt -> fieldnames(nt), nts))
+    s = join(syms, ",")
+    print(io, "Field{$s} (trunc disp)")
+end


### PR DESCRIPTION
I'm sure people are a bit tired of scrolling through gigantic stack traces. This PR adds a way to truncate stack traces by recursively searching through the type space and collecting all `NamedTuple`s. See this [build](https://buildkite.com/clima/climaatmos-ci/builds/784) for a demo.

With this, and putting the (incorrect) type restriction on `get_cache(::Int)` to throw the error, we get:

```
ERROR: LoadError: MethodError: no method matching get_cache(::ClimaCore.Fields.FieldVector{Float64, NamedTuple{(:c, :f), Tuple{Field{(:ρ, :ρe, :uₕ)} (trunc disp), Field{(:w,)} (trunc disp)}}}, ::BaroclinicWaveParameterSet{NamedTuple{(:dt,), Tuple{Float64}}}, ::Float64)
--
  | Closest candidates are:
  | get_cache(::Int64, ::Any, ::Any) at /central/scratch/esm/slurm-buildkite/climaatmos-ci/784/climaatmos-ci/examples/hybrid/staggered_nonhydrostatic_model.jl:101
  | Stacktrace:
  | [1] top-level scope
  | @ /central/scratch/esm/slurm-buildkite/climaatmos-ci/784/climaatmos-ci/examples/hybrid/driver.jl:171
```