### PR TITLE
Try to fix long runs by not upwinding

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -39,26 +39,14 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoe --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoe --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoeint --dt_save_to_sol 8640000" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoeint --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
-        agents:
-          slurm_cpus_per_task: 8
-
-      - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoe_largerdt --dt_save_to_sol 21600" # 1200 days
-        artifact_paths: "longrun_hs_rhoe_largerdt/*"
-        agents:
-          slurm_cpus_per_task: 8
-
-      - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --job_id longrun_hs_rhoeint_largerdt --dt_save_to_sol 21600" # 1200 days
-        artifact_paths: "longrun_hs_rhoeint_largerdt/*"
         agents:
           slurm_cpus_per_task: 8
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -74,6 +74,10 @@ function parse_commandline()
         help = "Set to `true` to truncate printing of ClimaCore `Field`s"
         arg_type = Bool
         default = true
+        "--fps"
+        help = "Frames per second for animations"
+        arg_type = Int
+        default = 5
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -12,7 +12,7 @@ end
 processed_varname(pc::Tuple) = process_name(join(pc, "_"))
 
 # TODO: Make this a RecipesBase.@recipe
-function profile_animation(sol, output_dir)
+function profile_animation(sol, output_dir, fps)
     # Column animations
     Y0 = first(sol.u)
     for prop_chain in Fields.property_chains(Y0)
@@ -60,11 +60,15 @@ function profile_animation(sol, output_dir)
             )
             Plots.title!("$(space_string(var_space))")
         end
-        Plots.mp4(anim, joinpath(output_dir, "profile_$var_name.mp4"), fps = 5)
+        Plots.mp4(
+            anim,
+            joinpath(output_dir, "profile_$var_name.mp4"),
+            fps = fps,
+        )
     end
 end
 
-function contour_animations(sol, output_dir)
+function contour_animations(sol, output_dir, fps)
     for prop_chain in Fields.property_chains(sol.u[end])
         var_name = processed_varname(prop_chain)
         @info "Creating animation for variable:`$(var_name)`"
@@ -78,11 +82,15 @@ function contour_animations(sol, output_dir)
             clim = (minimum(var), maximum(var))
             Plots.plot(var, level = level, clim = clim)
         end
-        Plots.mp4(anim, joinpath(output_dir, "contour_$var_name.mp4"), fps = 5)
+        Plots.mp4(
+            anim,
+            joinpath(output_dir, "contour_$var_name.mp4"),
+            fps = fps,
+        )
     end
 end
 
-function postprocessing(sol, output_dir)
+function postprocessing(sol, output_dir, fps)
     for prop_chain in Fields.property_chains(sol.u[1])
         var_name = processed_varname(prop_chain)
         var = Fields.single_field(sol.u[1], prop_chain)
@@ -94,13 +102,13 @@ function postprocessing(sol, output_dir)
         @info "L₂ norm of `$(var_name)` at t = $(sol.t[end]): $(norm(var))"
     end
 
-    # contour_animations(sol, output_dir) # For generic contours:
+    # contour_animations(sol, output_dir, fps) # For generic contours:
 
     anim = Plots.@animate for Y in sol.u
         ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
         Plots.plot(ᶜv, level = 3, clim = (-6, 6))
     end
-    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = 5)
+    Plots.mp4(anim, joinpath(output_dir, "v.mp4"), fps = fps)
 
     prop_chains = Fields.property_chains(sol.u[1])
     if any(pc -> pc == (:c, :ρq_tot), prop_chains)
@@ -108,12 +116,12 @@ function postprocessing(sol, output_dir)
             ᶜq_tot = Y.c.ρq_tot ./ Y.c.ρ
             Plots.plot(ᶜq_tot .* FT(1e3), level = 3, clim = (0, 1))
         end
-        Plots.mp4(anim, joinpath(output_dir, "contour_q_tot.mp4"), fps = 5)
+        Plots.mp4(anim, joinpath(output_dir, "contour_q_tot.mp4"), fps = fps)
     else
         @info "Moisture not found. property_chains: `$(prop_chains)`"
     end
 
-    profile_animation(sol, output_dir)
+    profile_animation(sol, output_dir, fps)
 end
 
 # plots in the Ullrish et al 2014 paper: surface pressure, 850 temperature and vorticity at day 8 and day 10

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -4,6 +4,7 @@ include("cli_options.jl")
 const FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
 TEST_NAME = parsed_args["TEST_NAME"]
 
+fps = parsed_args["fps"]
 microphy = parsed_args["microphy"]
 forcing = parsed_args["forcing"]
 idealized_h2o = parsed_args["idealized_h2o"]
@@ -353,7 +354,7 @@ if !is_distributed
     elseif TEST_NAME == "baroclinic_wave_rhoe_equilmoist"
         paperplots_moist_baro_wave_ρe(sol, output_dir, p, FT(90), FT(180))
     else
-        postprocessing(sol, output_dir)
+        postprocessing(sol, output_dir, fps)
     end
 end
 


### PR DESCRIPTION
This PR:
 - Tries to fix the long runs (#409) by not upwinding
 - Removes the low frequency output, since the output is visually difficult to follow
 - Adds `fps` CL arg and sets `fps = 30` for long run animations because they're slow and take time to review