### PR TITLE
Fix `parsed_args_from_command_line_flags`

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -241,7 +241,7 @@ function parsed_args_from_command_line_flags(str, parsed_args = Dict())
     parsed_args_list = split(s, " ")
     @assert iseven(length(parsed_args_list))
     parsed_arg_pairs = map(1:2:(length(parsed_args_list) - 1)) do i
-        Pair(parsed_args_list[i], parsed_args_list[i + 1])
+        Pair(parsed_args_list[i], strip(parsed_args_list[i + 1], '\"'))
     end
     function parse_arg(val)
         for T in (Bool, Int, Float32, Float64)


### PR DESCRIPTION
This PR fixes an edge case for the last CL argument (which can include a `\"`). Thanks for spotting this, @yairchn!