### PR TITLE
add coupled command line argument

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -40,6 +40,10 @@ function parse_commandline()
         help = "Vertical diffusion [`false` (default), `true`]"
         arg_type = Bool
         default = false
+        "--coupled"
+        help = "Coupled simulation [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--turbconv"
         help = "Turbulence convection scheme [`nothing` (default), `edmf`]"
         arg_type = String

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -12,6 +12,7 @@ idealized_h2o = parsed_args["idealized_h2o"]
 idealized_insolation = parsed_args["idealized_insolation"]
 idealized_clouds = parsed_args["idealized_clouds"]
 vert_diff = parsed_args["vert_diff"]
+coupled = parsed_args["coupled"]
 hyperdiff = parsed_args["hyperdiff"]
 turbconv = parsed_args["turbconv"]
 h_elem = parsed_args["h_elem"]
@@ -124,7 +125,7 @@ additional_cache(Y, params, dt; use_tempest_mode = false) = merge(
         idealized_clouds,
     ),
     vert_diff ?
-    vertical_diffusion_boundary_layer_cache(Y; diffuse_momentum) :
+    vertical_diffusion_boundary_layer_cache(Y; diffuse_momentum, coupled) :
     NamedTuple(),
     (;
         tendency_knobs = (;


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Adds a coupled command line argument so that we use surface fluxes directly from the cache when running coupled simulations.

## Benefits and Risks
It is a quick but not elegant way to allow us to run coupled simulations. A more elegant way would be to have a dispatch on the vertical diffusion tendency, but we think it would be better to change it when we change the atmos interface.

## Linked Issues

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
