### PR TITLE
add NVTX macro, tag implicit parts

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -5,6 +5,7 @@ end
 
 include("classify_case.jl")
 include("utilities.jl")
+include("nvtx.jl")
 const FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
 
 fps = parsed_args["fps"]
@@ -69,7 +70,6 @@ turbconv_model() = turbconv_model(FT, parsed_args, namelist)
 diffuse_momentum = vert_diff && !(forcing_type() isa HeldSuarezForcing)
 
 using Colors
-using NVTX
 using OrdinaryDiffEq
 using PrettyTables
 using DiffEqCallbacks
@@ -498,7 +498,7 @@ function make_save_to_disk_func(output_dir, p)
                 global_ᶜT = @. TD.air_temperature(thermo_params, global_ᶜts)
                 global_ᶜθ = @. TD.dry_pottemp(thermo_params, global_ᶜts)
 
-                # vorticity 
+                # vorticity
                 global_curl_uh = @. curlₕ(Y.c.uₕ)
                 global_ᶜvort = Geometry.WVector.(global_curl_uh)
                 Spaces.weighted_dss!(global_ᶜvort)
@@ -565,7 +565,7 @@ function make_save_to_disk_func(output_dir, p)
                     if radiation_model() isa
                        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics
 
-                        # make sure datatype is correct 
+                        # make sure datatype is correct
                         global_face_clear_lw_flux_dn = similar(ᶠz_field)
                         global_face_clear_lw_flux_up = similar(ᶠz_field)
                         global_face_clear_sw_flux_dn = similar(ᶠz_field)
@@ -683,7 +683,7 @@ function make_save_to_disk_func(output_dir, p)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)
 
-            # vorticity 
+            # vorticity
             curl_uh = @. curlₕ(Y.c.uₕ)
             ᶜvort = Geometry.WVector.(curl_uh)
             Spaces.weighted_dss!(ᶜvort)
@@ -824,19 +824,14 @@ save_to_disk_func = make_save_to_disk_func(output_dir, p)
 
 dss_callback = FunctionCallingCallback(func_start = true) do Y, t, integrator
     p = integrator.p
-    NVTX.isactive() && (
-        dss_dss_callback = NVTX.range_start(;
-            message = "dss callback",
-            color = colorant"yellow",
-        )
-    )
-    Spaces.weighted_dss_start!(Y.c, p.ghost_buffer.c)
-    Spaces.weighted_dss_start!(Y.f, p.ghost_buffer.f)
-    Spaces.weighted_dss_internal!(Y.c, p.ghost_buffer.c)
-    Spaces.weighted_dss_internal!(Y.f, p.ghost_buffer.f)
-    Spaces.weighted_dss_ghost!(Y.c, p.ghost_buffer.c)
-    Spaces.weighted_dss_ghost!(Y.f, p.ghost_buffer.f)
-    NVTX.isactive() && NVTX.range_end(dss_dss_callback)
+    @nvtx "dss callback" color = colorant"yellow" begin
+        Spaces.weighted_dss_start!(Y.c, p.ghost_buffer.c)
+        Spaces.weighted_dss_start!(Y.f, p.ghost_buffer.f)
+        Spaces.weighted_dss_internal!(Y.c, p.ghost_buffer.c)
+        Spaces.weighted_dss_internal!(Y.f, p.ghost_buffer.f)
+        Spaces.weighted_dss_ghost!(Y.c, p.ghost_buffer.c)
+        Spaces.weighted_dss_ghost!(Y.f, p.ghost_buffer.f)
+    end
 end
 save_to_disk_callback = if dt_save_to_disk == Inf
     nothing

--- a/examples/hybrid/hyperdiffusion.jl
+++ b/examples/hybrid/hyperdiffusion.jl
@@ -33,145 +33,132 @@ function hyperdiffusion_tendency!(Yₜ, Y, P, t)
 end
 
 function hyperdiffusion_tendency_clima!(Yₜ, Y, p, t)
-    NVTX.isactive() && (
-        profile_hyperdiffusion_tendency = NVTX.range_start(;
-            message = "hyperdiffusion tendency",
-            color = colorant"yellow",
-        )
-    )
-    ᶜρ = Y.c.ρ
-    ᶜuₕ = Y.c.uₕ
-    (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume ᶜp has been updated
-    (; ghost_buffer, κ₄, divergence_damping_factor, use_tempest_mode) = p
-    point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
-    is_ρq_tot = :ρq_tot in propertynames(Y.c)
-    is_2d_pt = point_type <: Geometry.Abstract2DPoint
-    is_3d_pt = !is_2d_pt
+    @nvtx "hyperdiffusion tendency" color = colorant"yellow" begin
+        ᶜρ = Y.c.ρ
+        ᶜuₕ = Y.c.uₕ
+        (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume ᶜp has been updated
+        (; ghost_buffer, κ₄, divergence_damping_factor, use_tempest_mode) = p
+        point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
+        is_ρq_tot = :ρq_tot in propertynames(Y.c)
+        is_2d_pt = point_type <: Geometry.Abstract2DPoint
+        is_3d_pt = !is_2d_pt
 
-    ᶜρs =
-        :ρe_tot in propertynames(Y.c) ? Y.c.ρe_tot :
-        (:ρe_int in propertynames(Y.c) ? Y.c.ρe_int : Y.c.ρθ)
-    ᵗρs =
-        :ρe_tot in propertynames(Y.c) ? Yₜ.c.ρe_tot :
-        (:ρe_int in propertynames(Y.c) ? Yₜ.c.ρe_int : Yₜ.c.ρθ)
+        ᶜρs =
+            :ρe_tot in propertynames(Y.c) ? Y.c.ρe_tot :
+            (:ρe_int in propertynames(Y.c) ? Y.c.ρe_int : Y.c.ρθ)
+        ᵗρs =
+            :ρe_tot in propertynames(Y.c) ? Yₜ.c.ρe_tot :
+            (:ρe_int in propertynames(Y.c) ? Yₜ.c.ρe_int : Yₜ.c.ρθ)
 
-    (:ρθ in propertynames(Y.c)) && (@. ᶜχ = wdivₕ(gradₕ(ᶜρs / ᶜρ)))
-    !(:ρθ in propertynames(Y.c)) && (@. ᶜχ = wdivₕ(gradₕ((ᶜρs + ᶜp) / ᶜρ)))
+        (:ρθ in propertynames(Y.c)) && (@. ᶜχ = wdivₕ(gradₕ(ᶜρs / ᶜρ)))
+        !(:ρθ in propertynames(Y.c)) && (@. ᶜχ = wdivₕ(gradₕ((ᶜρs + ᶜp) / ᶜρ)))
 
-    if is_ρq_tot
-        (; ᶜχρq_tot) = p
-        @. ᶜχρq_tot = wdivₕ(gradₕ(Y.c.ρq_tot / ᶜρ))
-    end
+        if is_ρq_tot
+            (; ᶜχρq_tot) = p
+            @. ᶜχρq_tot = wdivₕ(gradₕ(Y.c.ρq_tot / ᶜρ))
+        end
 
-    is_3d_pt && (@. ᶜχuₕ =
-        wgradₕ(divₕ(ᶜuₕ)) - Geometry.Covariant12Vector(
-            wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜuₕ))),
-        ))
-    is_2d_pt && (@. ᶜχuₕ = Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜuₕ))))
+        is_3d_pt && (@. ᶜχuₕ =
+            wgradₕ(divₕ(ᶜuₕ)) - Geometry.Covariant12Vector(
+                wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜuₕ))),
+            ))
+        is_2d_pt && (@. ᶜχuₕ = Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜuₕ))))
 
-    NVTX.isactive() && (
-        dss_hyperdiffusion_tendency = NVTX.range_start(;
-            message = "dss_hyperdiffusion_tendency",
-            color = colorant"green",
-        )
-    )
-    Spaces.weighted_dss_start!(ᶜχ, ghost_buffer.χ)
-    is_ρq_tot && (Spaces.weighted_dss_start!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
-    Spaces.weighted_dss_start!(ᶜχuₕ, ghost_buffer.χuₕ)
+        @nvtx "dss_hyperdiffusion_tendency" color = colorant"green" begin
+            Spaces.weighted_dss_start!(ᶜχ, ghost_buffer.χ)
+            is_ρq_tot &&
+                (Spaces.weighted_dss_start!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
+            Spaces.weighted_dss_start!(ᶜχuₕ, ghost_buffer.χuₕ)
 
-    Spaces.weighted_dss_internal!(ᶜχ, ghost_buffer.χ)
-    is_ρq_tot &&
-        (Spaces.weighted_dss_internal!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
-    Spaces.weighted_dss_internal!(ᶜχuₕ, ghost_buffer.χuₕ)
+            Spaces.weighted_dss_internal!(ᶜχ, ghost_buffer.χ)
+            is_ρq_tot &&
+                (Spaces.weighted_dss_internal!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
+            Spaces.weighted_dss_internal!(ᶜχuₕ, ghost_buffer.χuₕ)
 
-    Spaces.weighted_dss_ghost!(ᶜχ, ghost_buffer.χ)
-    is_ρq_tot && (Spaces.weighted_dss_ghost!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
-    Spaces.weighted_dss_ghost!(ᶜχuₕ, ghost_buffer.χuₕ)
-    NVTX.isactive() && NVTX.range_end(dss_hyperdiffusion_tendency)
+            Spaces.weighted_dss_ghost!(ᶜχ, ghost_buffer.χ)
+            is_ρq_tot &&
+                (Spaces.weighted_dss_ghost!(ᶜχρq_tot, ghost_buffer.ᶜχρq_tot))
+            Spaces.weighted_dss_ghost!(ᶜχuₕ, ghost_buffer.χuₕ)
+        end
 
-    @. ᵗρs -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχ))
-    if is_ρq_tot
-        @. Yₜ.c.ρq_tot -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
-        @. Yₜ.c.ρ -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
-    end
-    if is_3d_pt
-        @. Yₜ.c.uₕ -=
-            κ₄ * (
-                divergence_damping_factor * wgradₕ(divₕ(ᶜχuₕ)) -
-                Geometry.Covariant12Vector(
-                    wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜχuₕ))),
+        @. ᵗρs -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχ))
+        if is_ρq_tot
+            @. Yₜ.c.ρq_tot -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
+            @. Yₜ.c.ρ -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
+        end
+        if is_3d_pt
+            @. Yₜ.c.uₕ -=
+                κ₄ * (
+                    divergence_damping_factor * wgradₕ(divₕ(ᶜχuₕ)) -
+                    Geometry.Covariant12Vector(
+                        wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜχuₕ))),
+                    )
                 )
-            )
-    elseif is_2d_pt
-        @. Yₜ.c.uₕ -=
-            κ₄ *
-            divergence_damping_factor *
-            Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜχuₕ)))
+        elseif is_2d_pt
+            @. Yₜ.c.uₕ -=
+                κ₄ *
+                divergence_damping_factor *
+                Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜχuₕ)))
+        end
     end
-    NVTX.isactive() && NVTX.range_end(profile_hyperdiffusion_tendency)
     return nothing
 end
 
 function hyperdiffusion_tendency_tempest!(Yₜ, Y, p, t)
-    NVTX.isactive() && (
-        profile_hyperdiffusion_tendency = NVTX.range_start(;
-            message = "hyperdiffusion tendency",
-            color = colorant"yellow",
-        )
-    )
-    !(:ρθ in propertynames(Y.c)) &&
-        (error("use_tempest_mode must be false when not using ρθ"))
-    ᶜρ = Y.c.ρ
-    ᶜuₕ = Y.c.uₕ
-    (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume ᶜp has been updated
-    (; ghost_buffer, κ₄, divergence_damping_factor, use_tempest_mode) = p
-    point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
-    is_ρq_tot = :ρq_tot in propertynames(Y.c)
-    is_2d_pt = point_type <: Geometry.Abstract2DPoint
-    is_3d_pt = !is_2d_pt
+    @nvtx "hyperdiffusion tendency" color = colorant"yellow" begin
+        !(:ρθ in propertynames(Y.c)) &&
+            (error("use_tempest_mode must be false when not using ρθ"))
+        ᶜρ = Y.c.ρ
+        ᶜuₕ = Y.c.uₕ
+        (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume ᶜp has been updated
+        (; ghost_buffer, κ₄, divergence_damping_factor, use_tempest_mode) = p
+        point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
+        is_ρq_tot = :ρq_tot in propertynames(Y.c)
+        is_2d_pt = point_type <: Geometry.Abstract2DPoint
+        is_3d_pt = !is_2d_pt
 
-    @. ᶜχ = wdivₕ(gradₕ(ᶜρ)) # ᶜχρ
-    Spaces.weighted_dss!(ᶜχ, ghost_buffer.χ)
-    @. Yₜ.c.ρ -= κ₄ * wdivₕ(gradₕ(ᶜχ))
+        @. ᶜχ = wdivₕ(gradₕ(ᶜρ)) # ᶜχρ
+        Spaces.weighted_dss!(ᶜχ, ghost_buffer.χ)
+        @. Yₜ.c.ρ -= κ₄ * wdivₕ(gradₕ(ᶜχ))
 
-    @. ᶜχ = wdivₕ(gradₕ(Y.c.ρθ)) # ᶜχρθ
-    Spaces.weighted_dss!(ᶜχ, ghost_buffer.χ)
-    @. Yₜ.c.ρθ -= κ₄ * wdivₕ(gradₕ(ᶜχ))
+        @. ᶜχ = wdivₕ(gradₕ(Y.c.ρθ)) # ᶜχρθ
+        Spaces.weighted_dss!(ᶜχ, ghost_buffer.χ)
+        @. Yₜ.c.ρθ -= κ₄ * wdivₕ(gradₕ(ᶜχ))
 
-    (; ᶠχw_data) = p
-    @. ᶠχw_data = wdivₕ(gradₕ(Y.f.w.components.data.:1))
-    Spaces.weighted_dss!(ᶠχw_data, ghost_buffer.χ)
-    @. Yₜ.f.w.components.data.:1 -= κ₄ * wdivₕ(gradₕ(ᶠχw_data))
+        (; ᶠχw_data) = p
+        @. ᶠχw_data = wdivₕ(gradₕ(Y.f.w.components.data.:1))
+        Spaces.weighted_dss!(ᶠχw_data, ghost_buffer.χ)
+        @. Yₜ.f.w.components.data.:1 -= κ₄ * wdivₕ(gradₕ(ᶠχw_data))
 
-    if is_ρq_tot
-        (; ᶜχρq_tot) = p
-        @. ᶜχρq_tot = wdivₕ(gradₕ(Y.c.ρq_tot / ᶜρ))
-        Spaces.weighted_dss!(ᶜχρq_tot, ghost_buffer.χ)
-        @. Yₜ.c.ρq_tot -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
-        @. Yₜ.c.ρ -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
-    end
+        if is_ρq_tot
+            (; ᶜχρq_tot) = p
+            @. ᶜχρq_tot = wdivₕ(gradₕ(Y.c.ρq_tot / ᶜρ))
+            Spaces.weighted_dss!(ᶜχρq_tot, ghost_buffer.χ)
+            @. Yₜ.c.ρq_tot -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
+            @. Yₜ.c.ρ -= κ₄ * wdivₕ(ᶜρ * gradₕ(ᶜχρq_tot))
+        end
 
-    if is_3d_pt
-        @. ᶜχuₕ =
-            wgradₕ(divₕ(ᶜuₕ)) - Geometry.Covariant12Vector(
-                wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜuₕ))),
-            )
-        Spaces.weighted_dss!(ᶜχuₕ, ghost_buffer.χuₕ)
-        @. Yₜ.c.uₕ -=
-            κ₄ * (
-                divergence_damping_factor * wgradₕ(divₕ(ᶜχuₕ)) -
-                Geometry.Covariant12Vector(
-                    wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜχuₕ))),
+        if is_3d_pt
+            @. ᶜχuₕ =
+                wgradₕ(divₕ(ᶜuₕ)) - Geometry.Covariant12Vector(
+                    wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜuₕ))),
                 )
-            )
-    elseif is_2d_pt
-        @. ᶜχuₕ = Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜuₕ)))
-        Spaces.weighted_dss!(ᶜχuₕ, ghost_buffer.χuₕ)
-        @. Yₜ.c.uₕ -=
-            κ₄ *
-            divergence_damping_factor *
-            Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜχuₕ)))
+            Spaces.weighted_dss!(ᶜχuₕ, ghost_buffer.χuₕ)
+            @. Yₜ.c.uₕ -=
+                κ₄ * (
+                    divergence_damping_factor * wgradₕ(divₕ(ᶜχuₕ)) -
+                    Geometry.Covariant12Vector(
+                        wcurlₕ(Geometry.Covariant3Vector(curlₕ(ᶜχuₕ))),
+                    )
+                )
+        elseif is_2d_pt
+            @. ᶜχuₕ = Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜuₕ)))
+            Spaces.weighted_dss!(ᶜχuₕ, ghost_buffer.χuₕ)
+            @. Yₜ.c.uₕ -=
+                κ₄ *
+                divergence_damping_factor *
+                Geometry.Covariant12Vector(wgradₕ(divₕ(ᶜχuₕ)))
+        end
     end
-    NVTX.isactive() && NVTX.range_end(profile_hyperdiffusion_tendency)
     return nothing
 end

--- a/examples/hybrid/nvtx.jl
+++ b/examples/hybrid/nvtx.jl
@@ -1,0 +1,19 @@
+using NVTX, Colors
+
+if NVTX.isactive()
+    nvtx_domain = NVTX.Domain("ClimaAtmos")
+end
+macro nvtx(message, args...)
+    block = args[end]
+    kwargs = [Expr(:kw, arg.args...) for arg in args[1:(end - 1)]]
+    quote
+        range =
+            NVTX.isactive() ?
+            NVTX.range_start(nvtx_domain; message = $message, $(kwargs...)) :
+            nothing
+        $(esc(block))
+        if !isnothing(range)
+            NVTX.range_end(range)
+        end
+    end
+end


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Adds an `@nvtx` macro to make it easier to tag pieces for profiling.

## Benefits and Risks
Simplifies the code, but requires indentation.

## Linked Issues

- Fixes #550 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
