### PR TITLE
Centralize output folder

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -285,7 +285,8 @@ job_id = if isnothing(parsed_args["job_id"])
 else
     parsed_args["job_id"]
 end
-output_dir = parse_arg(parsed_args, "output_dir", job_id)
+default_output = haskey(ENV, "CI") ? job_id : joinpath("output", job_id)
+output_dir = parse_arg(parsed_args, "output_dir", default_output)
 @info "Output directory: `$output_dir`"
 mkpath(output_dir)
 


### PR DESCRIPTION
~This PR centralizes the output folder for all jobs that use the driver (+ the TC example).~

I was thinking a bit about what I previously did (prepending `output/` for all jobs), and it was a bit more complicated than what I really wanted--which is to only do this locally. We always print the output folder to the log, so it should always be clear. I think this is actually a lot simpler, though. This will help users from having too cluttered package directories. I need to double check that `haskey(ENV, "CI")` works on buildkite, if so then I think this solution should be fine.

Closes #407.