### PR TITLE
Fix test command in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ julia>]
 Currently, the simulations are stored in the `test` folder. Run all the test cases with:
 
 ```
-$ julia --project test/runtests.jl
+$ julia --project=test test/runtests.jl
 ```
 
 ## Contributing


### PR DESCRIPTION
While installing, it seemed like this test command was wrong:

```
michaels-mbp:ClimaAtmos.jl mike$ julia --project test/runtests.jl
ERROR: LoadError: package `ClimaAtmos [b2c96348]` has the same name or UUID as the active project
Stacktrace:
 [1] pkgerror(msg::String)
   @ Pkg.Types /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/Types.jl:68
 [2] develop(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; shared::Bool, preserve::Pkg.Types.PreserveLevel, platform::Base.BinaryPlatforms.Platform, kwargs::Base.Pairs{Symbol, Base.TTY, Tuple{Symbol}, NamedTuple{(:io,), Tuple{Base.TTY}}})
   @ Pkg.API /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/API.jl:208
 [3] develop(pkgs::Vector{Pkg.Types.PackageSpec}; io::Base.TTY, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Pkg.API /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/API.jl:149
 [4] develop(pkgs::Vector{Pkg.Types.PackageSpec})
   @ Pkg.API /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/API.jl:144
 [5] #develop#14
   @ /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/API.jl:141 [inlined]
 [6] develop(pkg::Pkg.Types.PackageSpec)
   @ Pkg.API /usr/local/Cellar/julia/1.7.2/share/julia/stdlib/v1.7/Pkg/src/API.jl:141
 [7] top-level scope
   @ ~/projects/ClimaAtmos.jl/test/runtests.jl:3
in expression starting at /Users/mike/projects/ClimaAtmos.jl/test/runtests.jl:1
```

However, with the `--project=test` change (which I got by comparing to buildkite config), tests ran & passed.

```
michaels-mbp:ClimaAtmos.jl mike$ julia --project=test test/runtests.jl
   Resolving package versions...
    Updating `~/projects/ClimaAtmos.jl/test/Project.toml`
  [b2c96348] + ClimaAtmos v0.1.0 `~/projects/ClimaAtmos.jl`
    Updating `~/projects/ClimaAtmos.jl/test/Manifest.toml`
  [b2c96348] + ClimaAtmos v0.1.0 `~/projects/ClimaAtmos.jl`
   Resolving package versions...
  No Changes to `~/projects/ClimaAtmos.jl/test/Project.toml`
  No Changes to `~/projects/ClimaAtmos.jl/test/Manifest.toml`
   Resolving package versions...
  No Changes to `~/projects/ClimaAtmos.jl/test/Project.toml`
  No Changes to `~/projects/ClimaAtmos.jl/test/Manifest.toml`
Test Summary: | Pass  Total
ClimaAtmos    |  333    333
```

Not sure that I didn't miss something, here, though.