### PR TITLE
Add repl scripts to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(
         "Contributor Guide" => "contributor_guide.md",
         "Function Index" => "function_index.md",
         "Equations" => "equations.md",
+        "REPL scripts" => "repl_scripts.md",
         "Command line arguments" => "cl_args.md",
     ],
 )

--- a/docs/src/repl_scripts.jl
+++ b/docs/src/repl_scripts.jl
@@ -1,0 +1,17 @@
+const ca_dir = joinpath(@__DIR__, "..", "..")
+include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"))
+using PrettyTables
+(s, parsed_args) = parse_commandline();
+
+buildkite_commands = readlines(joinpath(ca_dir, ".buildkite", "pipeline.yml"));
+filter!(x -> occursin("driver.jl", x), buildkite_commands)
+
+@assert length(buildkite_commands) > 0
+
+buildkite_flags = Dict()
+for bkcs in buildkite_commands
+    job_id = first(split(last(split(bkcs, "--job_id ")), " "))
+    println("### Buildkite job `$job_id`")
+    print_repl_script(bkcs)
+    println()
+end

--- a/docs/src/repl_scripts.md
+++ b/docs/src/repl_scripts.md
@@ -1,0 +1,5 @@
+# Julia scripts per Buildkite job
+
+```@example
+include("repl_scripts.jl")
+```


### PR DESCRIPTION
This PR
 - splits `print_repl_script` into `print_repl_script` and `parsed_args_from_command_line_flags`, which can be useful in its own right. 
 - Adds a new doc page that loops through all buildkite jobs and prints a repl script that can be used to run the job. Note that this does not include environment variables that may be set for that particular job

Here's the [doc page](https://clima.github.io/ClimaAtmos.jl/previews/PR559/repl_scripts/) that's added