### PR TITLE
Add vertically integrated precipitation to cache

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -334,7 +334,7 @@ function make_save_to_disk_func(output_dir, p, is_distributed)
         Y = integrator.u
 
         if :ρq_tot in propertynames(Y.c)
-            (; ᶜts, ᶜp, ᶜS_ρq_tot, params, ᶜK, ᶜΦ) = p
+            (; ᶜts, ᶜp, ᶜS_ρq_tot, params, col_integrated_precip, ᶜK, ᶜΦ) = p
         else
             (; ᶜts, ᶜp, params, ᶜK, ᶜΦ) = p
         end
@@ -384,12 +384,15 @@ function make_save_to_disk_func(output_dir, p, is_distributed)
                     params,
                     TD.PhasePartition(params, ᶜts),
                 )
+            col_integrated_precip =
+                vertical∫_col(ᶜS_ρq_tot) ./ FT(Planet.ρ_cloud_liq(params))
 
             moist_diagnostic = (;
                 cloud_liquid = ᶜcloud_liquid,
                 cloud_ice = ᶜcloud_ice,
                 water_vapor = ᶜwatervapor,
                 precipitation_removal = ᶜS_ρq_tot,
+                column_integrated_precip = col_integrated_precip,
                 relative_humidity = ᶜRH,
             )
         else

--- a/examples/hybrid/parameter_set.jl
+++ b/examples/hybrid/parameter_set.jl
@@ -22,6 +22,7 @@ Planet.MSLP(::BaroclinicWaveParameterSet) = 1.0e5
 Planet.grav(::BaroclinicWaveParameterSet) = 9.80616
 Planet.Omega(::BaroclinicWaveParameterSet) = 7.29212e-5
 Planet.planet_radius(::BaroclinicWaveParameterSet) = 6.371229e6
+Planet.ρ_cloud_liq(::BaroclinicWaveParameterSet) = 1e3
 
 # parameters for 0-Moment Microphysics
 Atmos.Microphysics_0M.τ_precip(param_set::BaroclinicWaveParameterSet) =


### PR DESCRIPTION
This PR adds vertically integrated precipitation to cache so that the coupler can pass the information to the land.

Meanwhile, it also adds a vertical integration function (works for the current sphere setup and needs more rigorous tests to implement on other domain setups). 

Closes #509 

Co-authored-by: Anna Jaruga <trontrytel@users.noreply.github.com>