### PR TITLE
Define and use some types

### DIFF
--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -128,26 +128,26 @@ end
 # Dispatcher:
 # baroclinic wave
 paperplots_baro_wave(args...) =
-    paperplots_baro_wave(Val(energy_name()), Val(moisture_mode()), args...)
+    paperplots_baro_wave(energy_form(), moisture_model(), args...)
 
-paperplots_baro_wave(::Val{:ρθ}, ::Val{:dry}, args...) =
+paperplots_baro_wave(::PotentialTemperature, ::DryModel, args...) =
     paperplots_baro_wave_ρθ(args...)
-paperplots_baro_wave(::Val{:ρe}, ::Val{:dry}, args...) =
+paperplots_baro_wave(::TotalEnergy, ::DryModel, args...) =
     paperplots_baro_wave_ρe(args...)
-paperplots_baro_wave(::Val{:ρe}, ::Val{:equil}, args...) =
+paperplots_baro_wave(::TotalEnergy, ::EquilMoistModel, args...) =
     paperplots_moist_baro_wave_ρe(args...)
 
 # held-suarez
 paperplots_held_suarez(args...) =
-    paperplots_held_suarez(Val(energy_name()), Val(moisture_mode()), args...)
+    paperplots_held_suarez(energy_form(), moisture_model(), args...)
 
-paperplots_held_suarez(::Val{:ρθ}, ::Val{:dry}, args...) =
+paperplots_held_suarez(::PotentialTemperature, ::DryModel, args...) =
     paperplots_dry_held_suarez_ρθ(args...)
-paperplots_held_suarez(::Val{:ρe}, ::Val{:dry}, args...) =
+paperplots_held_suarez(::TotalEnergy, ::DryModel, args...) =
     paperplots_dry_held_suarez_ρe(args...)
-paperplots_held_suarez(::Val{:ρe_int}, ::Val{:dry}, args...) =
+paperplots_held_suarez(::InternalEnergy, ::DryModel, args...) =
     paperplots_dry_held_suarez_ρe_int(args...)
-paperplots_held_suarez(::Val{:ρe}, ::Val{:equil}, args...) =
+paperplots_held_suarez(::TotalEnergy, ::EquilMoistModel, args...) =
     paperplots_moist_held_suarez_ρe(args...)
 
 # plots in the Ullrish et al 2014 paper: surface pressure, 850 temperature and vorticity at day 8 and day 10

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -6,8 +6,8 @@ using CLIMAParameters: AbstractEarthParameterSet, Planet, astro_unit
 
 function rrtmgp_model_cache(
     Y,
-    params;
-    radiation_mode = RRTMGPI.ClearSkyRadiation(),
+    params,
+    radiation_mode::RRTMGPI.AbstractRadiationMode = RRTMGPI.ClearSkyRadiation();
     interpolation = RRTMGPI.BestFit(),
     bottom_extrapolation = RRTMGPI.SameAsInterpolation(),
     idealized_insolation = true,

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -1,0 +1,74 @@
+abstract type AbstractMoistureModel end
+struct DryModel <: AbstractMoistureModel end
+struct EquilMoistModel <: AbstractMoistureModel end
+struct NonEquilMoistModel <: AbstractMoistureModel end
+
+function moisture_model(parsed_args)
+    moisture_name = parsed_args["moist"]
+    @assert moisture_name in ("dry", "equil", "nonequil")
+    return if moisture_name == "dry"
+        DryModel()
+    elseif moisture_name == "equil"
+        EquilMoistModel()
+    elseif moisture_name == "nonequil"
+        NonEquilMoistModel()
+    end
+end
+
+abstract type AbstractEnergyFormulation end
+struct PotentialTemperature <: AbstractEnergyFormulation end
+struct TotalEnergy <: AbstractEnergyFormulation end
+struct InternalEnergy <: AbstractEnergyFormulation end
+
+function energy_form(parsed_args)
+    energy_name = parse_arg(parsed_args, "energy_name", "rhoe")
+    @assert energy_name in ("rhoe", "rhoe_int", "rhotheta")
+    return if energy_name == "rhoe"
+        TotalEnergy()
+    elseif energy_name == "rhoe_int"
+        InternalEnergy()
+    elseif energy_name == "rhotheta"
+        PotentialTemperature()
+    end
+end
+
+
+function radiation_model(parsed_args)
+    radiation_name = parsed_args["rad"]
+    @assert radiation_name in (nothing, "clearsky", "gray", "allsky")
+    return if radiation_name == "clearsky"
+        RRTMGPI.ClearSkyRadiation()
+    elseif radiation_name == "gray"
+        RRTMGPI.GrayRadiation()
+    elseif radiation_name == "allsky"
+        RRTMGPI.AllSkyRadiation()
+    else
+        nothing
+    end
+end
+
+abstract type AbstractMicrophysicsModel end
+struct Microphysics0Moment <: AbstractMicrophysicsModel end
+
+function microphysics_model(parsed_args)
+    microphysics_name = parsed_args["microphy"]
+    @assert microphysics_name in (nothing, "0M")
+    return if microphysics_name == nothing
+        nothing
+    elseif microphysics_name == "0M"
+        Microphysics0Moment()
+    end
+end
+
+abstract type AbstractForcing end
+struct HeldSuarezForcing <: AbstractForcing end
+
+function forcing_type(parsed_args)
+    forcing = parsed_args["forcing"]
+    @assert forcing in (nothing, "held_suarez")
+    return if forcing == nothing
+        nothing
+    elseif forcing == "held_suarez"
+        HeldSuarezForcing()
+    end
+end


### PR DESCRIPTION
This PR is a prep PR for adding edmf. It makes more sense to use dispatch over further specializing with `Val` over more symbols that come with using edmf. So, this PR adds and uses some types, some of which will be used to create an edmf model, so that we can create the state vector. I think that the cache is nearly finished / compatible, so we're getting pretty close.

None of this is final, I think there's still many changes to come, it's just a small step towards being compatible with edmf requirements.

Once all of this is in, @dennisYatunin can apply the driver revamp and I suspect much of this will be more polished