### PR TITLE
Add surface elevation to default cache

### DIFF
--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -8,6 +8,8 @@ using Thermodynamics
 
 const TD = Thermodynamics
 
+using ClimaCore.Utilities: half
+
 include("schur_complement_W.jl")
 include("hyperdiffusion.jl")
 
@@ -110,6 +112,8 @@ get_cache(Y, params, upwinding_mode, dt) = merge(
 
 function default_cache(Y, params, upwinding_mode)
     ᶜcoord = Fields.local_geometry_field(Y.c).coordinates
+    ᶠcoord = Fields.local_geometry_field(Y.f).coordinates
+    z_sfc = Fields.level(ᶠcoord.z, half)
     if eltype(ᶜcoord) <: Geometry.LatLongZPoint
         Ω = FT(Planet.Omega(params))
         ᶜf = @. 2 * Ω * sind(ᶜcoord.lat)
@@ -154,6 +158,7 @@ function default_cache(Y, params, upwinding_mode)
         ᶠu¹² = similar(Y.f, Geometry.Contravariant12Vector{FT}),
         ᶠu³ = similar(Y.f, Geometry.Contravariant3Vector{FT}),
         ᶜf,
+        z_sfc,
         T_sfc,
         ∂ᶜK∂ᶠw_data = similar(
             Y.c,


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Add z_sfc to cache, access in surface flux computation. 

## Benefits and Risks
Adds surface elevation for local dz computation (required in Surface Flux calculations). Local elevation can also be computed wherever necessary if the elevation profile function is known, but accessing via default cache seems more useful. Should not change behaviour of current tests in the absence of prescribed orography. 

## Linked Issues
#408 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [N/A] Unit tests are included OR N/A. [Checked with buildkite regression tests]
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [N/A] Documentation has been added/updated OR N/A.
