### PR TITLE
Add surface temperature as default cache variable

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -146,7 +146,7 @@ ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 
 additional_callbacks = if !isnothing(radiation_model())
     # TODO: better if-else criteria?
-    dt_rad = parsed_args["config"] == "column" ? dt : FT(6 * 60 * 60)
+    dt_rad = parsed_args["config"] == "column" ? dt : FT(5 * 60 * 60)
     (
         PeriodicCallback(
             rrtmgp_model_callback!,

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -119,9 +119,9 @@ function rrtmgp_model_cache(
         interpolation,
         bottom_extrapolation,
         add_isothermal_boundary_layer = true,
-        center_pressure = NaN, # initialized in tendency
-        center_temperature = NaN, # initialized in tendency
-        surface_temperature = (@. 29 * exp(-(latitude / 26)^2 / 2) + 271),
+        center_pressure = NaN, # initialized in callback
+        center_temperature = NaN, # initialized in callback
+        surface_temperature = NaN, # initialized in callback
         surface_emissivity = mean(input_data["surface_emissivity"]),
         direct_sw_surface_albedo = mean(input_data["surface_albedo"]),
         diffuse_sw_surface_albedo = mean(input_data["surface_albedo"]),
@@ -158,7 +158,7 @@ function rrtmgp_model_callback!(integrator)
     p = integrator.p
     t = integrator.t
 
-    (; ᶜK, ᶜΦ, ᶜts, ᶜp, params) = p
+    (; ᶜK, ᶜΦ, ᶜts, ᶜp, T_sfc, params) = p
     (; ᶜT, ᶜvmr_h2o, insolation_tuple, zenith_angle, weighted_irradiance) = p
     (; ᶠradiation_flux, idealized_insolation, idealized_h2o, rrtmgp_model) = p
 
@@ -175,6 +175,7 @@ function rrtmgp_model_callback!(integrator)
     @. ᶜT = TD.air_temperature(params, ᶜts)
     rrtmgp_model.center_pressure .= RRTMGPI.field2array(ᶜp)
     rrtmgp_model.center_temperature .= RRTMGPI.field2array(ᶜT)
+    rrtmgp_model.surface_temperature .= RRTMGPI.field2array(T_sfc)
 
     if !(rrtmgp_model.radiation_mode isa RRTMGPI.GrayRadiation)
         if idealized_h2o

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -353,7 +353,7 @@ function eddy_diffusivity_coefficient(norm_v_a, z_a, p)
 end
 
 function constant_T_saturated_surface_coefs(
-    lat,
+    T_sfc,
     ts_int,
     uₕ_int,
     z_int,
@@ -362,7 +362,6 @@ function constant_T_saturated_surface_coefs(
     Ch,
     params,
 )
-    T_sfc = 29 * exp(-lat^2 / (2 * 26^2)) + 271
     T_int = TD.air_temperature(params, ts_int)
     Rm_int = TD.gas_constant_air(params, ts_int)
     ρ_sfc =
@@ -398,7 +397,7 @@ end
 
 function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     ᶜρ = Y.c.ρ
-    (; ᶜts, ᶜp, ᶠv_a, ᶠz_a, ᶠK_E) = p # assume ᶜts and ᶜp have been updated
+    (; ᶜts, ᶜp, T_sfc, ᶠv_a, ᶠz_a, ᶠK_E) = p # assume ᶜts and ᶜp have been updated
     (; flux_coefficients, dif_flux_energy, dif_flux_ρq_tot, Cd, Ch, params) = p
 
     ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
@@ -410,7 +409,7 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
 
     flux_coefficients .=
         constant_T_saturated_surface_coefs.(
-            Spaces.level(Fields.coordinate_field(Y.c).lat, 1),
+            T_sfc,
             Spaces.level(ᶜts, 1),
             Geometry.UVVector.(Spaces.level(Y.c.uₕ, 1)),
             Spaces.level(Fields.coordinate_field(Y.c).z, 1),

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -111,11 +111,14 @@ function default_cache(Y, params, upwinding_mode)
     if eltype(ᶜcoord) <: Geometry.LatLongZPoint
         Ω = FT(Planet.Omega(params))
         ᶜf = @. 2 * Ω * sind(ᶜcoord.lat)
+        lat_sfc = Fields.level(ᶜcoord.lat, 1)
     else
         f = FT(f_plane_coriolis_frequency(params))
         ᶜf = map(_ -> f, ᶜcoord)
+        lat_sfc = map(_ -> FT(0), Fields.level(ᶜcoord, 1))
     end
     ᶜf = @. Geometry.Contravariant3Vector(Geometry.WVector(ᶜf))
+    T_sfc = @. 29 * exp(-lat_sfc^2 / (2 * 26^2)) + 271
     if (
         :ρq_liq in propertynames(Y.c) &&
         :ρq_ice in propertynames(Y.c) &&
@@ -138,6 +141,7 @@ function default_cache(Y, params, upwinding_mode)
         ᶠu¹² = similar(Y.f, Geometry.Contravariant12Vector{FT}),
         ᶠu³ = similar(Y.f, Geometry.Contravariant3Vector{FT}),
         ᶜf,
+        T_sfc,
         ∂ᶜK∂ᶠw_data = similar(
             Y.c,
             Operators.StencilCoefs{-half, half, NTuple{2, FT}},


### PR DESCRIPTION
This PR puts `T_sfc` in the default cache and uses it to compute `vertical_diffusion_boundary_layer_tendency!` and `rrtmgp_model_tendency!`. The value of `T_sfc` is `29 * exp(-lat_sfc^2 / (2 * 26^2)) + 271`, where `lat_sfc` is the latitude of points on the surface in a spherical space and 0 degrees in a flat space.

Closes #451 