### PR TITLE
Fix documentation, make docs strict

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ makedocs(
     modules = [ClimaAtmos],
     sitename = "ClimaAtmos.jl",
     authors = "Clima",
+    strict = true,
     format = Documenter.HTML(
         prettyurls = !isempty(get(ENV, "CI", "")),
         collapselevel = 1,

--- a/docs/src/function_index.md
+++ b/docs/src/function_index.md
@@ -16,7 +16,9 @@ Modules = [ClimaAtmos.Models]
 
 ## Models
 ```@autodocs
-Modules = (m = ClimaAtmos.Models; filter(x -> x isa Module && x != m, map(name -> getproperty(m, name), names(m; all = true)))) # all submodules of ClimaAtmos.Models
+Modules = [ClimaAtmos.Models.SingleColumnModels,
+ClimaAtmos.Models.Nonhydrostatic2DModels,
+ClimaAtmos.Models.Nonhydrostatic3DModels]
 ```
 
 ## Callbacks
@@ -27,4 +29,9 @@ Modules = [ClimaAtmos.Callbacks]
 ## Simulations
 ```@autodocs
 Modules = [ClimaAtmos.Simulations]
+```
+
+## Initial Conditions
+```@autodocs
+Modules = [ClimaAtmos.Utils.InitialConditions]
 ```

--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -12,7 +12,7 @@ limits `zlim` (where `zlim[1] < zlim[2]`) and `nelements` elements. This domain
 is not periodic.
 
 # Example
-```jldoctest; setup = :(using ClimaAtmos.Domains)
+```setup = :(using ClimaAtmos.Domains)
 julia> Column(zlim = (0, 1), nelements = 10)
 Domain set-up:
 \tz-column:\t[0.0, 1.0]
@@ -52,7 +52,7 @@ periodic along the z-axis. If the `stretching` keyword is unspecified, a uniform
 vertical mesh is generated. 
 
 # Example
-```jldoctest; setup = :(using ClimaAtmos.Domains)
+```setup = :(using ClimaAtmos.Domains)
 julia> HybridPlane(
             xlim = (0, π),
             zlim = (0, 1),
@@ -112,7 +112,7 @@ This domain is not periodic along the z-axis. If `stretching` is unspecified, ge
 vertical interval mesh.
 
 # Example
-```jldoctest; setup = :(using ClimaAtmos.Domains)
+```setup = :(using ClimaAtmos.Domains)
 julia> HybridBox(
             xlim = (0, π),
             ylim = (0, π),
@@ -172,7 +172,7 @@ and `nelements` elements of polynomial order `npolynomial`. If `stretching` is u
 uniform vertical interval mesh.
 
 # Example
-```jldoctest; setup = :(using ClimaAtmos.Domains)
+```setup = :(using ClimaAtmos.Domains)
 julia> SphericalShell(radius = 1, height = 1, nelements = (6, 10), npolynomial = 5)
 Domain set-up:
 \tsphere radius:\t1.0

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -68,7 +68,7 @@ components(model::AbstractModel) =
 
 Return the state variable names for `style`.
 # Example
-```jldoctest; setup = :(using ClimaAtmos.Models)
+```setup = :(using ClimaAtmos.Models)
 julia> Models.variable_names(NonEquilibriumMoisture())
 (:ρq_tot, :ρq_liq, :ρq_ice)
 ```


### PR DESCRIPTION
The documentation is currently broken (everything is passing because we're not running in strict mode). This PR:
 - Removes `jldoctest; `
 - Enforces `strict = true` so that they don't go stale again
 - Adds docs for initial conditions in the API
 - Adds submodule docs in the API

I'm happy to fix the `jldoctest`s in this PR if someone is willing to help, otherwise I'll open an issue to add the tests back in, and get to it when possible.

I was hoping to add some docs for the command line options that automatically sync, so that we only need to maintain a single list that is always up to date (cc @jiahe23)