### PR TITLE
Add time_to_string func for cl args

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -39,13 +39,13 @@ steps:
       # TODO: Add all milestone long simulation runs
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoe --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --t_end 1200days --upwinding none --fps 30 --job_id longrun_hs_rhoe --dt_save_to_sol 6hours"
         artifact_paths: "longrun_hs_rhoe/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_int)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --energy_name rhoe_int --t_end 103680000 --upwinding none --fps 30 --job_id longrun_hs_rhoeint --dt_save_to_sol 21600" # 1200 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --energy_name rhoe_int --t_end 1200days --upwinding none --fps 30 --job_id longrun_hs_rhoeint --dt_save_to_sol 6hours"
         artifact_paths: "longrun_hs_rhoeint/*"
         agents:
           slurm_cpus_per_task: 8
@@ -55,7 +55,7 @@ steps:
     steps:
 
       - label: ":computer: held suarez (ρe)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --dt 300 --t_end 69120000 --fps 30 --job_id longrun_hs_rhoe_dt300 --dt_save_to_sol 21600" # 800 days
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --dt 300secs --t_end 800days --fps 30 --job_id longrun_hs_rhoe_dt300 --dt_save_to_sol 6hours"
         artifact_paths: "longrun_hs_rhoe_dt300/*"
         agents:
           slurm_cpus_per_task: 8

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,18 +127,18 @@ steps:
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 200 --t_end 432000"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 200secs --t_end 5days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200 --t_end 432000"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200secs --t_end 5days"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Milestones"
     steps:
 
       - label: ":computer: single column radiative equilibrium"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --rad clearsky --idealized_h2o true --hyperdiff false --config column --t_end 31536000 --dt 10800 --dt_save_to_sol 108000 --job_id sphere_single_column_radiative_equilibrium"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --rad clearsky --idealized_h2o true --hyperdiff false --config column --t_end 654days --dt 3hours --dt_save_to_sol 30hours --job_id sphere_single_column_radiative_equilibrium"
         artifact_paths: "sphere_single_column_radiative_equilibrium/*"
 
       - label: ":computer: baroclinic wave (ρe)"
@@ -146,7 +146,7 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 300secs"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe)"
@@ -158,7 +158,7 @@ steps:
         artifact_paths: "sphere_held_suarez_rhoe_int/*"
 
       - label: ":computer: aquaplanet (ρe) equilmoist gray radiation"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --rad gray --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_gray --dt 200 --t_end 432000"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --rad gray --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_gray --dt 200secs --t_end 5days"
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_gray/*"
 
   - group: "Performance"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -7,19 +7,21 @@ function parse_commandline()
         arg_type = String
         default = "Float32"
         "--t_end"
-        help = "Simulation end time"
-        arg_type = Float64
+        help = "Simulation end time. Examples: [`1200days`, `40secs`]"
+        arg_type = String
+        default = "10days"
         "--dt"
-        help = "Simulation time step"
-        arg_type = Float64
-        "--dt_save_to_sol" # TODO: should we default to Inf?
-        help = "Time between saving solution, 0 means do not save"
-        arg_type = Float64
-        default = Float64(60 * 60 * 24)
+        help = "Simulation time step. Examples: [`10secs`, `1hours`]"
+        arg_type = String
+        default = "400secs"
+        "--dt_save_to_sol"
+        help = "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"
+        arg_type = String
+        default = "1days"
         "--dt_save_to_disk"
-        help = "Time between saving to disk, 0 means do not save"
-        arg_type = Float64
-        default = Float64(0)
+        help = "Time between saving to disk. Examples: [`10secs`, `1hours`, `Inf` (do not save)]"
+        arg_type = String
+        default = "Inf"
         "--config" # TODO: add box
         help = "Spatial configuration [`sphere` (default), `column`]"
         arg_type = String


### PR DESCRIPTION
@jiahe23 suggested enabling specifying `t_end` with `20days` or `20secs`. This PR adds support for this and updates the docs accordingly. For now I've added this to `t_end` and `dt`, would it be useful for other CL args?