### PR TITLE
Improve postproc for dry held-suarez

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -393,6 +393,8 @@ if !is_distributed
         paperplots_baro_wave(sol, output_dir, p, FT(90), FT(180))
     elseif is_column_radiative_equilibrium(parsed_args)
         custom_postprocessing(sol, output_dir)
+    elseif forcing == "held_suarez" && t_end >= (3600 * 24 * 400)
+        paperplots_held_suarez(sol, output_dir, p, FT(90), FT(180))
     else
         postprocessing(sol, output_dir, fps)
     end


### PR DESCRIPTION
This postproc is only turned on when the simulation time is greater or equal to 400 days. The first 200 days are thrown away for the statistics computation.

It produces plots comparable to Figs 1-3 in [this paper](https://journals.ametsoc.org/view/journals/bams/75/10/1520-0477_1994_075_1825_apftio_2_0_co_2.xml?tab_body=pdf). Fig 4 needs additional capability of spectra calculation, which will be added later.

closes #421 