### PR TITLE
Add simple cloudy radiation example

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,6 +115,10 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --rad clearsky --idealized_insolation false --idealized_h2o true --hyperdiff false --config column --z_max 70e3 --z_elem 70 --t_end 654days --dt 3hours --dt_save_to_sol 30hours --job_id sphere_single_column_radiative_equilibrium_clearsky_insolation"
         artifact_paths: "sphere_single_column_radiative_equilibrium_clearsky_insolation/*"
 
+      - label: ":computer: single column radiative equilibrium allsky idealized clouds"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --rad allskywithclear --idealized_h2o true --idealized_clouds true --hyperdiff false --config column --z_max 70e3 --z_elem 70 --t_end 654days --dt 3hours --dt_save_to_sol 30hours --job_id sphere_single_column_radiative_equilibrium_allsky_idealized_clouds"
+        artifact_paths: "sphere_single_column_radiative_equilibrium_allsky_idealized_clouds/*"
+
   - group: "MPI Examples"
     steps:
 
@@ -156,6 +160,10 @@ steps:
       - label: ":computer: held suarez (ρe_int) equilmoist"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200secs --t_end 5days"
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
+      
+      - label: ":computer: aquaplanet (ρe_tot) equilmoist allsky radiation"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --rad allskywithclear --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_allsky --dt 200secs --t_end 5days"
+        artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky/*"
 
   - group: "Milestones"
     steps:

--- a/examples/RRTMGPInterface.jl
+++ b/examples/RRTMGPInterface.jl
@@ -653,7 +653,7 @@ function RRTMGPModel(
                     Int,
                     FT,
                     DA,
-                    !use_pade_cloud_optics_method,
+                    !use_pade_cloud_optics_mode,
                 )
                 close(ds_sw_cld)
                 lookups = (; lookups..., lookup_sw_cld)

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -55,6 +55,10 @@ function parse_commandline()
         help = "Use idealized H2O in radiation model [`false` (default), `true`]"
         arg_type = Bool
         default = false
+        "--idealized_clouds"
+        help = "Use idealized clouds in radiation model [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--rad"
         help = "Radiation model [`clearsky`, `gray`, `allsky`] (default: no radiation)"
         arg_type = String

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -10,6 +10,7 @@ const FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
 fps = parsed_args["fps"]
 idealized_h2o = parsed_args["idealized_h2o"]
 idealized_insolation = parsed_args["idealized_insolation"]
+idealized_clouds = parsed_args["idealized_clouds"]
 vert_diff = parsed_args["vert_diff"]
 hyperdiff = parsed_args["hyperdiff"]
 turbconv = parsed_args["turbconv"]
@@ -29,6 +30,7 @@ dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
 
 @assert idealized_insolation in (true, false)
 @assert idealized_h2o in (true, false)
+@assert idealized_clouds in (true, false)
 @assert vert_diff in (true, false)
 @assert hyperdiff in (true, false)
 @assert parsed_args["config"] in ("sphere", "column")
@@ -109,6 +111,7 @@ additional_cache(Y, params, dt; use_tempest_mode = false) = merge(
         radiation_model();
         idealized_insolation,
         idealized_h2o,
+        idealized_clouds,
     ),
     vert_diff ?
     vertical_diffusion_boundary_layer_cache(Y; diffuse_momentum) :

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -35,13 +35,16 @@ end
 
 function radiation_model(parsed_args)
     radiation_name = parsed_args["rad"]
-    @assert radiation_name in (nothing, "clearsky", "gray", "allsky")
+    @assert radiation_name in
+            (nothing, "clearsky", "gray", "allsky", "allskywithclear")
     return if radiation_name == "clearsky"
         RRTMGPI.ClearSkyRadiation()
     elseif radiation_name == "gray"
         RRTMGPI.GrayRadiation()
     elseif radiation_name == "allsky"
         RRTMGPI.AllSkyRadiation()
+    elseif radiation_name == "allskywithclear"
+        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics()
     else
         nothing
     end


### PR DESCRIPTION
This PR adds support for all-sky radiation to `rrtmgp_model_callback`. Specifically, it allows for cloud properties to be computed based on the thermodynamic state, or, if `idealized_clouds == true`, it puts an icy cloud between 4km and 5km, and it puts a wet cloud between 1km and 1.5km.