### PR TITLE
Add config flag, move column parts to driver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,7 +138,7 @@ steps:
     steps:
 
       - label: ":computer: single column radiative equilibrium"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --rad clearsky --idealized_h2o true --hyperdiff false --job_id sphere_single_column_radiative_equilibrium"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --rad clearsky --idealized_h2o true --hyperdiff false --config column --job_id sphere_single_column_radiative_equilibrium"
         artifact_paths: "sphere_single_column_radiative_equilibrium/*"
 
       - label: ":computer: baroclinic wave (ρe)"

--- a/examples/common_spaces.jl
+++ b/examples/common_spaces.jl
@@ -30,7 +30,7 @@ function cubed_sphere_mesh(; radius, h_elem)
     return Meshes.EquiangularCubedSphere(domain, h_elem)
 end
 
-function make_horizontal_space(mesh, quad)
+function make_horizontal_space(mesh, quad, ::Nothing)
     if mesh isa Meshes.AbstractMesh1D
         topology = Topologies.IntervalTopology(mesh)
         space = Spaces.SpectralElementSpace1D(topology, quad)
@@ -41,7 +41,7 @@ function make_horizontal_space(mesh, quad)
     return space
 end
 
-function make_distributed_horizontal_space(mesh, quad, comms_ctx)
+function make_horizontal_space(mesh, quad, comms_ctx)
     if mesh isa Meshes.AbstractMesh1D
         error("Distributed mode does not work with 1D horizontal spaces.")
     elseif mesh isa Meshes.AbstractMesh2D

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -20,6 +20,10 @@ function parse_commandline()
         help = "Time between saving to disk, 0 means do not save"
         arg_type = Float64
         default = Float64(0)
+        "--config" # TODO: add box
+        help = "Spatial configuration [`sphere` (default), `column`]"
+        arg_type = String
+        default = "sphere"
         "--moist"
         help = "Moisture model [`dry` (default), `equil`, `non_equil`]"
         arg_type = String

--- a/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
+++ b/examples/hybrid/sphere/single_column_radiative_equilibrium.jl
@@ -1,20 +1,9 @@
-using PrettyTables
-
 struct EarthParameterSet <: AbstractEarthParameterSet end
 
-Δx = FT(1) # Note: This value shouldn't matter, since we only have 1 column.
-
 params = EarthParameterSet()
-horizontal_mesh =
-    periodic_rectangle_mesh(; x_max = Δx, y_max = Δx, x_elem = 1, y_elem = 1)
-quad = Spaces.Quadratures.GL{1}()
-z_max = FT(70e3)
-z_elem = 70
-z_stretch = Meshes.GeneralizedExponentialStretching(FT(100), FT(10000))
 t_end = FT(60 * 60 * 24 * 365.25)
 dt = FT(60 * 60 * 3)
 dt_save_to_sol = 10 * dt
-ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 
 additional_callbacks = (PeriodicCallback(
     rrtmgp_model_callback!,


### PR DESCRIPTION
This PR:
 - Adds the `config` CL option, and uses it for the column radiation case
 - Combines `make_distributed_horizontal_space` and `make_horizontal_space` and use dispatch
 - inlines some included contents in `single_column_radiative_equilibrium.jl`
 - Adds a TODO for a bug I found in the restart block:
```
    # TODO:   quad, horizontal_mesh, z_stretch,
    #         z_max, z_elem should be taken from Y.
```
Otherwise restarting can result in inconsistent grid data.

This is another small step towards removing the `TEST_NAME` flag.