### PR TITLE
Fix some variables that should be constant

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -174,7 +174,7 @@ steps:
         artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
       
       - label: ":computer: aquaplanet (ρe_tot) equilmoist allsky radiation"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --rad allskywithclear --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_allsky --dt 200secs --t_end 5days"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --rad allskywithclear --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_allsky --dt 150secs --t_end 3.75days"
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky/*"
 
   - group: "Milestones"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -43,11 +43,9 @@ dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
 
 include("types.jl")
 
-import TurbulenceConvection
-const TC = TurbulenceConvection
+import TurbulenceConvection as TC
 include("TurbulenceConvectionUtils.jl")
-import .TurbulenceConvectionUtils
-TCU = TurbulenceConvectionUtils
+import .TurbulenceConvectionUtils as TCU
 namelist = if turbconv == "edmf"
     nl = TCU.NameList.default_namelist("Bomex")
     nl["set_src_seed"] = true
@@ -81,8 +79,7 @@ using ClimaCore
 import Random
 Random.seed!(1234)
 include(joinpath("..", "RRTMGPInterface.jl"))
-import .RRTMGPInterface
-RRTMGPI = RRTMGPInterface
+import .RRTMGPInterface as RRTMGPI
 
 !isnothing(radiation_model()) && include("radiation_utilities.jl")
 
@@ -210,7 +207,8 @@ else
 end
 
 import ClimaCore: enable_threading
-enable_threading() = parsed_args["enable_threading"]
+const enable_clima_core_threading = parsed_args["enable_threading"]
+enable_threading() = enable_clima_core_threading
 
 # TODO: When is_distributed is true, automatically compute the maximum number of
 # bytes required to store an element from Y.c or Y.f (or, really, from any Field

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -3,7 +3,7 @@ using SurfaceFluxes
 using CloudMicrophysics
 const SF = SurfaceFluxes
 const CCG = ClimaCore.Geometry
-const TC = TurbulenceConvection
+import TurbulenceConvection as TC
 const CM = CloudMicrophysics
 import ClimaAtmos.Parameters as CAP
 


### PR DESCRIPTION
JET found 654 possible errors. This PR fixes a few: some variables should be declared `const` to avoid runtime checks.

cc @simonbyrne 