### PR TITLE
Remove TEST_NAME

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -39,13 +39,13 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoe --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoe --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoe/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoeint --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoeint --dt_save_to_sol 21600" # 1200 days
         artifact_paths: "longrun_hs_rhoeint/*"
         agents:
           slurm_cpus_per_task: 8
@@ -55,7 +55,7 @@ steps:
     steps:
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --dt 300 --t_end 69120000 --fps 30 --job_id longrun_hs_rhoe_dt300 --dt_save_to_sol 21600" # 800 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --dt 300 --t_end 69120000 --fps 30 --job_id longrun_hs_rhoe_dt300 --dt_save_to_sol 21600" # 800 days
         artifact_paths: "longrun_hs_rhoe_dt300/*"
         agents:
           slurm_cpus_per_task: 8

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,7 @@ steps:
     steps:
 
       - label: ":computer: MPI baroclinic wave (ρe)"
-        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --job_id mpi_baroclinic_wave_rhoe"
+        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --job_id mpi_baroclinic_wave_rhoe"
         artifact_paths: "mpi_baroclinic_wave_rhoe/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -115,63 +115,63 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhoe_Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhoe_Float64"
         artifact_paths: "sphere_baroclinic_wave_rhoe_Float64/*"
 
       - label: ":computer: baroclinic wave (ρθ) Float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhotheta --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64"
         artifact_paths: "sphere_baroclinic_wave_rhotheta_Float64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhotheta --energy_name rhotheta --forcing held_suarez --job_id sphere_held_suarez_rhotheta --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --energy_name rhotheta --forcing held_suarez --job_id sphere_held_suarez_rhotheta --regression_test true"
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_equilmoist --vert_diff true --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 200 --t_end 432000"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 200 --t_end 432000"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int_equilmoist --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200 --t_end 432000"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200 --t_end 432000"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: single column radiative equilibrium"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME single_column_radiative_equilibrium --rad clearsky --idealized_h2o true --hyperdiff false --config column --t_end 31536000 --dt 10800 --dt_save_to_sol 108000 --job_id sphere_single_column_radiative_equilibrium"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --rad clearsky --idealized_h2o true --hyperdiff false --config column --t_end 31536000 --dt 10800 --dt_save_to_sol 108000 --job_id sphere_single_column_radiative_equilibrium"
         artifact_paths: "sphere_single_column_radiative_equilibrium/*"
 
       - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe --job_id sphere_baroclinic_wave_rhoe --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --regression_test true"
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist radiation"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME baroclinic_wave_rhoe_equilmoist_radiation --moist equil --microphy 0M --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_radiation --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_radiation --dt 300"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_radiation/*"
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe --forcing held_suarez --job_id sphere_held_suarez_rhoe --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --forcing held_suarez --job_id sphere_held_suarez_rhoe --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe/*"
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --TEST_NAME held_suarez_rhoe_int --forcing held_suarez --energy_name rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --forcing held_suarez --energy_name rhoe_int --job_id sphere_held_suarez_rhoe_int --regression_test true"
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
   - group: "Performance"
     steps:
 
       - label: ":rocket: flame graph: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=perf perf/flame.jl --TEST_NAME baroclinic_wave_rhoe --job_id flame_sphere_baroclinic_wave_rhoe"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_sphere_baroclinic_wave_rhoe"
         artifact_paths: "flame_sphere_baroclinic_wave_rhoe/*"
         env:
           CI_PERF_CPUPROFILE: "true"
 
       - label: ":rocket: benchmark: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --TEST_NAME baroclinic_wave_rhoe --job_id bm_sphere_baroclinic_wave_rhoe"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"
         env:
           CI_PERF_CPUPROFILE: "true"
 

--- a/examples/hybrid/classify_case.jl
+++ b/examples/hybrid/classify_case.jl
@@ -1,0 +1,8 @@
+is_baro_wave(parsed_args) =
+    all((parsed_args["config"] == "sphere", parsed_args["forcing"] == nothing))
+
+is_column_radiative_equilibrium(parsed_args) = all((
+    parsed_args["config"] == "column",
+    parsed_args["forcing"] == nothing,
+    parsed_args["rad"] != nothing,
+))

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -65,9 +65,6 @@ function parse_commandline()
         help = "Enable multi-threading. Note: Julia must be launched with (e.g.,) `--threads=8`"
         arg_type = Bool
         default = true
-        "--TEST_NAME"
-        help = "Job name"
-        arg_type = String
         "--output_dir"
         help = "Output directory"
         arg_type = String

--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -124,6 +124,17 @@ function postprocessing(sol, output_dir, fps)
     profile_animation(sol, output_dir, fps)
 end
 
+# Dispatcher:
+paperplots_baro_wave(args...) =
+    paperplots_baro_wave(Val(energy_name()), Val(moisture_mode()), args...)
+
+paperplots_baro_wave(::Val{:ρθ}, ::Val{:dry}, args...) =
+    paperplots_baro_wave_ρθ(args...)
+paperplots_baro_wave(::Val{:ρe}, ::Val{:dry}, args...) =
+    paperplots_baro_wave_ρe(args...)
+paperplots_baro_wave(::Val{:ρe}, ::Val{:equil}, args...) =
+    paperplots_moist_baro_wave_ρe(args...)
+
 # plots in the Ullrish et al 2014 paper: surface pressure, 850 temperature and vorticity at day 8 and day 10
 function paperplots_baro_wave_ρθ(sol, output_dir, p, nlat, nlon)
     (; ghost_buffer, ᶜts, ᶜp, params) = p

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,8 +1,8 @@
 include("cli_options.jl")
+include("classify_case.jl")
 (s, parsed_args) = parse_commandline()
 
 const FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
-TEST_NAME = parsed_args["TEST_NAME"]
 
 fps = parsed_args["fps"]
 microphy = parsed_args["microphy"]
@@ -133,7 +133,7 @@ include("../common_spaces.jl")
 include(joinpath("sphere", "baroclinic_wave_utilities.jl"))
 
 # Variables required for driver.jl (modify as needed)
-params = if TEST_NAME == "single_column_radiative_equilibrium"
+params = if is_column_radiative_equilibrium(parsed_args)
     EarthParameterSet()
 else
     BaroclinicWaveParameterSet((; dt))
@@ -364,14 +364,10 @@ import OrderedCollections
 include(joinpath(@__DIR__, "define_post_processing.jl"))
 if !is_distributed
     ENV["GKSwstype"] = "nul" # avoid displaying plots
-    if TEST_NAME == "baroclinic_wave_rhoe"
-        paperplots_baro_wave_ρe(sol, output_dir, p, FT(90), FT(180))
-    elseif TEST_NAME == "baroclinic_wave_rhotheta"
-        paperplots_baro_wave_ρθ(sol, output_dir, p, FT(90), FT(180))
-    elseif TEST_NAME == "single_column_radiative_equilibrium"
+    if is_baro_wave(parsed_args)
+        paperplots_baro_wave(sol, output_dir, p, FT(90), FT(180))
+    elseif is_column_radiative_equilibrium(parsed_args)
         custom_postprocessing(sol, output_dir)
-    elseif TEST_NAME == "baroclinic_wave_rhoe_equilmoist"
-        paperplots_moist_baro_wave_ρe(sol, output_dir, p, FT(90), FT(180))
     else
         postprocessing(sol, output_dir, fps)
     end

--- a/examples/hybrid/sphere/README.md
+++ b/examples/hybrid/sphere/README.md
@@ -27,14 +27,13 @@ DRIVER=$CA_EXAMPLE'hybrid/driver.jl'
 julia --project=$CA_EXAMPLE -e 'using Pkg; Pkg.instantiate()'
 julia --project=$CA_EXAMPLE -e 'using Pkg; Pkg.API.precompile()'
 
-julia --project=$CA_EXAMPLE --threads=8 $DRIVER --TEST_NAME held_suarez_rhoe --output_dir=$YOUR_SIMULATION_OUTPUT_DIR
+julia --project=$CA_EXAMPLE --threads=8 $DRIVER --forcing held_suarez --output_dir=$YOUR_SIMULATION_OUTPUT_DIR
 
 ```
 In the runscript, one needs to specify the following environmant variable:
 * `RESTART_FILE`: if run from a pre-existing jld2 data saved from a previous simulation.
 
 Commonly used command line arguements for experiment setps:
-* `--TEST_NAME`: specifies which experiment are to run (e.g., baroclinic_wave_rhoe);
 * `--t_end`: specifies the simulation time in seconds;
 * `--FLOAT_TYPE`: can be Float32 or Float64; is default to Float32 if not specified;
 * `--regression_test`: a boolean var to specify whether the regression test is performed; is default to true if not specified;

--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -21,8 +21,8 @@ dirs_to_monitor = [
 #! format: off
 
 cli_options = [
-    ("--TEST_NAME baroclinic_wave_rhoe --job_id alloc_sphere_baroclinic_wave_rhoe"),
-    ("--TEST_NAME held_suarez_rhoe_equilmoist --vert_diff true --moist equil --forcing held_suarez --microphy 0M"),
+    ("--job_id alloc_sphere_baroclinic_wave_rhoe"),
+    ("--vert_diff true --moist equil --forcing held_suarez --microphy 0M"),
 ]
 #! format: on
 


### PR DESCRIPTION
This PR removes the `TEST_NAME` flag, and adds two functions: `is_baro_wave`, `is_column_radiative_equilibrium` which are in some ways similar to `TEST_NAME`-- except that they're determined from the configuration, physics, etc. not the other way around.

We could effectively inline these functions, but it's not clear to me what all the right "boxes" are for each core config/model/physics we want to pivot off of.