### PR TITLE
Add option to disable qt hyperdiffusion

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -141,4 +141,10 @@ steps:
         artifact_paths: "longrun_hs_rhoe_equil_dt250/*"
         agents:
           slurm_cpus_per_task: 8
+      
+      - label: ":computer: held suarez (ρe_tot) equilmoist noqthyper"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --dt 400secs --disable_qt_hyperdiffusion true --t_end 1000days --fps 30 --job_id longrun_hs_rhoe_equil_noqthyper --dt_save_to_sol 6hours --dt_save_to_disk 10days"
+        artifact_paths: "longrun_hs_rhoe_equil_noqthyper/*"
+        agents:
+          slurm_cpus_per_task: 8
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -156,6 +156,10 @@ function parse_commandline()
         help = "Apply filter to moisture"
         arg_type = Bool
         default = false
+        "--disable_qt_hyperdiffusion"
+        help = "Disable the hyperdiffusion of specific humidity [`true`, `false` (default)] (TODO: reconcile this with ρe_tot or remove if instability fixed with limiters)"
+        arg_type = Bool
+        default = false
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -15,6 +15,7 @@ idealized_clouds = parsed_args["idealized_clouds"]
 vert_diff = parsed_args["vert_diff"]
 coupled = parsed_args["coupled"]
 hyperdiff = parsed_args["hyperdiff"]
+disable_qt_hyperdiffusion = parsed_args["disable_qt_hyperdiffusion"]
 turbconv = parsed_args["turbconv"]
 h_elem = parsed_args["h_elem"]
 z_elem = Int(parsed_args["z_elem"])
@@ -104,7 +105,12 @@ test_implicit_solver = false # makes solver extremely slow when set to `true`
 
 # TODO: flip order so that NamedTuple() is fallback.
 additional_cache(Y, params, dt; use_tempest_mode = false) = merge(
-    hyperdiffusion_cache(Y; κ₄ = FT(κ₄), use_tempest_mode),
+    hyperdiffusion_cache(
+        Y;
+        κ₄ = FT(κ₄),
+        use_tempest_mode,
+        disable_qt_hyperdiffusion,
+    ),
     rayleigh_sponge ?
     rayleigh_sponge_cache(Y, dt; zd_rayleigh = FT(zd_rayleigh)) :
     NamedTuple(),

--- a/examples/hybrid/hyperdiffusion.jl
+++ b/examples/hybrid/hyperdiffusion.jl
@@ -3,6 +3,7 @@ hyperdiffusion_cache(
     κ₄ = FT(0),
     divergence_damping_factor = FT(1),
     use_tempest_mode = false,
+    disable_qt_hyperdiffusion = false,
 ) =
     (:ρq_tot in propertynames(Y.c)) ?
     merge(
@@ -13,6 +14,7 @@ hyperdiffusion_cache(
             κ₄,
             divergence_damping_factor,
             use_tempest_mode,
+            disable_qt_hyperdiffusion,
         ),
         use_tempest_mode ? (; ᶠχw_data = similar(Y.F, FT)) : NamedTuple(),
     ) :
@@ -23,6 +25,7 @@ hyperdiffusion_cache(
             κ₄,
             divergence_damping_factor,
             use_tempest_mode,
+            disable_qt_hyperdiffusion,
         ),
         use_tempest_mode ? (; ᶠχw_data = similar(Y.F, FT)) : NamedTuple(),
     )
@@ -37,9 +40,15 @@ function hyperdiffusion_tendency_clima!(Yₜ, Y, p, t)
         ᶜρ = Y.c.ρ
         ᶜuₕ = Y.c.uₕ
         (; ᶜp, ᶜχ, ᶜχuₕ) = p # assume ᶜp has been updated
-        (; ghost_buffer, κ₄, divergence_damping_factor, use_tempest_mode) = p
+        (;
+            ghost_buffer,
+            κ₄,
+            divergence_damping_factor,
+            use_tempest_mode,
+            disable_qt_hyperdiffusion,
+        ) = p
         point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
-        is_ρq_tot = :ρq_tot in propertynames(Y.c)
+        is_ρq_tot = :ρq_tot in propertynames(Y.c) && !disable_qt_hyperdiffusion
         is_2d_pt = point_type <: Geometry.Abstract2DPoint
         is_3d_pt = !is_2d_pt
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
- adds an option to disable hyperdiffusion of qt 

## Benefits and Risks
- benefit: adds stability (similar timestep compared to the dry run)
- risk: this is not the final solution (may need to adjust `e_tot` or use limiters in the future)

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
