### PR TITLE
Auto-document CL arguments

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -20,6 +20,12 @@ git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 version = "3.3.3"
 
+[[deps.ArgParse]]
+deps = ["Logging", "TextWrap"]
+git-tree-sha1 = "3102bce13da501c9104df33549f511cd25264d7d"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "1.1.4"
+
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
@@ -192,6 +198,11 @@ git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
 uuid = "adafc99b-e345-5852-983c-f28acb93d879"
 version = "0.3.1"
 
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
 [[deps.CubedSphere]]
 deps = ["Elliptic", "Printf", "Rotations", "TaylorSeries", "Test"]
 git-tree-sha1 = "f66fabd1ee5df59a7ba47c7873a6332c19e0c03f"
@@ -340,6 +351,12 @@ deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticAr
 git-tree-sha1 = "56956d1e4c1221000b7781104c58c34019792951"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
 version = "2.11.0"
+
+[[deps.Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
@@ -699,6 +716,12 @@ git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.3.0"
 
+[[deps.PrettyTables]]
+deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
+git-tree-sha1 = "dfb54c4e414caa595a1f2ed759b160f5a3ddcba5"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "1.3.1"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -930,6 +953,11 @@ version = "0.10.13"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.TextWrap]]
+git-tree-sha1 = "9250ef9b01b66667380cf3275b3f7488d0e25faf"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "1.0.1"
 
 [[deps.Thermodynamics]]
 deps = ["CLIMAParameters", "DocStringExtensions", "KernelAbstractions", "Random", "RootSolvers"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 ClimaAtmos = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(
         "Contributor Guide" => "contributor_guide.md",
         "Function Index" => "function_index.md",
         "Equations" => "equations.md",
+        "Command line arguments" => "cl_args.md",
     ],
 )
 

--- a/docs/src/cl_args.jl
+++ b/docs/src/cl_args.jl
@@ -1,0 +1,17 @@
+const ca_dir = joinpath(@__DIR__, "..", "..")
+include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"))
+using PrettyTables
+(s, parsed_args) = parse_commandline();
+flags = map(arg -> arg.dest_name, s.args_table.fields)
+flag_types = map(arg -> string(arg.arg_type), s.args_table.fields)
+flag_help = map(arg -> arg.help, s.args_table.fields)
+data = hcat(flags, flag_types, flag_help)
+
+pretty_table(
+    data;
+    title = "Command line arguments",
+    header = ["flag", "type", "help msg"],
+    alignment = :l,
+    crop = :none,
+)
+nothing

--- a/docs/src/cl_args.md
+++ b/docs/src/cl_args.md
@@ -1,0 +1,5 @@
+# Command line arguments
+
+```@example
+include("cl_args.jl");
+```


### PR DESCRIPTION
This PR builds ontop of #414 and auto-documents the CL arguments. Here's an example of the output on one of the newly added [doc page](https://clima.github.io/ClimaAtmos.jl/previews/PR415/cl_args/).

I think there's ways that we can improve formatting. It might be nice if we point to this page in the `examples/sphere/README.md`. That way we have a single consistent command line argument list. I'm open to moving that entire readme into the docs proper, too. Let's follow that up in a subsequent PR.