### PR TITLE
change gray radiation parameters

### DIFF
--- a/examples/RRTMGPInterface.jl
+++ b/examples/RRTMGPInterface.jl
@@ -1178,7 +1178,7 @@ function compute_optical_props_kernel!(
         p_lev[glay, gcol],
         p_lev[glay + 1, gcol],
         p_lev[1, gcol],
-        FT(0.22), # hardcode the value of τ₀ for shortwave gray radiation
+        FT(0), # hardcode the value of τ₀ for shortwave gray radiation
     )
     if op isa RRTMGP.Optics.TwoStream
         op.ssa[glaycol...] = FT(0)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -146,7 +146,7 @@ ode_algorithm = OrdinaryDiffEq.Rosenbrock23
 
 additional_callbacks = if !isnothing(radiation_model())
     # TODO: better if-else criteria?
-    dt_rad = parsed_args["config"] == "column" ? dt : FT(5 * 60 * 60)
+    dt_rad = parsed_args["config"] == "column" ? dt : FT(6 * 60 * 60)
     (
         PeriodicCallback(
             rrtmgp_model_callback!,

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -22,9 +22,8 @@ function rrtmgp_model_cache(
     if radiation_mode isa RRTMGPI.GrayRadiation
         kwargs = (;
             lapse_rate = 3.5,
-            optical_thickness_parameter = (@. (
-                (300 + 60 * (FT(1 / 3) - sind(latitude)^2)) / 200
-            )^4 - 1),
+            optical_thickness_parameter = (@. 7.2 +
+                                              (1.8 - 7.2) * sind(latitude)^2),
         )
     else
         # the pressure and ozone concentrations are provided for each of 100
@@ -108,8 +107,6 @@ function rrtmgp_model_cache(
         error("idealized_h2o cannot be used with GrayRadiation")
     end
 
-    # surface_emissivity and surface_albedo are provided for each of 100 sites,
-    # which we average across
     rrtmgp_model = RRTMGPI.RRTMGPModel(
         params;
         FT = Float64,
@@ -122,9 +119,9 @@ function rrtmgp_model_cache(
         center_pressure = NaN, # initialized in callback
         center_temperature = NaN, # initialized in callback
         surface_temperature = NaN, # initialized in callback
-        surface_emissivity = mean(input_data["surface_emissivity"]),
-        direct_sw_surface_albedo = mean(input_data["surface_albedo"]),
-        diffuse_sw_surface_albedo = mean(input_data["surface_albedo"]),
+        surface_emissivity = FT(1),
+        direct_sw_surface_albedo = FT(0.38),
+        diffuse_sw_surface_albedo = FT(0.38),
         solar_zenith_angle,
         weighted_irradiance,
         kwargs...,


### PR DESCRIPTION
This PR changes gray radiation parameters to match those in this [paper](https://journals.ametsoc.org/view/journals/clim/21/15/2007jcli2065.1.xml). There is one small difference. The paper requires different optical depths for downward (0.22) and upward (0) shortwave radiation. This is not easy to do with the current code, so I set the optical depth for shortwave to be 0 altogether. It should be fine, because some previous version of the model in the paper also assume the optical depth for shortwave to be 0.

Closes #463 