### PR TITLE
Port TurbulenceConvection to ClimaAtmos

### DIFF
--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -1834,12 +1834,6 @@ git-tree-sha1 = "859e2e9a7222553a0c052e423557cedb49376da9"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 version = "0.3.4"
 
-[[deps.TurbulenceConvection]]
-deps = ["ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "ee448605313de213260ce38bc723761d77c33eaa"
-uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "0.33.0"
-
 [[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -59,7 +59,6 @@ SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
-TurbulenceConvection = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
@@ -110,7 +109,6 @@ StochasticDiffEq = "6.42"
 SurfaceFluxes = "0.4"
 TerminalLoggers = "0.1"
 Thermodynamics = "0.9"
-TurbulenceConvection = "0.33"
 UnPack = "1"
 julia = "1.7"
 

--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -1,6 +1,7 @@
 module TurbulenceConvectionUtils
 
 using LinearAlgebra, StaticArrays
+import ClimaAtmos
 import ClimaAtmos.Parameters as CAP
 import ClimaCore as CC
 import ClimaCore.Geometry as CCG

--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -7,23 +7,23 @@ import ClimaCore.Geometry as CCG
 import ClimaCore.Operators as CCO
 import ClimaCore.Geometry: ⊗
 import OrdinaryDiffEq as ODE
-import TurbulenceConvection
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection
+import ClimaAtmos.TurbulenceConvection as TC
 
 import UnPack
 import Logging
 import TerminalLoggers
 Logging.global_logger(TerminalLoggers.TerminalLogger())
 
-const tc_dir = pkgdir(TC)
+const ca_dir = pkgdir(ClimaAtmos)
 
-include(joinpath(tc_dir, "driver", "Cases.jl"))
+include(joinpath(ca_dir, "tc_driver", "Cases.jl"))
 import .Cases
 
-include(joinpath(tc_dir, "driver", "dycore.jl"))
-include(joinpath(tc_dir, "driver", "Surface.jl"))
-include(joinpath(tc_dir, "driver", "initial_conditions.jl"))
-include(joinpath(tc_dir, "driver", "generate_namelist.jl"))
+include(joinpath(ca_dir, "tc_driver", "dycore.jl"))
+include(joinpath(ca_dir, "tc_driver", "Surface.jl"))
+include(joinpath(ca_dir, "tc_driver", "initial_conditions.jl"))
+include(joinpath(ca_dir, "tc_driver", "generate_namelist.jl"))
 import .NameList
 
 function get_aux(edmf, Y, ::Type{FT}) where {FT}

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -44,7 +44,7 @@ dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
 
 include("types.jl")
 
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection as TC
 include("TurbulenceConvectionUtils.jl")
 import .TurbulenceConvectionUtils as TCU
 namelist = if turbconv == "edmf"

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -3,7 +3,7 @@ using SurfaceFluxes
 using CloudMicrophysics
 const SF = SurfaceFluxes
 const CCG = ClimaCore.Geometry
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection as TC
 const CM = CloudMicrophysics
 import ClimaAtmos.Parameters as CAP
 

--- a/parameters/create_parameters.jl
+++ b/parameters/create_parameters.jl
@@ -1,4 +1,4 @@
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection as TC
 import CLIMAParameters as CP
 import RRTMGP.Parameters as RP
 import CloudMicrophysics as CM
@@ -7,7 +7,7 @@ import ClimaAtmos.Parameters as CAP
 import SurfaceFluxes as SF
 import SurfaceFluxes.UniversalFunctions as UF
 import Thermodynamics as TD
-import TurbulenceConvection.Parameters as TCP
+import ClimaAtmos.TurbulenceConvection.Parameters as TCP
 
 # TODO: move to corresponding packages
 Base.broadcastable(ps::SF.Parameters.SurfaceFluxesParameters) = Ref(ps)

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -10,4 +10,6 @@ include("Callbacks/Callbacks.jl")
 include("Simulations/Simulations.jl")
 include("Utils/Utils.jl")
 
+include("TurbulenceConvection/TurbulenceConvection.jl")
+
 end # module

--- a/src/TurbulenceConvection/EDMF_Environment.jl
+++ b/src/TurbulenceConvection/EDMF_Environment.jl
@@ -1,0 +1,390 @@
+function microphysics(
+    ::SGSMean,
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    precip_model::AbstractPrecipitationModel,
+    Δt::Real,
+    param_set::APS,
+)
+    FT = float_type(state)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    tendencies_pr = center_tendencies_precipitation(state)
+    aux_en = center_aux_environment(state)
+    prog_pr = center_prog_precipitation(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    ts_env = center_aux_environment(state).ts
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    aux_en_sat = aux_en.sat
+    aux_en_unsat = aux_en.unsat
+    precip_fraction = compute_precip_fraction(edmf, state)
+
+    @inbounds for k in real_center_indices(grid)
+        # condensation
+        ts = ts_env[k]
+        # autoconversion and accretion
+        mph = precipitation_formation(
+            param_set,
+            precip_model,
+            prog_pr.q_rai[k],
+            prog_pr.q_sno[k],
+            aux_en.area[k],
+            ρ_c[k],
+            FT(grid.zc[k].z),
+            Δt,
+            ts,
+            precip_fraction,
+        )
+
+        # update_sat_unsat
+        if TD.has_condensate(thermo_params, ts)
+            aux_en.cloud_fraction[k] = 1
+            aux_en_sat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts)
+            aux_en_sat.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts)
+            aux_en_sat.T[k] = TD.air_temperature(thermo_params, ts)
+            aux_en_sat.q_tot[k] = TD.total_specific_humidity(thermo_params, ts)
+            aux_en_sat.q_vap[k] = TD.vapor_specific_humidity(thermo_params, ts)
+        else
+            aux_en.cloud_fraction[k] = 0
+            aux_en_unsat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts)
+            aux_en_unsat.θ_virt[k] = TD.virtual_pottemp(thermo_params, ts)
+            aux_en_unsat.q_tot[k] = TD.total_specific_humidity(thermo_params, ts)
+        end
+
+        # update_env_precip_tendencies
+        # TODO: move ..._tendency_precip_formation to diagnostics
+        aux_en.qt_tendency_precip_formation[k] = mph.qt_tendency * aux_en.area[k]
+        aux_en.e_tot_tendency_precip_formation[k] = mph.e_tot_tendency * aux_en.area[k]
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            aux_en.ql_tendency_precip_formation[k] = mph.ql_tendency * aux_en.area[k]
+            aux_en.qi_tendency_precip_formation[k] = mph.qi_tendency * aux_en.area[k]
+        end
+        tendencies_pr.q_rai[k] += mph.qr_tendency * aux_en.area[k]
+        tendencies_pr.q_sno[k] += mph.qs_tendency * aux_en.area[k]
+    end
+    return nothing
+end
+
+function quad_loop(en_thermo::SGSQuadrature, precip_model, vars, param_set, Δt::Real)
+
+    env_len = 8
+    src_len = 9
+    i_ql, i_qi, i_T, i_cf, i_qt_sat, i_qt_unsat, i_T_sat, i_T_unsat = 1:env_len
+    i_SH_qt, i_Sqt_H, i_SH_H, i_Sqt_qt, i_Sqt, i_SH, i_Sqr, i_Sqs, i_Se_tot = 1:src_len
+
+    thermo_params = TCP.thermodynamics_params(param_set)
+    quadrature_type = en_thermo.quadrature_type
+    quad_order = quadrature_order(en_thermo)
+    χ = en_thermo.a
+    weights = en_thermo.w
+
+    # qt - total water specific humidity
+    # θl - liquid ice potential temperature
+    # _mean and ′ - subdomain mean and (co)variances
+    # q_rai, q_sno - grid mean precipitation
+    UnPack.@unpack qt′qt′, qt_mean, θl′θl′, θl_mean, θl′qt′, subdomain_area, q_rai, q_sno, ρ_c, p_c, zc, precip_frac =
+        vars
+
+    FT = eltype(ρ_c)
+
+    inner_env = SA.MVector{env_len, FT}(undef)
+    outer_env = SA.MVector{env_len, FT}(undef)
+    inner_src = SA.MVector{src_len, FT}(undef)
+    outer_src = SA.MVector{src_len, FT}(undef)
+
+    sqpi_inv = FT(1 / sqrt(π))
+    sqrt2 = FT(sqrt(2))
+
+    # Epsilon defined per typical variable fluctuation
+    eps_q = qt_mean ≈ FT(0) ? eps(FT) : eps(FT) * qt_mean
+    eps_θ = eps(FT)
+
+    if quadrature_type isa LogNormalQuad
+        # Lognormal parameters (ν, s) from mean and variance
+        ν_q = log(qt_mean^2 / max(sqrt(qt_mean^2 + qt′qt′), eps_q))
+        ν_θ = log(θl_mean^2 / sqrt(θl_mean^2 + θl′θl′))
+        s_q = sqrt(log(qt′qt′ / max(qt_mean, eps_q)^2 + 1))
+        s_θ = sqrt(log(θl′θl′ / θl_mean^2 + 1))
+
+        # Enforce Cauchy-Schwarz inequality, numerically stable compute
+        corr = θl′qt′ / max(sqrt(qt′qt′), eps_q)
+        corr = max(min(corr / max(sqrt(θl′θl′), eps_θ), 1), -1)
+
+        # Conditionals
+        s2_θq = log(corr * sqrt(θl′θl′ * qt′qt′) / θl_mean / max(qt_mean, eps_q) + 1)
+        s_c = sqrt(max(s_θ^2 - s2_θq^2 / max(s_q, eps_q)^2, 0))
+
+    elseif quadrature_type isa GaussianQuad
+        # limit σ_q to prevent negative qt_hat
+        σ_q_lim = -qt_mean / (sqrt2 * χ[1])
+        σ_q = min(sqrt(qt′qt′), σ_q_lim)
+        σ_θ = sqrt(θl′θl′)
+
+        # Enforce Cauchy-Schwarz inequality, numerically stable compute
+        corr = θl′qt′ / max(σ_q, eps_q)
+        corr = max(min(corr / max(σ_θ, eps_θ), 1), -1)
+
+        # Conditionals
+        σ_c = sqrt(max(1 - corr * corr, 0)) * σ_θ
+    end
+
+    # zero outer quadrature points
+    @inbounds for idx in 1:env_len
+        outer_env[idx] = 0
+    end
+    @inbounds for idx in 1:src_len
+        outer_src[idx] = 0
+    end
+
+    @inbounds for m_q in 1:quad_order
+        if quadrature_type isa LogNormalQuad
+            qt_hat = exp(ν_q + sqrt2 * s_q * χ[m_q])
+            ν_c = ν_θ + s2_θq / max(s_q, eps_q)^2 * (log(qt_hat) - ν_q)
+        elseif quadrature_type isa GaussianQuad
+            qt_hat = qt_mean + sqrt2 * σ_q * χ[m_q]
+            μ_c = θl_mean + sqrt2 * corr * σ_θ * χ[m_q]
+        end
+
+        # zero inner quadrature points
+        inner_env .= 0
+        inner_src .= 0
+
+        for m_h in 1:quad_order
+            if quadrature_type isa LogNormalQuad
+                h_hat = exp(ν_c + sqrt2 * s_c * χ[m_h])
+            elseif quadrature_type isa GaussianQuad
+                h_hat = μ_c + sqrt2 * σ_c * χ[m_h]
+            end
+
+            # condensation
+            ts = thermo_state_pθq(param_set, p_c, h_hat, qt_hat)
+            q_liq_en = TD.liquid_specific_humidity(thermo_params, ts)
+            q_ice_en = TD.ice_specific_humidity(thermo_params, ts)
+            T = TD.air_temperature(thermo_params, ts)
+            # autoconversion and accretion
+            mph = precipitation_formation(
+                param_set,
+                precip_model,
+                q_rai,
+                q_sno,
+                subdomain_area,
+                ρ_c,
+                zc,
+                Δt,
+                ts,
+                precip_frac,
+            )
+
+            # environmental variables
+            inner_env[i_ql] += q_liq_en * weights[m_h] * sqpi_inv
+            inner_env[i_qi] += q_ice_en * weights[m_h] * sqpi_inv
+            inner_env[i_T] += T * weights[m_h] * sqpi_inv
+            # cloudy/dry categories for buoyancy in TKE
+            if TD.has_condensate(q_liq_en + q_ice_en)
+                inner_env[i_cf] += weights[m_h] * sqpi_inv
+                inner_env[i_qt_sat] += qt_hat * weights[m_h] * sqpi_inv
+                inner_env[i_T_sat] += T * weights[m_h] * sqpi_inv
+            else
+                inner_env[i_qt_unsat] += qt_hat * weights[m_h] * sqpi_inv
+                inner_env[i_T_unsat] += T * weights[m_h] * sqpi_inv
+            end
+            # products for variance and covariance source terms
+            inner_src[i_Sqt] += mph.qt_tendency * weights[m_h] * sqpi_inv
+            inner_src[i_Sqr] += mph.qr_tendency * weights[m_h] * sqpi_inv
+            inner_src[i_Sqs] += mph.qs_tendency * weights[m_h] * sqpi_inv
+            inner_src[i_SH] += mph.θ_liq_ice_tendency * weights[m_h] * sqpi_inv
+            inner_src[i_Se_tot] += mph.e_tot_tendency * weights[m_h] * sqpi_inv
+            inner_src[i_Sqt_H] += mph.qt_tendency * h_hat * weights[m_h] * sqpi_inv
+            inner_src[i_Sqt_qt] += mph.qt_tendency * qt_hat * weights[m_h] * sqpi_inv
+            inner_src[i_SH_H] += mph.θ_liq_ice_tendency * h_hat * weights[m_h] * sqpi_inv
+            inner_src[i_SH_qt] += mph.θ_liq_ice_tendency * qt_hat * weights[m_h] * sqpi_inv
+        end
+
+        for idx in 1:env_len
+            outer_env[idx] += inner_env[idx] * weights[m_q] * sqpi_inv
+        end
+        for idx in 1:src_len
+            outer_src[idx] += inner_src[idx] * weights[m_q] * sqpi_inv
+        end
+    end
+    outer_src_nt = (;
+        SH_qt = outer_src[i_SH_qt],
+        Sqt_H = outer_src[i_Sqt_H],
+        SH_H = outer_src[i_SH_H],
+        Sqt_qt = outer_src[i_Sqt_qt],
+        Sqt = outer_src[i_Sqt],
+        SH = outer_src[i_SH],
+        Se_tot = outer_src[i_Se_tot],
+        Sqr = outer_src[i_Sqr],
+        Sqs = outer_src[i_Sqs],
+    )
+    outer_env_nt = (;
+        ql = outer_env[i_ql],
+        qi = outer_env[i_qi],
+        T = outer_env[i_T],
+        cf = outer_env[i_cf],
+        qt_sat = outer_env[i_qt_sat],
+        qt_unsat = outer_env[i_qt_unsat],
+        T_sat = outer_env[i_T_sat],
+        T_unsat = outer_env[i_T_unsat],
+    )
+    return outer_env_nt, outer_src_nt
+end
+
+function microphysics(
+    en_thermo::SGSQuadrature,
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    precip_model,
+    Δt::Real,
+    param_set::APS,
+)
+    FT = float_type(state)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_en = center_aux_environment(state)
+    prog_pr = center_prog_precipitation(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_en_unsat = aux_en.unsat
+    aux_en_sat = aux_en.sat
+    tendencies_pr = center_tendencies_precipitation(state)
+    ts_env = center_aux_environment(state).ts
+    precip_fraction = compute_precip_fraction(edmf, state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+
+    #TODO - if we start using eos_smpl for the updrafts calculations
+    #       we can get rid of the two categories for outer and inner quad. points
+
+    # arrays for storing quadarature points and ints for labeling items in the arrays
+    # a python dict would be nicer, but its 30% slower than this (for python 2.7. It might not be the case for python 3)
+
+    epsilon = 10e-14 # eps(float)
+
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        error("The SGS quadrature microphysics is not compatible with non-equilibrium moisture")
+    end
+
+    # initialize the quadrature points and their labels
+
+    @inbounds for k in real_center_indices(grid)
+        if (
+            aux_en.QTvar[k] > epsilon &&
+            aux_en.Hvar[k] > epsilon &&
+            abs(aux_en.HQTcov[k]) > epsilon &&
+            aux_en.q_tot[k] > epsilon &&
+            sqrt(aux_en.QTvar[k]) < aux_en.q_tot[k]
+        )
+            vars = (;
+                qt′qt′ = aux_en.QTvar[k],
+                qt_mean = aux_en.q_tot[k],
+                θl′θl′ = aux_en.Hvar[k],
+                θl_mean = aux_en.θ_liq_ice[k],
+                θl′qt′ = aux_en.HQTcov[k],
+                subdomain_area = aux_en.area[k],
+                q_rai = prog_pr.q_rai[k],
+                q_sno = prog_pr.q_sno[k],
+                ρ_c = ρ_c[k],
+                p_c = p_c[k],
+                precip_frac = precip_fraction,
+                zc = FT(grid.zc[k].z),
+            )
+            outer_env, outer_src = quad_loop(en_thermo, precip_model, vars, param_set, Δt)
+
+            # update environmental variables
+
+            # update_env_precip_tendencies
+            qt_tendency = outer_src.Sqt
+            θ_liq_ice_tendency = outer_src.SH
+            e_tot_tendency = outer_src.Se_tot
+            qr_tendency = outer_src.Sqr
+            qs_tendency = outer_src.Sqs
+            # TODO: move ..._tendency_precip_formation to diagnostics
+            aux_en.qt_tendency_precip_formation[k] = qt_tendency * aux_en.area[k]
+            aux_en.e_tot_tendency_precip_formation[k] = e_tot_tendency * aux_en.area[k]
+
+            tendencies_pr.q_rai[k] += qr_tendency * aux_en.area[k]
+            tendencies_pr.q_sno[k] += qs_tendency * aux_en.area[k]
+
+            # update cloudy/dry variables for buoyancy in TKE
+            aux_en.cloud_fraction[k] = outer_env.cf
+            if aux_en.cloud_fraction[k] < 1
+                aux_en_unsat.q_tot[k] = outer_env.qt_unsat / (1 - aux_en.cloud_fraction[k])
+                T_unsat = outer_env.T_unsat / (1 - aux_en.cloud_fraction[k])
+                ts_unsat = TD.PhaseEquil_pTq(thermo_params, p_c[k], T_unsat, aux_en_unsat.q_tot[k])
+                aux_en_unsat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts_unsat)
+            else
+                aux_en_unsat.q_tot[k] = 0
+                aux_en_unsat.θ_dry[k] = 0
+            end
+
+            if aux_en.cloud_fraction[k] > 0
+                aux_en_sat.T[k] = outer_env.T_sat / aux_en.cloud_fraction[k]
+                aux_en_sat.q_tot[k] = outer_env.qt_sat / aux_en.cloud_fraction[k]
+                aux_en_sat.q_vap[k] = (outer_env.qt_sat - outer_env.ql - outer_env.qi) / aux_en.cloud_fraction[k]
+                ts_sat = TD.PhaseEquil_pTq(thermo_params, p_c[k], aux_en_sat.T[k], aux_en_sat.q_tot[k])
+                aux_en_sat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts_sat)
+                aux_en_sat.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts_sat)
+            else
+                aux_en_sat.T[k] = 0
+                aux_en_sat.q_vap[k] = 0
+                aux_en_sat.q_tot[k] = 0
+                aux_en_sat.θ_dry[k] = 0
+                aux_en_sat.θ_liq_ice[k] = 0
+            end
+
+            # update var/covar rain sources
+            aux_en.Hvar_rain_dt[k] = outer_src.SH_H - outer_src.SH * aux_en.θ_liq_ice[k]
+            aux_en.QTvar_rain_dt[k] = outer_src.Sqt_qt - outer_src.Sqt * aux_en.q_tot[k]
+            aux_en.HQTcov_rain_dt[k] =
+                outer_src.SH_qt - outer_src.SH * aux_en.q_tot[k] + outer_src.Sqt_H - outer_src.Sqt * aux_en.θ_liq_ice[k]
+
+        else
+            # if variance and covariance are zero do the same as in SA_mean
+            ts = ts_env[k]
+            mph = precipitation_formation(
+                param_set,
+                precip_model,
+                prog_pr.q_rai[k],
+                prog_pr.q_sno[k],
+                aux_en.area[k],
+                ρ_c[k],
+                FT(grid.zc[k].z),
+                Δt,
+                ts,
+                precip_fraction,
+            )
+
+            # update_env_precip_tendencies
+            # TODO: move ..._tendency_precip_formation to diagnostics
+            aux_en.qt_tendency_precip_formation[k] = mph.qt_tendency * aux_en.area[k]
+            aux_en.e_tot_tendency_precip_formation[k] = mph.e_tot_tendency * aux_en.area[k]
+            tendencies_pr.q_rai[k] += mph.qr_tendency * aux_en.area[k]
+            tendencies_pr.q_sno[k] += mph.qs_tendency * aux_en.area[k]
+
+            # update_sat_unsat
+            if TD.has_condensate(thermo_params, ts)
+                aux_en.cloud_fraction[k] = 1
+                aux_en_sat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts)
+                aux_en_sat.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts)
+                aux_en_sat.T[k] = TD.air_temperature(thermo_params, ts)
+                aux_en_sat.q_tot[k] = TD.total_specific_humidity(thermo_params, ts)
+                aux_en_sat.q_vap[k] = TD.vapor_specific_humidity(thermo_params, ts)
+            else
+                aux_en.cloud_fraction[k] = 0
+                aux_en_unsat.θ_dry[k] = TD.dry_pottemp(thermo_params, ts)
+                aux_en_unsat.θ_virt[k] = TD.virtual_pottemp(thermo_params, ts)
+                aux_en_unsat.q_tot[k] = TD.total_specific_humidity(thermo_params, ts)
+            end
+
+            aux_en.Hvar_rain_dt[k] = 0
+            aux_en.QTvar_rain_dt[k] = 0
+            aux_en.HQTcov_rain_dt[k] = 0
+        end
+    end
+
+    return nothing
+end

--- a/src/TurbulenceConvection/EDMF_Precipitation.jl
+++ b/src/TurbulenceConvection/EDMF_Precipitation.jl
@@ -1,0 +1,157 @@
+"""
+    compute_precip_fraction
+
+Computes diagnostic precipitation fraction
+"""
+compute_precip_fraction(edmf::EDMFModel, state::State) = compute_precip_fraction(edmf.precip_fraction_model, state)
+
+compute_precip_fraction(precip_fraction_model::PrescribedPrecipFraction, ::State) =
+    precip_fraction_model.prescribed_precip_frac_value
+
+function compute_precip_fraction(precip_fraction_model::DiagnosticPrecipFraction, state::State)
+    aux_gm = center_aux_grid_mean(state)
+    maxcf = maximum(aux_gm.cloud_fraction)
+    return max(maxcf, precip_fraction_model.precip_fraction_limiter)
+end
+
+"""
+Computes the rain and snow advection (down) tendency
+"""
+compute_precipitation_advection_tendencies(
+    ::AbstractPrecipitationModel,
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+) = nothing
+
+function compute_precipitation_advection_tendencies(
+    ::Clima1M,
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+)
+    FT = float_type(state)
+
+    tendencies_pr = center_tendencies_precipitation(state)
+    prog_pr = center_prog_precipitation(state)
+    aux_tc = center_aux_turbconv(state)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+
+    # helper to calculate the rain velocity
+    # TODO: assuming w_gm = 0
+    # TODO: verify translation
+    term_vel_rain = aux_tc.term_vel_rain
+    term_vel_snow = aux_tc.term_vel_snow
+
+    precip_fraction = compute_precip_fraction(edmf, state)
+
+    q_rai = prog_pr.q_rai #./ precip_fraction
+    q_sno = prog_pr.q_sno #./ precip_fraction
+
+    If = CCO.DivergenceF2C()
+    RB = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
+    ∇ = CCO.DivergenceF2C(; bottom = CCO.Extrapolate())
+    wvec = CC.Geometry.WVector
+
+    # TODO - some positivity limiters are needed
+    @. aux_tc.qr_tendency_advection = ∇(wvec(RB(ρ_c * q_rai * term_vel_rain))) / ρ_c# * precip_fraction
+    @. aux_tc.qs_tendency_advection = ∇(wvec(RB(ρ_c * q_sno * term_vel_snow))) / ρ_c# * precip_fraction
+
+    @. tendencies_pr.q_rai += aux_tc.qr_tendency_advection
+    @. tendencies_pr.q_sno += aux_tc.qs_tendency_advection
+    return nothing
+end
+
+"""
+Computes the tendencies to θ_liq_ice, q_tot, q_rain and q_snow
+due to rain evaporation, snow deposition and sublimation and snow melt
+"""
+compute_precipitation_sink_tendencies(
+    ::AbstractPrecipitationModel,
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+    Δt::Real,
+) = nothing
+
+function compute_precipitation_sink_tendencies(
+    ::Clima1M,
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+    Δt::Real,
+)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    microphys_params = TCP.microphysics_params(param_set)
+    aux_gm = center_aux_grid_mean(state)
+    aux_tc = center_aux_turbconv(state)
+    prog_gm = center_prog_grid_mean(state)
+    prog_pr = center_prog_precipitation(state)
+    ρ_c = prog_gm.ρ
+    tendencies_pr = center_tendencies_precipitation(state)
+    ts_gm = aux_gm.ts
+
+    precip_fraction = compute_precip_fraction(edmf, state)
+
+    @inbounds for k in real_center_indices(grid)
+        qr = prog_pr.q_rai[k] / precip_fraction
+        qs = prog_pr.q_sno[k] / precip_fraction
+        ρ = ρ_c[k]
+        q_tot_gm = aux_gm.q_tot[k]
+        T_gm = aux_gm.T[k]
+        # When we fuse loops, this should hopefully disappear
+        ts = ts_gm[k]
+        q = TD.PhasePartition(thermo_params, ts)
+        qv = TD.vapor_specific_humidity(thermo_params, ts)
+
+        Π_m = TD.exner(thermo_params, ts)
+        c_pm = TD.cp_m(thermo_params, ts)
+        c_vm = TD.cv_m(thermo_params, ts)
+        R_m = TD.gas_constant_air(thermo_params, ts)
+        R_v = TCP.R_v(param_set)
+        L_v0 = TCP.LH_v0(param_set)
+        L_s0 = TCP.LH_s0(param_set)
+        L_v = TD.latent_heat_vapor(thermo_params, ts)
+        L_s = TD.latent_heat_sublim(thermo_params, ts)
+        L_f = TD.latent_heat_fusion(thermo_params, ts)
+
+        I_l = TD.internal_energy_liquid(thermo_params, ts)
+        I_i = TD.internal_energy_ice(thermo_params, ts)
+        I = TD.internal_energy(thermo_params, ts)
+        Φ = geopotential(param_set, grid.zc.z[k])
+
+        α_evp = TCP.microph_scaling(param_set)
+        α_dep_sub = TCP.microph_scaling_dep_sub(param_set)
+        α_melt = TCP.microph_scaling_melt(param_set)
+
+        # TODO - move limiters elsewhere
+        # TODO - when using adaptive timestepping we are limiting the source terms
+        #        with the previous timestep dt
+        S_qr_evap =
+            -min(qr / Δt, -α_evp * CM1.evaporation_sublimation(microphys_params, rain_type, q, qr, ρ, T_gm)) *
+            precip_fraction
+        S_qs_melt = -min(qs / Δt, α_melt * CM1.snow_melt(microphys_params, qs, ρ, T_gm)) * precip_fraction
+        tmp = α_dep_sub * CM1.evaporation_sublimation(microphys_params, snow_type, q, qs, ρ, T_gm) * precip_fraction
+        if tmp > 0
+            S_qs_sub_dep = min(qv / Δt, tmp)
+        else
+            S_qs_sub_dep = -min(qs / Δt, -tmp)
+        end
+
+        aux_tc.qr_tendency_evap[k] = S_qr_evap
+        aux_tc.qs_tendency_melt[k] = S_qs_melt
+        aux_tc.qs_tendency_dep_sub[k] = S_qs_sub_dep
+
+        tendencies_pr.q_rai[k] += S_qr_evap - S_qs_melt
+        tendencies_pr.q_sno[k] += S_qs_sub_dep + S_qs_melt
+
+        aux_tc.qt_tendency_precip_sinks[k] = -S_qr_evap - S_qs_sub_dep
+        aux_tc.e_tot_tendency_precip_sinks[k] = -S_qr_evap * (I_l + Φ) - S_qs_sub_dep * (I_i + Φ) + S_qs_melt * L_f
+    end
+    return nothing
+end

--- a/src/TurbulenceConvection/EDMF_Updrafts.jl
+++ b/src/TurbulenceConvection/EDMF_Updrafts.jl
@@ -1,0 +1,128 @@
+"""
+Computes tendencies to q_liq and q_ice due to
+condensation, evaporation, deposition and sublimation
+"""
+function compute_nonequilibrium_moisture_tendencies!(
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    Δt::Real,
+    param_set::APS,
+)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    N_up = n_updrafts(edmf)
+    aux_gm = center_aux_grid_mean(state)
+    aux_up = center_aux_updrafts(state)
+    aux_bulk = center_aux_bulk(state)
+    prog_gm = center_prog_grid_mean(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+
+    @inbounds for i in 1:N_up
+        @inbounds for k in real_center_indices(grid)
+            T_up = aux_up[i].T[k]
+            q_up = TD.PhasePartition(aux_up[i].q_tot[k], aux_up[i].q_liq[k], aux_up[i].q_ice[k])
+            ts_up = TD.PhaseNonEquil_pTq(thermo_params, p_c[k], T_up, q_up)
+
+            # condensation/evaporation, deposition/sublimation
+            mph = noneq_moisture_sources(param_set, aux_up[i].area[k], ρ_c[k], Δt, ts_up)
+            aux_up[i].ql_tendency_noneq[k] = mph.ql_tendency * aux_up[i].area[k]
+            aux_up[i].qi_tendency_noneq[k] = mph.qi_tendency * aux_up[i].area[k]
+        end
+    end
+    @inbounds for k in real_center_indices(grid)
+        aux_bulk.ql_tendency_noneq[k] = 0
+        aux_bulk.qi_tendency_noneq[k] = 0
+        @inbounds for i in 1:N_up
+            aux_bulk.ql_tendency_noneq[k] += aux_up[i].ql_tendency_noneq[k]
+            aux_bulk.qi_tendency_noneq[k] += aux_up[i].qi_tendency_noneq[k]
+        end
+    end
+    return nothing
+end
+
+"""
+Computes tendencies to qt and θ_liq_ice due to precipitation formation
+"""
+function compute_precipitation_formation_tendencies(
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    precip_model::AbstractPrecipitationModel,
+    Δt::Real,
+    param_set::APS,
+)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_up = center_aux_updrafts(state)
+    aux_bulk = center_aux_bulk(state)
+    prog_pr = center_prog_precipitation(state)
+    tendencies_pr = center_tendencies_precipitation(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+
+    precip_fraction = compute_precip_fraction(edmf, state)
+
+    @inbounds for i in 1:N_up
+        @inbounds for k in real_center_indices(grid)
+            T_up = aux_up[i].T[k]
+            q_tot_up = aux_up[i].q_tot[k]
+            if edmf.moisture_model isa EquilibriumMoisture
+                ts_up = TD.PhaseEquil_pTq(thermo_params, p_c[k], T_up, q_tot_up)
+            elseif edmf.moisture_model isa NonEquilibriumMoisture
+                q_liq_up = aux_up[i].q_liq[k]
+                q_ice_up = aux_up[i].q_ice[k]
+                q = TD.PhasePartition(q_tot_up, q_liq_up, q_ice_up)
+                ts_up = TD.PhaseNonEquil_pTq(thermo_params, p_c[k], T_up, q)
+            else
+                error(
+                    "Something went wrong in EDMF_Updrafts. The expected moisture model is Equilibrium or NonEquilibrium",
+                )
+            end
+
+            # autoconversion and accretion
+            mph = precipitation_formation(
+                param_set,
+                precip_model,
+                prog_pr.q_rai[k],
+                prog_pr.q_sno[k],
+                aux_up[i].area[k],
+                ρ_c[k],
+                FT(grid.zc[k].z),
+                Δt,
+                ts_up,
+                precip_fraction,
+            )
+            aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
+            aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]
+            aux_up[i].e_tot_tendency_precip_formation[k] = mph.e_tot_tendency * aux_up[i].area[k]
+            if edmf.moisture_model isa NonEquilibriumMoisture
+                aux_up[i].ql_tendency_precip_formation[k] = mph.ql_tendency * aux_up[i].area[k]
+                aux_up[i].qi_tendency_precip_formation[k] = mph.qi_tendency * aux_up[i].area[k]
+            end
+            tendencies_pr.q_rai[k] += mph.qr_tendency * aux_up[i].area[k]
+            tendencies_pr.q_sno[k] += mph.qs_tendency * aux_up[i].area[k]
+        end
+    end
+    # TODO - to be deleted once we sum all tendencies elsewhere
+    @inbounds for k in real_center_indices(grid)
+        aux_bulk.e_tot_tendency_precip_formation[k] = 0
+        aux_bulk.qt_tendency_precip_formation[k] = 0
+        @inbounds for i in 1:N_up
+            aux_bulk.e_tot_tendency_precip_formation[k] += aux_up[i].e_tot_tendency_precip_formation[k]
+            aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
+        end
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            aux_bulk.ql_tendency_precip_formation[k] = 0
+            aux_bulk.qi_tendency_precip_formation[k] = 0
+            @inbounds for i in 1:N_up
+                aux_bulk.ql_tendency_precip_formation[k] += aux_up[i].ql_tendency_precip_formation[k]
+                aux_bulk.qi_tendency_precip_formation[k] += aux_up[i].qi_tendency_precip_formation[k]
+            end
+        end
+    end
+    return nothing
+end

--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -1,0 +1,1113 @@
+
+function update_cloud_frac(edmf::EDMFModel, grid::Grid, state::State)
+    # update grid-mean cloud fraction and cloud cover
+    aux_bulk = center_aux_bulk(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_en = center_aux_environment(state)
+    a_up_bulk = aux_bulk.area
+    @inbounds for k in real_center_indices(grid) # update grid-mean cloud fraction and cloud cover
+        aux_gm.cloud_fraction[k] = aux_en.area[k] * aux_en.cloud_fraction[k] + a_up_bulk[k] * aux_bulk.cloud_fraction[k]
+    end
+end
+
+function compute_turbconv_tendencies!(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+    surf::SurfaceBase,
+    Δt::Real,
+)
+    compute_up_tendencies!(edmf, grid, state, param_set, surf)
+    compute_en_tendencies!(edmf, grid, state, param_set, Val(:tke), Val(:ρatke))
+
+    if edmf.thermo_covariance_model isa PrognosticThermoCovariances
+        compute_en_tendencies!(edmf, grid, state, param_set, Val(:Hvar), Val(:ρaHvar))
+        compute_en_tendencies!(edmf, grid, state, param_set, Val(:QTvar), Val(:ρaQTvar))
+        compute_en_tendencies!(edmf, grid, state, param_set, Val(:HQTcov), Val(:ρaHQTcov))
+    end
+
+    return nothing
+end
+function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    N_up = n_updrafts(edmf)
+    tendencies_gm = center_tendencies_grid_mean(state)
+    FT = float_type(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_up = center_aux_updrafts(state)
+    aux_tc_f = face_aux_turbconv(state)
+    aux_up_f = face_aux_updrafts(state)
+    ρ_f = aux_gm_f.ρ
+    ρ_c = prog_gm.ρ
+    p_c = aux_gm.p
+    kf_surf = kf_surface(grid)
+    kc_surf = kc_surface(grid)
+    massflux = aux_tc_f.massflux
+    massflux_h = aux_tc_f.massflux_h
+    massflux_qt = aux_tc_f.massflux_qt
+    aux_tc = center_aux_turbconv(state)
+
+    wvec = CC.Geometry.WVector
+    ∇c = CCO.DivergenceF2C()
+
+    # TODO: we shouldn't need to call parent here
+    a_en = aux_en.area
+    w_en = aux_en_f.w
+    w_gm = prog_gm_f.w
+    h_tot_gm = aux_gm.h_tot
+    q_tot_gm = aux_gm.q_tot
+    q_tot_en = aux_en.q_tot
+    a_en_bcs = a_en_boundary_conditions(surf, edmf)
+    Ifae = CCO.InterpolateC2F(; a_en_bcs...)
+    If = CCO.InterpolateC2F(; bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
+    Ic = CCO.InterpolateF2C()
+
+    # compute total enthalpies
+    ts_en = center_aux_environment(state).ts
+    ts_gm = center_aux_grid_mean(state).ts
+    @. h_tot_gm = total_enthalpy(param_set, prog_gm.ρe_tot / ρ_c, ts_gm)
+    # Compute the mass flux and associated scalar fluxes
+    @. massflux = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm))
+    @. massflux_h = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm)) * (If(aux_en.h_tot) - If(h_tot_gm))
+    @. massflux_qt = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm)) * (If(q_tot_en) - If(q_tot_gm))
+    @inbounds for i in 1:N_up
+        aux_up_f_i = aux_up_f[i]
+        aux_up_i = aux_up[i]
+        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        Ifau = CCO.InterpolateC2F(; a_up_bcs...)
+        a_up = aux_up[i].area
+        w_up_i = aux_up_f[i].w
+        q_tot_up = aux_up_i.q_tot
+        h_tot_up = aux_up_i.h_tot
+        @. aux_up_f[i].massflux = ρ_f * Ifau(a_up) * (w_up_i - toscalar(w_gm))
+        @. massflux_h += ρ_f * (Ifau(a_up) * (w_up_i - toscalar(w_gm)) * (If(h_tot_up) - If(h_tot_gm)))
+        @. massflux_qt += ρ_f * (Ifau(a_up) * (w_up_i - toscalar(w_gm)) * (If(q_tot_up) - If(q_tot_gm)))
+    end
+
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        massflux_en = aux_tc_f.massflux_en
+        massflux_ql = aux_tc_f.massflux_ql
+        massflux_qi = aux_tc_f.massflux_qi
+        q_liq_en = aux_en.q_liq
+        q_ice_en = aux_en.q_ice
+        q_liq_gm = prog_gm.q_liq
+        q_ice_gm = prog_gm.q_ice
+        @. massflux_en = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm))
+        @. massflux_ql = massflux_en * (If(q_liq_en) - If(q_liq_gm))
+        @. massflux_qi = massflux_en * (If(q_ice_en) - If(q_ice_gm))
+        @inbounds for i in 1:N_up
+            aux_up_f_i = aux_up_f[i]
+            aux_up_i = aux_up[i]
+            q_liq_up = aux_up_i.q_liq
+            q_ice_up = aux_up_i.q_ice
+            massflux_up_i = aux_up_f[i].massflux
+            @. massflux_ql += massflux_up_i * (If(q_liq_up) - If(q_liq_gm))
+            @. massflux_qi += massflux_up_i * (If(q_ice_up) - If(q_ice_gm))
+        end
+        massflux_ql[kf_surf] = 0
+        massflux_qi[kf_surf] = 0
+    end
+
+    massflux_h[kf_surf] = 0
+    massflux_qt[kf_surf] = 0
+
+    massflux_tendency_h = aux_tc.massflux_tendency_h
+    massflux_tendency_qt = aux_tc.massflux_tendency_qt
+    # Compute the  mass flux tendencies
+    # Adjust the values of the grid mean variables
+    # Prepare the output
+    @. massflux_tendency_h = -∇c(wvec(massflux_h)) / ρ_c
+    @. massflux_tendency_qt = -∇c(wvec(massflux_qt)) / ρ_c
+
+    diffusive_flux_h = aux_tc_f.diffusive_flux_h
+    diffusive_flux_qt = aux_tc_f.diffusive_flux_qt
+    diffusive_flux_uₕ = aux_tc_f.diffusive_flux_uₕ
+
+    sgs_flux_h_tot = aux_gm_f.sgs_flux_h_tot
+    sgs_flux_q_tot = aux_gm_f.sgs_flux_q_tot
+    sgs_flux_uₕ = aux_gm_f.sgs_flux_uₕ
+
+    @. sgs_flux_h_tot = diffusive_flux_h + massflux_h
+    @. sgs_flux_q_tot = diffusive_flux_qt + massflux_qt
+    @. sgs_flux_uₕ = diffusive_flux_uₕ # + massflux_u
+
+    # apply surface BC as SGS flux at lowest level
+    lg_surf = CC.Fields.local_geometry_field(axes(ρ_f))[kf_surf]
+    sgs_flux_h_tot[kf_surf] = surf.ρe_tot_flux
+    sgs_flux_q_tot[kf_surf] = surf.ρq_tot_flux
+    sgs_flux_uₕ[kf_surf] =
+        CCG.Covariant3Vector(wvec(FT(1)), lg_surf) ⊗
+        CCG.Covariant12Vector(CCG.UVVector(surf.ρu_flux, surf.ρv_flux), lg_surf)
+
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        massflux_tendency_ql = aux_tc.massflux_tendency_ql
+        massflux_tendency_qi = aux_tc.massflux_tendency_qi
+
+        @. massflux_tendency_ql = -∇c(wvec(massflux_ql)) / ρ_c
+        @. massflux_tendency_qi = -∇c(wvec(massflux_qi)) / ρ_c
+
+        diffusive_flux_ql = aux_tc_f.diffusive_flux_ql
+        diffusive_flux_qi = aux_tc_f.diffusive_flux_qi
+
+        sgs_flux_q_liq = aux_gm_f.sgs_flux_q_liq
+        sgs_flux_q_ice = aux_gm_f.sgs_flux_q_ice
+
+        @. sgs_flux_q_liq = diffusive_flux_ql + massflux_ql
+        @. sgs_flux_q_ice = diffusive_flux_qi + massflux_qi
+
+        sgs_flux_q_liq[kf_surf] = surf.ρq_liq_flux
+        sgs_flux_q_ice[kf_surf] = surf.ρq_ice_flux
+    end
+
+    return nothing
+end
+
+function compute_diffusive_fluxes(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    FT = float_type(state)
+    aux_bulk = center_aux_bulk(state)
+    aux_tc_f = face_aux_turbconv(state)
+    aux_en_f = face_aux_environment(state)
+    aux_en = center_aux_environment(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
+    aeKM = center_aux_turbconv(state).ϕ_temporary
+    aeKH = center_aux_turbconv(state).ψ_temporary
+    prog_gm_uₕ = grid_mean_uₕ(state)
+
+    ρ_f = aux_gm_f.ρ
+    a_en = aux_en.area
+    @. aeKM = a_en * KM
+    @. aeKH = a_en * KH
+    kc_surf = kc_surface(grid)
+    kc_toa = kc_top_of_atmos(grid)
+    kf_surf = kf_surface(grid)
+    prog_gm = center_prog_grid_mean(state)
+    IfKH = CCO.InterpolateC2F(; bottom = CCO.SetValue(aeKH[kc_surf]), top = CCO.SetValue(aeKH[kc_toa]))
+    IfKM = CCO.InterpolateC2F(; bottom = CCO.SetValue(aeKM[kc_surf]), top = CCO.SetValue(aeKM[kc_toa]))
+    Ic = CCO.InterpolateF2C()
+
+    @. aux_tc_f.ρ_ae_KH = IfKH(aeKH) * ρ_f
+    @. aux_tc_f.ρ_ae_KM = IfKM(aeKM) * ρ_f
+
+    aeKHq_tot_bc = -surf.ρq_tot_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KH[kf_surf]
+    aeKHh_tot_bc = -surf.ρe_tot_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KH[kf_surf]
+    aeKMu_bc = -surf.ρu_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
+    aeKMv_bc = -surf.ρv_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
+
+    aeKMuₕ_bc = CCG.UVVector(aeKMu_bc, aeKMv_bc)
+
+    ∇q_tot_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHq_tot_bc), top = CCO.SetDivergence(FT(0)))
+    ∇h_tot_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHh_tot_bc), top = CCO.SetDivergence(FT(0)))
+    # CCG.Covariant3Vector(FT(1)) ⊗ CCG.Covariant12Vector(FT(aeKMu_bc),FT(aeKMv_bc))
+    local_geometry_surf = CC.Fields.local_geometry_field(axes(ρ_f))[kf_surf]
+    wvec = CC.Geometry.WVector
+    ∇uₕ_gm = CCO.GradientC2F(;
+        bottom = CCO.SetGradient(
+            CCG.Covariant3Vector(wvec(FT(1)), local_geometry_surf) ⊗
+            CCG.Covariant12Vector(aeKMuₕ_bc, local_geometry_surf),
+        ),
+        top = CCO.SetGradient(
+            CCG.Covariant3Vector(wvec(FT(0)), local_geometry_surf) ⊗ CCG.Covariant12Vector(FT(0), FT(0)),
+        ),
+    )
+
+    @. aux_tc_f.diffusive_flux_qt = -aux_tc_f.ρ_ae_KH * ∇q_tot_en(wvec(aux_en.q_tot))
+    @. aux_tc_f.diffusive_flux_h = -aux_tc_f.ρ_ae_KH * ∇h_tot_en(wvec(aux_en.h_tot))
+    @. aux_tc_f.diffusive_flux_uₕ = -aux_tc_f.ρ_ae_KM * ∇uₕ_gm(prog_gm_uₕ)
+
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        aeKHq_liq_bc = FT(0)
+        aeKHq_ice_bc = FT(0)
+
+        ∇q_liq_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHq_liq_bc), top = CCO.SetDivergence(FT(0)))
+        ∇q_ice_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHq_ice_bc), top = CCO.SetDivergence(FT(0)))
+
+        @. aux_tc_f.diffusive_flux_ql = -aux_tc_f.ρ_ae_KH * ∇q_liq_en(wvec(aux_en.q_liq))
+        @. aux_tc_f.diffusive_flux_qi = -aux_tc_f.ρ_ae_KH * ∇q_ice_en(wvec(aux_en.q_ice))
+    end
+
+    return nothing
+end
+
+function affect_filter!(edmf::EDMFModel, grid::Grid, state::State, param_set::APS, surf::SurfaceBase, t::Real)
+    prog_en = center_prog_environment(state)
+    aux_en = center_aux_environment(state)
+    ###
+    ### Filters
+    ###
+    set_edmf_surface_bc(edmf, grid, state, surf, param_set)
+    filter_updraft_vars(edmf, grid, state, surf, param_set)
+
+    @inbounds for k in real_center_indices(grid)
+        prog_en.ρatke[k] = max(prog_en.ρatke[k], 0.0)
+        if edmf.thermo_covariance_model isa PrognosticThermoCovariances
+            prog_en.ρaHvar[k] = max(prog_en.ρaHvar[k], 0.0)
+            prog_en.ρaQTvar[k] = max(prog_en.ρaQTvar[k], 0.0)
+            prog_en.ρaHQTcov[k] = max(prog_en.ρaHQTcov[k], -sqrt(prog_en.ρaHvar[k] * prog_en.ρaQTvar[k]))
+            prog_en.ρaHQTcov[k] = min(prog_en.ρaHQTcov[k], sqrt(prog_en.ρaHvar[k] * prog_en.ρaQTvar[k]))
+        end
+    end
+    return nothing
+end
+
+function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kf_surf = kf_surface(grid)
+    aux_gm = center_aux_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    prog_gm = center_prog_grid_mean(state)
+    prog_up = center_prog_updrafts(state)
+    prog_en = center_prog_environment(state)
+    prog_up_f = face_prog_updrafts(state)
+    aux_bulk = center_aux_bulk(state)
+    ts_gm = aux_gm.ts
+    cp = TD.cp_m(thermo_params, ts_gm[kc_surf])
+    ρ_c = prog_gm.ρ
+    ρ_f = aux_gm_f.ρ
+    ae_surf::FT = 1
+    @inbounds for i in 1:N_up
+        θ_surf = θ_surface_bc(surf, grid, state, edmf, i, param_set)
+        q_surf = q_surface_bc(surf, grid, state, edmf, i)
+        a_surf = area_surface_bc(surf, edmf, i)
+        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
+        prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
+        prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            q_liq_surf = FT(0)
+            q_ice_surf = FT(0)
+            prog_up[i].ρaq_liq[kc_surf] = prog_up[i].ρarea[kc_surf] * q_liq_surf
+            prog_up[i].ρaq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * q_ice_surf
+        end
+        prog_up_f[i].ρaw[kf_surf] = ρ_f[kf_surf] * w_surface_bc(surf)
+        ae_surf -= a_surf
+    end
+
+    flux1 = surf.shf / cp
+    flux2 = surf.ρq_tot_flux
+    zLL::FT = grid.zc[kc_surf].z
+    ustar = surf.ustar
+    oblength = surf.obukhov_length
+    ρLL = prog_gm.ρ[kc_surf]
+    ρ_ae = ρ_c[kc_surf] * ae_surf
+    mix_len_params = mixing_length_params(edmf)
+    prog_en.ρatke[kc_surf] = ρ_ae * get_surface_tke(mix_len_params, surf.ustar, zLL, surf.obukhov_length)
+    if edmf.thermo_covariance_model isa PrognosticThermoCovariances
+        prog_en.ρaHvar[kc_surf] = ρ_ae * get_surface_variance(flux1 / ρLL, flux1 / ρLL, ustar, zLL, oblength)
+        prog_en.ρaQTvar[kc_surf] = ρ_ae * get_surface_variance(flux2 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+        prog_en.ρaHQTcov[kc_surf] = ρ_ae * get_surface_variance(flux1 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+    end
+    return nothing
+end
+
+function surface_helper(surf::SurfaceBase, grid::Grid, state::State)
+    FT = float_type(state)
+    kc_surf = kc_surface(grid)
+    prog_gm = center_prog_grid_mean(state)
+    zLL::FT = grid.zc[kc_surf].z
+    ustar = surf.ustar
+    oblength = surf.obukhov_length
+    ρLL = prog_gm.ρ[kc_surf]
+    return (; ustar, zLL, oblength, ρLL)
+end
+
+function a_up_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel, i::Int)
+    a_surf = area_surface_bc(surf, edmf, i)
+    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+end
+
+function a_bulk_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel)
+    N_up = n_updrafts(edmf)
+    a_surf = sum(i -> area_surface_bc(surf, edmf, i), 1:N_up)
+    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+end
+
+function a_en_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel)
+    N_up = n_updrafts(edmf)
+    a_surf = 1 - sum(i -> area_surface_bc(surf, edmf, i), 1:N_up)
+    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+end
+
+function area_surface_bc(surf::SurfaceBase{FT}, edmf::EDMFModel, i::Int)::FT where {FT}
+    N_up = n_updrafts(edmf)
+    return surf.bflux > 0 ? edmf.surface_area / N_up : FT(0)
+end
+
+function w_surface_bc(::SurfaceBase{FT})::FT where {FT}
+    return FT(0)
+end
+function uₕ_bcs()
+    return CCO.InterpolateC2F(bottom = CCO.Extrapolate(), top = CCO.Extrapolate())
+end
+function θ_surface_bc(
+    surf::SurfaceBase{FT},
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    i::Int,
+    param_set::APS,
+)::FT where {FT}
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_gm = center_aux_grid_mean(state)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    kc_surf = kc_surface(grid)
+    ts_gm = aux_gm.ts
+    c_p = TD.cp_m(thermo_params, ts_gm[kc_surf])
+    UnPack.@unpack ustar, zLL, oblength, ρLL = surface_helper(surf, grid, state)
+
+    surf.bflux > 0 || return FT(0)
+    set_src_seed = edmf.set_src_seed
+    a_total = edmf.surface_area
+    a_ = area_surface_bc(surf, edmf, i)
+    ρθ_liq_ice_flux = surf.shf / c_p # assuming no ql,qi flux
+    h_var = get_surface_variance(ρθ_liq_ice_flux / ρLL, ρθ_liq_ice_flux / ρLL, ustar, zLL, oblength)
+    surface_scalar_coeff =
+        percentile_bounds_mean_norm(1 - a_total + (i - 1) * a_, 1 - a_total + i * a_, 1000, set_src_seed)
+    return aux_gm.θ_liq_ice[kc_surf] + surface_scalar_coeff * sqrt(h_var)
+end
+function q_surface_bc(surf::SurfaceBase{FT}, grid::Grid, state::State, edmf::EDMFModel, i::Int)::FT where {FT}
+    aux_gm = center_aux_grid_mean(state)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    kc_surf = kc_surface(grid)
+    surf.bflux > 0 || return aux_gm.q_tot[kc_surf]
+    a_total = edmf.surface_area
+    set_src_seed = edmf.set_src_seed
+    a_ = area_surface_bc(surf, edmf, i)
+    UnPack.@unpack ustar, zLL, oblength, ρLL = surface_helper(surf, grid, state)
+    ρq_tot_flux = surf.ρq_tot_flux
+    qt_var = get_surface_variance(ρq_tot_flux / ρLL, ρq_tot_flux / ρLL, ustar, zLL, oblength)
+    surface_scalar_coeff =
+        percentile_bounds_mean_norm(1 - a_total + (i - 1) * a_, 1 - a_total + i * a_, 1000, set_src_seed)
+    return aux_gm.q_tot[kc_surf] + surface_scalar_coeff * sqrt(qt_var)
+end
+function ql_surface_bc(surf::SurfaceBase{FT})::FT where {FT}
+    return FT(0)
+end
+function qi_surface_bc(surf::SurfaceBase{FT})::FT where {FT}
+    return FT(0)
+end
+
+function get_GMV_CoVar(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_sym},
+    ::Val{ϕ_sym},
+    ::Val{ψ_sym},
+) where {covar_sym, ϕ_sym, ψ_sym}
+    N_up = n_updrafts(edmf)
+    is_tke = covar_sym == :tke
+    FT = float_type(state)
+    tke_factor = is_tke ? FT(0.5) : 1
+    aux_gm_c = center_aux_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    prog_gm_c = center_prog_grid_mean(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en_c = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_en = is_tke ? aux_en_f : aux_en_c
+    aux_up_c = center_aux_updrafts(state)
+    aux_up = is_tke ? aux_up_f : aux_up_c
+    gmv_covar = getproperty(center_aux_grid_mean(state), covar_sym)
+    covar_e = getproperty(center_aux_environment(state), covar_sym)
+    gm = is_tke ? prog_gm_f : aux_gm_c
+    to_scalar = is_tke ? toscalar : x -> x
+    ϕ_gm = getproperty(gm, ϕ_sym)
+    ψ_gm = getproperty(gm, ψ_sym)
+    ϕ_en = getproperty(aux_en, ϕ_sym)
+    ψ_en = getproperty(aux_en, ψ_sym)
+    area_en = aux_en_c.area
+
+    Icd = is_tke ? CCO.InterpolateF2C() : x -> x
+    @. gmv_covar = tke_factor * area_en * Icd(ϕ_en - to_scalar(ϕ_gm)) * Icd(ψ_en - to_scalar(ψ_gm)) + area_en * covar_e
+    @inbounds for i in 1:N_up
+        ϕ_up = getproperty(aux_up[i], ϕ_sym)
+        ψ_up = getproperty(aux_up[i], ψ_sym)
+        @. gmv_covar += tke_factor * aux_up_c[i].area * Icd(ϕ_up - to_scalar(ϕ_gm)) * Icd(ψ_up - to_scalar(ψ_gm))
+    end
+    return nothing
+end
+
+function compute_updraft_top(grid::Grid{FT}, state::State, i::Int)::FT where {FT}
+    aux_up = center_aux_updrafts(state)
+    return z_findlast_center(k -> aux_up[i].area[k] > 1e-3, grid)
+end
+
+function compute_plume_scale_height(grid::Grid, state::State, H_up_min::FT, i::Int)::FT where {FT}
+    updraft_top::FT = compute_updraft_top(grid, state, i)
+    return max(updraft_top, H_up_min)
+end
+
+function compute_up_stoch_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param_set::APS, surf::SurfaceBase)
+    N_up = n_updrafts(edmf)
+
+    aux_up = center_aux_updrafts(state)
+    tendencies_up = center_tendencies_updrafts(state)
+
+    @inbounds for i in 1:N_up
+        # prognostic entr/detr
+        tends_ε_nondim = tendencies_up[i].ε_nondim
+        tends_δ_nondim = tendencies_up[i].δ_nondim
+
+        c_gen_stoch = edmf.entr_closure.c_gen_stoch
+        mean_entr = aux_up[i].ε_nondim
+        mean_detr = aux_up[i].δ_nondim
+        ε_σ² = c_gen_stoch[1]
+        δ_σ² = c_gen_stoch[2]
+        ε_λ = c_gen_stoch[3]
+        δ_λ = c_gen_stoch[4]
+        @. tends_ε_nondim = √(2ε_λ * mean_entr * ε_σ²)
+        @. tends_δ_nondim = √(2δ_λ * mean_detr * δ_σ²)
+    end
+end
+
+
+function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param_set::APS, surf::SurfaceBase)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kf_surf = kf_surface(grid)
+    FT = float_type(state)
+
+    aux_up = center_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_up_f = face_aux_updrafts(state)
+    prog_up = center_prog_updrafts(state)
+    prog_up_f = face_prog_updrafts(state)
+    tendencies_up = center_tendencies_updrafts(state)
+    tendencies_up_f = face_tendencies_updrafts(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    ρ_f = aux_gm_f.ρ
+    au_lim = edmf.max_area
+
+    @inbounds for i in 1:N_up
+        aux_up_i = aux_up[i]
+        @. aux_up_i.entr_turb_dyn = aux_up_i.entr_sc + aux_up_i.frac_turb_entr
+        @. aux_up_i.detr_turb_dyn = aux_up_i.detr_sc + aux_up_i.frac_turb_entr
+    end
+
+    UB = CCO.UpwindBiasedProductC2F(bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
+    Ic = CCO.InterpolateF2C()
+
+    wvec = CC.Geometry.WVector
+    ∇c = CCO.DivergenceF2C()
+    w_bcs = (; bottom = CCO.SetValue(wvec(FT(0))), top = CCO.SetValue(wvec(FT(0))))
+    LBF = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(FT(0)))
+
+    # Solve for updraft area fraction
+    @inbounds for i in 1:N_up
+        aux_up_i = aux_up[i]
+        w_up = aux_up_f[i].w
+        a_up = aux_up_i.area
+        q_tot_up = aux_up_i.q_tot
+        q_tot_en = aux_en.q_tot
+        θ_liq_ice_en = aux_en.θ_liq_ice
+        θ_liq_ice_up = aux_up_i.θ_liq_ice
+        entr_turb_dyn = aux_up_i.entr_turb_dyn
+        detr_turb_dyn = aux_up_i.detr_turb_dyn
+        θ_liq_ice_tendency_precip_formation = aux_up_i.θ_liq_ice_tendency_precip_formation
+        qt_tendency_precip_formation = aux_up_i.qt_tendency_precip_formation
+
+        ρarea = prog_up[i].ρarea
+        ρaθ_liq_ice = prog_up[i].ρaθ_liq_ice
+        ρaq_tot = prog_up[i].ρaq_tot
+
+        tends_ρarea = tendencies_up[i].ρarea
+        tends_ρaθ_liq_ice = tendencies_up[i].ρaθ_liq_ice
+        tends_ρaq_tot = tendencies_up[i].ρaq_tot
+
+        @. tends_ρarea =
+            -∇c(wvec(LBF(Ic(w_up) * ρarea))) + (ρarea * Ic(w_up) * entr_turb_dyn) - (ρarea * Ic(w_up) * detr_turb_dyn)
+
+        @. tends_ρaθ_liq_ice =
+            -∇c(wvec(LBF(Ic(w_up) * ρaθ_liq_ice))) + (ρarea * Ic(w_up) * entr_turb_dyn * θ_liq_ice_en) -
+            (ρaθ_liq_ice * Ic(w_up) * detr_turb_dyn) + (ρ_c * θ_liq_ice_tendency_precip_formation)
+
+        @. tends_ρaq_tot =
+            -∇c(wvec(LBF(Ic(w_up) * ρaq_tot))) + (ρarea * Ic(w_up) * entr_turb_dyn * q_tot_en) -
+            (ρaq_tot * Ic(w_up) * detr_turb_dyn) + (ρ_c * qt_tendency_precip_formation)
+
+        if edmf.moisture_model isa NonEquilibriumMoisture
+
+            q_liq_up = aux_up_i.q_liq
+            q_ice_up = aux_up_i.q_ice
+            q_liq_en = aux_en.q_liq
+            q_ice_en = aux_en.q_ice
+
+            ql_tendency_noneq = aux_up_i.ql_tendency_noneq
+            qi_tendency_noneq = aux_up_i.qi_tendency_noneq
+            ql_tendency_precip_formation = aux_up_i.ql_tendency_precip_formation
+            qi_tendency_precip_formation = aux_up_i.qi_tendency_precip_formation
+
+            ρaq_liq = prog_up[i].ρaq_liq
+            ρaq_ice = prog_up[i].ρaq_ice
+
+            tends_ρaq_liq = tendencies_up[i].ρaq_liq
+            tends_ρaq_ice = tendencies_up[i].ρaq_ice
+
+            @. tends_ρaq_liq =
+                -∇c(wvec(LBF(Ic(w_up) * ρaq_liq))) + (ρarea * Ic(w_up) * entr_turb_dyn * q_liq_en) -
+                (ρaq_liq * Ic(w_up) * detr_turb_dyn) + (ρ_c * (ql_tendency_precip_formation + ql_tendency_noneq))
+
+            @. tends_ρaq_ice =
+                -∇c(wvec(LBF(Ic(w_up) * ρaq_ice))) + (ρarea * Ic(w_up) * entr_turb_dyn * q_ice_en) -
+                (ρaq_ice * Ic(w_up) * detr_turb_dyn) + (ρ_c * (qi_tendency_precip_formation + qi_tendency_noneq))
+
+            tends_ρaq_liq[kc_surf] = 0
+            tends_ρaq_ice[kc_surf] = 0
+        end
+
+        # prognostic entr/detr
+        if edmf.entr_closure isa PrognosticNoisyRelaxationProcess
+            c_gen_stoch = edmf.entr_closure.c_gen_stoch
+            mean_entr = aux_up[i].ε_nondim
+            mean_detr = aux_up[i].δ_nondim
+            ε_λ = c_gen_stoch[3]
+            δ_λ = c_gen_stoch[4]
+            tends_ε_nondim = tendencies_up[i].ε_nondim
+            tends_δ_nondim = tendencies_up[i].δ_nondim
+            ε_nondim = prog_up[i].ε_nondim
+            δ_nondim = prog_up[i].δ_nondim
+            @. tends_ε_nondim = ε_λ * (mean_entr - ε_nondim)
+            @. tends_δ_nondim = δ_λ * (mean_detr - δ_nondim)
+        end
+
+        tends_ρarea[kc_surf] = 0
+        tends_ρaθ_liq_ice[kc_surf] = 0
+        tends_ρaq_tot[kc_surf] = 0
+    end
+
+    # Solve for updraft velocity
+
+    # We know that, since W = 0 at z = 0, BCs for entr, detr,
+    # and buoyancy should not matter in the end
+    zero_bcs = (; bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
+    I0f = CCO.InterpolateC2F(; zero_bcs...)
+    adv_bcs = (; bottom = CCO.SetValue(wvec(FT(0))), top = CCO.SetValue(wvec(FT(0))))
+    LBC = CCO.LeftBiasedF2C(; bottom = CCO.SetValue(FT(0)))
+    ∇f = CCO.DivergenceC2F(; adv_bcs...)
+
+    @inbounds for i in 1:N_up
+        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        Iaf = CCO.InterpolateC2F(; a_up_bcs...)
+        ρaw = prog_up_f[i].ρaw
+        tends_ρaw = tendencies_up_f[i].ρaw
+        nh_pressure = aux_up_f[i].nh_pressure
+        a_up = aux_up[i].area
+        w_up = aux_up_f[i].w
+        w_en = aux_en_f.w
+        entr_w = aux_up[i].entr_turb_dyn
+        detr_w = aux_up[i].detr_turb_dyn
+        buoy = aux_up[i].buoy
+
+        @. tends_ρaw = -(∇f(wvec(LBC(ρaw * w_up))))
+        @. tends_ρaw += (ρaw * (I0f(entr_w) * w_en - I0f(detr_w) * w_up)) + (ρ_f * Iaf(a_up) * I0f(buoy)) + nh_pressure
+        tends_ρaw[kf_surf] = 0
+    end
+
+    return nothing
+end
+
+function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kf_surf = kf_surface(grid)
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+
+    prog_up = center_prog_updrafts(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    prog_up_f = face_prog_updrafts(state)
+    ρ_c = prog_gm.ρ
+    ρ_f = aux_gm_f.ρ
+    a_min = edmf.minimum_area
+    a_max = edmf.max_area
+
+    @inbounds for i in 1:N_up
+        prog_up[i].ρarea .= max.(prog_up[i].ρarea, 0)
+        prog_up[i].ρaθ_liq_ice .= max.(prog_up[i].ρaθ_liq_ice, 0)
+        prog_up[i].ρaq_tot .= max.(prog_up[i].ρaq_tot, 0)
+        if edmf.entr_closure isa PrognosticNoisyRelaxationProcess
+            @. prog_up[i].ε_nondim = max(prog_up[i].ε_nondim, 0)
+            @. prog_up[i].δ_nondim = max(prog_up[i].δ_nondim, 0)
+        end
+        @inbounds for k in real_center_indices(grid)
+            prog_up[i].ρarea[k] = min(prog_up[i].ρarea[k], ρ_c[k] * a_max)
+        end
+    end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for i in 1:N_up
+            prog_up[i].ρaq_liq .= max.(prog_up[i].ρaq_liq, 0)
+            prog_up[i].ρaq_ice .= max.(prog_up[i].ρaq_ice, 0)
+        end
+    end
+
+    @inbounds for i in 1:N_up
+        @. prog_up_f[i].ρaw = max.(prog_up_f[i].ρaw, 0)
+        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        If = CCO.InterpolateC2F(; a_up_bcs...)
+        @. prog_up_f[i].ρaw = Int(If(prog_up[i].ρarea) >= ρ_f * a_min) * prog_up_f[i].ρaw
+    end
+
+    @inbounds for k in real_center_indices(grid)
+        @inbounds for i in 1:N_up
+            is_surface_center(grid, k) && continue
+            prog_up[i].ρaq_tot[k] = max(prog_up[i].ρaq_tot[k], 0)
+            # this is needed to make sure Rico is unchanged.
+            # TODO : look into it further to see why
+            # a similar filtering of ρaθ_liq_ice breaks the simulation
+            if prog_up[i].ρarea[k] / ρ_c[k] < a_min
+                prog_up[i].ρaq_tot[k] = 0
+            end
+        end
+    end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for k in real_center_indices(grid)
+            @inbounds for i in 1:N_up
+                is_surface_center(grid, k) && continue
+                prog_up[i].ρaq_tot[k] = max(prog_up[i].ρaq_tot[k], 0)
+                # this is needed to make sure Rico is unchanged.
+                # TODO : look into it further to see why
+                # a similar filtering of ρaθ_liq_ice breaks the simulation
+                if prog_up[i].ρarea[k] / ρ_c[k] < a_min
+                    prog_up[i].ρaq_liq[k] = 0
+                    prog_up[i].ρaq_ice[k] = 0
+                end
+            end
+        end
+    end
+
+
+    Ic = CCO.InterpolateF2C()
+    @inbounds for i in 1:N_up
+        @. prog_up[i].ρarea = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρarea)
+        @. prog_up[i].ρaθ_liq_ice = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaθ_liq_ice)
+        @. prog_up[i].ρaq_tot = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_tot)
+        θ_surf = θ_surface_bc(surf, grid, state, edmf, i, param_set)
+        q_surf = q_surface_bc(surf, grid, state, edmf, i)
+        a_surf = area_surface_bc(surf, edmf, i)
+        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
+        prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
+        prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
+    end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for i in 1:N_up
+            @. prog_up[i].ρaq_liq = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_liq)
+            @. prog_up[i].ρaq_ice = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_ice)
+            ql_surf = ql_surface_bc(surf)
+            qi_surf = qi_surface_bc(surf)
+            prog_up[i].ρaq_liq[kc_surf] = prog_up[i].ρarea[kc_surf] * ql_surf
+            prog_up[i].ρaq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * qi_surf
+        end
+    end
+    return nothing
+end
+
+function compute_covariance_shear(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_sym},
+    ::Val{ϕ_en_sym},
+    ::Val{ψ_en_sym},
+) where {covar_sym, ϕ_en_sym, ψ_en_sym}
+
+    aux_tc = center_aux_turbconv(state)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    is_tke = covar_sym == :tke
+    FT = float_type(state)
+    k_eddy = is_tke ? aux_tc.KM : aux_tc.KH
+    aux_en_2m = center_aux_environment_2m(state)
+    aux_covar = getproperty(aux_en_2m, covar_sym)
+    uₕ_gm = grid_mean_uₕ(state)
+
+    aux_en_c = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_en = is_tke ? aux_en_f : aux_en_c
+    wvec = CC.Geometry.WVector
+    ϕ_en = getproperty(aux_en, ϕ_en_sym)
+    ψ_en = getproperty(aux_en, ψ_en_sym)
+
+    bcs = (; bottom = CCO.Extrapolate(), top = CCO.SetGradient(wvec(zero(FT))))
+    If = CCO.InterpolateC2F(; bcs...)
+    area_en = aux_en_c.area
+    shear = aux_covar.shear
+
+    C123 = CCG.Covariant123Vector
+    local_geometry = CC.Fields.local_geometry_field(axes(ρ_c))
+    k̂ = @. CCG.Contravariant3Vector(CCG.WVector(FT(1)), local_geometry)
+    Ifuₕ = uₕ_bcs()
+    ∇uvw = CCO.GradientF2C()
+    # TODO: k_eddy and Shear² should probably be tensors (Contravariant3 tensor),
+    #       so that the result (a contraction) is a scalar.
+    if is_tke
+        uvw = @. C123(Ifuₕ(uₕ_gm)) + C123(wvec(ϕ_en)) # ϕ_en === ψ_en
+        Shear² = @. LA.norm_sqr(adjoint(∇uvw(uvw)) * k̂)
+        @. shear = ρ_c * area_en * k_eddy * Shear²
+    else
+        ∇c = CCO.GradientF2C()
+        @. shear = 2 * ρ_c * area_en * k_eddy * LA.dot(∇c(If(ϕ_en)), k̂) * LA.dot(∇c(If(ψ_en)), k̂)
+    end
+    return nothing
+end
+
+function compute_covariance_interdomain_src(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_sym},
+    ::Val{ϕ_sym},
+    ::Val{ψ_sym},
+) where {covar_sym, ϕ_sym, ψ_sym}
+    N_up = n_updrafts(edmf)
+    is_tke = covar_sym == :tke
+    FT = float_type(state)
+    tke_factor = is_tke ? FT(0.5) : 1
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en_2m = center_aux_environment_2m(state)
+    interdomain = getproperty(aux_en_2m, covar_sym).interdomain
+    prog_up = is_tke ? aux_up_f : aux_up
+    aux_en_c = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_en = is_tke ? aux_en_f : aux_en_c
+    ϕ_en = getproperty(aux_en, ϕ_sym)
+    ψ_en = getproperty(aux_en, ψ_sym)
+    Ic = is_tke ? CCO.InterpolateF2C() : x -> x
+
+    parent(interdomain) .= 0
+    @inbounds for i in 1:N_up
+        ϕ_up = getproperty(prog_up[i], ϕ_sym)
+        ψ_up = getproperty(prog_up[i], ψ_sym)
+        a_up = aux_up[i].area
+        @. interdomain += tke_factor * a_up * (1 - a_up) * (Ic(ϕ_up) - Ic(ϕ_en)) * (Ic(ψ_up) - Ic(ψ_en))
+    end
+    return nothing
+end
+
+function compute_covariance_entr(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_sym},
+    ::Val{ϕ_sym},
+    ::Val{ψ_sym},
+) where {covar_sym, ϕ_sym, ψ_sym}
+
+    N_up = n_updrafts(edmf)
+    FT = float_type(state)
+    is_tke = covar_sym == :tke
+    tke_factor = is_tke ? FT(0.5) : 1
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_gm_c = center_aux_grid_mean(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    gm = is_tke ? prog_gm_f : aux_gm_c
+    prog_up = is_tke ? aux_up_f : aux_up
+    to_scalar = is_tke ? toscalar : x -> x
+    ϕ_gm = getproperty(gm, ϕ_sym)
+    ψ_gm = getproperty(gm, ψ_sym)
+    aux_en_2m = center_aux_environment_2m(state)
+    aux_covar = getproperty(aux_en_2m, covar_sym)
+    aux_en_c = center_aux_environment(state)
+    covar = getproperty(aux_en_c, covar_sym)
+    aux_en_f = face_aux_environment(state)
+    aux_en = is_tke ? aux_en_f : aux_en_c
+    ϕ_en = getproperty(aux_en, ϕ_sym)
+    ψ_en = getproperty(aux_en, ψ_sym)
+    entr_gain = aux_covar.entr_gain
+    detr_loss = aux_covar.detr_loss
+    Ic = CCO.InterpolateF2C()
+    Idc = is_tke ? Ic : x -> x
+    # TODO: we shouldn't need `parent` call here:
+    parent(entr_gain) .= 0
+    parent(detr_loss) .= 0
+    min_area = edmf.minimum_area
+
+    @inbounds for i in 1:N_up
+        aux_up_i = aux_up[i]
+        frac_turb_entr = aux_up_i.frac_turb_entr
+        eps_turb = frac_turb_entr
+        detr_sc = aux_up_i.detr_sc
+        entr_sc = aux_up_i.entr_sc
+        w_up = aux_up_f[i].w
+        prog_up_i = prog_up[i]
+        ϕ_up = getproperty(prog_up_i, ϕ_sym)
+        ψ_up = getproperty(prog_up_i, ψ_sym)
+
+        a_up = aux_up_i.area
+
+        @. entr_gain +=
+            Int(a_up > min_area) *
+            (tke_factor * ρ_c * a_up * abs(Ic(w_up)) * detr_sc * (Idc(ϕ_up) - Idc(ϕ_en)) * (Idc(ψ_up) - Idc(ψ_en))) + (
+                tke_factor *
+                ρ_c *
+                a_up *
+                abs(Ic(w_up)) *
+                eps_turb *
+                (
+                    (Idc(ϕ_en) - Idc(to_scalar(ϕ_gm))) * (Idc(ψ_up) - Idc(ψ_en)) +
+                    (Idc(ψ_en) - Idc(to_scalar(ψ_gm))) * (Idc(ϕ_up) - Idc(ϕ_en))
+                )
+            )
+
+        @. detr_loss += Int(a_up > min_area) * tke_factor * ρ_c * a_up * abs(Ic(w_up)) * (entr_sc + eps_turb) * covar
+
+    end
+
+    return nothing
+end
+
+function compute_covariance_dissipation(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_sym},
+    param_set::APS,
+) where {covar_sym}
+    FT = float_type(state)
+    c_d = mixing_length_params(edmf).c_d
+    aux_tc = center_aux_turbconv(state)
+    prog_en = center_prog_environment(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_en = center_aux_environment(state)
+    ρ_c = prog_gm.ρ
+    aux_en_2m = center_aux_environment_2m(state)
+    aux_covar = getproperty(aux_en_2m, covar_sym)
+    covar = getproperty(aux_en, covar_sym)
+    dissipation = aux_covar.dissipation
+    area_en = aux_en.area
+    tke_en = aux_en.tke
+    mixing_length = aux_tc.mixing_length
+
+    @. dissipation = ρ_c * area_en * covar * max(tke_en, 0)^FT(0.5) / max(mixing_length, FT(1.0e-3)) * c_d
+    return nothing
+end
+
+function compute_en_tendencies!(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+    ::Val{covar_sym},
+    ::Val{prog_sym},
+) where {covar_sym, prog_sym}
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kc_toa = kc_top_of_atmos(grid)
+    aux_gm_f = face_aux_grid_mean(state)
+    prog_en = center_prog_environment(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_en_2m = center_aux_environment_2m(state)
+    tendencies_en = center_tendencies_environment(state)
+    tend_covar = getproperty(tendencies_en, prog_sym)
+    prog_covar = getproperty(prog_en, prog_sym)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    covar = getproperty(aux_en, covar_sym)
+    aux_covar = getproperty(aux_en_2m, covar_sym)
+    aux_up = center_aux_updrafts(state)
+    w_en_f = face_aux_environment(state).w
+    ρ_c = prog_gm.ρ
+    ρ_f = aux_gm_f.ρ
+    c_d = mixing_length_params(edmf).c_d
+    is_tke = covar_sym == :tke
+    FT = float_type(state)
+
+    ρ_ae_K = face_aux_turbconv(state).ρ_ae_K
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
+    aux_tc = center_aux_turbconv(state)
+    aux_bulk = center_aux_bulk(state)
+    D_env = aux_tc.ϕ_temporary
+    aeK = aux_tc.ψ_temporary
+    a_bulk = aux_bulk.area
+    if is_tke
+        @. aeK = (1 - a_bulk) * KM
+    else
+        @. aeK = (1 - a_bulk) * KH
+    end
+
+    press = aux_covar.press
+    buoy = aux_covar.buoy
+    shear = aux_covar.shear
+    entr_gain = aux_covar.entr_gain
+    rain_src = aux_covar.rain_src
+
+    wvec = CC.Geometry.WVector
+    aeK_bcs = (; bottom = CCO.SetValue(aeK[kc_surf]), top = CCO.SetValue(aeK[kc_toa]))
+    prog_bcs = (; bottom = CCO.SetGradient(wvec(FT(0))), top = CCO.SetGradient(wvec(FT(0))))
+
+    If = CCO.InterpolateC2F(; aeK_bcs...)
+    ∇f = CCO.GradientC2F(; prog_bcs...)
+    ∇c = CCO.DivergenceF2C()
+
+    mixing_length = aux_tc.mixing_length
+    min_area = edmf.minimum_area
+
+    Ic = CCO.InterpolateF2C()
+    area_en = aux_en.area
+    tke_en = aux_en.tke
+
+    parent(D_env) .= 0
+
+    @inbounds for i in 1:N_up
+        turb_entr = aux_up[i].frac_turb_entr
+        entr_sc = aux_up[i].entr_sc
+        w_up = aux_up_f[i].w
+        a_up = aux_up[i].area
+        # TODO: using `Int(bool) *` means that NaNs can propagate
+        # into the solution. Could we somehow call `ifelse` instead?
+        @. D_env += Int(a_up > min_area) * ρ_c * a_up * Ic(w_up) * (entr_sc + turb_entr)
+    end
+
+    RB = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
+    @. tend_covar =
+        press + buoy + shear + entr_gain + rain_src - D_env * covar -
+        (c_d * sqrt(max(tke_en, 0)) / max(mixing_length, 1)) * prog_covar - ∇c(wvec(RB(prog_covar * Ic(w_en_f)))) +
+        ∇c(ρ_f * If(aeK) * ∇f(covar))
+
+    return nothing
+end
+
+function update_diagnostic_covariances!(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    param_set::APS,
+    ::Val{covar_sym},
+) where {covar_sym}
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kc_toa = kc_top_of_atmos(grid)
+    prog_gm = center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    aux_en_2m = center_aux_environment_2m(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    covar = getproperty(aux_en, covar_sym)
+    aux_covar = getproperty(aux_en_2m, covar_sym)
+    aux_up = center_aux_updrafts(state)
+    w_en_f = face_aux_environment(state).w
+    c_d = mixing_length_params(edmf).c_d
+    covar_lim = edmf.thermo_covariance_model.covar_lim
+
+    ρ_ae_K = face_aux_turbconv(state).ρ_ae_K
+    KH = center_aux_turbconv(state).KH
+    aux_tc = center_aux_turbconv(state)
+    aux_bulk = center_aux_bulk(state)
+    D_env = aux_tc.ϕ_temporary
+    a_bulk = aux_bulk.area
+    tke_en = aux_en.tke
+
+    shear = aux_covar.shear
+    entr_gain = aux_covar.entr_gain
+    rain_src = aux_covar.rain_src
+    mixing_length = aux_tc.mixing_length
+    min_area = edmf.minimum_area
+
+    Ic = CCO.InterpolateF2C()
+    area_en = aux_en.area
+
+    parent(D_env) .= 0
+    @inbounds for i in 1:N_up
+        turb_entr = aux_up[i].frac_turb_entr
+        entr_sc = aux_up[i].entr_sc
+        w_up = aux_up_f[i].w
+        a_up = aux_up[i].area
+        # TODO: using `Int(bool) *` means that NaNs can propagate
+        # into the solution. Could we somehow call `ifelse` instead?
+        @. D_env += Int(a_up > min_area) * ρ_c * a_up * Ic(w_up) * (entr_sc + turb_entr)
+    end
+
+    @. covar =
+        (shear + entr_gain + rain_src) /
+        max(D_env + ρ_c * area_en * c_d * sqrt(max(tke_en, 0)) / max(mixing_length, 1), covar_lim)
+    return nothing
+end
+
+
+function GMV_third_m(
+    edmf::EDMFModel,
+    grid::Grid,
+    state::State,
+    ::Val{covar_en_sym},
+    ::Val{var},
+    ::Val{gm_third_m_sym},
+) where {covar_en_sym, var, gm_third_m_sym}
+
+    N_up = n_updrafts(edmf)
+    gm_third_m = getproperty(center_aux_grid_mean(state), gm_third_m_sym)
+    kc_surf = kc_surface(grid)
+    FT = float_type(state)
+
+    aux_bulk = center_aux_bulk(state)
+    aux_up_f = face_aux_updrafts(state)
+    is_tke = covar_en_sym == :tke
+    aux_en_c = center_aux_environment(state)
+    covar_en = getproperty(aux_en_c, covar_en_sym)
+    aux_en_f = face_aux_environment(state)
+    aux_en = is_tke ? aux_en_f : aux_en_c
+    aux_up_c = center_aux_updrafts(state)
+    aux_tc = center_aux_turbconv(state)
+    ϕ_gm = aux_tc.ϕ_gm
+    ϕ_gm_cov = aux_tc.ϕ_gm_cov
+    ϕ_en_cov = aux_tc.ϕ_en_cov
+    ϕ_up_cubed = aux_tc.ϕ_up_cubed
+    aux_up = is_tke ? aux_up_f : aux_up_c
+    var_en = getproperty(aux_en, var)
+    area_en = aux_en_c.area
+    Ic = is_tke ? CCO.InterpolateF2C() : x -> x
+    wvec = CC.Geometry.WVector
+    ∇c = CCO.DivergenceF2C()
+    w_en = aux_en_f.w
+
+    @. ϕ_gm = area_en * Ic(var_en)
+    @inbounds for i in 1:N_up
+        a_up = aux_up_c[i].area
+        var_up = getproperty(aux_up[i], var)
+        @. ϕ_gm += a_up * Ic(var_up)
+    end
+
+    # w'w' ≈ 2/3 TKE (isotropic turbulence assumption)
+    if is_tke
+        @. ϕ_en_cov = FT(2 / 3) * covar_en
+    else
+        @. ϕ_en_cov = covar_en
+    end
+
+    parent(ϕ_up_cubed) .= 0
+    @. ϕ_gm_cov = area_en * (ϕ_en_cov + (Ic(var_en) - ϕ_gm)^2)
+    @inbounds for i in 1:N_up
+        a_up = aux_up_c[i].area
+        var_up = getproperty(aux_up[i], var)
+        @. ϕ_gm_cov += a_up * (Ic(var_up) - ϕ_gm)^2
+        @. ϕ_up_cubed += a_up * Ic(var_up)^3
+    end
+
+    @. gm_third_m = ϕ_up_cubed + area_en * (Ic(var_en)^3 + 3 * Ic(var_en) * ϕ_en_cov) - ϕ_gm^3 - 3 * ϕ_gm_cov * ϕ_gm
+
+    gm_third_m[kc_surf] = 0
+    return nothing
+end

--- a/src/TurbulenceConvection/Fields.jl
+++ b/src/TurbulenceConvection/Fields.jl
@@ -1,0 +1,101 @@
+# A complementary struct to ClimaCore's `PlusHalf` type.
+struct Cent{I <: Integer}
+    i::I
+end
+
+Base.:+(h::Cent) = h
+Base.:-(h::Cent) = Cent(-h.i - one(h.i))
+Base.:+(i::Integer, h::Cent) = Cent(i + h.i)
+Base.:+(h::Cent, i::Integer) = Cent(h.i + i)
+Base.:+(h1::Cent, h2::Cent) = h1.i + h2.i + one(h1.i)
+Base.:-(i::Integer, h::Cent) = Cent(i - h.i - one(h.i))
+Base.:-(h::Cent, i::Integer) = Cent(h.i - i)
+Base.:-(h1::Cent, h2::Cent) = h1.i - h2.i
+
+Base.:<=(h1::Cent, h2::Cent) = h1.i <= h2.i
+Base.:<(h1::Cent, h2::Cent) = h1.i < h2.i
+Base.max(h1::Cent, h2::Cent) = Cent(max(h1.i, h2.i))
+Base.min(h1::Cent, h2::Cent) = Cent(min(h1.i, h2.i))
+
+toscalar(x::CCG.Covariant3Vector) = x.u₃
+
+const FDFields = Union{CC.Fields.ExtrudedFiniteDifferenceField, CC.Fields.FiniteDifferenceField}
+
+const FaceFields = Union{CC.Fields.FaceExtrudedFiniteDifferenceField, CC.Fields.FaceFiniteDifferenceField}
+
+const CenterFields = Union{CC.Fields.CenterExtrudedFiniteDifferenceField, CC.Fields.CenterFiniteDifferenceField}
+
+Base.@propagate_inbounds Base.getindex(field::FDFields, i::Integer) = Base.getproperty(field, i)
+
+Base.@propagate_inbounds Base.getindex(field::CenterFields, i::Cent) = Base.getindex(CC.Fields.field_values(field), i.i)
+Base.@propagate_inbounds Base.setindex!(field::CenterFields, v, i::Cent) =
+    Base.setindex!(CC.Fields.field_values(field), v, i.i)
+
+Base.@propagate_inbounds Base.getindex(field::FaceFields, i::CCO.PlusHalf) =
+    Base.getindex(CC.Fields.field_values(field), i.i)
+Base.@propagate_inbounds Base.setindex!(field::FaceFields, v, i::CCO.PlusHalf) =
+    Base.setindex!(CC.Fields.field_values(field), v, i.i)
+
+Base.@propagate_inbounds Base.getindex(field::FaceFields, ::Cent) =
+    error("Attempting to getindex with a center index (Cent) into a Face field")
+Base.@propagate_inbounds Base.getindex(field::CenterFields, ::CCO.PlusHalf) =
+    error("Attempting to getindex with a face index (PlusHalf) into a Center field")
+
+Base.@propagate_inbounds Base.setindex!(field::FaceFields, v, ::Cent) =
+    error("Attempting to setindex with a center index (Cent) into a Face field")
+Base.@propagate_inbounds Base.setindex!(field::CenterFields, v, ::CCO.PlusHalf) =
+    error("Attempting to setindex with a face index (PlusHalf) into a Center field")
+
+# TODO: deprecate, we should not overload getindex/setindex for ordinary arrays.
+Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Cent) = Base.getindex(arr, i.i)
+Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Cent) = Base.setindex!(arr, v, i.i)
+Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::CCO.PlusHalf) = Base.getindex(arr, i.i)
+Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::CCO.PlusHalf) = Base.setindex!(arr, v, i.i)
+Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Int, j::Cent) = Base.getindex(arr, i, j.i)
+Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Int, j::Cent) = Base.setindex!(arr, v, i, j.i)
+Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Int, j::CCO.PlusHalf) = Base.getindex(arr, i, j.i)
+Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Int, j::CCO.PlusHalf) = Base.setindex!(arr, v, i, j.i)
+
+# Constant field
+function FieldFromNamedTuple(space, nt::NamedTuple)
+    cmv(z) = nt
+    return cmv.(CC.Fields.coordinate_field(space))
+end
+# Non-constant field
+function FieldFromNamedTuple(space, initial_conditions::Function, ::Type{FT}, params...) where {FT}
+    local_geometry = CC.Fields.local_geometry_field(space)
+    return initial_conditions.(FT, local_geometry, params...)
+end
+
+function Base.cumsum(field::CC.Fields.FiniteDifferenceField)
+    Base.cumsum(parent(CC.Fields.weighted_jacobian(field)) .* vec(field), dims = 1)
+end
+function Base.cumsum!(fieldout::CC.Fields.FiniteDifferenceField, fieldin::CC.Fields.FiniteDifferenceField)
+    Base.cumsum!(fieldout, parent(CC.Fields.weighted_jacobian(fieldin)) .* vec(fieldin), dims = 1)
+end
+
+get_Δz(field::CC.Fields.FiniteDifferenceField) = parent(CC.Fields.weighted_jacobian(field))
+
+# TODO: move these things into ClimaCore
+
+isa_center_space(space) = false
+isa_center_space(::CC.Spaces.CenterFiniteDifferenceSpace) = true
+isa_center_space(::CC.Spaces.CenterExtrudedFiniteDifferenceSpace) = true
+
+isa_face_space(space) = false
+isa_face_space(::CC.Spaces.FaceFiniteDifferenceSpace) = true
+isa_face_space(::CC.Spaces.FaceExtrudedFiniteDifferenceSpace) = true
+
+const CallableZType = Union{Function, Dierckx.Spline1D}
+
+function set_z!(field::CC.Fields.Field, u::CallableZType = x -> x, v::CallableZType = y -> y)
+    z = CC.Fields.coordinate_field(axes(field)).z
+    @. field = CCG.Covariant12Vector(CCG.UVVector(u(z), v(z)))
+end
+
+function set_z!(field::CC.Fields.Field, u::Real, v::Real)
+    lg = CC.Fields.local_geometry_field(axes(field))
+    uconst(coord) = u
+    vconst(coord) = v
+    @. field = CCG.Covariant12Vector(CCG.UVVector(uconst(lg), vconst(lg)))
+end

--- a/src/TurbulenceConvection/Grid.jl
+++ b/src/TurbulenceConvection/Grid.jl
@@ -1,0 +1,216 @@
+
+"""
+    TCMeshFromGCMMesh(gcm_mesh; z_max)
+
+Returns a case-specific subset of the expected GCM mesh between the surface and z_max
+ - `gcm_mesh` :: a ClimaCore mesh for expected GCM grid
+ - `z_max`    :: maximum height for a specific TC case
+"""
+function TCMeshFromGCMMesh(gcm_mesh; z_max::FT) where {FT <: AbstractFloat}
+    gcm_grid = Grid(gcm_mesh)
+    k_star = kf_top_of_atmos(gcm_grid)
+    for k in real_face_indices(gcm_grid)
+        if gcm_grid.zf[k].z > z_max || z_max ≈ gcm_grid.zf[k].z
+            k_star = k
+            break
+        end
+    end
+    z₀ = zf_surface(gcm_grid).z
+    z₁ = gcm_grid.zf[k_star].z
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(z₀),
+        CC.Geometry.ZPoint{FT}(z₁),
+        boundary_tags = (:bottom, :top),
+    )
+    faces = map(1:(k_star.i)) do k
+        CC.Geometry.ZPoint{FT}(gcm_grid.zf[CCO.PlusHalf(k)].z)
+    end
+    return CC.Meshes.IntervalMesh(domain, faces)
+end
+
+struct Grid{FT, NZ, CS, FS, SC, SF}
+    zmin::FT
+    zmax::FT
+    Δz::FT
+    cs::CS
+    fs::FS
+    zc::SC
+    zf::SF
+    function Grid(space::CC.Spaces.CenterFiniteDifferenceSpace)
+
+        nz = length(space)
+        cs = space
+        fs = CC.Spaces.FaceFiniteDifferenceSpace(cs)
+        zc = CC.Fields.coordinate_field(cs)
+        zf = CC.Fields.coordinate_field(fs)
+        Δz = zf[CCO.PlusHalf(2)].z - zf[CCO.PlusHalf(1)].z
+        FT = eltype(parent(zf))
+
+        zmin = zf.z[CCO.PlusHalf(1)]
+        zmax = zf.z[CCO.PlusHalf(nz + 1)]
+        CS = typeof(cs)
+        FS = typeof(fs)
+        SC = typeof(zc)
+        SF = typeof(zf)
+        return new{FT, nz, CS, FS, SC, SF}(zmin, zmax, Δz, cs, fs, zc, zf)
+    end
+end
+
+Grid(mesh::CC.Meshes.IntervalMesh) = Grid(CC.Spaces.CenterFiniteDifferenceSpace(mesh))
+
+function Grid(Δz::FT, nz::Int) where {FT <: AbstractFloat}
+    z₀, z₁ = FT(0), FT(nz * Δz)
+
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(z₀),
+        CC.Geometry.ZPoint{FT}(z₁),
+        boundary_tags = (:bottom, :top),
+    )
+
+    mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
+    return Grid(mesh)
+end
+
+n_cells(::Grid{FT, NZ}) where {FT, NZ} = NZ
+
+# Index of the first interior cell above the surface
+kc_surface(grid::Grid) = Cent(1)
+kf_surface(grid::Grid) = CCO.PlusHalf(1)
+kc_top_of_atmos(grid::Grid) = Cent(n_cells(grid))
+kf_top_of_atmos(grid::Grid) = CCO.PlusHalf(n_cells(grid) + 1)
+
+is_surface_center(grid::Grid, k) = k == kc_surface(grid)
+is_toa_center(grid::Grid, k) = k == kc_top_of_atmos(grid)
+is_surface_face(grid::Grid, k) = k == kf_surface(grid)
+is_toa_face(grid::Grid, k) = k == kf_top_of_atmos(grid)
+
+zc_surface(grid::Grid) = grid.zc[kc_surface(grid)]
+zf_surface(grid::Grid) = grid.zf[kf_surface(grid)]
+zc_toa(grid::Grid) = grid.zc[kc_top_of_atmos(grid)]
+zf_toa(grid::Grid) = grid.zf[kf_top_of_atmos(grid)]
+
+real_center_indices(grid::Grid) = CenterIndices(grid)
+real_face_indices(grid::Grid) = FaceIndices(grid)
+
+struct FaceIndices{Nstart, Nstop, G}
+    grid::G
+    function FaceIndices(grid::G) where {G <: Grid}
+        Nstart, Nstop = kf_surface(grid).i, kf_top_of_atmos(grid).i
+        new{Nstart, Nstop, G}(grid)
+    end
+end
+
+struct CenterIndices{Nstart, Nstop, G}
+    grid::G
+    function CenterIndices(grid::G) where {G <: Grid}
+        Nstart, Nstop = kc_surface(grid).i, kc_top_of_atmos(grid).i
+        new{Nstart, Nstop, G}(grid)
+    end
+end
+
+Base.keys(ci::CenterIndices) = 1:length(ci)
+Base.keys(fi::FaceIndices) = 1:length(fi)
+
+n_start(::CenterIndices{Nstart}) where {Nstart} = Nstart
+n_start(::FaceIndices{Nstart}) where {Nstart} = Nstart
+n_stop(::CenterIndices{Nstart, Nstop}) where {Nstart, Nstop} = Nstop
+n_stop(::FaceIndices{Nstart, Nstop}) where {Nstart, Nstop} = Nstop
+
+Base.getindex(ci::CenterIndices, i::Int) = Cent(Base.getindex(n_start(ci):n_stop(ci), i))
+Base.getindex(fi::FaceIndices, i::Int) = CCO.PlusHalf(Base.getindex(n_start(fi):n_stop(fi), i))
+
+Base.length(::FaceIndices{Nstart, Nstop}) where {Nstart, Nstop} = Nstop - Nstart + 1
+Base.length(::CenterIndices{Nstart, Nstop}) where {Nstart, Nstop} = Nstop - Nstart + 1
+
+Base.iterate(fi::CenterIndices{Nstart, Nstop}, state = Nstart) where {Nstart, Nstop} =
+    state > Nstop ? nothing : (Cent(state), state + 1)
+
+Base.iterate(fi::FaceIndices{Nstart, Nstop}, state = Nstart) where {Nstart, Nstop} =
+    state > Nstop ? nothing : (CCO.PlusHalf(state), state + 1)
+
+Base.iterate(fi::Base.Iterators.Reverse{T}, state = Nstop) where {Nstart, Nstop, T <: CenterIndices{Nstart, Nstop}} =
+    state < Nstart ? nothing : (Cent(state), state - 1)
+
+Base.iterate(fi::Base.Iterators.Reverse{T}, state = Nstop) where {Nstart, Nstop, T <: FaceIndices{Nstart, Nstop}} =
+    state < Nstart ? nothing : (CCO.PlusHalf(state), state - 1)
+
+face_space(grid::Grid) = grid.fs
+center_space(grid::Grid) = grid.cs
+
+#=
+    findfirst_center
+    findlast_center
+    findfirst_face
+    findlast_face
+
+Grid-aware find-first / find-last indices with
+surface/toa (respectively) as the default index
+=#
+
+function findfirst_center(f::Function, grid::Grid)
+    RI = real_center_indices(grid)
+    k = findfirst(f, RI)
+    return RI[isnothing(k) ? kc_surface(grid).i : k]
+end
+function findlast_center(f::Function, grid::Grid)
+    RI = real_center_indices(grid)
+    k = findlast(f, RI)
+    return RI[isnothing(k) ? kc_top_of_atmos(grid).i : k]
+end
+z_findfirst_center(f::F, grid::Grid) where {F} = grid.zc[findfirst_center(f, grid)].z
+z_findlast_center(f::F, grid::Grid) where {F} = grid.zc[findlast_center(f, grid)].z
+
+function findfirst_face(f::F, grid::Grid) where {F}
+    RI = real_face_indices(grid)
+    k = findfirst(f, RI)
+    return RI[isnothing(k) ? kf_surface(grid).i : k]
+end
+function findlast_face(f::F, grid::Grid) where {F}
+    RI = real_face_indices(grid)
+    k = findlast(f, RI)
+    return RI[isnothing(k) ? kf_top_of_atmos(grid).i : k]
+end
+z_findfirst_face(f::F, grid::Grid) where {F} = grid.zf[findfirst_face(f, grid)].z
+z_findlast_face(f::F, grid::Grid) where {F} = grid.zf[findlast_face(f, grid)].z
+
+
+Base.eltype(::Grid{FT}) where {FT} = FT
+
+#####
+##### Column iterator # TODO: Move these things into ClimaCore
+#####
+
+struct ColumnIterator{Nh, Nj, Ni}
+    function ColumnIterator(space::CC.Spaces.AbstractSpace)
+        lgd = CC.Spaces.local_geometry_data(space)
+        Ni, Nj, _, _, Nh = size(CC.Spaces.local_geometry_data(space))
+        return new{Nh, Nj, Ni}()
+    end
+end
+
+Base.iterate(iter::ColumnIterator{Nh, Nj, Ni}, state = (1, 1, 1)) where {Nh, Nj, Ni} =
+    Iterators.product(1:Ni, 1:Nj, 1:Nh)
+
+iterate_columns(space::CC.Spaces.AbstractSpace) = Base.iterate(ColumnIterator(space))
+
+Base.length(::ColumnIterator{Nh, Nj, Ni}) where {Nh, Nj, Ni} = prod((Nh, Nj, Ni))
+
+
+const ColumnIteratorTypes = Union{CC.Fields.ExtrudedFiniteDifferenceField, CC.Fields.FiniteDifferenceField}
+
+"""
+    iterate_columns(::ExtrudedFiniteDifferenceField)
+    iterate_columns(::FiniteDifferenceField)
+
+Iterates over columns given a field (or space)
+
+```julia
+for inds in Spaces.iterate_columns(field)
+    column_field = Fields.column(field, inds...)
+end
+```
+"""
+iterate_columns(field::ColumnIteratorTypes) = iterate_columns(axes(field))
+
+number_of_columns(field::ColumnIteratorTypes) = number_of_columns(axes(field))
+number_of_columns(space::CC.Spaces.AbstractSpace) = length(ColumnIterator(space))

--- a/src/TurbulenceConvection/Operators.jl
+++ b/src/TurbulenceConvection/Operators.jl
@@ -1,0 +1,31 @@
+#####
+##### Masked operators
+#####
+
+"""
+    shrink_mask!(f, mask)
+
+Shrinks the subdomains of `f` where `mask == 1`.
+
+Example:
+
+```julia
+using Test
+f = Int[0, 0, 0, 1, 1, 1, 0, 0, 1, 1]
+mask = Bool[0, 0, 0, 1, 1, 1, 0, 0, 1, 1]
+@test shrink_mask!(f, mask) == Bool[0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+```
+"""
+function shrink_mask!(f::AbstractArray, mask::AbstractArray)
+    @inbounds for (i, m) in enumerate(mask)
+        if i == 1 || i == length(mask)
+            f[i] = m
+        elseif m == 1 && mask[i - 1] == 0
+            f[i] = 0
+        elseif m == 1 && mask[i + 1] == 0
+            f[i] = 0
+        else
+            f[i] = m
+        end
+    end
+end

--- a/src/TurbulenceConvection/Parameters.jl
+++ b/src/TurbulenceConvection/Parameters.jl
@@ -1,0 +1,66 @@
+"""
+    Parameters
+
+"""
+module Parameters
+
+import Thermodynamics as TD
+import SurfaceFluxes as SF
+import CloudMicrophysics as CM
+
+abstract type AbstractTurbulenceConvectionParameters end
+const ATCP = AbstractTurbulenceConvectionParameters
+
+#####
+##### TurbulenceConvection parameters
+#####
+
+Base.@kwdef struct TurbulenceConvectionParameters{FT, MP, SFP} <: ATCP
+    Omega::FT
+    planet_radius::FT
+    microph_scaling::FT # TODO: move to microphysics parameter set? or Clima1M?
+    microph_scaling_dep_sub::FT # TODO: move to microphysics parameter set? or Clima1M?
+    microph_scaling_melt::FT # TODO: move to microphysics parameter set? or Clima1M?
+    microphys_params::MP
+    surf_flux_params::SFP
+end
+
+thermodynamics_params(ps::ATCP) = CM.Parameters.thermodynamics_params(ps.microphys_params)
+surface_fluxes_params(ps::ATCP) = ps.surf_flux_params
+microphysics_params(ps::ATCP) = ps.microphys_params
+
+Base.eltype(::TurbulenceConvectionParameters{FT}) where {FT} = FT
+Omega(ps::ATCP) = ps.Omega
+planet_radius(ps::ATCP) = ps.planet_radius
+microph_scaling(ps::ATCP) = ps.microph_scaling
+microph_scaling_dep_sub(ps::ATCP) = ps.microph_scaling_dep_sub
+microph_scaling_melt(ps::ATCP) = ps.microph_scaling_melt
+
+#####
+##### Forwarding parameters
+#####
+
+##### Forwarding Thermodynamics.jl
+
+const TDPS = TD.Parameters.ThermodynamicsParameters
+for var in fieldnames(TDPS)
+    @eval $var(ps::ATCP) = TD.Parameters.$var(thermodynamics_params(ps))
+end
+
+# derived parameters
+molmass_ratio(ps::ATCP) = TD.Parameters.molmass_ratio(thermodynamics_params(ps))
+R_d(ps::ATCP) = TD.Parameters.R_d(thermodynamics_params(ps))
+R_v(ps::ATCP) = TD.Parameters.R_v(thermodynamics_params(ps))
+cp_d(ps::ATCP) = TD.Parameters.cp_d(thermodynamics_params(ps))
+cv_v(ps::ATCP) = TD.Parameters.cv_v(thermodynamics_params(ps))
+cv_l(ps::ATCP) = TD.Parameters.cv_l(thermodynamics_params(ps))
+
+##### Forwarding SurfaceFluxes.jl
+
+von_karman_const(ps::ATCP) = SF.Parameters.von_karman_const(surface_fluxes_params(ps))
+
+##### Forwarding CloudMicrophysics.jl
+
+ρ_cloud_liq(ps::ATCP) = CM.Parameters.ρ_cloud_liq(microphysics_params(ps))
+
+end

--- a/src/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection/TurbulenceConvection.jl
@@ -1,0 +1,150 @@
+module TurbulenceConvection
+
+import ClimaCore as CC
+import ClimaCore.Geometry as CCG
+import ClimaCore.Geometry: ⊗
+import ClimaCore.Operators as CCO
+import LinearAlgebra as LA
+import LinearAlgebra: ×
+import DocStringExtensions
+import StaticArrays as SA
+import StatsBase
+import Dierckx
+import LambertW
+import Thermodynamics as TD
+import Distributions
+import FastGaussQuadrature
+import CloudMicrophysics as CM
+import CloudMicrophysics.MicrophysicsNonEq as CMNe
+import CloudMicrophysics.Microphysics0M as CM0
+import CloudMicrophysics.Microphysics1M as CM1
+import UnPack
+import Random
+import StochasticDiffEq as SDE
+import Flux
+import OperatorFlux as OF
+
+const liq_type = CM.CommonTypes.LiquidType()
+const ice_type = CM.CommonTypes.IceType()
+const rain_type = CM.CommonTypes.RainType()
+const snow_type = CM.CommonTypes.SnowType()
+
+include("Parameters.jl")
+import .Parameters as TCP
+const APS = TCP.AbstractTurbulenceConvectionParameters
+
+up_sum(vals::AbstractArray) = reshape(sum(vals; dims = 1), size(vals, 2))
+
+function parse_namelist(namelist, keys...; default = nothing, valid_options = nothing)
+    param = namelist
+    for k in keys
+        if haskey(param, k)
+            param = param[k]
+            if valid_options ≠ nothing && !(param isa Dict)
+                @assert param in valid_options
+            end
+        else
+            if default == nothing
+                error("No default value given for parameter (`$(join(keys, ", "))`).")
+            else
+                @info "Using default value, $default, for parameter (`$(join(keys, ", "))`)."
+                return default
+            end
+        end
+    end
+    return param
+end
+
+Base.broadcastable(param_set::APS) = Ref(param_set)
+
+#=
+    debug_state(state, code_location::String)
+
+A simple function for debugging the entire state,
+specifically for when quantities that should remain
+positive-definite become negative.
+
+=#
+function debug_state(state, code_location::String)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+
+    prog_up = center_prog_updrafts(state)
+    aux_up = center_aux_updrafts(state)
+    prog_up_f = face_prog_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+
+    prog_en = center_prog_environment(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+
+    ######
+    ###### Positive-definite variables
+    ######
+
+    vars_positive = [
+        vec(prog_gm.ρe_tot),
+        vec(prog_gm_f.w),
+        vec(prog_up[1].ρarea),
+        vec(prog_up[1].ρaθ_liq_ice),
+        vec(prog_up_f[1].ρaw),
+        vec(aux_en.area),
+        vec(aux_en.θ_liq_ice),
+    ]
+    vars = vars_positive
+    vars_conds = map(v -> any(v .< 0), vars)
+
+    if any(vars_conds)
+        @show code_location
+        for (i, vc, v) in zip(1:length(vars), vars_conds, vars)
+            vc || continue
+            @show i, v
+        end
+        @show vars_conds
+        error("Negative state for positive-definite field(s)")
+    end
+
+    ######
+    ###### All listed variables
+    ######
+    vars = vars_positive
+    vars_conds = map(v -> any(isnan.(v)) || any(isinf.(v)), vars)
+
+    if any(vars_conds)
+        @show code_location
+        for (i, vc, v) in zip(1:length(vars), vars_conds, vars)
+            vc || continue
+            @show i, v
+        end
+        @show vars_conds
+        error("Nan/Inf state for field(s)")
+    end
+end
+
+include("Grid.jl")
+include("dycore_api.jl")
+include("diagnostics.jl")
+include("Fields.jl")
+include("types.jl")
+include("name_aliases.jl")
+include("Operators.jl")
+
+include("microphysics_coupling.jl")
+include("turbulence_functions.jl")
+include("utility_functions.jl")
+include("variables.jl")
+include("EDMF_Precipitation.jl")
+include("EDMF_Environment.jl")
+include("EDMF_Updrafts.jl")
+include("update_aux.jl")
+include("EDMF_functions.jl")
+include("thermodynamics.jl")
+include("closures/perturbation_pressure.jl")
+include("closures/entr_detr.jl")
+include("closures/nondimensional_exchange_functions.jl")
+include("closures/mixing_length.jl")
+include("closures/buoyancy_gradients.jl")
+
+end

--- a/src/TurbulenceConvection/closures/buoyancy_gradients.jl
+++ b/src/TurbulenceConvection/closures/buoyancy_gradients.jl
@@ -1,0 +1,78 @@
+"""
+    buoyancy_gradients(
+        param_set,
+        bg_model::EnvBuoyGrad{FT, EBG}
+    ) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
+
+Returns the vertical buoyancy gradients in the environment, as well as in its dry and cloudy volume fractions.
+The dispatch on EnvBuoyGrad type is performed at the EnvBuoyGrad construction time, and the analytical solutions
+used here are consistent for both mean fields and conditional fields obtained from assumed distributions
+over the conserved thermodynamic variables.
+"""
+function buoyancy_gradients(
+    param_set::APS,
+    bg_model::EnvBuoyGrad{FT, EBG},
+) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
+
+    thermo_params = TCP.thermodynamics_params(param_set)
+    g = TCP.grav(param_set)
+    molmass_ratio = TCP.molmass_ratio(param_set)
+    R_d = TCP.R_d(param_set)
+    R_v = TCP.R_v(param_set)
+
+    phase_part = TD.PhasePartition(FT(0), FT(0), FT(0)) # assuming R_d = R_m
+    Π = TD.exner_given_pressure(thermo_params, bg_model.p, phase_part)
+
+    ∂b∂θv = g * (R_d * bg_model.ρ / bg_model.p) * Π
+
+    if bg_model.en_cld_frac > 0.0
+        ts_sat = thermo_state_pθq(param_set, bg_model.p, bg_model.θ_liq_ice_sat, bg_model.qt_sat)
+        phase_part = TD.PhasePartition(thermo_params, ts_sat)
+        lh = TD.latent_heat_liq_ice(thermo_params, phase_part)
+        cp_m = TD.cp_m(thermo_params, ts_sat)
+        ∂b∂θl_sat = (
+            ∂b∂θv * (1 + molmass_ratio * (1 + lh / R_v / bg_model.t_sat) * bg_model.qv_sat - bg_model.qt_sat) /
+            (1 + lh * lh / cp_m / R_v / bg_model.t_sat / bg_model.t_sat * bg_model.qv_sat)
+        )
+        ∂b∂qt_sat = (lh / cp_m / bg_model.t_sat * ∂b∂θl_sat - ∂b∂θv) * bg_model.θ_sat
+    else
+        ∂b∂θl_sat = FT(0)
+        ∂b∂qt_sat = FT(0)
+    end
+
+    ∂b∂z, ∂b∂z_unsat, ∂b∂z_sat = buoyancy_gradient_chain_rule(bg_model, ∂b∂θv, ∂b∂θl_sat, ∂b∂qt_sat)
+    return GradBuoy{FT}(∂b∂z, ∂b∂z_unsat, ∂b∂z_sat)
+end
+
+"""
+    buoyancy_gradient_chain_rule(
+        bg_model::EnvBuoyGrad{FT, EBG},
+        ∂b∂θv::FT,
+        ∂b∂θl_sat::FT,
+        ∂b∂qt_sat::FT,
+    ) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
+
+Returns the vertical buoyancy gradients in the environment, as well as in its dry and cloudy volume fractions,
+from the partial derivatives with respect to thermodynamic variables in dry and cloudy volumes.
+"""
+function buoyancy_gradient_chain_rule(
+    bg_model::EnvBuoyGrad{FT, EBG},
+    ∂b∂θv::FT,
+    ∂b∂θl_sat::FT,
+    ∂b∂qt_sat::FT,
+) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
+    if bg_model.en_cld_frac > FT(0)
+        ∂b∂z_θl_sat = ∂b∂θl_sat * bg_model.∂θl∂z_sat
+        ∂b∂z_qt_sat = ∂b∂qt_sat * bg_model.∂qt∂z_sat
+    else
+        ∂b∂z_θl_sat = FT(0)
+        ∂b∂z_qt_sat = FT(0)
+    end
+
+    ∂b∂z_unsat = bg_model.en_cld_frac < FT(1) ? ∂b∂θv * bg_model.∂θv∂z_unsat : FT(0)
+
+    ∂b∂z_sat = ∂b∂z_θl_sat + ∂b∂z_qt_sat
+    ∂b∂z = (1 - bg_model.en_cld_frac) * ∂b∂z_unsat + bg_model.en_cld_frac * ∂b∂z_sat
+
+    return ∂b∂z, ∂b∂z_unsat, ∂b∂z_sat
+end

--- a/src/TurbulenceConvection/closures/entr_detr.jl
+++ b/src/TurbulenceConvection/closures/entr_detr.jl
@@ -1,0 +1,398 @@
+#### Entrainment-Detrainment kernels
+
+function compute_turbulent_entrainment(c_γ::FT, a_up::FT, w_up::FT, tke::FT, H_up::FT) where {FT}
+
+    ε_turb = if w_up * a_up > 0
+        2 * c_γ * sqrt(max(tke, 0)) / (w_up * H_up)
+    else
+        FT(0)
+    end
+
+    return ε_turb
+end
+
+function compute_inverse_timescale(εδ_model, b_up::FT, b_en::FT, w_up::FT, w_en::FT, tke::FT) where {FT}
+    Δb = b_up - b_en
+    Δw = get_Δw(εδ_model, w_up, w_en)
+    c_λ = εδ_params(εδ_model).c_λ
+
+    l_1 = c_λ * abs(Δb / sqrt(tke + 1e-8))
+    l_2 = abs(Δb / Δw)
+    l = SA.SVector(l_1, l_2)
+    return lamb_smooth_minimum(l, FT(0.1), FT(0.0005))
+end
+
+function get_Δw(εδ_model, w_up::FT, w_en::FT) where {FT}
+    Δw = w_up - w_en
+    Δw += copysign(FT(εδ_params(εδ_model).w_min), Δw)
+    return Δw
+end
+
+function get_MdMdz(M::FT, dMdz::FT) where {FT}
+    MdMdz_ε = max(dMdz / max(M, eps(FT)), 0)
+    MdMdz_δ = max(-dMdz / max(M, eps(FT)), 0)
+    return MdMdz_ε, MdMdz_δ
+end
+
+function entrainment_inv_length_scale(
+    εδ_model,
+    b_up::FT,
+    b_en::FT,
+    w_up::FT,
+    w_en::FT,
+    tke::FT,
+    zc_i::FT,
+    ::BuoyVelEntrDimScale,
+) where {FT}
+    Δw = get_Δw(εδ_model, w_up, w_en)
+    λ = compute_inverse_timescale(εδ_model, b_up, b_en, w_up, w_en, tke)
+    return (λ / Δw)
+end
+
+function entrainment_inv_length_scale(
+    εδ_model,
+    b_up::FT,
+    b_en::FT,
+    w_up::FT,
+    w_en::FT,
+    tke::FT,
+    zc_i::FT,
+    ::InvZEntrDimScale,
+) where {FT}
+    return (1 / zc_i)
+end
+
+function entrainment_inv_length_scale(
+    εδ_model,
+    b_up::FT,
+    b_en::FT,
+    w_up::FT,
+    w_en::FT,
+    tke::FT,
+    zc_i::FT,
+    ::InvMeterEntrDimScale,
+) where {FT}
+    return FT(1)
+end
+
+"""A convenience wrapper for entrainment_inv_length_scale"""
+function entrainment_inv_length_scale(εδ_model, εδ_vars, dim_scale)
+    return entrainment_inv_length_scale(
+        εδ_model,
+        εδ_vars.b_up,
+        εδ_vars.b_en,
+        εδ_vars.w_up,
+        εδ_vars.w_en,
+        εδ_vars.tke_en,
+        εδ_vars.zc_i,
+        dim_scale,
+    )
+end
+
+"""
+    εδ_dyn(εδ_model, εδ_vars, entr_dim_scale, detr_dim_scale, ε_nondim, δ_nondim)
+
+Returns the fractional dynamical entrainment and detrainment rates [1/m] given non-dimensional rates
+
+Parameters:
+ - `εδ_model`       :: entrainment-detrainment model
+ - `εδ_vars`        :: structure containing variables
+ - `entr_dim_scale` :: type of dimensional fractional entrainment scale
+ - `detr_dim_scale` :: type of dimensional fractional detrainment scale
+ - `ε_nondim`       :: nondimensional fractional entrainment
+ - `δ_nondim`       :: nondimensional fractional detrainment
+"""
+function εδ_dyn(εδ_model, εδ_vars, entr_dim_scale, detr_dim_scale, ε_nondim, δ_nondim)
+    FT = eltype(εδ_vars.q_cond_up)
+    ε_dim_scale = entrainment_inv_length_scale(εδ_model, εδ_vars, entr_dim_scale)
+    δ_dim_scale = entrainment_inv_length_scale(εδ_model, εδ_vars, detr_dim_scale)
+
+    area_limiter = max_area_limiter(εδ_model, εδ_vars.max_area, εδ_vars.a_up)
+
+    c_div = εδ_params(εδ_model).c_div
+    MdMdz_ε, MdMdz_δ = get_MdMdz(εδ_vars.M, εδ_vars.dMdz) .* c_div
+
+    # fractional dynamical entrainment / detrainment [1 / m]
+    ε_dyn = ε_dim_scale * ε_nondim + MdMdz_ε
+    δ_dyn = δ_dim_scale * (δ_nondim + area_limiter) + MdMdz_δ
+
+    return ε_dyn, δ_dyn
+end
+
+"""
+    entr_detr(εδ_model, εδ_vars, entr_dim_scale, detr_dim_scale)
+
+Returns the fractional dynamical entrainment and detrainment rates [1/m],
+as well as the turbulent entrainment rate
+
+Parameters:
+ - `εδ_model`       :: type of non-dimensional model for entrainment/detrainment
+ - `εδ_vars`        :: structure containing variables
+ - `entr_dim_scale` :: type of dimensional fractional entrainment scale
+ - `detr_dim_scale` :: type of dimensional fractional detrainment scale
+"""
+function entr_detr(εδ_model, εδ_vars, entr_dim_scale, detr_dim_scale)
+    FT = eltype(εδ_vars.q_cond_up)
+
+    # fractional entrainment / detrainment
+    ε_nondim, δ_nondim = non_dimensional_function(εδ_model, εδ_vars)
+    ε_dyn, δ_dyn = εδ_dyn(εδ_model, εδ_vars, entr_dim_scale, detr_dim_scale, ε_nondim, δ_nondim)
+
+    # turbulent entrainment
+    ε_turb =
+        compute_turbulent_entrainment(εδ_params(εδ_model).c_γ, εδ_vars.a_up, εδ_vars.w_up, εδ_vars.tke_en, εδ_vars.H_up)
+
+    return EntrDetr{FT}(ε_dyn, δ_dyn, ε_turb, ε_nondim, δ_nondim)
+end
+
+##### Compute entr detr
+function compute_entr_detr!(
+    state::State,
+    grid::Grid,
+    edmf::EDMFModel,
+    param_set::APS,
+    surf::SurfaceBase,
+    Δt::Real,
+    εδ_closure::AbstractEntrDetrModel,
+)
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    aux_up = center_aux_updrafts(state)
+    prog_up = center_prog_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_tc = center_aux_turbconv(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    g::FT = TCP.grav(param_set)
+    w_up_c = aux_tc.w_up_c
+    w_en_c = aux_tc.w_en_c
+    m_entr_detr = aux_tc.ϕ_temporary
+    ∇m_entr_detr = aux_tc.ψ_temporary
+    wvec = CC.Geometry.WVector
+    max_area = edmf.max_area
+    plume_scale_height = map(1:N_up) do i
+        compute_plume_scale_height(grid, state, edmf.H_up_min, i)
+    end
+    Ic = CCO.InterpolateF2C()
+    ∇c = CCO.DivergenceF2C()
+    LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(FT(0)))
+    @inbounds for i in 1:N_up
+        # compute ∇m at cell centers
+        a_up = aux_up[i].area
+        w_up = aux_up_f[i].w
+        w_en = aux_en_f.w
+        w_gm = prog_gm_f.w
+        @. m_entr_detr = a_up * (Ic(w_up) - toscalar(Ic(w_gm)))
+        @. ∇m_entr_detr = ∇c(wvec(LB(m_entr_detr)))
+        @. w_up_c = Ic(w_up)
+        @. w_en_c = Ic(w_en)
+        @inbounds for k in real_center_indices(grid)
+            # entrainment
+
+            q_cond_up = TD.condensate(TD.PhasePartition(aux_up[i].q_tot[k], aux_up[i].q_liq[k], aux_up[i].q_ice[k]))
+            q_cond_en = TD.condensate(TD.PhasePartition(aux_en.q_tot[k], aux_en.q_liq[k], aux_en.q_ice[k]))
+
+            if aux_up[i].area[k] > 0.0
+                εδ_model_vars = (;
+                    q_cond_up = q_cond_up, # updraft condensate (liquid water + ice)
+                    q_cond_en = q_cond_en, # environment condensate (liquid water + ice)
+                    w_up = w_up_c[k], # updraft vertical velocity
+                    w_en = w_en_c[k], # environment vertical velocity
+                    b_up = aux_up[i].buoy[k], # updraft buoyancy
+                    b_en = aux_en.buoy[k], # environment buoyancy
+                    tke_gm = aux_gm.tke[k], # grid mean tke
+                    tke_en = aux_en.tke[k], # environment tke
+                    dMdz = ∇m_entr_detr[k], # updraft momentum divergence
+                    M = m_entr_detr[k], # updraft momentum
+                    a_up = aux_up[i].area[k], # updraft area fraction
+                    a_en = aux_en.area[k], # environment area fraction
+                    H_up = plume_scale_height[i], # plume scale height
+                    ref_H = p_c[k] / (ρ_c[k] * g), # reference state scale height
+                    RH_up = aux_up[i].RH[k], # updraft relative humidity
+                    RH_en = aux_en.RH[k], # environment relative humidity
+                    max_area = max_area, # maximum updraft area
+                    zc_i = FT(grid.zc[k].z), # vertical coordinate
+                    Δt = Δt, # Model time step
+                    ε_nondim = aux_up[i].ε_nondim[k], # nondimensional fractional dynamical entrainment
+                    δ_nondim = aux_up[i].δ_nondim[k], # nondimensional fractional dynamical detrainment
+                    wstar = surf.wstar, # convective velocity
+                    entr_Π_subset = entrainment_Π_subset(edmf), # indices of Pi groups to include
+                )
+
+                # update fractional and turbulent entr/detr
+                if εδ_closure isa PrognosticNoisyRelaxationProcess
+                    # fractional dynamical entrainment from prognostic state
+                    ε_nondim, δ_nondim = prog_up[i].ε_nondim[k], prog_up[i].δ_nondim[k]
+                    mean_model = εδ_closure.mean_model
+                    ε_dyn, δ_dyn =
+                        εδ_dyn(mean_model, εδ_model_vars, edmf.entr_dim_scale, edmf.detr_dim_scale, ε_nondim, δ_nondim)
+                    # turbulent & mean nondimensional entrainment
+                    er = entr_detr(mean_model, εδ_model_vars, edmf.entr_dim_scale, edmf.detr_dim_scale)
+                else
+                    # fractional, turbulent & nondimensional entrainment
+                    er = entr_detr(εδ_closure, εδ_model_vars, edmf.entr_dim_scale, edmf.detr_dim_scale)
+                    ε_dyn, δ_dyn = er.ε_dyn, er.δ_dyn
+                end
+                aux_up[i].entr_sc[k] = ε_dyn
+                aux_up[i].detr_sc[k] = δ_dyn
+                aux_up[i].frac_turb_entr[k] = er.ε_turb
+                # update nondimensional entr/detr
+                aux_up[i].ε_nondim[k] = er.ε_nondim
+                aux_up[i].δ_nondim[k] = er.δ_nondim
+            else
+                aux_up[i].entr_sc[k] = 0.0
+                aux_up[i].detr_sc[k] = 0.0
+                aux_up[i].frac_turb_entr[k] = 0.0
+                aux_up[i].ε_nondim[k] = 0.0
+                aux_up[i].δ_nondim[k] = 0.0
+            end
+        end
+    end
+end
+
+function compute_entr_detr!(
+    state::State,
+    grid::Grid,
+    edmf::EDMFModel,
+    param_set::APS,
+    surf::SurfaceBase,
+    Δt::Real,
+    εδ_model::AbstractNonLocalEntrDetrModel,
+)
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    prog_gm_f = face_prog_grid_mean(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_tc = center_aux_turbconv(state)
+    prog_gm = center_prog_grid_mean(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    g::FT = TCP.grav(param_set)
+    w_up_c = aux_tc.w_up_c
+    w_en_c = aux_tc.w_en_c
+    m_entr_detr = aux_tc.ϕ_temporary
+    ∇m_entr_detr = aux_tc.ψ_temporary
+    wvec = CC.Geometry.WVector
+    max_area = edmf.max_area
+    plume_scale_height = map(1:N_up) do i
+        compute_plume_scale_height(grid, state, edmf.H_up_min, i)
+    end
+
+    Ic = CCO.InterpolateF2C()
+    ∇c = CCO.DivergenceF2C()
+    LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(FT(0)))
+    c_div = εδ_params(εδ_model).c_div
+    @inbounds for i in 1:N_up
+        # compute ∇m at cell centers
+        a_up = aux_up[i].area
+        w_up = aux_up_f[i].w
+        w_en = aux_en_f.w
+        w_gm = prog_gm_f.w
+        @. m_entr_detr = a_up * (Ic(w_up) - Ic(toscalar(w_gm)))
+        @. ∇m_entr_detr = ∇c(wvec(LB(m_entr_detr)))
+        @. w_up_c = Ic(w_up)
+        @. w_en_c = Ic(w_en)
+
+        @inbounds for k in real_center_indices(grid)
+            # entrainment
+
+            q_cond_up = TD.condensate(TD.PhasePartition(aux_up[i].q_tot[k], aux_up[i].q_liq[k], aux_up[i].q_ice[k]))
+            q_cond_en = TD.condensate(TD.PhasePartition(aux_en.q_tot[k], aux_en.q_liq[k], aux_en.q_ice[k]))
+
+            if aux_up[i].area[k] > 0.0
+                εδ_model_vars = (;
+                    q_cond_up = q_cond_up, # updraft condensate (liquid water + ice)
+                    q_cond_en = q_cond_en, # environment condensate (liquid water + ice)
+                    w_up = w_up_c[k], # updraft vertical velocity
+                    w_en = w_en_c[k], # environment vertical velocity
+                    b_up = aux_up[i].buoy[k], # updraft buoyancy
+                    b_en = aux_en.buoy[k], # environment buoyancy
+                    tke_gm = aux_gm.tke[k], # grid mean tke
+                    tke_en = aux_en.tke[k], # environment tke
+                    dMdz = ∇m_entr_detr[k], # updraft momentum divergence
+                    M = m_entr_detr[k], # updraft momentum
+                    a_up = aux_up[i].area[k], # updraft area fraction
+                    a_en = aux_en.area[k], # environment area fraction
+                    H_up = plume_scale_height[i], # plume scale height
+                    ref_H = p_c[k] / (ρ_c[k] * g), # reference state scale height
+                    RH_up = aux_up[i].RH[k], # updraft relative humidity
+                    RH_en = aux_en.RH[k], # environment relative humidity
+                    max_area = max_area, # maximum updraft area
+                    zc_i = FT(grid.zc[k].z), # vertical coordinate
+                    Δt = Δt, # Model time step
+                    ε_nondim = aux_up[i].ε_nondim[k], # nondimensional fractional dynamical entrainment
+                    δ_nondim = aux_up[i].δ_nondim[k], # nondimensional fractional dynamical detrainment
+                    wstar = surf.wstar, # convective velocity
+                    entr_Π_subset = entrainment_Π_subset(edmf), # indices of Pi groups to include
+                )
+                Π = non_dimensional_groups(εδ_model, εδ_model_vars)
+                @assert length(Π) == n_Π_groups(edmf)
+                for Π_i in 1:length(entrainment_Π_subset(edmf))
+                    aux_up[i].Π_groups[Π_i][k] = Π[Π_i]
+                end
+
+            else
+                for Π_i in 1:length(entrainment_Π_subset(edmf))
+                    aux_up[i].Π_groups[Π_i][k] = 0.0
+                end
+            end
+        end
+
+        Π_groups = parent(aux_up[i].Π_groups)
+        ε_nondim = parent(aux_up[i].ε_nondim)
+        δ_nondim = parent(aux_up[i].δ_nondim)
+        non_dimensional_function!(ε_nondim, δ_nondim, Π_groups, εδ_model)
+
+        @inbounds for k in real_center_indices(grid)
+            ε_turb = compute_turbulent_entrainment(
+                FT(εδ_params(εδ_model).c_γ),
+                aux_up[i].area[k],
+                w_up_c[k],
+                aux_en.tke[k],
+                FT(plume_scale_height[i]),
+            )
+            ε_dim_scale = entrainment_inv_length_scale(
+                εδ_model,
+                aux_up[i].buoy[k],
+                aux_en.buoy[k],
+                w_up_c[k],
+                w_en_c[k],
+                aux_en.tke[k],
+                FT(grid.zc[k].z),
+                edmf.entr_dim_scale,
+            )
+            δ_dim_scale = entrainment_inv_length_scale(
+                εδ_model,
+                aux_up[i].buoy[k],
+                aux_en.buoy[k],
+                w_up_c[k],
+                w_en_c[k],
+                aux_en.tke[k],
+                FT(grid.zc[k].z),
+                edmf.detr_dim_scale,
+            )
+            area_limiter = max_area_limiter(εδ_model, max_area, aux_up[i].area[k])
+            MdMdz_ε, MdMdz_δ = get_MdMdz(m_entr_detr[k], ∇m_entr_detr[k]) .* c_div
+
+            aux_up[i].entr_sc[k] = ε_dim_scale * aux_up[i].ε_nondim[k] + MdMdz_ε
+            aux_up[i].detr_sc[k] = δ_dim_scale * (aux_up[i].δ_nondim[k] + area_limiter) + MdMdz_δ
+            aux_up[i].frac_turb_entr[k] = ε_turb
+        end
+
+        @. aux_up[i].ε_nondim = ifelse(aux_up[i].area > 0, aux_up[i].ε_nondim, 0)
+        @. aux_up[i].δ_nondim = ifelse(aux_up[i].area > 0, aux_up[i].δ_nondim, 0)
+        @. aux_up[i].entr_sc = ifelse(aux_up[i].area > 0, aux_up[i].entr_sc, 0)
+        @. aux_up[i].detr_sc = ifelse(aux_up[i].area > 0, aux_up[i].detr_sc, 0)
+        @. aux_up[i].frac_turb_entr = ifelse(aux_up[i].area > 0, aux_up[i].frac_turb_entr, 0)
+
+    end
+end

--- a/src/TurbulenceConvection/closures/mixing_length.jl
+++ b/src/TurbulenceConvection/closures/mixing_length.jl
@@ -1,0 +1,61 @@
+function mixing_length(mix_len_params, param_set, ml_model::MinDisspLen{FT}) where {FT}
+    c_m = mix_len_params.c_m
+    c_d = mix_len_params.c_d
+    smin_ub = mix_len_params.smin_ub
+    smin_rm = mix_len_params.smin_rm
+    l_max = mix_len_params.l_max
+    c_b = mix_len_params.c_b
+    g::FT = TCP.grav(param_set)
+    molmass_ratio::FT = TCP.molmass_ratio(param_set)
+    vkc::FT = TCP.von_karman_const(param_set)
+    ustar = ml_model.ustar
+    z = ml_model.z
+    tke_surf = ml_model.tke_surf
+    ∂b∂z = ml_model.∇b.∂b∂z
+    tke = ml_model.tke
+
+    # kz scale (surface layer)
+    if ml_model.obukhov_length < 0.0 #unstable
+        l_W =
+            vkc * z / (sqrt(tke_surf / ustar / ustar) * c_m) *
+            min((1 - 100 * z / ml_model.obukhov_length)^FT(0.2), 1 / vkc)
+    else # neutral or stable
+        l_W = vkc * z / (sqrt(tke_surf / ustar / ustar) * c_m)
+    end
+
+    # compute l_TKE - the production-dissipation balanced length scale
+    a_pd = c_m * (ml_model.Shear² - ∂b∂z / ml_model.Pr) * sqrt(tke)
+    # Dissipation term
+    c_neg = c_d * tke * sqrt(tke)
+    # Subdomain exchange term
+    b_exch = ml_model.b_exch
+
+    if abs(a_pd) > eps(FT) && 4 * a_pd * c_neg > -b_exch * b_exch
+        l_TKE = max(-b_exch / 2 / a_pd + sqrt(b_exch * b_exch + 4 * a_pd * c_neg) / 2 / a_pd, 0)
+    elseif abs(a_pd) < eps(FT) && abs(b_exch) > eps(FT)
+        l_TKE = c_neg / b_exch
+    else
+        l_TKE = FT(0)
+    end
+
+    # compute l_N - the effective static stability length scale.
+    N_eff = sqrt(max(∂b∂z, 0))
+    if N_eff > 0.0
+        l_N = min(sqrt(max(c_b * tke, 0)) / N_eff, l_max)
+    else
+        l_N = l_max
+    end
+
+    # add limiters
+    l = SA.SVector(
+        (l_N < eps(FT) || l_N > l_max) ? l_max : l_N,
+        (l_TKE < eps(FT) || l_TKE > l_max) ? l_max : l_TKE,
+        (l_W < eps(FT) || l_W > l_max) ? l_max : l_W,
+    )
+
+    # get soft minimum
+    min_len, min_len_ind = findmin(l)
+    mix_len = lamb_smooth_minimum(l, smin_ub, smin_rm)
+    ml_ratio = mix_len / min_len
+    return MixLen(min_len_ind, mix_len, ml_ratio)
+end

--- a/src/TurbulenceConvection/closures/nondimensional_exchange_functions.jl
+++ b/src/TurbulenceConvection/closures/nondimensional_exchange_functions.jl
@@ -1,0 +1,399 @@
+#### Non-dimensional Entrainment-Detrainment functions
+function max_area_limiter(εδ_model, max_area, a_up)
+    FT = eltype(a_up)
+    γ_lim = εδ_params(εδ_model).γ_lim
+    β_lim = εδ_params(εδ_model).β_lim
+    logistic_term = (2 - 1 / (1 + exp(-γ_lim * (max_area - a_up))))
+    return (logistic_term)^β_lim - 1
+end
+
+function non_dimensional_groups(εδ_model, εδ_model_vars)
+    FT = eltype(εδ_model_vars.tke_en)
+    Δw = get_Δw(εδ_model, εδ_model_vars.w_up, εδ_model_vars.w_en)
+    Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
+    Π_norm = εδ_params(εδ_model).Π_norm
+    Π₁ = (εδ_model_vars.zc_i * Δb) / (Δw^2 + εδ_model_vars.wstar^2) / Π_norm[1]
+    Π₂ =
+        (εδ_model_vars.tke_gm - εδ_model_vars.a_en * εδ_model_vars.tke_en) / (εδ_model_vars.tke_gm + eps(FT)) /
+        Π_norm[2]
+    Π₃ = √(εδ_model_vars.a_up) / Π_norm[3]
+    Π₄ = (εδ_model_vars.RH_up - εδ_model_vars.RH_en) / Π_norm[4]
+    Π₅ = εδ_model_vars.zc_i / εδ_model_vars.H_up / Π_norm[5]
+    Π₆ = εδ_model_vars.zc_i / εδ_model_vars.ref_H / Π_norm[6]
+    Π_groups = (Π₁, Π₂, Π₃, Π₄, Π₅, Π₆)
+
+    return map(i -> Π_groups[i], εδ_model_vars.entr_Π_subset)
+end
+
+"""
+    non_dimensional_function(εδ_model::MDEntr, εδ_model_vars)
+
+Returns the nondimensional entrainment and detrainment
+functions following Cohen et al. (JAMES, 2020), given:
+ - `εδ_model`       :: MDEntr - Moisture deficit entrainment closure
+ - `εδ_model_vars`  :: structure containing variables
+"""
+function non_dimensional_function(εδ_model::MDEntr, εδ_model_vars)
+    FT = eltype(εδ_model_vars.q_cond_up)
+    Δw = get_Δw(εδ_model, εδ_model_vars.w_up, εδ_model_vars.w_en)
+    c_ε = εδ_params(εδ_model).c_ε
+    μ_0 = εδ_params(εδ_model).μ_0
+    β = εδ_params(εδ_model).β
+    χ = εδ_params(εδ_model).χ
+    c_δ = if !TD.has_condensate(εδ_model_vars.q_cond_up + εδ_model_vars.q_cond_en)
+        FT(0)
+    else
+        εδ_model.params.c_δ
+    end
+
+    Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
+    μ_ij = (χ - εδ_model_vars.a_up / (εδ_model_vars.a_up + εδ_model_vars.a_en)) * Δb / Δw
+    exp_arg = μ_ij / μ_0
+    D_ε = 1 / (1 + exp(-exp_arg))
+    D_δ = 1 / (1 + exp(exp_arg))
+
+    M_δ = (max((εδ_model_vars.RH_up)^β - (εδ_model_vars.RH_en)^β, 0))^(1 / β)
+    M_ε = (max((εδ_model_vars.RH_en)^β - (εδ_model_vars.RH_up)^β, 0))^(1 / β)
+
+    nondim_ε = (c_ε * D_ε + c_δ * M_ε)
+    nondim_δ = (c_ε * D_δ + c_δ * M_δ)
+    return nondim_ε, nondim_δ
+end
+
+"""
+    non_dimensional_function!(nondim_ε, nondim_δ, Π_groups, εδ_model::FNOEntr)
+
+Uses a non local (Fourier) neural network to predict the fields of
+    non-dimensional components of dynamical entrainment/detrainment.
+ - `nondim_ε`   :: output - non dimensional entr from FNO, as column fields
+ - `nondim_δ`   :: output - non dimensional detr from FNO, as column fields
+ - `Π_groups`   :: input - non dimensional groups, as column fields
+ - `::FNOEntr ` a non-local entrainment-detrainment model type
+"""
+function non_dimensional_function!(
+    nondim_ε::AbstractArray{FT}, # output
+    nondim_δ::AbstractArray{FT}, # output
+    Π_groups::AbstractArray{FT}, # input
+    εδ_model::FNOEntr,
+) where {FT <: Real}
+
+    width = εδ_model.w_fno
+    modes = εδ_model.nm_fno
+    c_fno = εδ_model.c_fno
+    n_params = length(c_fno)
+    n_input_vars = size(Π_groups)[2]
+    M = size(Π_groups)[1]
+    z = LinRange(0, 1, M)
+    Π_groups = hcat(Π_groups, z)
+    Π = Π_groups'
+    Π = reshape(Π, (size(Π)..., 1)) # (C, X, B)
+    even = Bool(mod(M, 2)) ? false : true
+
+    expected_n_params = (
+        (n_input_vars + 1) * width +
+        width +
+        modes * width * width * 2 +
+        width * width +
+        width +
+        width * width +
+        width +
+        2 * width +
+        2
+    )# 3rd dense layer
+
+    if expected_n_params != n_params
+        error("Incorrect number of parameters ($n_params) for requested FNO architecture ($expected_n_params)!")
+    end
+
+    trafo = OF.FourierTransform(modes = (modes,), even = even)
+    model = OF.Chain(
+        Flux.Dense(n_input_vars + 1, width, Flux.tanh),
+        OF.SpectralKernelOperator(trafo, width => width, Flux.tanh),
+        Flux.Dense(width, width, Flux.tanh),
+        Flux.Dense(width, 2),
+    )
+
+    index = 1
+    for p in Flux.params(model)
+        len_p = length(p)
+        if eltype(p) <: Real
+            p[:] .= c_fno[index:(index + len_p - 1)]
+            index += len_p
+        elseif eltype(p) <: Complex
+            p[:] .= c_fno[index:(index + len_p - 1)] + c_fno[(index + len_p):(index + len_p * 2 - 1)] * im
+            index += len_p * 2
+        else
+            error("Bad eltype in Flux params")
+        end
+    end
+
+    output = model(Π)
+    nondim_ε .= Flux.relu.(output[1, :] .+ 0.5)
+    nondim_δ .= Flux.relu.(output[2, :])
+
+    return nothing
+end
+
+"""
+    Count number of parameters in fully-connected NN model given Array specifying architecture following
+        the pattern: [#inputs, #neurons in L1, #neurons in L2, ...., #outputs]. Equal to the number of weights + biases.
+"""
+num_params_from_arc(nn_arc::AbstractArray{Int}) = num_weights_from_arc(nn_arc) + num_biases_from_arc(nn_arc)
+
+"""
+    Count number of weights in fully-connected NN architecture.
+"""
+num_weights_from_arc(nn_arc::AbstractArray{Int}) = sum(i -> nn_arc[i] * nn_arc[i + 1], 1:(length(nn_arc) - 1))
+
+"""
+    Count number of biases in fully-connected NN architecture.
+"""
+num_biases_from_arc(nn_arc::AbstractArray{Int}) = sum(i -> nn_arc[i + 1], 1:(length(nn_arc) - 1))
+
+
+"""
+    construct_fully_connected_nn(
+        arc::AbstractArray{Int},
+        params::AbstractArray{FT};
+        biases_bool::bool = false,
+        activation_function::Flux.Function = Flux.sigmoid,
+        output_layer_activation_function::Flux.Function = Flux.relu,)
+
+    Given network architecture and parameter vectors, construct NN model and unpack weights (and biases if `biases_bool` is true).
+    - `arc` :: vector specifying network architecture
+    - `params` :: parameter vector containing weights (and biases if `biases_bool` is true)
+    - `biases_bool` :: bool specifying whether `params` includes biases.
+    - `activation_function` :: activation function for hidden layers
+    - `output_layer_activation_function` :: activation function for output layer
+"""
+function construct_fully_connected_nn(
+    arc::AbstractArray{Int},
+    params::AbstractArray{FT};
+    biases_bool::Bool = false,
+    activation_function::Flux.Function = Flux.sigmoid,
+    output_layer_activation_function::Flux.Function = Flux.relu,
+) where {FT <: Real}
+
+    # check consistency of architecture and parameters
+    if biases_bool
+        n_params_nn = num_params_from_arc(arc)
+        n_params_vect = length(params)
+    else
+        n_params_nn = num_weights_from_arc(arc)
+        n_params_vect = length(params)
+    end
+    if n_params_nn != n_params_vect
+        error("Incorrect number of parameters ($n_params_vect) for requested NN architecture ($n_params_nn)!")
+    end
+
+    layers = []
+    parameters_i = 1
+    # unpack parameters in parameter vector into network
+    for layer_i in 1:(length(arc) - 1)
+        if layer_i == length(arc) - 1
+            activation_function = output_layer_activation_function
+        end
+        layer_num_weights = arc[layer_i] * arc[layer_i + 1]
+
+        nn_biases = if biases_bool
+            params[(parameters_i + layer_num_weights):(parameters_i + layer_num_weights + arc[layer_i + 1] - 1)]
+        else
+            biases_bool
+        end
+
+        layer = Flux.Dense(
+            reshape(params[parameters_i:(parameters_i + layer_num_weights - 1)], arc[layer_i + 1], arc[layer_i]),
+            nn_biases,
+            activation_function,
+        )
+        parameters_i += layer_num_weights
+
+        if biases_bool
+            parameters_i += arc[layer_i + 1]
+        end
+        push!(layers, layer)
+    end
+
+    return Flux.Chain(layers...)
+end
+
+"""
+    non_dimensional_function!(nondim_ε, nondim_δ, Π_groups, εδ_model::NNEntrNonlocal)
+
+Uses a fully connected neural network to predict the non-dimensional components of dynamical entrainment/detrainment.
+    non-dimensional components of dynamical entrainment/detrainment.
+ - `nondim_ε`   :: output - non dimensional entr from FNO, as column fields
+ - `nondim_δ`   :: output - non dimensional detr from FNO, as column fields
+ - `Π_groups`   :: input - non dimensional groups, as column fields
+ - `::NNEntrNonlocal ` a non-local entrainment-detrainment model type
+"""
+function non_dimensional_function!(
+    nondim_ε::AbstractArray{FT}, # output
+    nondim_δ::AbstractArray{FT}, # output
+    Π_groups::AbstractArray{FT}, # input
+    εδ_model::NNEntrNonlocal,
+) where {FT <: Real}
+    # neural network architecture
+    nn_arc = εδ_model.nn_arc
+    c_nn_params = εδ_model.c_nn_params
+    nn_model = construct_fully_connected_nn(nn_arc, c_nn_params; biases_bool = εδ_model.biases_bool)
+    output = nn_model(Π_groups')
+    nondim_ε .= output[1, :]
+    nondim_δ .= output[2, :]
+
+    return nothing
+end
+
+"""
+    non_dimensional_function(εδ_model::NNEntr, εδ_model_vars)
+
+Uses a fully connected neural network to predict the non-dimensional components of dynamical entrainment/detrainment.
+ - `εδ_model`       :: NNEntr - Neural network entrainment closure
+ - `εδ_model_vars`  :: structure containing variables
+"""
+function non_dimensional_function(εδ_model::NNEntr, εδ_model_vars)
+    nn_arc = εδ_model.nn_arc
+    c_nn_params = εδ_model.c_nn_params
+
+    nondim_groups = collect(non_dimensional_groups(εδ_model, εδ_model_vars))
+    # neural network architecture
+    nn_model = construct_fully_connected_nn(nn_arc, c_nn_params; biases_bool = εδ_model.biases_bool)
+
+    nondim_ε, nondim_δ = nn_model(nondim_groups)
+    return nondim_ε, nondim_δ
+end
+
+"""
+    non_dimensional_function(εδ_model::LinearEntr, εδ_model_vars)
+
+Uses a simple linear model to predict the non-dimensional components of dynamical entrainment/detrainment.
+ - `εδ_model`       :: LinearEntr - linear entrainment closure
+ - `εδ_model_vars`  :: structure containing variables
+"""
+function non_dimensional_function(εδ_model::LinearEntr, εδ_model_vars)
+    c_linear = εδ_model.c_linear
+
+    nondim_groups = collect(non_dimensional_groups(εδ_model, εδ_model_vars))
+    # Linear closure
+    lin_arc = (length(nondim_groups), 1)  # (#inputs, #outputs)
+    lin_model_ε = Flux.Dense(reshape(c_linear[1:6], lin_arc[2], lin_arc[1]), [c_linear[7]], Flux.relu)
+    lin_model_δ = Flux.Dense(reshape(c_linear[8:13], lin_arc[2], lin_arc[1]), [c_linear[14]], Flux.relu)
+
+    nondim_ε = lin_model_ε(nondim_groups)[1]
+    nondim_δ = lin_model_δ(nondim_groups)[1]
+    return nondim_ε, nondim_δ
+end
+
+
+"""
+    non_dimensional_function(εδ_model::RFEntr, εδ_model_vars)
+
+Uses a Random Feature model to predict the non-dimensional components of dynamical entrainment/detrainment.
+ - `εδ_model`       :: RFEntr - basic RF entrainment closure
+ - `εδ_model_vars`  :: structure containing variables
+"""
+function non_dimensional_function(εδ_model::RFEntr{d, m}, εδ_model_vars) where {d, m}
+    # d inputs, p=2 outputs, m random features
+    nondim_groups = non_dimensional_groups(εδ_model, εδ_model_vars)
+
+    # Learnable and fixed parameters
+    c_rf_fix = εδ_model.c_rf_fix # 2 x m x (1 + d), fix
+    c_rf_opt = εδ_model.c_rf_opt # 2 x (m + 1 + d), learn
+
+    # Random Features
+    scale_x_entr = (c_rf_opt[1, (m + 2):(m + d + 1)] .^ 2) .* nondim_groups
+    scale_x_detr = (c_rf_opt[2, (m + 2):(m + d + 1)] .^ 2) .* nondim_groups
+    f_entr = c_rf_opt[1, m + 1]^2 * sqrt(2) * cos.(c_rf_fix[1, :, 2:(d + 1)] * scale_x_entr + c_rf_fix[1, :, 1])
+    f_detr = c_rf_opt[2, m + 1]^2 * sqrt(2) * cos.(c_rf_fix[2, :, 2:(d + 1)] * scale_x_detr + c_rf_fix[2, :, 1])
+
+    # Square output for nonnegativity for prediction
+    nondim_ε = sum(c_rf_opt[1, 1:m] .* f_entr) / sqrt(m)
+    nondim_δ = sum(c_rf_opt[2, 1:m] .* f_detr) / sqrt(m)
+    return nondim_ε^2, nondim_δ^2
+end
+
+"""
+    non_dimensional_function(εδ_model::LogNormalScalingProcess, εδ_model_vars)
+
+Uses a LogNormal random variable to scale a deterministic process
+to predict the non-dimensional components of dynamical entrainment/detrainment.
+
+Arguments:
+ - `εδ_model_vars`  :: structure containing variables
+ - `εδ_model`       :: LogNormalScalingProcess - Stochastic lognormal scaling
+"""
+function non_dimensional_function(εδ_model::LogNormalScalingProcess, εδ_model_vars)
+    FT = eltype(εδ_model_vars.q_cond_up)
+    # model parameters
+    mean_model = εδ_model.mean_model
+    c_gen_stoch = εδ_model.c_gen_stoch
+    ε_σ² = c_gen_stoch[1]
+    δ_σ² = c_gen_stoch[2]
+
+    # Mean model closure
+    ε_mean_nondim, δ_mean_nondim = non_dimensional_function(εδ_model, εδ_model_vars, mean_model)
+
+    # lognormal scaling
+    nondim_ε = ε_mean_nondim * lognormal_sampler(FT(1), ε_σ²)
+    nondim_δ = δ_mean_nondim * lognormal_sampler(FT(1), δ_σ²)
+
+    return nondim_ε, nondim_δ
+end
+
+function lognormal_sampler(m::FT, var::FT)::FT where {FT}
+    μ = log(m^2 / √(m^2 + var))
+    σ = √(log(1 + var / m^2))
+    return rand(Distributions.LogNormal(μ, σ))
+end
+
+"""
+    non_dimensional_function(εδ_model::NoisyRelaxationProcess, εδ_model_vars)
+
+Uses a noisy relaxation process to predict the non-dimensional components
+of dynamical entrainment/detrainment. A deterministic closure is used as the
+equilibrium mean function for the relaxation process.
+
+Arguments:
+ - `εδ_model_vars`  :: structure containing variables
+ - `εδ_model`       :: NoisyRelaxationProcess - A noisy relaxation process closure
+"""
+function non_dimensional_function(εδ_model::NoisyRelaxationProcess, εδ_model_vars)
+    # model parameters
+    mean_model = εδ_model.mean_model
+    c_gen_stoch = εδ_model.c_gen_stoch
+    ε_σ² = c_gen_stoch[1]
+    δ_σ² = c_gen_stoch[2]
+    ε_λ = c_gen_stoch[3]
+    δ_λ = c_gen_stoch[4]
+
+    # Mean model closure
+    ε_mean_nondim, δ_mean_nondim = non_dimensional_function(mean_model, εδ_model_vars)
+
+    # noisy relaxation process
+    ε_u0 = εδ_model_vars.ε_nondim
+    δ_u0 = εδ_model_vars.δ_nondim
+    Δt = εδ_model_vars.Δt
+    nondim_ε = noisy_relaxation_process(ε_mean_nondim, ε_λ, ε_σ², ε_u0, Δt)
+    nondim_δ = noisy_relaxation_process(δ_mean_nondim, δ_λ, δ_σ², δ_u0, Δt)
+
+    return nondim_ε, nondim_δ
+end
+
+"""
+    Solve a noisy relaxation process numerically
+
+In this formulation, the noise amplitude is scaled by the speed of
+reversion λ and the long-term mean μ, in addition to the variance σ² as is usual,
+
+    `du = λ(μ - u)⋅dt + √(2λμσ²)⋅dW`
+
+To ensure non-negativity, the solution is passed through a relu filter.
+"""
+function noisy_relaxation_process(μ::FT, λ::FT, σ²::FT, u0::FT, Δt::FT)::FT where {FT}
+    f(u, p, t) = λ * (μ - u)        # mean-reverting process
+    g(u, p, t) = √(2λ * μ * σ²)     # noise fluctuation
+    tspan = (FT(0), Δt)
+    prob = SDE.SDEProblem(f, g, u0, tspan; save_start = false, saveat = last(tspan))
+    sol = SDE.solve(prob, SDE.SOSRI())
+    return Flux.relu(sol.u[end])
+end

--- a/src/TurbulenceConvection/closures/perturbation_pressure.jl
+++ b/src/TurbulenceConvection/closures/perturbation_pressure.jl
@@ -1,0 +1,73 @@
+"""
+    compute_nh_pressure!(
+        state::State,
+        grid::Grid,
+        edmf::EDMFModel,
+        surf::SurfaceBase,
+    )
+
+Computes the
+    - perturbation pressure gradient
+    - (perturbation?) pressure advection
+    - (perturbation?) pressure drag
+
+for all updrafts, following [He2020](@cite), given:
+
+ - `state`: state
+ - `grid`: grid
+ - `edmf`: EDMF model
+ - `surf`: surface model
+"""
+function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
+
+    FT = float_type(state)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kc_toa = kc_top_of_atmos(grid)
+
+    Ifc = CCO.InterpolateF2C()
+    wvec = CC.Geometry.WVector
+    w_bcs = (; bottom = CCO.SetValue(wvec(FT(0))), top = CCO.SetValue(wvec(FT(0))))
+    ∇ = CCO.DivergenceC2F(; w_bcs...)
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    aux_en_f = face_aux_environment(state)
+    ρ_f = aux_gm_f.ρ
+    plume_scale_height = map(1:N_up) do i
+        compute_plume_scale_height(grid, state, edmf.H_up_min, i)
+    end
+
+    # Note: Independence of aspect ratio hardcoded in implementation.
+    α₂_asp_ratio² = FT(0)
+    press_model_params = pressure_model_params(edmf)
+    α_b = press_model_params.α_b
+    α_a = press_model_params.α_a
+    α_d = press_model_params.α_d
+
+    @inbounds for i in 1:N_up
+        # pressure
+        b_up = aux_up[i].buoy
+        a_up = aux_up[i].area
+        w_up = aux_up_f[i].w
+        H_up = plume_scale_height[i]
+        w_en = aux_en_f.w
+
+        b_bcs = (; bottom = CCO.SetValue(b_up[kc_surf]), top = CCO.SetValue(b_up[kc_toa]))
+        a_bcs = a_up_boundary_conditions(surf, edmf, i)
+        Ifb = CCO.InterpolateC2F(; b_bcs...)
+        Ifa = CCO.InterpolateC2F(; a_bcs...)
+
+        nh_press_buoy = aux_up_f[i].nh_pressure_b
+        nh_press_adv = aux_up_f[i].nh_pressure_adv
+        nh_press_drag = aux_up_f[i].nh_pressure_drag
+        nh_pressure = aux_up_f[i].nh_pressure
+
+        @. nh_press_buoy = Int(Ifa(a_up) > 0) * -α_b / (1 + α₂_asp_ratio²) * ρ_f * Ifa(a_up) * Ifb(b_up)
+        @. nh_press_adv = Int(Ifa(a_up) > 0) * ρ_f * Ifa(a_up) * α_a * w_up * ∇(wvec(Ifc(w_up)))
+        # drag as w_dif and account for downdrafts
+        @. nh_press_drag = Int(Ifa(a_up) > 0) * -1 * ρ_f * Ifa(a_up) * α_d * (w_up - w_en) * abs(w_up - w_en) / H_up
+        @. nh_pressure = nh_press_buoy + nh_press_adv + nh_press_drag
+    end
+    return nothing
+end

--- a/src/TurbulenceConvection/diagnostics.jl
+++ b/src/TurbulenceConvection/diagnostics.jl
@@ -1,0 +1,148 @@
+#####
+##### Diagnostics
+#####
+
+#=
+    io_dictionary_aux()
+
+These functions return a dictionary whose
+ - `keys` are the nc variable names
+ - `values` are NamedTuples corresponding to
+    - `dims` (`("z")`  or `("z", "t")`) and
+    - `group` (`"reference"` or, e.g., `"profiles"`)
+=#
+
+#! format: off
+# TODO: use a better name, this exports fields from the prognostic state, and the aux state.
+function io_dictionary_aux()
+    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
+    io_dict = Dict{String, DT}(
+        "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).area),
+        "updraft_ql" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).q_liq),
+        "updraft_qi" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).q_ice),
+        "updraft_RH" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).RH),
+        "updraft_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).q_tot),
+        "updraft_w" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_bulk(state).w),
+        "updraft_temperature" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).T),
+        "updraft_thetal" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).θ_liq_ice),
+        "updraft_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).buoy),
+        "H_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).H_third_m),
+        "W_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).W_third_m),
+        "QT_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).QT_third_m),
+        "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
+        "buoyancy_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).buoy),
+        "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
+        "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
+        "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
+        "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),
+        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
+        "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
+        "Hvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).Hvar),
+        "QTvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).QTvar),
+        "HQTcov_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).HQTcov),
+        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> physical_grid_mean_u(state)),
+        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> physical_grid_mean_v(state)),
+        "w_mean" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_prog_grid_mean(state).w),
+        "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_tot),
+        "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).θ_liq_ice),
+        "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KM),
+        "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KH),
+        "env_tke" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).tke),
+        "env_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).buoy),
+        "env_Hvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).Hvar),
+        "env_QTvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).QTvar),
+        "env_HQTcov" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).HQTcov),
+
+        "tke_buoy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.buoy),
+        "tke_pressure" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.press),
+        "tke_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.dissipation),
+        "tke_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.entr_gain),
+        "tke_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.detr_loss),
+        "tke_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.shear),
+        "tke_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.interdomain),
+
+        "Hvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.dissipation),
+        "Hvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.entr_gain),
+        "Hvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.detr_loss),
+        "Hvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.interdomain),
+        "Hvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.rain_src),
+        "Hvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.shear),
+
+        "QTvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.dissipation),
+        "QTvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.entr_gain),
+        "QTvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.detr_loss),
+        "QTvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.shear),
+        "QTvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.rain_src),
+        "QTvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.interdomain),
+
+        "HQTcov_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.rain_src),
+        "HQTcov_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.dissipation),
+        "HQTcov_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.entr_gain),
+        "HQTcov_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.detr_loss),
+        "HQTcov_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.shear),
+        "HQTcov_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.interdomain),
+
+        "env_w" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_environment(state).w),
+        "env_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).q_tot),
+        "env_ql" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).q_liq),
+        "env_qi" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).q_ice),
+        "env_area" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).area),
+        "env_temperature" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).T),
+        "env_RH" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).RH),
+        "env_thetal" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).θ_liq_ice),
+        "env_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).cloud_fraction),
+        "massflux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s),
+        "diffusive_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).diffusive_flux_s),
+        "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
+
+        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
+
+        "mixing_length" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).mixing_length),
+
+        "updraft_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).cloud_fraction),
+
+        "updraft_qt_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).qt_tendency_precip_formation),
+        "updraft_e_tot_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).e_tot_tendency_precip_formation),
+
+        "massflux_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_h),
+        "massflux_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_qt),
+        "diffusive_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).diffusive_tendency_h),
+        "diffusive_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).diffusive_tendency_qt),
+
+        "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
+        "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
+
+        "ed_length_scheme" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).mls),
+        "mixing_length_ratio" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).ml_ratio),
+        "entdet_balance_length" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).l_entdet),
+
+        "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).dTdt_rad),
+        "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).f_rad),
+    )
+    return io_dict
+end
+
+function io_dictionary_aux_calibrate()
+    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
+    io_dict = Dict{String, DT}(
+        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> physical_grid_mean_u(state)),
+        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> physical_grid_mean_v(state)),
+        "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
+        "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_tot),
+        "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),
+        "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
+        "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
+        "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
+        "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).θ_liq_ice),
+        "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
+        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
+        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
+        "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
+        "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
+        "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
+    )
+    return io_dict
+end
+#! format: on

--- a/src/TurbulenceConvection/dycore_api.jl
+++ b/src/TurbulenceConvection/dycore_api.jl
@@ -1,0 +1,82 @@
+#####
+##### Dycore API
+#####
+
+abstract type FieldLocation end
+struct CentField <: FieldLocation end
+struct FaceField <: FieldLocation end
+struct SingleValuePerColumn <: FieldLocation end
+
+field_loc(::CentField) = :cent
+field_loc(::FaceField) = :face
+field_loc(::SingleValuePerColumn) = :svpc
+
+#=
+This file provides a list of methods that TurbulenceConvection.jl
+expects that the host dycore supports. This is experimental, as
+we're not sure how the data structures / flow control will shake out.
+=#
+
+#####
+##### Grid mean fields
+#####
+
+""" Prognostic fields for the host model """
+prognostic(state, fl) = getproperty(state.prog, field_loc(fl))
+
+center_prog_grid_mean(state) = prognostic(state, CentField())
+face_prog_grid_mean(state) = prognostic(state, FaceField())
+
+""" Auxiliary fields for the host model """
+aux(state, fl) = getproperty(state.aux, field_loc(fl))
+
+center_aux_grid_mean(state) = aux(state, CentField())
+face_aux_grid_mean(state) = aux(state, FaceField())
+
+""" Tendency fields for the host model """
+tendencies(state, fl) = getproperty(state.tendencies, field_loc(fl))
+
+center_tendencies_grid_mean(state) = tendencies(state, CentField())
+
+#####
+##### TurbulenceConvection fields
+#####
+
+#= Prognostic fields for TurbulenceConvection =#
+prognostic_turbconv(state, fl) = prognostic(state, fl).turbconv
+
+center_prog_updrafts(state) = prognostic_turbconv(state, CentField()).up
+face_prog_updrafts(state) = prognostic_turbconv(state, FaceField()).up
+center_prog_environment(state) = prognostic_turbconv(state, CentField()).en
+center_prog_precipitation(state) = prognostic_turbconv(state, CentField()).pr
+
+#= Auxiliary fields for TurbulenceConvection =#
+aux_turbconv(state, fl) = aux(state, fl).turbconv
+
+center_aux_turbconv(state) = aux_turbconv(state, CentField())
+face_aux_turbconv(state) = aux_turbconv(state, FaceField())
+center_aux_updrafts(state) = aux_turbconv(state, CentField()).up
+face_aux_updrafts(state) = aux_turbconv(state, FaceField()).up
+center_aux_environment(state) = aux_turbconv(state, CentField()).en
+center_aux_bulk(state) = aux_turbconv(state, CentField()).bulk
+face_aux_bulk(state) = aux_turbconv(state, FaceField()).bulk
+center_aux_environment_2m(state) = aux_turbconv(state, CentField()).en_2m
+face_aux_environment(state) = aux_turbconv(state, FaceField()).en
+
+#= Tendency fields for TurbulenceConvection =#
+tendencies_turbconv(state, fl) = tendencies(state, fl).turbconv
+
+center_tendencies_turbconv(state) = tendencies_turbconv(state, CentField())
+face_tendencies_turbconv(state) = tendencies_turbconv(state, FaceField())
+center_tendencies_updrafts(state) = tendencies_turbconv(state, CentField()).up
+center_tendencies_environment(state) = tendencies_turbconv(state, CentField()).en
+center_tendencies_precipitation(state) = tendencies_turbconv(state, CentField()).pr
+face_tendencies_updrafts(state) = tendencies_turbconv(state, FaceField()).up
+
+physical_grid_mean_uₕ(state) = CCG.UVVector.(grid_mean_uₕ(state))
+physical_grid_mean_u(state) = map(x -> x.u, physical_grid_mean_uₕ(state))
+physical_grid_mean_v(state) = map(x -> x.v, physical_grid_mean_uₕ(state))
+grid_mean_uₕ(state) = center_prog_grid_mean(state).uₕ
+grid_mean_uₕ_g(state) = center_aux_grid_mean(state).uₕ_g
+
+tendencies_grid_mean_uₕ(state) = center_tendencies_grid_mean(state).uₕ

--- a/src/TurbulenceConvection/microphysics_coupling.jl
+++ b/src/TurbulenceConvection/microphysics_coupling.jl
@@ -1,0 +1,200 @@
+"""
+Computes the tendencies to qt and θ_liq_ice due to precipitation formation
+(autoconversion + accretion)
+"""
+function noneq_moisture_sources(param_set::APS, area::FT, ρ::FT, Δt::Real, ts) where {FT}
+    thermo_params = TCP.thermodynamics_params(param_set)
+    microphys_params = TCP.microphysics_params(param_set)
+    # TODO - when using adaptive timestepping we are limiting the source terms
+    #        with the previous timestep Δt
+    ql_tendency = FT(0)
+    qi_tendency = FT(0)
+    if area > 0
+
+        q = TD.PhasePartition(thermo_params, ts)
+        T = TD.air_temperature(thermo_params, ts)
+        q_vap = TD.vapor_specific_humidity(thermo_params, ts)
+
+        # TODO - is that the state we want to be relaxing to?
+        ts_eq = TD.PhaseEquil_ρTq(thermo_params, ρ, T, q.tot)
+        q_eq = TD.PhasePartition(thermo_params, ts_eq)
+
+        S_ql = CMNe.conv_q_vap_to_q_liq_ice(microphys_params, liq_type, q_eq, q)
+        S_qi = CMNe.conv_q_vap_to_q_liq_ice(microphys_params, ice_type, q_eq, q)
+
+        # TODO - handle limiters elswhere
+        if S_ql >= FT(0)
+            S_ql = min(S_ql, q_vap / Δt)
+        else
+            S_ql = -min(-S_ql, q.liq / Δt)
+        end
+        if S_qi >= FT(0)
+            S_qi = min(S_qi, q_vap / Δt)
+        else
+            S_qi = -min(-S_qi, q.ice / Δt)
+        end
+
+        ql_tendency += S_ql
+        qi_tendency += S_qi
+    end
+    return NoneqMoistureSources{FT}(ql_tendency, qi_tendency)
+end
+
+"""
+Computes the tendencies to qt and θ_liq_ice due to precipitation formation
+(autoconversion + accretion)
+"""
+function precipitation_formation(
+    param_set::APS,
+    precip_model::AbstractPrecipitationModel,
+    qr::FT,
+    qs::FT,
+    area::FT,
+    ρ::FT,
+    z::FT,
+    Δt::Real,
+    ts,
+    precip_fraction,
+) where {FT}
+    thermo_params = TCP.thermodynamics_params(param_set)
+
+    microphys_params = TCP.microphysics_params(param_set)
+    # TODO - when using adaptive timestepping we are limiting the source terms
+    #        with the previous timestep Δt
+    qt_tendency = FT(0)
+    ql_tendency = FT(0)
+    qi_tendency = FT(0)
+    qr_tendency = FT(0)
+    qs_tendency = FT(0)
+    θ_liq_ice_tendency = FT(0)
+    e_tot_tendency = FT(0)
+
+    if area > 0
+
+        q = TD.PhasePartition(thermo_params, ts)
+
+        Π_m = TD.exner(thermo_params, ts)
+        c_pm = TD.cp_m(thermo_params, ts)
+        L_v0 = TCP.LH_v0(param_set)
+        L_s0 = TCP.LH_s0(param_set)
+        I_l = TD.internal_energy_liquid(thermo_params, ts)
+        I_i = TD.internal_energy_ice(thermo_params, ts)
+        I = TD.internal_energy(thermo_params, ts)
+        Φ = geopotential(param_set, z)
+
+        if precip_model isa Clima0M
+            qsat = TD.q_vap_saturation(thermo_params, ts)
+            λ = TD.liquid_fraction(thermo_params, ts)
+
+            S_qt = -min((q.liq + q.ice) / Δt, -CM0.remove_precipitation(microphys_params, q, qsat))
+
+            qr_tendency -= S_qt * λ
+            qs_tendency -= S_qt * (1 - λ)
+            qt_tendency += S_qt
+            ql_tendency += S_qt * λ
+            qi_tendency += S_qt * (1 - λ)
+            θ_liq_ice_tendency -= S_qt / Π_m / c_pm * (L_v0 * λ + L_s0 * (1 - λ))
+            e_tot_tendency += (λ * I_l + (1 - λ) * I_i + Φ) * S_qt
+        end
+
+        if precip_model isa Clima1M
+            T = TD.air_temperature(thermo_params, ts)
+            T_fr = TCP.T_freeze(param_set)
+            c_vl = TCP.cv_l(param_set)
+            c_vm = TD.cv_m(thermo_params, ts)
+            Rm = TD.gas_constant_air(thermo_params, ts)
+            Lf = TD.latent_heat_fusion(thermo_params, ts)
+
+            qr = qr / precip_fraction
+            qs = qs / precip_fraction
+
+            # Autoconversion of cloud ice to snow is done with a simplified rate.
+            # The saturation adjustment scheme prevents using the
+            # 1-moment snow autoconversion rate that assumes
+            # that the supersaturation is present in the domain.
+            S_qt_rain = -min(q.liq / Δt, CM1.conv_q_liq_to_q_rai(microphys_params, q.liq))
+            S_qt_snow = -min(q.ice / Δt, CM1.conv_q_ice_to_q_sno_no_supersat(microphys_params, q.ice))
+            qr_tendency -= S_qt_rain
+            qs_tendency -= S_qt_snow
+            qt_tendency += S_qt_rain + S_qt_snow
+            ql_tendency += S_qt_rain
+            qi_tendency += S_qt_snow
+            θ_liq_ice_tendency -= 1 / Π_m / c_pm * (L_v0 * S_qt_rain + L_s0 * S_qt_snow)
+            e_tot_tendency += S_qt_rain * (I_l + Φ) + S_qt_snow * (I_i + Φ)
+
+            # accretion cloud water + rain
+            S_qr = min(q.liq / Δt, CM1.accretion(microphys_params, liq_type, rain_type, q.liq, qr, ρ)) * precip_fraction
+            qr_tendency += S_qr
+            qt_tendency -= S_qr
+            ql_tendency -= S_qr
+            θ_liq_ice_tendency += S_qr / Π_m / c_pm * L_v0
+            e_tot_tendency -= S_qr * (I_l + Φ)
+
+            # accretion cloud ice + snow
+            S_qs = min(q.ice / Δt, CM1.accretion(microphys_params, ice_type, snow_type, q.ice, qs, ρ)) * precip_fraction
+            qs_tendency += S_qs
+            qt_tendency -= S_qs
+            qi_tendency -= S_qs
+            θ_liq_ice_tendency += S_qs / Π_m / c_pm * L_s0
+            e_tot_tendency -= S_qs * (I_i + Φ)
+
+            # sink of cloud water via accretion cloud water + snow
+            S_qt =
+                -min(q.liq / Δt, CM1.accretion(microphys_params, liq_type, snow_type, q.liq, qs, ρ)) * precip_fraction
+            if T < T_fr # cloud droplets freeze to become snow)
+                qs_tendency -= S_qt
+                qt_tendency += S_qt
+                ql_tendency += S_qt
+                θ_liq_ice_tendency -= S_qt / Π_m / c_pm * Lf * (1 + Rm / c_vm)
+                e_tot_tendency += S_qt * (I_i + Φ)
+            else # snow melts, both cloud water and snow become rain
+                α::FT = c_vl / Lf * (T - T_fr)
+                qt_tendency += S_qt
+                ql_tendency += S_qt
+                qs_tendency += S_qt * α
+                qr_tendency -= S_qt * (1 + α)
+                θ_liq_ice_tendency += S_qt / Π_m / c_pm * (Lf * (1 + Rm / c_vm) * α - L_v0)
+                e_tot_tendency += S_qt * ((1 + α) * I_l - α * I_i + Φ)
+            end
+
+            # sink of cloud ice via accretion cloud ice - rain
+            S_qt =
+                -min(q.ice / Δt, CM1.accretion(microphys_params, ice_type, rain_type, q.ice, qr, ρ)) * precip_fraction
+            # sink of rain via accretion cloud ice - rain
+            S_qr = -min(qr / Δt, CM1.accretion_rain_sink(microphys_params, q.ice, qr, ρ)) * precip_fraction
+            qt_tendency += S_qt
+            qi_tendency += S_qt
+            qr_tendency += S_qr
+            qs_tendency += -(S_qt + S_qr)
+            θ_liq_ice_tendency -= 1 / Π_m / c_pm * (S_qr * Lf * (1 + Rm / c_vm) + S_qt * L_s0)
+            e_tot_tendency += S_qt * (I_i + Φ)
+            e_tot_tendency -= S_qr * Lf
+
+            # accretion rain - snow
+            if T < T_fr
+                S_qs =
+                    min(qr / Δt, CM1.accretion_snow_rain(microphys_params, snow_type, rain_type, qs, qr, ρ)) *
+                    precip_fraction *
+                    precip_fraction
+            else
+                S_qs =
+                    -min(qs / Δt, CM1.accretion_snow_rain(microphys_params, rain_type, snow_type, qr, qs, ρ)) *
+                    precip_fraction *
+                    precip_fraction
+            end
+            qs_tendency += S_qs
+            qr_tendency -= S_qs
+            θ_liq_ice_tendency += S_qs * Lf / Π_m / c_vm
+            e_tot_tendency += S_qs * Lf
+        end
+    end
+    return PrecipFormation{FT}(
+        θ_liq_ice_tendency,
+        e_tot_tendency,
+        qt_tendency,
+        ql_tendency,
+        qi_tendency,
+        qr_tendency,
+        qs_tendency,
+    )
+end

--- a/src/TurbulenceConvection/name_aliases.jl
+++ b/src/TurbulenceConvection/name_aliases.jl
@@ -1,0 +1,58 @@
+"""
+    name_aliases()
+
+Returns a `Dict` containing:
+ - a key (`String`), which we consider to be our core variable name
+ - values (`Tuple` of `String`s), which we consider to be aliases of our core variable name
+"""
+function name_aliases()
+    dict = Dict(
+        "zc" => ("z_half",),
+        "zf" => ("z",),
+        "p_c" => ("p_half",),
+        "p_f" => ("p",),
+        "ρ_c" => ("rho0_half",),
+        "ρ_f" => ("rho0",),
+        "updraft_area" => ("updraft_fraction",),
+        "updraft_thetal" => ("updraft_thetali",),
+        "thetal_mean" => ("thetali_mean", "theta_mean"),
+        "total_flux_h" => ("resolved_z_flux_thetali", "resolved_z_flux_theta"),
+        "total_flux_qt" => ("resolved_z_flux_qt", "qt_flux_z"),
+        "u_mean" => ("u_translational_mean",),
+        "v_mean" => ("v_translational_mean",),
+        "tke_mean" => ("tke_nd_mean",),
+        "total_flux_s" => ("s_flux_z",),
+        "lwp_mean" => ("lwp",),
+        "iwp_mean" => ("iwp",),
+        "rwp_mean" => ("rwp",),
+        "swp_mean" => ("swp",),
+        "cloud_base_mean" => ("cloud_base",),
+        "cloud_top_mean" => ("cloud_top",),
+    )
+    return dict
+end
+
+"""
+    get_nc_data(ds::NCDatasets.Dataset, var::String)
+
+Returns the data for variable `var`, trying first its aliases
+defined in `name_aliases`, in the `ds::NCDatasets.Dataset`.
+"""
+function get_nc_data(ds, var::String)
+    dict = name_aliases()
+    key_options = haskey(dict, var) ? (dict[var]..., var) : (var,)
+
+    for key in key_options
+        if haskey(ds, key)
+            return ds[key]
+        else
+            for group_option in ["profiles", "reference", "timeseries"]
+                haskey(ds.group, group_option) || continue
+                if haskey(ds.group[group_option], key)
+                    return ds.group[group_option][key]
+                end
+            end
+        end
+    end
+    return nothing
+end

--- a/src/TurbulenceConvection/thermodynamics.jl
+++ b/src/TurbulenceConvection/thermodynamics.jl
@@ -1,0 +1,68 @@
+function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT) where {FT}
+    # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
+    # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
+    config = ()
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseEquil_pθq(thermo_params, p, θ_liq_ice, q_tot, config...)
+end
+function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
+    config = ()
+    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_pθq(thermo_params, p, θ_liq_ice, q, config...)
+end
+
+
+function thermo_state_peq(param_set::APS, p::FT, e_int::FT, q_tot::FT) where {FT}
+    # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
+    # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
+    config = ()
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseEquil_peq(thermo_params, p, e_int, q_tot, config...)
+end
+
+function thermo_state_peq(param_set::APS, p::FT, e_int::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
+    config = ()
+    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_peq(thermo_params, p, e_int, q, config...)
+end
+
+function thermo_state_phq(param_set::APS, p::FT, h::FT, q_tot::FT) where {FT}
+    config = ()
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseEquil_phq(thermo_params, p, h, q_tot, config...)
+end
+
+function thermo_state_phq(param_set::APS, p::FT, h::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
+    config = ()
+    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_phq(thermo_params, p, h, q, config...)
+end
+
+function geopotential(param_set, z::Real)
+    FT = eltype(param_set)
+    grav = FT(TCP.grav(param_set))
+    return grav * z
+end
+
+# TODO: move to Thermodynamics.jl
+function total_enthalpy(param_set::APS, e_tot::FT, ts) where {FT}
+    thermo_params = TCP.thermodynamics_params(param_set)
+    Rm = TD.gas_constant_air(thermo_params, ts)
+    T = TD.air_temperature(thermo_params, ts)
+    return e_tot + Rm * T
+end
+
+function total_enthalpy(param_set::APS, e_tot::FT, p::FT, ρ::FT) where {FT}
+    return e_tot + p / ρ
+end
+
+function enthalpy(h_tot::FT, e_kin::FT, e_pot::FT) where {FT}
+    return h_tot - e_kin - e_pot
+end
+
+function enthalpy(mse::FT, e_pot::FT) where {FT}
+    return mse - e_pot
+end

--- a/src/TurbulenceConvection/turbulence_functions.jl
+++ b/src/TurbulenceConvection/turbulence_functions.jl
@@ -1,0 +1,87 @@
+# convective velocity scale
+get_wstar(bflux, zi) = cbrt(max(bflux * zi, 0))
+
+function buoyancy_c(param_set::APS, ρ::FT, ρ_i::FT) where {FT}
+    g::FT = TCP.grav(param_set)
+    return g * (ρ - ρ_i) / ρ
+end
+
+# BL height
+function get_inversion(grid::Grid, state::State, param_set::APS, Ri_bulk_crit)
+    FT = float_type(state)
+    g::FT = TCP.grav(param_set)
+    kc_surf = kc_surface(grid)
+    θ_virt = center_aux_grid_mean(state).θ_virt
+    u = physical_grid_mean_u(state)
+    v = physical_grid_mean_v(state)
+    Ri_bulk = center_aux_grid_mean(state).Ri
+    θ_virt_b = θ_virt[kc_surf]
+    z_c = grid.zc
+    ∇c = CCO.DivergenceF2C()
+    wvec = CC.Geometry.WVector
+
+    # test if we need to look at the free convective limit
+    if (u[kc_surf]^2 + v[kc_surf]^2) <= 0.01
+        ∇θ_virt = center_aux_turbconv(state).ϕ_temporary
+        k_star = findlast_center(k -> θ_virt[k] > θ_virt_b, grid)
+        LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(θ_virt[kc_surf]))
+        @. ∇θ_virt = ∇c(wvec(LB(θ_virt)))
+        h = (θ_virt_b - θ_virt[k_star - 1]) / ∇θ_virt[k_star] + z_c[k_star - 1].z
+    else
+        ∇Ri_bulk = center_aux_turbconv(state).ϕ_temporary
+        Ri_bulk_fn(k) = g * (θ_virt[k] - θ_virt_b) * z_c[k].z / θ_virt_b / (u[k] * u[k] + v[k] * v[k])
+
+        @inbounds for k in real_center_indices(grid)
+            Ri_bulk[k] = Ri_bulk_fn(k)
+        end
+        k_star = findlast_center(k -> Ri_bulk_fn(k) > Ri_bulk_crit, grid)
+        LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(Ri_bulk[kc_surf]))
+        @. ∇Ri_bulk = ∇c(wvec(LB(Ri_bulk)))
+        h = (Ri_bulk_crit - Ri_bulk[k_star - 1]) / ∇Ri_bulk[k_star] + z_c[k_star - 1].z
+    end
+
+    return h
+end
+# Teixiera convective tau
+function get_mixing_tau(zi::FT, wstar::FT) where {FT}
+    # return 0.5 * zi / wstar
+    #return zi / (max(wstar, FT(1e-5)))
+    return zi / (wstar + FT(0.001))
+end
+
+# MO scaling of near surface tke and scalar variance
+function get_surface_tke(mixing_length_params, ustar::FT, zLL::FT, oblength::FT) where {FT}
+    κ_star² = mixing_length_params.κ_star²
+    if oblength < 0
+        return ((κ_star² + cbrt(zLL / oblength * zLL / oblength)) * ustar * ustar)
+    else
+        return κ_star² * ustar * ustar
+    end
+end
+function get_surface_variance(flux1::FT, flux2::FT, ustar::FT, zLL::FT, oblength::FT) where {FT}
+    c_star1 = -flux1 / ustar
+    c_star2 = -flux2 / ustar
+    if oblength < 0
+        return 4 * c_star1 * c_star2 * (1 - FT(8.3) * zLL / oblength)^(-FT(2 / 3))
+    else
+        return 4 * c_star1 * c_star2
+    end
+end
+
+function gradient_Richardson_number(mixing_length_params, ∂b∂z::FT, Shear²::FT, ϵ::FT) where {FT}
+    Ri_c::FT = mixing_length_params.Ri_c
+    return min(∂b∂z / max(Shear², ϵ), Ri_c)
+end
+
+# Turbulent Prandtl number given the obukhov length sign and the gradient Richardson number
+function turbulent_Prandtl_number(mixing_length_params, obukhov_length::FT, ∇Ri::FT) where {FT}
+    ω_pr = mixing_length_params.ω_pr
+    Pr_n = mixing_length_params.Pr_n
+    if obukhov_length > 0 && ∇Ri > 0 #stable
+        # CSB (Dan Li, 2019, eq. 75), where ω_pr = ω_1 + 1 = 53.0/13.0
+        prandtl_nvec = Pr_n * (2 * ∇Ri / (1 + ω_pr * ∇Ri - sqrt((1 + ω_pr * ∇Ri)^2 - 4 * ∇Ri)))
+    else
+        prandtl_nvec = Pr_n
+    end
+    return prandtl_nvec
+end

--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -1,0 +1,791 @@
+"""
+    PrecipFormation
+
+Storage for tendencies due to precipitation formation
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct PrecipFormation{FT}
+    θ_liq_ice_tendency::FT
+    e_tot_tendency::FT
+    qt_tendency::FT
+    ql_tendency::FT
+    qi_tendency::FT
+    qr_tendency::FT
+    qs_tendency::FT
+end
+
+"""
+    NoneqMoistureSources
+
+Storage for tendencies due to nonequilibrium moisture formation
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct NoneqMoistureSources{FT}
+    ql_tendency::FT
+    qi_tendency::FT
+end
+
+"""
+    EntrDetr
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct EntrDetr{FT}
+    "Fractional dynamical entrainment [1/m]"
+    ε_dyn::FT
+    "Fractional dynamical detrainment [1/m]"
+    δ_dyn::FT
+    "Turbulent entrainment"
+    ε_turb::FT
+    "Nondimensional fractional dynamical entrainment"
+    ε_nondim::FT
+    "Nondimensional fractional dynamical detrainment"
+    δ_nondim::FT
+end
+
+Base.@kwdef struct εδModelParams{FT, AFT}
+    c_div::FT
+    w_min::FT # minimum updraft velocity to avoid zero division in b/w²
+    c_ε::FT # factor multiplier for dry term in entrainment/detrainment
+    μ_0::FT # dimensional scale logistic function in the dry term in entrainment/detrainment
+    β::FT # sorting power for ad-hoc moisture detrainment function
+    χ::FT # fraction of updraft air for buoyancy mixing in entrainment/detrainment (0≤χ≤1)
+    c_λ::FT # scaling factor for TKE in entrainment scale calculations
+    γ_lim::FT
+    β_lim::FT
+    c_γ::FT # scaling factor for turbulent entrainment rate
+    c_δ::FT # factor multiplier for moist term in entrainment/detrainment
+    Π_norm::AFT
+end
+
+abstract type AbstractEntrDetrModel end
+abstract type AbstractNonLocalEntrDetrModel <: AbstractEntrDetrModel end
+abstract type AbstractNoisyEntrDetrModel <: AbstractEntrDetrModel end
+Base.@kwdef struct MDEntr{P} <: AbstractEntrDetrModel
+    params::P
+end  # existing model
+
+Base.@kwdef struct NNEntr{P, AFT, T} <: AbstractEntrDetrModel
+    params::P
+    c_nn_params::AFT
+    nn_arc::T
+    biases_bool::Bool
+end
+Base.@kwdef struct NNEntrNonlocal{P, AFT, T} <: AbstractNonLocalEntrDetrModel
+    params::P
+    c_nn_params::AFT
+    nn_arc::T
+    biases_bool::Bool
+end
+Base.@kwdef struct LinearEntr{P, T} <: AbstractEntrDetrModel
+    params::P
+    c_linear::T
+end
+Base.@kwdef struct FNOEntr{P, T} <: AbstractNonLocalEntrDetrModel
+    params::P
+    w_fno::Int
+    nm_fno::Int
+    c_fno::T
+end
+struct RFEntr{d, m, P, A, B} <: AbstractEntrDetrModel
+    params::P
+    c_rf_fix::A
+    c_rf_opt::B
+    function RFEntr(params::P, c_rf_fix::A, c_rf_opt::B, d::Int) where {P, A, B}
+        c_rf_fix = reshape(c_rf_fix, 2, :, 1 + d) # 2 x m x (1 + d), fix
+        c_rf_fix = SA.SArray{Tuple{size(c_rf_fix)...}}(c_rf_fix)
+        m = size(c_rf_fix, 2)
+        c_rf_opt = reshape(c_rf_opt, 2, m + 1 + d) # 2 x (m + 1 + d), learn
+        c_rf_opt = SA.SArray{Tuple{size(c_rf_opt)...}}(c_rf_opt)
+        return new{d, m, P, typeof(c_rf_fix), typeof(c_rf_opt)}(params, c_rf_fix, c_rf_opt)
+    end
+end
+
+Base.@kwdef struct NoisyRelaxationProcess{MT, T} <: AbstractNoisyEntrDetrModel
+    mean_model::MT
+    c_gen_stoch::T
+end
+Base.@kwdef struct LogNormalScalingProcess{MT, T} <: AbstractNoisyEntrDetrModel
+    mean_model::MT
+    c_gen_stoch::T
+end
+
+Base.@kwdef struct PrognosticNoisyRelaxationProcess{MT, T} <: AbstractNoisyEntrDetrModel
+    mean_model::MT
+    c_gen_stoch::T
+end
+
+εδ_params(m::AbstractEntrDetrModel) = m.params
+εδ_params(m::AbstractNoisyEntrDetrModel) = m.mean_model.params
+
+abstract type EntrDimScale end
+struct BuoyVelEntrDimScale <: EntrDimScale end
+struct InvZEntrDimScale <: EntrDimScale end
+struct InvMeterEntrDimScale <: EntrDimScale end
+
+"""
+    GradBuoy
+
+Environmental buoyancy gradients.
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct GradBuoy{FT}
+    "environmental vertical buoyancy gradient"
+    ∂b∂z::FT
+    "vertical buoyancy gradient in the unsaturated part of the environment"
+    ∂b∂z_unsat::FT
+    "vertical buoyancy gradient in the saturated part of the environment"
+    ∂b∂z_sat::FT
+end
+
+abstract type AbstractEnvBuoyGradClosure end
+struct BuoyGradMean <: AbstractEnvBuoyGradClosure end
+struct BuoyGradQuadratures <: AbstractEnvBuoyGradClosure end
+
+"""
+    EnvBuoyGrad
+
+Variables used in the environmental buoyancy gradient computation.
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct EnvBuoyGrad{FT, EBC <: AbstractEnvBuoyGradClosure}
+    "temperature in the saturated part"
+    t_sat::FT
+    "vapor specific humidity  in the saturated part"
+    qv_sat::FT
+    "total specific humidity in the saturated part"
+    qt_sat::FT
+    "potential temperature in the saturated part"
+    θ_sat::FT
+    "liquid ice potential temperature in the saturated part"
+    θ_liq_ice_sat::FT
+    "virtual potential temperature gradient in the non saturated part"
+    ∂θv∂z_unsat::FT
+    "total specific humidity gradient in the saturated part"
+    ∂qt∂z_sat::FT
+    "liquid ice potential temperature gradient in the saturated part"
+    ∂θl∂z_sat::FT
+    "reference pressure"
+    p::FT
+    "cloud fraction"
+    en_cld_frac::FT
+    "density"
+    ρ::FT
+end
+function EnvBuoyGrad(::EBG; t_sat::FT, bg_kwargs...) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
+    return EnvBuoyGrad{FT, EBG}(; t_sat, bg_kwargs...)
+end
+
+"""
+    MixLen
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct MixLen{FT}
+    "minimum length number"
+    min_len_ind::Int
+    "mixing length"
+    mixing_length::FT
+    "length ratio"
+    ml_ratio::FT
+end
+
+Base.@kwdef struct MixingLengthParams{FT}
+    ω_pr::FT # cospectral budget factor for turbulent Prandtl number
+    c_m::FT # tke diffusivity coefficient
+    c_d::FT # tke dissipation coefficient
+    c_b::FT # static stability coefficient
+    κ_star²::FT # Ratio of TKE to squared friction velocity in surface layer
+    Pr_n::FT # turbulent Prandtl number in neutral conditions
+    Ri_c::FT # critical Richardson number
+    smin_ub::FT # lower limit for smin function
+    smin_rm::FT # upper ratio limit for smin function
+    l_max::FT
+end
+
+"""
+    MinDisspLen
+
+Minimum dissipation model
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct MinDisspLen{FT}
+    "height"
+    z::FT
+    "obukhov length"
+    obukhov_length::FT
+    "surface TKE values"
+    tke_surf::FT
+    "u star - surface velocity scale"
+    ustar::FT
+    "turbulent Prandtl number"
+    Pr::FT
+    "reference pressure"
+    p::FT
+    "vertical buoyancy gradient struct"
+    ∇b::GradBuoy{FT}
+    "env shear"
+    Shear²::FT
+    "environment turbulent kinetic energy"
+    tke::FT
+    "Updraft tke source"
+    b_exch::FT
+end
+
+Base.@kwdef struct PressureModelParams{FT}
+    α_b::FT # factor multiplier for pressure buoyancy terms (effective buoyancy is (1-α_b))
+    α_a::FT # factor multiplier for pressure advection
+    α_d::FT # factor multiplier for pressure drag
+end
+
+abstract type AbstractMoistureModel end
+struct EquilibriumMoisture <: AbstractMoistureModel end
+struct NonEquilibriumMoisture <: AbstractMoistureModel end
+
+abstract type AbstractCovarianceModel end
+struct PrognosticThermoCovariances <: AbstractCovarianceModel end
+struct DiagnosticThermoCovariances{FT} <: AbstractCovarianceModel
+    covar_lim::FT
+end
+
+abstract type AbstractPrecipitationModel end
+struct NoPrecipitation <: AbstractPrecipitationModel end
+struct Clima0M <: AbstractPrecipitationModel end
+struct Clima1M <: AbstractPrecipitationModel end
+
+abstract type AbstractPrecipFractionModel end
+struct PrescribedPrecipFraction{FT} <: AbstractPrecipFractionModel
+    prescribed_precip_frac_value::FT
+end
+struct DiagnosticPrecipFraction{FT} <: AbstractPrecipFractionModel
+    precip_fraction_limiter::FT
+end
+
+abstract type AbstractQuadratureType end
+struct LogNormalQuad <: AbstractQuadratureType end
+struct GaussianQuad <: AbstractQuadratureType end
+
+abstract type AbstractEnvThermo end
+struct SGSMean <: AbstractEnvThermo end
+struct SGSQuadrature{N, QT, A, W} <: AbstractEnvThermo
+    quadrature_type::QT
+    a::A
+    w::W
+    function SGSQuadrature(::Type{FT}, namelist) where {FT}
+        N = parse_namelist(namelist, "thermodynamics", "quadrature_order"; default = 3)
+        quadrature_name = parse_namelist(namelist, "thermodynamics", "quadrature_type"; default = "log-normal")
+        quadrature_type = if quadrature_name == "log-normal"
+            LogNormalQuad()
+        elseif quadrature_name == "gaussian"
+            GaussianQuad()
+        else
+            error("Invalid thermodynamics quadrature $(quadrature_name)")
+        end
+        # TODO: double check this python-> julia translation
+        # a, w = np.polynomial.hermite.hermgauss(N)
+        a, w = FastGaussQuadrature.gausshermite(N)
+        a, w = SA.SVector{N, FT}(a), SA.SVector{N, FT}(w)
+        QT = typeof(quadrature_type)
+        return new{N, QT, typeof(a), typeof(w)}(quadrature_type, a, w)
+    end
+end
+quadrature_order(::SGSQuadrature{N}) where {N} = N
+quad_type(::SGSQuadrature{N}) where {N} = N
+
+abstract type FrictionVelocityType end
+struct FixedFrictionVelocity <: FrictionVelocityType end
+struct VariableFrictionVelocity <: FrictionVelocityType end
+
+abstract type AbstractSurfaceParameters{FT <: Real} end
+
+const FloatOrFunc{FT} = Union{FT, Function, Dierckx.Spline1D}
+
+Base.@kwdef struct FixedSurfaceFlux{FT, FVT <: FrictionVelocityType, TS, QS, SHF, LHF} <: AbstractSurfaceParameters{FT}
+    zrough::FT = FT(0)
+    Tsurface::TS = FT(0)
+    qsurface::QS = FT(0)
+    shf::SHF = FT(0)
+    lhf::LHF = FT(0)
+    cq::FT = FT(0)
+    Ri_bulk_crit::FT = FT(0)
+    ustar::FT = FT(0)
+    zero_uv_fluxes::Bool = false
+end
+
+function FixedSurfaceFlux(
+    ::Type{FT},
+    ::Type{FVT};
+    Tsurface::FloatOrFunc{FT},
+    qsurface::FloatOrFunc{FT},
+    shf::FloatOrFunc{FT},
+    lhf::FloatOrFunc{FT},
+    kwargs...,
+) where {FT, FVT}
+    TS = typeof(Tsurface)
+    QS = typeof(qsurface)
+    SHF = typeof(shf)
+    LHF = typeof(lhf)
+    return FixedSurfaceFlux{FT, FVT, TS, QS, SHF, LHF}(; Tsurface, qsurface, shf, lhf, kwargs...)
+end
+
+Base.@kwdef struct FixedSurfaceCoeffs{FT, TS, QS, CH, CM} <: AbstractSurfaceParameters{FT}
+    zrough::FT = FT(0)
+    Tsurface::TS = FT(0)
+    qsurface::QS = FT(0)
+    ch::CH = FT(0)
+    cm::CM = FT(0)
+    Ri_bulk_crit::FT = FT(0)
+end
+
+function FixedSurfaceCoeffs(
+    ::Type{FT};
+    Tsurface::FloatOrFunc{FT},
+    qsurface::FloatOrFunc{FT},
+    ch::FloatOrFunc{FT},
+    cm::FloatOrFunc{FT},
+    kwargs...,
+) where {FT, FVT}
+    TS = typeof(Tsurface)
+    QS = typeof(qsurface)
+    CH = typeof(ch)
+    CM = typeof(cm)
+    return FixedSurfaceCoeffs{FT, TS, QS, CH, CM}(; Tsurface, qsurface, ch, cm, kwargs...)
+end
+
+Base.@kwdef struct MoninObukhovSurface{FT, TS, QS} <: AbstractSurfaceParameters{FT}
+    zrough::FT = FT(0)
+    Tsurface::TS = FT(0)
+    qsurface::QS = FT(0)
+    Ri_bulk_crit::FT = FT(0)
+end
+
+function MoninObukhovSurface(
+    ::Type{FT};
+    Tsurface::FloatOrFunc{FT},
+    qsurface::FloatOrFunc{FT},
+    kwargs...,
+) where {FT, FVT}
+    TS = typeof(Tsurface)
+    QS = typeof(qsurface)
+    return MoninObukhovSurface{FT, TS, QS}(; Tsurface, qsurface, kwargs...)
+end
+
+float_or_func(s::Function, t::Real) = s(t)
+float_or_func(s::Dierckx.Spline1D, t::Real) = s(t)
+float_or_func(s::Real, t::Real) = s
+
+surface_temperature(s::AbstractSurfaceParameters, t::Real = 0) = float_or_func(s.Tsurface, t)
+surface_q_tot(s::AbstractSurfaceParameters, t::Real = 0) = float_or_func(s.qsurface, t)
+sensible_heat_flux(s::AbstractSurfaceParameters, t::Real = 0) = float_or_func(s.shf, t)
+latent_heat_flux(s::AbstractSurfaceParameters, t::Real = 0) = float_or_func(s.lhf, t)
+
+fixed_ustar(::FixedSurfaceFlux{FT, FixedFrictionVelocity}) where {FT} = true
+fixed_ustar(::FixedSurfaceFlux{FT, VariableFrictionVelocity}) where {FT} = false
+
+Base.@kwdef struct SurfaceBase{FT}
+    shf::FT = 0
+    lhf::FT = 0
+    cm::FT = 0
+    ch::FT = 0
+    bflux::FT = 0
+    ustar::FT = 0
+    ρq_tot_flux::FT = 0
+    ρq_liq_flux::FT = 0
+    ρq_ice_flux::FT = 0
+    ρe_tot_flux::FT = 0
+    ρu_flux::FT = 0
+    ρv_flux::FT = 0
+    obukhov_length::FT = 0
+    wstar::FT = 0
+end
+
+struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC, EDS, DDS, EPG}
+    surface_area::FT
+    max_area::FT
+    minimum_area::FT
+    moisture_model::MM
+    thermo_covariance_model::TCM
+    precip_model::PM
+    precip_fraction_model::PFM
+    en_thermo::ENT
+    bg_closure::EBGC
+    mixing_length_params::MLP
+    pressure_model_params::PMP
+    entr_closure::EC
+    entr_dim_scale::EDS
+    detr_dim_scale::DDS
+    entr_pi_subset::EPG
+    set_src_seed::Bool
+    H_up_min::FT # minimum updraft top to avoid zero division in pressure drag and turb-entr
+end
+function EDMFModel(::Type{FT}, namelist, precip_model) where {FT}
+
+    # Set the number of updrafts (1)
+    n_updrafts = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "updraft_number"; default = 1)
+    set_src_seed::Bool = namelist["set_src_seed"]
+
+    pressure_func_drag_str = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "pressure_closure_drag";
+        default = "normalmode",
+        valid_options = ["normalmode", "normalmode_signdf"],
+    )
+
+    surface_area = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "surface_area"; default = 0.1)
+    max_area = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "max_area"; default = 0.9)
+    minimum_area = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "min_area"; default = 1e-5)
+
+    moisture_model_name = parse_namelist(namelist, "thermodynamics", "moisture_model"; default = "equilibrium")
+
+    moisture_model = if moisture_model_name == "equilibrium"
+        EquilibriumMoisture()
+    elseif moisture_model_name == "nonequilibrium"
+        NonEquilibriumMoisture()
+    else
+        error("Something went wrong. Invalid moisture model: '$moisture_model_name'")
+    end
+
+    thermo_covariance_model_name =
+        parse_namelist(namelist, "thermodynamics", "thermo_covariance_model"; default = "prognostic")
+
+    thermo_covariance_model = if thermo_covariance_model_name == "prognostic"
+        PrognosticThermoCovariances()
+    elseif thermo_covariance_model_name == "diagnostic"
+        covar_lim = parse_namelist(namelist, "thermodynamics", "diagnostic_covar_limiter")
+        DiagnosticThermoCovariances(covar_lim)
+    else
+        error("Something went wrong. Invalid thermo_covariance model: '$thermo_covariance_model_name'")
+    end
+
+    precip_fraction_model_name =
+        parse_namelist(namelist, "microphysics", "precip_fraction_model"; default = "prescribed")
+
+    precip_fraction_model = if precip_fraction_model_name == "prescribed"
+        prescribed_precip_frac_value =
+            parse_namelist(namelist, "microphysics", "prescribed_precip_frac_value"; default = 1.0)
+        PrescribedPrecipFraction(prescribed_precip_frac_value)
+    elseif precip_fraction_model_name == "cloud_cover"
+        precip_fraction_limiter = parse_namelist(namelist, "microphysics", "precip_fraction_limiter"; default = 0.3)
+        DiagnosticPrecipFraction(precip_fraction_limiter)
+    else
+        error("Something went wrong. Invalid `precip_fraction` model: `$precip_fraction_model_name`")
+    end
+
+    # Create the environment variable class (major diagnostic and prognostic variables)
+
+    # Create the class for environment thermodynamics and buoyancy gradient computation
+    en_sgs_name =
+        parse_namelist(namelist, "thermodynamics", "sgs"; default = "mean", valid_options = ["mean", "quadrature"])
+    en_thermo = if en_sgs_name == "mean"
+        SGSMean()
+    elseif en_sgs_name == "quadrature"
+        SGSQuadrature(FT, namelist)
+    else
+        error("Something went wrong. Invalid environmental sgs type '$en_sgs_name'")
+    end
+    bg_closure = if en_sgs_name == "mean"
+        BuoyGradMean()
+    elseif en_sgs_name == "quadrature"
+        BuoyGradQuadratures()
+    else
+        error("Something went wrong. Invalid environmental buoyancy gradient closure type '$en_sgs_name'")
+    end
+    if moisture_model_name == "nonequilibrium" && en_thermo == "quadrature"
+        error("SGS quadratures are not yet implemented for non-equilibrium moisture. Please use the option: mean.")
+    end
+
+    # entr closure
+    stoch_entr_type = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "stochastic_entrainment";
+        default = "deterministic",
+        valid_options = [
+            "deterministic",
+            "noisy_relaxation_process",
+            "lognormal_scaling",
+            "prognostic_noisy_relaxation_process",
+        ],
+    )
+    entr_type = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "entrainment";
+        default = "moisture_deficit",
+        valid_options = ["moisture_deficit", "NN", "NN_nonlocal", "FNO", "Linear", "RF"],
+    )
+
+    nn_biases = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "nn_ent_biases";
+        default = false,
+        valid_options = [true, false],
+    )
+
+    c_div =
+        parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entrainment_massflux_div_factor"; default = 0.0)
+    w_min = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "min_upd_velocity")
+    c_ε = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entrainment_factor")
+    μ_0 = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entrainment_scale")
+    β = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "sorting_power")
+    χ = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "updraft_mixing_frac")
+    c_λ = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entrainment_smin_tke_coeff")
+    γ_lim = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "area_limiter_scale")
+    β_lim = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "area_limiter_power")
+    c_γ = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "turbulent_entrainment_factor")
+    c_δ = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "detrainment_factor")
+    Π_norm = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "pi_norm_consts")
+    Π_norm = SA.SVector{length(Π_norm), FT}(Π_norm)
+
+    εδ_params = εδModelParams{FT, typeof(Π_norm)}(; c_div, w_min, c_ε, μ_0, β, χ, c_λ, γ_lim, β_lim, c_γ, c_δ, Π_norm)
+
+    entr_pi_subset = Tuple(parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entr_pi_subset"))
+
+    mean_entr_closure = if entr_type == "moisture_deficit"
+        MDEntr(; params = εδ_params)
+    elseif entr_type == "NN"
+        c_nn_params = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "nn_ent_params")
+        nn_arc = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "nn_arc")
+        NNEntr(; params = εδ_params, biases_bool = nn_biases, c_nn_params, nn_arc)
+    elseif entr_type == "NN_nonlocal"
+        c_nn_params = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "nn_ent_params")
+        nn_arc = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "nn_arc")
+        NNEntrNonlocal(; params = εδ_params, biases_bool = nn_biases, c_nn_params, nn_arc)
+    elseif entr_type == "FNO"
+        w_fno = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "fno_ent_width")
+        nm_fno = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "fno_ent_n_modes")
+        c_fno = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "fno_ent_params")
+        FNOEntr(; params = εδ_params, w_fno, nm_fno, c_fno)
+    elseif entr_type == "Linear"
+        c_linear = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "linear_ent_params")
+        LinearEntr(; params = εδ_params, c_linear)
+    elseif entr_type == "RF"
+        c_rf_fix = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "rf_fix_ent_params")
+        c_rf_opt = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "rf_opt_ent_params")
+        RFEntr(εδ_params, c_rf_fix, c_rf_opt, length(entr_pi_subset))
+    else
+        error("Something went wrong. Invalid entrainment type '$entr_type'")
+    end
+
+    # Overwrite `entr_closure` if a noisy relaxation process is used
+    entr_closure = if stoch_entr_type == "noisy_relaxation_process"
+        c_gen_stoch = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "general_stochastic_ent_params")
+        NoisyRelaxationProcess(; mean_model = mean_entr_closure, c_gen_stoch)
+    elseif stoch_entr_type == "lognormal_scaling"
+        c_gen_stoch = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "general_stochastic_ent_params")
+        LogNormalScalingProcess(; mean_model = mean_entr_closure, c_gen_stoch)
+    elseif stoch_entr_type == "deterministic"
+        mean_entr_closure
+    elseif stoch_entr_type == "prognostic_noisy_relaxation_process"
+        c_gen_stoch = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "general_stochastic_ent_params")
+        PrognosticNoisyRelaxationProcess(; mean_model = mean_entr_closure, c_gen_stoch)
+    else
+        error("Something went wrong. Invalid stochastic entrainment type '$stoch_entr_type'")
+    end
+
+    # minimum updraft top to avoid zero division in pressure drag and turb-entr
+    H_up_min = FT(parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "min_updraft_top"))
+
+    entr_dim_scale = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "entr_dim_scale";
+        default = "buoy_vel",
+        valid_options = ["buoy_vel", "inv_z", "none"],
+    )
+
+    pressure_model_params = PressureModelParams{FT}(;
+        α_b = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "pressure_normalmode_buoy_coeff1"),
+        α_a = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "pressure_normalmode_adv_coeff"),
+        α_d = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "pressure_normalmode_drag_coeff"),
+    )
+
+    mixing_length_params = MixingLengthParams{FT}(;
+        ω_pr = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Prandtl_number_scale"),
+        c_m = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_ed_coeff"),
+        c_d = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_diss_coeff"),
+        c_b = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "static_stab_coeff"; default = 0.4), # this is here due to a value error in CliMAParmameters.j,
+        κ_star² = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_surf_scale"),
+        Pr_n = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Prandtl_number_0"),
+        Ri_c = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Ri_crit"),
+        smin_ub = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_ub"),
+        smin_rm = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_rm"),
+        l_max = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "l_max"; default = 1.0e6),
+    )
+
+    entr_dim_scale = if entr_dim_scale == "buoy_vel"
+        BuoyVelEntrDimScale()
+    elseif entr_dim_scale == "inv_z"
+        InvZEntrDimScale()
+    elseif entr_dim_scale == "none"
+        InvMeterEntrDimScale()
+    else
+        error("Something went wrong. Invalid entrainment dimension scale '$entr_dim_scale'")
+    end
+
+    detr_dim_scale = parse_namelist(
+        namelist,
+        "turbulence",
+        "EDMF_PrognosticTKE",
+        "detr_dim_scale";
+        default = "buoy_vel",
+        valid_options = ["buoy_vel", "inv_z", "none"],
+    )
+
+    detr_dim_scale = if detr_dim_scale == "buoy_vel"
+        BuoyVelEntrDimScale()
+    elseif detr_dim_scale == "inv_z"
+        InvZEntrDimScale()
+    elseif detr_dim_scale == "none"
+        InvMeterEntrDimScale()
+    else
+        error("Something went wrong. Invalid entrainment dimension scale '$detr_dim_scale'")
+    end
+
+    EDS = typeof(entr_dim_scale)
+    DDS = typeof(detr_dim_scale)
+    EC = typeof(entr_closure)
+    MM = typeof(moisture_model)
+    TCM = typeof(thermo_covariance_model)
+    PM = typeof(precip_model)
+    PFM = typeof(precip_fraction_model)
+    EBGC = typeof(bg_closure)
+    ENT = typeof(en_thermo)
+    EPG = typeof(entr_pi_subset)
+    MLP = typeof(mixing_length_params)
+    PMP = typeof(pressure_model_params)
+    return EDMFModel{n_updrafts, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC, EDS, DDS, EPG}(
+        surface_area,
+        max_area,
+        minimum_area,
+        moisture_model,
+        thermo_covariance_model,
+        precip_model,
+        precip_fraction_model,
+        en_thermo,
+        bg_closure,
+        mixing_length_params,
+        pressure_model_params,
+        entr_closure,
+        entr_dim_scale,
+        detr_dim_scale,
+        entr_pi_subset,
+        set_src_seed,
+        H_up_min,
+    )
+end
+
+parameter_set(obj) = obj.param_set
+n_updrafts(::EDMFModel{N_up}) where {N_up} = N_up
+Base.eltype(::EDMFModel{N_up, FT}) where {N_up, FT} = FT
+n_Π_groups(m::EDMFModel) = length(m.entr_pi_subset)
+entrainment_Π_subset(m::EDMFModel) = m.entr_pi_subset
+pressure_model_params(m::EDMFModel) = m.pressure_model_params
+mixing_length_params(m::EDMFModel) = m.mixing_length_params
+
+Base.broadcastable(edmf::EDMFModel) = Ref(edmf)
+
+function Base.summary(io::IO, edmf::EDMFModel)
+    pns = string.(propertynames(edmf))
+    buf = maximum(length.(pns))
+    keys = propertynames(edmf)
+    vals = repeat.(" ", map(s -> buf - length(s) + 2, pns))
+    bufs = (; zip(keys, vals)...)
+    print(io, '\n')
+    for pn in propertynames(edmf)
+        prop = getproperty(edmf, pn)
+        # Skip some data:
+        prop isa Bool && continue
+        prop isa NTuple && continue
+        prop isa Int && continue
+        prop isa Float64 && continue
+        prop isa Float32 && continue
+        s = string(
+            "  ", # needed for some reason
+            getproperty(bufs, pn),
+            '`',
+            string(pn),
+            '`',
+            "::",
+            '`',
+            typeof(prop),
+            '`',
+            '\n',
+        )
+        print(io, s)
+    end
+end
+
+
+struct State{P, A, T}
+    prog::P
+    aux::A
+    tendencies::T
+end
+
+"""
+    column_state(prog, aux, tendencies, inds...)
+
+Create a columnar state given full 3D states
+ - `prog` prognostic state
+ - `aux` auxiliary state
+ - `tendencies` tendencies state
+ - `inds` indices
+
+## Example
+```julia
+for inds in TC.iterate_columns(prog.cent)
+    state = TC.column_state(prog, aux, tendencies, inds...)
+    ...
+end
+"""
+function column_state(prog, aux, tendencies, inds...)
+    prog_cent_column = CC.column(prog.cent, inds...)
+    prog_face_column = CC.column(prog.face, inds...)
+    aux_cent_column = CC.column(aux.cent, inds...)
+    aux_face_column = CC.column(aux.face, inds...)
+    tends_cent_column = CC.column(tendencies.cent, inds...)
+    tends_face_column = CC.column(tendencies.face, inds...)
+    prog_column = CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
+    aux_column = CC.Fields.FieldVector(cent = aux_cent_column, face = aux_face_column)
+    tends_column = CC.Fields.FieldVector(cent = tends_cent_column, face = tends_face_column)
+
+    return State(prog_column, aux_column, tends_column)
+end
+
+function column_prog_aux(prog, aux, inds...)
+    prog_cent_column = CC.column(prog.cent, inds...)
+    prog_face_column = CC.column(prog.face, inds...)
+    aux_cent_column = CC.column(aux.cent, inds...)
+    aux_face_column = CC.column(aux.face, inds...)
+    prog_column = CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
+    aux_column = CC.Fields.FieldVector(cent = aux_cent_column, face = aux_face_column)
+
+    return State(prog_column, aux_column, nothing)
+end
+
+function column_diagnostics(diagnostics, inds...)
+    diag_cent_column = CC.column(diagnostics.cent, inds...)
+    diag_face_column = CC.column(diagnostics.face, inds...)
+    diag_svpc_column = CC.column(diagnostics.svpc, inds...)
+    return CC.Fields.FieldVector(cent = diag_cent_column, face = diag_face_column, svpc = diag_svpc_column)
+end
+
+
+Grid(state::State) = Grid(axes(state.prog.cent))
+
+float_type(state::State) = eltype(state.prog)
+# float_type(field::CC.Fields.Field) = CC.Spaces.undertype(axes(field))
+float_type(field::CC.Fields.Field) = eltype(parent(field))

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -1,0 +1,517 @@
+function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS, t::Real, Δt::Real)
+    #####
+    ##### Unpack common variables
+    #####
+    thermo_params = TCP.thermodynamics_params(param_set)
+    microphys_params = TCP.microphysics_params(param_set)
+    N_up = n_updrafts(edmf)
+    kc_surf = kc_surface(grid)
+    kf_surf = kf_surface(grid)
+    kc_toa = kc_top_of_atmos(grid)
+    c_m = mixing_length_params(edmf).c_m
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
+    obukhov_length = surf.obukhov_length
+    FT = float_type(state)
+    prog_gm = center_prog_grid_mean(state)
+    aux_up = center_aux_updrafts(state)
+    aux_up_f = face_aux_updrafts(state)
+    aux_en = center_aux_environment(state)
+    aux_en_f = face_aux_environment(state)
+    aux_gm = center_aux_grid_mean(state)
+    aux_gm_f = face_aux_grid_mean(state)
+    aux_tc_f = face_aux_turbconv(state)
+    aux_tc = center_aux_turbconv(state)
+    aux_bulk = center_aux_bulk(state)
+    prog_en = center_prog_environment(state)
+    aux_en_2m = center_aux_environment_2m(state)
+    prog_up = center_prog_updrafts(state)
+    prog_up_f = face_prog_updrafts(state)
+    ρ_f = aux_gm_f.ρ
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    aux_en_unsat = aux_en.unsat
+    aux_en_sat = aux_en.sat
+    m_entr_detr = aux_tc.ϕ_temporary
+    ∇m_entr_detr = aux_tc.ψ_temporary
+    wvec = CC.Geometry.WVector
+    max_area = edmf.max_area
+    ts_gm = center_aux_grid_mean(state).ts
+    ts_env = center_aux_environment(state).ts
+
+    prog_gm_uₕ = grid_mean_uₕ(state)
+    Ic = CCO.InterpolateF2C()
+    #####
+    ##### center variables
+    #####
+    C123 = CCG.Covariant123Vector
+    @. aux_en.e_kin = LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(wvec(aux_en_f.w)))) / 2
+
+    @inbounds for i in 1:N_up
+        @. aux_up[i].e_kin = LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(wvec(aux_up_f[i].w)))) / 2
+    end
+
+    @inbounds for k in real_center_indices(grid)
+        #####
+        ##### Set primitive variables
+        #####
+        e_pot = geopotential(param_set, grid.zc.z[k])
+        @inbounds for i in 1:N_up
+            if prog_up[i].ρarea[k] / ρ_c[k] >= edmf.minimum_area
+                aux_up[i].θ_liq_ice[k] = prog_up[i].ρaθ_liq_ice[k] / prog_up[i].ρarea[k]
+                aux_up[i].q_tot[k] = prog_up[i].ρaq_tot[k] / prog_up[i].ρarea[k]
+                aux_up[i].area[k] = prog_up[i].ρarea[k] / ρ_c[k]
+            else
+                aux_up[i].θ_liq_ice[k] = aux_gm.θ_liq_ice[k]
+                aux_up[i].q_tot[k] = aux_gm.q_tot[k]
+                aux_up[i].area[k] = 0
+                aux_up[i].e_kin[k] = aux_gm.e_kin[k]
+            end
+            thermo_args = ()
+            if edmf.moisture_model isa NonEquilibriumMoisture
+                if prog_up[i].ρarea[k] / ρ_c[k] >= edmf.minimum_area
+                    aux_up[i].q_liq[k] = prog_up[i].ρaq_liq[k] / prog_up[i].ρarea[k]
+                    aux_up[i].q_ice[k] = prog_up[i].ρaq_ice[k] / prog_up[i].ρarea[k]
+                else
+                    aux_up[i].q_liq[k] = prog_gm.q_liq[k]
+                    aux_up[i].q_ice[k] = prog_gm.q_ice[k]
+                end
+                thermo_args = (aux_up[i].q_liq[k], aux_up[i].q_ice[k])
+            end
+            ts_up_i = thermo_state_pθq(param_set, p_c[k], aux_up[i].θ_liq_ice[k], aux_up[i].q_tot[k], thermo_args...)
+            aux_up[i].e_tot[k] = TD.total_energy(thermo_params, ts_up_i, aux_up[i].e_kin[k], e_pot)
+            aux_up[i].h_tot[k] = total_enthalpy(param_set, aux_up[i].e_tot[k], ts_up_i)
+        end
+
+        #####
+        ##### compute bulk
+        #####
+        aux_bulk.q_tot[k] = 0
+        aux_bulk.h_tot[k] = 0
+        aux_bulk.θ_liq_ice[k] = 0
+        aux_bulk.area[k] = sum(i -> aux_up[i].area[k], 1:N_up)
+        if aux_bulk.area[k] > 0
+            @inbounds for i in 1:N_up
+                a_k = aux_up[i].area[k]
+                a_bulk_k = aux_bulk.area[k]
+                aux_bulk.q_tot[k] += a_k * aux_up[i].q_tot[k] / a_bulk_k
+                aux_bulk.θ_liq_ice[k] += a_k * aux_up[i].θ_liq_ice[k] / a_bulk_k
+                aux_bulk.h_tot[k] += a_k * aux_up[i].h_tot[k] / a_bulk_k
+            end
+        else
+            aux_bulk.q_tot[k] = aux_gm.q_tot[k]
+            aux_bulk.θ_liq_ice[k] = aux_gm.θ_liq_ice[k]
+            aux_bulk.h_tot[k] = aux_gm.h_tot[k]
+        end
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            aux_bulk.q_liq[k] = 0
+            aux_bulk.q_ice[k] = 0
+            if aux_bulk.area[k] > 0
+                @inbounds for i in 1:N_up
+                    a_k = aux_up[i].area[k]
+                    a_bulk_k = aux_bulk.area[k]
+                    aux_bulk.q_liq[k] += a_k * aux_up[i].q_liq[k] / a_bulk_k
+                    aux_bulk.q_ice[k] += a_k * aux_up[i].q_ice[k] / a_bulk_k
+                end
+            else
+                aux_bulk.q_liq[k] = prog_gm.q_liq[k]
+                aux_bulk.q_ice[k] = prog_gm.q_ice[k]
+            end
+        end
+        aux_en.area[k] = 1 - aux_bulk.area[k]
+        aux_en.tke[k] = prog_en.ρatke[k] / (ρ_c[k] * aux_en.area[k])
+        if edmf.thermo_covariance_model isa PrognosticThermoCovariances
+            aux_en.Hvar[k] = prog_en.ρaHvar[k] / (ρ_c[k] * aux_en.area[k])
+            aux_en.QTvar[k] = prog_en.ρaQTvar[k] / (ρ_c[k] * aux_en.area[k])
+            aux_en.HQTcov[k] = prog_en.ρaHQTcov[k] / (ρ_c[k] * aux_en.area[k])
+        end
+
+        #####
+        ##### decompose_environment
+        #####
+        a_bulk_c = aux_bulk.area[k]
+        val1 = 1 / (1 - a_bulk_c)
+        val2 = a_bulk_c * val1
+        aux_en.q_tot[k] = max(val1 * aux_gm.q_tot[k] - val2 * aux_bulk.q_tot[k], 0) #Yair - this is here to prevent negative QT
+        aux_en.h_tot[k] = val1 * aux_gm.h_tot[k] - val2 * aux_bulk.h_tot[k]
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            aux_en.q_liq[k] = max(val1 * prog_gm.q_liq[k] - val2 * aux_bulk.q_liq[k], 0)
+            aux_en.q_ice[k] = max(val1 * prog_gm.q_ice[k] - val2 * aux_bulk.q_ice[k], 0)
+        end
+
+        #####
+        ##### condensation, etc (done via saturation_adjustment or non-equilibrium) and buoyancy
+        #####
+        thermo_args = if edmf.moisture_model isa EquilibriumMoisture
+            ()
+        elseif edmf.moisture_model isa NonEquilibriumMoisture
+            (aux_en.q_liq[k], aux_en.q_ice[k])
+        else
+            error("Something went wrong. The moisture_model options are equilibrium or nonequilibrium")
+        end
+
+        h_en = enthalpy(aux_en.h_tot[k], e_pot, aux_en.e_kin[k])
+        ts_env[k] = thermo_state_phq(param_set, p_c[k], h_en, aux_en.q_tot[k], thermo_args...)
+        ts_en = ts_env[k]
+        aux_en.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts_en)
+        aux_en.e_tot[k] = TD.total_energy(thermo_params, ts_en, aux_en.e_kin[k], e_pot)
+        aux_en.T[k] = TD.air_temperature(thermo_params, ts_en)
+        aux_en.θ_virt[k] = TD.virtual_pottemp(thermo_params, ts_en)
+        aux_en.θ_dry[k] = TD.dry_pottemp(thermo_params, ts_en)
+        aux_en.q_liq[k] = TD.liquid_specific_humidity(thermo_params, ts_en)
+        aux_en.q_ice[k] = TD.ice_specific_humidity(thermo_params, ts_en)
+        rho = TD.air_density(thermo_params, ts_en)
+        aux_en.buoy[k] = buoyancy_c(param_set, ρ_c[k], rho)
+        aux_en.RH[k] = TD.relative_humidity(thermo_params, ts_en)
+    end
+
+    microphysics(edmf.en_thermo, grid, state, edmf, edmf.precip_model, Δt, param_set)
+
+    @inbounds for k in real_center_indices(grid)
+        a_bulk_c = aux_bulk.area[k]
+        @inbounds for i in 1:N_up
+            if aux_up[i].area[k] < edmf.minimum_area && k > kc_surf && aux_up[i].area[k - 1] > 0.0
+                qt = aux_up[i].q_tot[k - 1]
+                h = aux_up[i].θ_liq_ice[k - 1]
+                if edmf.moisture_model isa EquilibriumMoisture
+                    ts_up = thermo_state_pθq(param_set, p_c[k], h, qt)
+                elseif edmf.moisture_model isa NonEquilibriumMoisture
+                    ql = aux_up[i].q_liq[k - 1]
+                    qi = aux_up[i].q_ice[k - 1]
+                    ts_up = thermo_state_pθq(param_set, p_c[k], h, qt, ql, qi)
+                else
+                    error("Something went wrong. emdf.moisture_model options are equilibrium or nonequilibrium")
+                end
+            else
+                if edmf.moisture_model isa EquilibriumMoisture
+                    ts_up = thermo_state_pθq(param_set, p_c[k], aux_up[i].θ_liq_ice[k], aux_up[i].q_tot[k])
+                elseif edmf.moisture_model isa NonEquilibriumMoisture
+                    ts_up = thermo_state_pθq(
+                        param_set,
+                        p_c[k],
+                        aux_up[i].θ_liq_ice[k],
+                        aux_up[i].q_tot[k],
+                        aux_up[i].q_liq[k],
+                        aux_up[i].q_ice[k],
+                    )
+                else
+                    error("Something went wrong. emdf.moisture_model options are equilibrium or nonequilibrium")
+                end
+            end
+            aux_up[i].q_liq[k] = TD.liquid_specific_humidity(thermo_params, ts_up)
+            aux_up[i].q_ice[k] = TD.ice_specific_humidity(thermo_params, ts_up)
+            aux_up[i].T[k] = TD.air_temperature(thermo_params, ts_up)
+            ρ = TD.air_density(thermo_params, ts_up)
+            aux_up[i].buoy[k] = buoyancy_c(param_set, ρ_c[k], ρ)
+            aux_up[i].RH[k] = TD.relative_humidity(thermo_params, ts_up)
+        end
+        aux_gm.buoy[k] = (1.0 - aux_bulk.area[k]) * aux_en.buoy[k]
+        @inbounds for i in 1:N_up
+            aux_gm.buoy[k] += aux_up[i].area[k] * aux_up[i].buoy[k]
+        end
+        @inbounds for i in 1:N_up
+            aux_up[i].buoy[k] -= aux_gm.buoy[k]
+        end
+        aux_en.buoy[k] -= aux_gm.buoy[k]
+
+
+        #####
+        ##### compute bulk thermodynamics
+        #####
+        aux_bulk.q_liq[k] = 0
+        aux_bulk.q_ice[k] = 0
+        aux_bulk.T[k] = 0
+        aux_bulk.RH[k] = 0
+        aux_bulk.buoy[k] = 0
+        if a_bulk_c > 0
+            @inbounds for i in 1:N_up
+                aux_bulk.q_liq[k] += aux_up[i].area[k] * aux_up[i].q_liq[k] / a_bulk_c
+                aux_bulk.q_ice[k] += aux_up[i].area[k] * aux_up[i].q_ice[k] / a_bulk_c
+                aux_bulk.T[k] += aux_up[i].area[k] * aux_up[i].T[k] / a_bulk_c
+                aux_bulk.RH[k] += aux_up[i].area[k] * aux_up[i].RH[k] / a_bulk_c
+                aux_bulk.buoy[k] += aux_up[i].area[k] * aux_up[i].buoy[k] / a_bulk_c
+            end
+        else
+            aux_bulk.RH[k] = aux_en.RH[k]
+            aux_bulk.T[k] = aux_en.T[k]
+        end
+
+        #####
+        ##### update_GMV_diagnostics
+        #####
+        aux_gm.q_liq[k] = (aux_bulk.area[k] * aux_bulk.q_liq[k] + (1 - aux_bulk.area[k]) * aux_en.q_liq[k])
+        aux_gm.q_ice[k] = (aux_bulk.area[k] * aux_bulk.q_ice[k] + (1 - aux_bulk.area[k]) * aux_en.q_ice[k])
+        aux_gm.T[k] = (aux_bulk.area[k] * aux_bulk.T[k] + (1 - aux_bulk.area[k]) * aux_en.T[k])
+        aux_gm.buoy[k] = (aux_bulk.area[k] * aux_bulk.buoy[k] + (1 - aux_bulk.area[k]) * aux_en.buoy[k])
+
+        has_condensate = TD.has_condensate(aux_bulk.q_liq[k] + aux_bulk.q_ice[k])
+        aux_bulk.cloud_fraction[k] = if has_condensate && a_bulk_c > 1e-3
+            1
+        else
+            0
+        end
+    end
+    #####
+    ##### face variables: diagnose primitive, diagnose env and compute bulk
+    #####
+    # TODO: figure out why `ifelse` is allocating
+    @inbounds for i in 1:N_up
+        a_surf = area_surface_bc(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        If = CCO.InterpolateC2F(; a_up_bcs...)
+        a_min = edmf.minimum_area
+        a_up = aux_up[i].area
+        @. aux_up_f[i].w = ifelse(If(a_up) >= a_min, max(prog_up_f[i].ρaw / (ρ_f * If(a_up)), 0), FT(0))
+    end
+    @inbounds for i in 1:N_up
+        aux_up_f[i].w[kf_surf] = w_surface_bc(surf)
+    end
+
+    parent(aux_tc_f.bulk.w) .= 0
+    a_bulk_bcs = a_bulk_boundary_conditions(surf, edmf)
+    Ifb = CCO.InterpolateC2F(; a_bulk_bcs...)
+    @inbounds for i in 1:N_up
+        a_up = aux_up[i].area
+        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        Ifu = CCO.InterpolateC2F(; a_up_bcs...)
+        @. aux_tc_f.bulk.w += ifelse(Ifb(aux_bulk.area) > 0, Ifu(a_up) * aux_up_f[i].w / Ifb(aux_bulk.area), FT(0))
+    end
+    # Assuming w_gm = 0!
+    @. aux_en_f.w = -Ifb(aux_bulk.area) / (1 - Ifb(aux_bulk.area)) * aux_tc_f.bulk.w
+
+    #####
+    #####  diagnose_GMV_moments
+    #####
+    get_GMV_CoVar(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    get_GMV_CoVar(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    get_GMV_CoVar(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
+
+    #####
+    ##### compute_updraft_closures
+    #####
+    #TODO - AJ add the non-equilibrium tendency computation here
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        compute_nonequilibrium_moisture_tendencies!(grid, state, edmf, Δt, param_set)
+    end
+    compute_entr_detr!(state, grid, edmf, param_set, surf, Δt, edmf.entr_closure)
+    compute_nh_pressure!(state, grid, edmf, surf)
+
+    #####
+    ##### compute_eddy_diffusivities_tke
+    #####
+
+    # Subdomain exchange term
+    ∇c = CCO.DivergenceF2C()
+    Ic = CCO.InterpolateF2C()
+    b_exch = center_aux_turbconv(state).b_exch
+    parent(b_exch) .= 0
+    a_en = aux_en.area
+    w_en = aux_en_f.w
+    tke_en = aux_en.tke
+    @inbounds for i in 1:N_up
+        a_up = aux_up[i].area
+        w_up = aux_up_f[i].w
+        δ_dyn = aux_up[i].detr_sc
+        ε_turb = aux_up[i].frac_turb_entr
+        @. b_exch +=
+            a_up * Ic(w_up) * δ_dyn / a_en * (1 / 2 * (Ic(w_up) - Ic(w_en))^2 - tke_en) -
+            a_up * Ic(w_up) * (Ic(w_up) - Ic(w_en)) * ε_turb * Ic(w_en) / a_en
+    end
+
+    Shear² = center_aux_turbconv(state).Shear²
+    ∂qt∂z = center_aux_turbconv(state).∂qt∂z
+    ∂θl∂z = center_aux_turbconv(state).∂θl∂z
+    ∂θv∂z = center_aux_turbconv(state).∂θv∂z
+    ∂qt∂z_sat = center_aux_turbconv(state).∂qt∂z_sat
+    ∂θl∂z_sat = center_aux_turbconv(state).∂θl∂z_sat
+    ∂θv∂z_unsat = center_aux_turbconv(state).∂θv∂z_unsat
+
+    ∇0_bcs = (; bottom = CCO.Extrapolate(), top = CCO.Extrapolate())
+    If0 = CCO.InterpolateC2F(; ∇0_bcs...)
+
+    uₕ_gm = grid_mean_uₕ(state)
+    w_en = aux_en_f.w
+    # compute shear
+
+    # TODO: Will need to be changed with topography
+    local_geometry = CC.Fields.local_geometry_field(axes(ρ_c))
+    k̂ = @. CCG.Contravariant3Vector(CCG.WVector(FT(1)), local_geometry)
+    Ifuₕ = uₕ_bcs()
+    ∇uvw = CCO.GradientF2C()
+    uvw = @. C123(Ifuₕ(uₕ_gm)) + C123(wvec(w_en))
+    @. Shear² = LA.norm_sqr(adjoint(∇uvw(uvw)) * k̂)
+
+    q_tot_en = aux_en.q_tot
+    θ_liq_ice_en = aux_en.θ_liq_ice
+    θ_virt_en = aux_en.θ_virt
+    @. ∂qt∂z = ∇c(wvec(If0(q_tot_en)))
+    @. ∂θl∂z = ∇c(wvec(If0(θ_liq_ice_en)))
+    @. ∂θv∂z = ∇c(wvec(If0(θ_virt_en)))
+
+    # Second order approximation: Use dry and cloudy environmental fields.
+    cf = aux_en.cloud_fraction
+    shm = copy(cf)
+    pshm = parent(shm)
+    shrink_mask!(pshm, vec(cf))
+    mix_len_params = mixing_length_params(edmf)
+
+    # Since NaN*0 ≠ 0, we need to conditionally replace
+    # our gradients by their default values.
+    @. ∂qt∂z_sat = ∇c(wvec(If0(aux_en_sat.q_tot)))
+    @. ∂θl∂z_sat = ∇c(wvec(If0(aux_en_sat.θ_liq_ice)))
+    @. ∂θv∂z_unsat = ∇c(wvec(If0(aux_en_unsat.θ_virt)))
+    @. ∂qt∂z_sat = ifelse(shm == 0, ∂qt∂z, ∂qt∂z_sat)
+    @. ∂θl∂z_sat = ifelse(shm == 0, ∂θl∂z, ∂θl∂z_sat)
+    @. ∂θv∂z_unsat = ifelse(shm == 0, ∂θv∂z, ∂θv∂z_unsat)
+
+    @inbounds for k in real_center_indices(grid)
+
+        # buoyancy_gradients
+        if edmf.bg_closure == BuoyGradMean()
+            # First order approximation: Use environmental mean fields.
+            ts_en = ts_env[k]
+            bg_kwargs = (;
+                t_sat = aux_en.T[k],
+                qv_sat = TD.vapor_specific_humidity(thermo_params, ts_en),
+                qt_sat = aux_en.q_tot[k],
+                θ_sat = aux_en.θ_dry[k],
+                θ_liq_ice_sat = aux_en.θ_liq_ice[k],
+                ∂θv∂z_unsat = ∂θv∂z[k],
+                ∂qt∂z_sat = ∂qt∂z[k],
+                ∂θl∂z_sat = ∂θl∂z[k],
+                p = p_c[k],
+                en_cld_frac = aux_en.cloud_fraction[k],
+                ρ = ρ_c[k],
+            )
+            bg_model = EnvBuoyGrad(edmf.bg_closure; bg_kwargs...)
+
+        elseif edmf.bg_closure == BuoyGradQuadratures()
+
+            bg_kwargs = (;
+                t_sat = aux_en_sat.T[k],
+                qv_sat = aux_en_sat.q_vap[k],
+                qt_sat = aux_en_sat.q_tot[k],
+                θ_sat = aux_en_sat.θ_dry[k],
+                θ_liq_ice_sat = aux_en_sat.θ_liq_ice[k],
+                ∂θv∂z_unsat = ∂θv∂z_unsat[k],
+                ∂qt∂z_sat = ∂qt∂z_sat[k],
+                ∂θl∂z_sat = ∂θl∂z_sat[k],
+                p = p_c[k],
+                en_cld_frac = aux_en.cloud_fraction[k],
+                ρ = ρ_c[k],
+            )
+            bg_model = EnvBuoyGrad(edmf.bg_closure; bg_kwargs...)
+        else
+            error("Something went wrong. The buoyancy gradient model is not specified")
+        end
+        bg = buoyancy_gradients(param_set, bg_model)
+
+        # Limiting stratification scale (Deardorff, 1976)
+        # compute ∇Ri and Pr
+        ∇_Ri = gradient_Richardson_number(mix_len_params, bg.∂b∂z, Shear²[k], FT(eps(FT)))
+        aux_tc.prandtl_nvec[k] = turbulent_Prandtl_number(mix_len_params, obukhov_length, ∇_Ri)
+
+        ml_model = MinDisspLen{FT}(;
+            z = FT(grid.zc[k].z),
+            obukhov_length = obukhov_length,
+            tke_surf = aux_en.tke[kc_surf],
+            ustar = surf.ustar,
+            Pr = aux_tc.prandtl_nvec[k],
+            p = p_c[k],
+            ∇b = bg,
+            Shear² = Shear²[k],
+            tke = aux_en.tke[k],
+            b_exch = b_exch[k],
+        )
+
+        ml = mixing_length(mix_len_params, param_set, ml_model)
+        aux_tc.mls[k] = ml.min_len_ind
+        aux_tc.mixing_length[k] = ml.mixing_length
+        aux_tc.ml_ratio[k] = ml.ml_ratio
+
+        KM[k] = c_m * ml.mixing_length * sqrt(max(aux_en.tke[k], 0))
+        KH[k] = KM[k] / aux_tc.prandtl_nvec[k]
+
+        aux_en_2m.tke.buoy[k] = -aux_en.area[k] * ρ_c[k] * KH[k] * bg.∂b∂z
+    end
+
+    #####
+    ##### compute covarinaces tendendies
+    #####
+    tke_press = aux_en_2m.tke.press
+    w_en = aux_en_f.w
+    parent(tke_press) .= 0
+    @inbounds for i in 1:N_up
+        w_up = aux_up_f[i].w
+        nh_press = aux_up_f[i].nh_pressure
+        @. tke_press += (Ic(w_en) - Ic(w_up)) * Ic(nh_press)
+    end
+
+    compute_covariance_entr(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    compute_covariance_entr(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    compute_covariance_entr(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    compute_covariance_entr(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
+    compute_covariance_shear(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    compute_covariance_shear(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    compute_covariance_shear(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    compute_covariance_shear(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
+    compute_covariance_dissipation(edmf, grid, state, Val(:tke), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:Hvar), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:QTvar), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:HQTcov), param_set)
+
+    # TODO defined again in compute_covariance_shear and compute_covaraince
+    @inbounds for k in real_center_indices(grid)
+        aux_en_2m.tke.rain_src[k] = 0
+        aux_en_2m.Hvar.rain_src[k] = ρ_c[k] * aux_en.area[k] * 2 * aux_en.Hvar_rain_dt[k]
+        aux_en_2m.QTvar.rain_src[k] = ρ_c[k] * aux_en.area[k] * 2 * aux_en.QTvar_rain_dt[k]
+        aux_en_2m.HQTcov.rain_src[k] = ρ_c[k] * aux_en.area[k] * aux_en.HQTcov_rain_dt[k]
+    end
+
+    get_GMV_CoVar(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+
+    compute_diffusive_fluxes(edmf, grid, state, surf, param_set)
+
+    # TODO: use dispatch
+    if edmf.precip_model isa Clima1M
+        # helper to calculate the rain velocity
+        # TODO: assuming w_gm = 0
+        # TODO: verify translation
+        term_vel_rain = aux_tc.term_vel_rain
+        term_vel_snow = aux_tc.term_vel_snow
+        prog_pr = center_prog_precipitation(state)
+
+        #precip_fraction = compute_precip_fraction(edmf, state)
+
+        @inbounds for k in real_center_indices(grid)
+            term_vel_rain[k] = CM1.terminal_velocity(microphys_params, rain_type, ρ_c[k], prog_pr.q_rai[k])# / precip_fraction)
+            term_vel_snow[k] = CM1.terminal_velocity(microphys_params, snow_type, ρ_c[k], prog_pr.q_sno[k])# / precip_fraction)
+        end
+    end
+
+    ### Diagnostic thermodynamiccovariances
+    if edmf.thermo_covariance_model isa DiagnosticThermoCovariances
+        flux1 = surf.shf / TD.cp_m(thermo_params, ts_gm[kc_surf])
+        flux2 = surf.ρq_tot_flux
+        zLL::FT = grid.zc[kc_surf].z
+        ustar = surf.ustar
+        oblength = surf.obukhov_length
+        prog_gm = center_prog_grid_mean(state)
+        ρLL = prog_gm.ρ[kc_surf]
+        update_diagnostic_covariances!(edmf, grid, state, param_set, Val(:Hvar))
+        update_diagnostic_covariances!(edmf, grid, state, param_set, Val(:QTvar))
+        update_diagnostic_covariances!(edmf, grid, state, param_set, Val(:HQTcov))
+        @inbounds for k in real_center_indices(grid)
+            aux_en.Hvar[k] = max(aux_en.Hvar[k], 0)
+            aux_en.QTvar[k] = max(aux_en.QTvar[k], 0)
+            aux_en.HQTcov[k] = max(aux_en.HQTcov[k], -sqrt(aux_en.Hvar[k] * aux_en.QTvar[k]))
+            aux_en.HQTcov[k] = min(aux_en.HQTcov[k], sqrt(aux_en.Hvar[k] * aux_en.QTvar[k]))
+        end
+        ae_surf = 1 - aux_bulk.area[kc_surf]
+        aux_en.Hvar[kc_surf] = ae_surf * get_surface_variance(flux1 / ρLL, flux1 / ρLL, ustar, zLL, oblength)
+        aux_en.QTvar[kc_surf] = ae_surf * get_surface_variance(flux2 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+        aux_en.HQTcov[kc_surf] = ae_surf * get_surface_variance(flux1 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+    end
+    compute_precipitation_formation_tendencies(grid, state, edmf, edmf.precip_model, Δt, param_set)
+    return nothing
+end

--- a/src/TurbulenceConvection/utility_functions.jl
+++ b/src/TurbulenceConvection/utility_functions.jl
@@ -1,0 +1,152 @@
+# compute the mean of the values between two percentiles (0 to 1) for a standard normal distribution
+# this gives the surface scalar coefficients for 1 to n-1 updrafts when using n updrafts
+function percentile_bounds_mean_norm(
+    low_percentile::FT,
+    high_percentile::FT,
+    n_samples::I,
+    set_src_seed,
+) where {FT <: Real, I}
+    D = Distributions
+    set_src_seed && Random.seed!(123)
+    x = rand(D.Normal(), n_samples)
+    xp_low = D.quantile(D.Normal(), low_percentile)
+    xp_high = D.quantile(D.Normal(), high_percentile)
+    filter!(y -> xp_low < y < xp_high, x)
+    return StatsBase.mean(x)
+end
+
+function logistic(x, slope, mid)
+    return 1 / (1 + exp(-slope * (x - mid)))
+end
+
+# lambert_2_over_e(::Type{FT}) where {FT} = FT(LambertW.lambertw(FT(2) / FT(MathConstants.e)))
+lambert_2_over_e(::Type{FT}) where {FT} = FT(0.46305551336554884) # since we can evaluate
+
+function lamb_smooth_minimum(l::SA.SVector, lower_bound::FT, upper_bound::FT) where {FT}
+    x_min = minimum(l)
+    λ_0 = max(x_min * lower_bound / lambert_2_over_e(FT), upper_bound)
+
+    num = sum(l_i -> l_i * exp(-(l_i - x_min) / λ_0), l)
+    den = sum(l_i -> exp(-(l_i - x_min) / λ_0), l)
+    smin = num / den
+    return smin
+end
+
+mean_nc_data(data, group, var, imin, imax) = StatsBase.mean(data.group[group][var][:][:, imin:imax], dims = 2)[:]
+
+#= Simple linear interpolation function, wrapping Dierckx =#
+function pyinterp(x, xp, fp)
+    spl = Dierckx.Spline1D(xp, fp; k = 1)
+    return spl(vec(x))
+end
+
+"""
+    compare(a::Field, a::Field)
+    compare(a::FieldVector, b::FieldVector)
+
+Recursively compare two identically structured
+`Field`s, or `FieldVector`s, with potentially different
+data. If `!(maximum(abs.(parent(a) .- parent(b))) == 0.0)`
+for any single field, then `compare` will print out the fields
+and `err`. This can be helpful for debugging where and why
+two `Field`/`FieldVector`s are different.
+"""
+function compare(a::FV, b::FV, pn0 = "") where {FV <: CC.Fields.FieldVector}
+    for pn in propertynames(a)
+        pa = getproperty(a, pn)
+        pb = getproperty(b, pn)
+        compare(pa, pb, "$pn0.$pn")
+    end
+end
+
+function compare(a::F, b::F, pn0 = "") where {F <: CC.Fields.Field}
+    if isempty(propertynames(a))
+        err = abs.(parent(a) .- parent(b))
+        if !(maximum(err) == 0.0)
+            println("--- Comparing field $pn0")
+            @show a
+            @show b
+            @show err
+        end
+    else
+        for pn in propertynames(a)
+            pa = getproperty(a, pn)
+            pb = getproperty(b, pn)
+            compare(pa, pb, "$pn0.$pn")
+        end
+    end
+end
+### Utility functions for LES_driven_SCM cases
+"""
+    get_LES_library
+Hierarchical dictionary of available LES simulations described in [Shen2022](@cite).
+The following cfsites are available across listed models, months,
+and experiments.
+"""
+function get_LES_library()
+    LES_library = Dict("HadGEM2-A" => Dict(), "CNRM-CM5" => Dict(), "CNRM-CM6-1" => Dict())
+    Shen_et_al_sites = collect(2:15)
+    append!(Shen_et_al_sites, collect(17:23))
+    Shen_et_al_deep_convection_sites = (collect(30:33)..., collect(66:70)..., 82, 92, 94, 96, 99, 100)
+    append!(Shen_et_al_sites, Shen_et_al_deep_convection_sites)
+
+    LES_library["HadGEM2-A"]["10"] = Dict()
+    LES_library["HadGEM2-A"]["10"]["cfsite_numbers"] = setdiff(Shen_et_al_sites, [94, 100])
+    LES_library["HadGEM2-A"]["07"] = Dict()
+    LES_library["HadGEM2-A"]["07"]["cfsite_numbers"] = Shen_et_al_sites
+    LES_library["HadGEM2-A"]["04"] = Dict()
+    LES_library["HadGEM2-A"]["04"]["cfsite_numbers"] = setdiff(Shen_et_al_sites, [15, 17, 18, 32, 92, 94])
+    LES_library["HadGEM2-A"]["01"] = Dict()
+    LES_library["HadGEM2-A"]["01"]["cfsite_numbers"] = setdiff(Shen_et_al_sites, [15, 17, 18, 19, 20])
+
+    for month in ["01", "04", "07", "10"]
+        LES_library["HadGEM2-A"][month]["experiments"] = ["amip", "amip4K"]
+    end
+
+    LES_library_full = deepcopy(LES_library)
+    for month in ["01", "04", "07", "10"]
+        LES_library_full["HadGEM2-A"][month]["cfsite_numbers"] = Dict()
+        for cfsite_number in LES_library["HadGEM2-A"][month]["cfsite_numbers"]
+            cfsite_number_str = string(cfsite_number, pad = 2)
+            LES_library_full["HadGEM2-A"][month]["cfsite_numbers"][cfsite_number_str] = if cfsite_number >= 30
+                "deep"
+            else
+                "shallow"
+            end
+        end
+    end
+    return LES_library_full
+end
+
+"""
+    parse_les_path(les_path)
+Given path to LES stats file, return cfsite_number, forcing_model, month, and experiment from filename.
+    LES filename should follow pattern: `Stats.cfsite<SITE-NUMBER>_<FORCING-MODEL>_<EXPERIMENT>_2004-2008.<MONTH>.nc`
+Inputs:
+ - les_path - path to les simulation containing stats folder
+Outputs:
+ - cfsite_number  :: cfsite number
+ - forcing_model :: {"HadGEM2-A", "CNRM-CM5", "CNRM-CM6-1", "IPSL-CM6A-LR"} - name of climate model used for forcing. Currently, only "HadGEM2-A" simulations are available reliably.
+ - month :: {1, 4, 7, 10} - month of simulation.
+ - experiment :: {"amip", "amip4K"} - experiment from which LES was forced.
+"""
+function parse_les_path(les_path)
+    fname = basename(les_path)
+    fname_split = split(fname, ('.', '_'))
+    forcing_model = fname_split[3]
+    experiment = fname_split[4]
+    month = parse(Int64, fname_split[6])
+    cfsite_number = parse(Int64, replace(fname_split[2], "cfsite" => ""))
+    return (cfsite_number, forcing_model, month, experiment)
+end
+
+function valid_lespath(les_path)
+    cfsite_number, forcing_model, month, experiment = parse_les_path(les_path)
+    month = string(month, pad = 2)
+    cfsite_number = string(cfsite_number, pad = 2)
+    LES_library = get_LES_library()
+    @assert forcing_model in keys(LES_library)
+    @assert month in keys(LES_library[forcing_model])
+    @assert cfsite_number in keys(LES_library[forcing_model][month]["cfsite_numbers"])
+    @assert experiment in LES_library[forcing_model][month]["experiments"]
+end

--- a/src/TurbulenceConvection/variables.jl
+++ b/src/TurbulenceConvection/variables.jl
@@ -1,0 +1,286 @@
+#####
+##### Fields
+#####
+import ClimaCore.Geometry: ⊗
+
+# Helpers for adding empty thermodynamic state fields:
+thermo_state(FT, ::EquilibriumMoisture) = TD.PhaseEquil{FT}(0, 0, 0, 0, 0)
+thermo_state(FT, ::NonEquilibriumMoisture) = TD.PhaseNonEquil{FT}(0, 0, TD.PhasePartition(FT(0), FT(0), FT(0)))
+
+##### Auxiliary fields
+
+# Center only
+cent_aux_vars_en_2m(FT) = (;
+    dissipation = FT(0),
+    shear = FT(0),
+    entr_gain = FT(0),
+    detr_loss = FT(0),
+    press = FT(0),
+    buoy = FT(0),
+    interdomain = FT(0),
+    rain_src = FT(0),
+)
+cent_aux_vars_up_moisture(FT, ::NonEquilibriumMoisture) = (;
+    ql_tendency_precip_formation = FT(0),
+    qi_tendency_precip_formation = FT(0),
+    ql_tendency_noneq = FT(0),
+    qi_tendency_noneq = FT(0),
+)
+cent_aux_vars_up_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+cent_aux_vars_up(FT, local_geometry, edmf) = (;
+    ts = thermo_state(FT, edmf.moisture_model),
+    q_liq = FT(0),
+    q_ice = FT(0),
+    T = FT(0),
+    RH = FT(0),
+    s = FT(0),
+    buoy = FT(0),
+    area = FT(0),
+    q_tot = FT(0),
+    θ_liq_ice = FT(0),
+    e_tot = FT(0),
+    e_kin = FT(0),
+    h_tot = FT(0),
+    θ_liq_ice_tendency_precip_formation = FT(0),
+    e_tot_tendency_precip_formation = FT(0),
+    qt_tendency_precip_formation = FT(0),
+    cent_aux_vars_up_moisture(FT, edmf.moisture_model)...,
+    entr_sc = FT(0),
+    detr_sc = FT(0),
+    ε_nondim = FT(0),  # nondimensional entrainment
+    δ_nondim = FT(0),  # nondimensional detrainment
+    frac_turb_entr = FT(0),
+    entr_turb_dyn = FT(0),
+    detr_turb_dyn = FT(0),
+    asp_ratio = FT(0),
+    Π_groups = ntuple(i -> FT(0), n_Π_groups(edmf)),
+)
+cent_aux_vars_edmf_bulk_moisture(FT, ::NonEquilibriumMoisture) = (;
+    ql_tendency_precip_formation = FT(0),
+    qi_tendency_precip_formation = FT(0),
+    ql_tendency_noneq = FT(0),
+    qi_tendency_noneq = FT(0),
+)
+cent_aux_vars_edmf_bulk_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+cent_aux_vars_edmf_en_moisture(FT, ::NonEquilibriumMoisture) = (;
+    ql_tendency_precip_formation = FT(0),
+    qi_tendency_precip_formation = FT(0),
+    ql_tendency_noneq = FT(0),
+    qi_tendency_noneq = FT(0),
+)
+cent_aux_vars_edmf_en_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+cent_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
+    massflux_tendency_ql = FT(0),
+    massflux_tendency_qi = FT(0),
+    diffusive_tendency_ql = FT(0),
+    diffusive_tendency_qi = FT(0),
+)
+cent_aux_vars_edmf_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
+    turbconv = (;
+        ϕ_temporary = FT(0),
+        ψ_temporary = FT(0),
+        bulk = (;
+            area = FT(0),
+            θ_liq_ice = FT(0),
+            e_tot = FT(0),
+            h_tot = FT(0),
+            RH = FT(0),
+            buoy = FT(0),
+            q_tot = FT(0),
+            q_liq = FT(0),
+            q_ice = FT(0),
+            T = FT(0),
+            cloud_fraction = FT(0),
+            e_tot_tendency_precip_formation = FT(0),
+            qt_tendency_precip_formation = FT(0),
+            cent_aux_vars_edmf_bulk_moisture(FT, edmf.moisture_model)...,
+        ),
+        up = ntuple(i -> cent_aux_vars_up(FT, local_geometry, edmf), Val(n_updrafts(edmf))),
+        en = (;
+            ts = thermo_state(FT, edmf.moisture_model),
+            w = FT(0),
+            area = FT(0),
+            q_tot = FT(0),
+            q_liq = FT(0),
+            q_ice = FT(0),
+            θ_liq_ice = FT(0),
+            e_tot = FT(0),
+            e_kin = FT(0),
+            h_tot = FT(0),
+            θ_virt = FT(0),
+            θ_dry = FT(0),
+            RH = FT(0),
+            s = FT(0),
+            T = FT(0),
+            buoy = FT(0),
+            cloud_fraction = FT(0),
+            tke = FT(0),
+            Hvar = FT(0),
+            QTvar = FT(0),
+            HQTcov = FT(0),
+            #θ_liq_ice_tendency_precip_formation = FT(0),
+            e_tot_tendency_precip_formation = FT(0),
+            qt_tendency_precip_formation = FT(0),
+            cent_aux_vars_edmf_en_moisture(FT, edmf.moisture_model)...,
+            unsat = (; q_tot = FT(0), θ_dry = FT(0), θ_virt = FT(0)),
+            sat = (; T = FT(0), q_vap = FT(0), q_tot = FT(0), θ_dry = FT(0), θ_liq_ice = FT(0)),
+            Hvar_rain_dt = FT(0),
+            QTvar_rain_dt = FT(0),
+            HQTcov_rain_dt = FT(0),
+        ),
+        θ_liq_ice_tendency_precip_sinks = FT(0),
+        e_tot_tendency_precip_sinks = FT(0),
+        qt_tendency_precip_sinks = FT(0),
+        qr_tendency_evap = FT(0),
+        qs_tendency_melt = FT(0),
+        qs_tendency_dep_sub = FT(0),
+        qr_tendency_advection = FT(0),
+        qs_tendency_advection = FT(0),
+        en_2m = (;
+            tke = cent_aux_vars_en_2m(FT),
+            Hvar = cent_aux_vars_en_2m(FT),
+            QTvar = cent_aux_vars_en_2m(FT),
+            HQTcov = cent_aux_vars_en_2m(FT),
+        ),
+        term_vel_rain = FT(0),
+        term_vel_snow = FT(0),
+        KM = FT(0),
+        KH = FT(0),
+        mixing_length = FT(0),
+        massflux_tendency_h = FT(0),
+        massflux_tendency_qt = FT(0),
+        diffusive_tendency_h = FT(0),
+        diffusive_tendency_qt = FT(0),
+        cent_aux_vars_edmf_moisture(FT, edmf.moisture_model)...,
+        prandtl_nvec = FT(0),
+        # Added by Ignacio : Length scheme in use (mls), and smooth min effect (ml_ratio)
+        # Variable Prandtl number initialized as neutral value.
+        mls = FT(0),
+        b_exch = FT(0),
+        ml_ratio = FT(0),
+        w_up_c = FT(0),
+        w_en_c = FT(0),
+        Shear² = FT(0),
+        ∂θv∂z = FT(0),
+        ∂qt∂z = FT(0),
+        ∂θl∂z = FT(0),
+        ∂θv∂z_unsat = FT(0),
+        ∂qt∂z_sat = FT(0),
+        ∂θl∂z_sat = FT(0),
+        l_entdet = FT(0),
+        ϕ_gm = FT(0), # temporary for grid-mean variables
+        ϕ_gm_cov = FT(0), # temporary for grid-mean covariance variables
+        ϕ_en_cov = FT(0), # temporary for environmental covariance variables
+        ϕ_up_cubed = FT(0), # temporary for cubed updraft variables in grid mean 3rd moment functions
+    )
+)
+
+# Face only
+face_aux_vars_up(FT, local_geometry) = (;
+    w = FT(0),
+    nh_pressure = FT(0),
+    nh_pressure_b = FT(0),
+    nh_pressure_adv = FT(0),
+    nh_pressure_drag = FT(0),
+    massflux = FT(0),
+)
+face_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
+    massflux_en = FT(0), # TODO: is this the right place for this?
+    massflux_ql = FT(0),
+    massflux_qi = FT(0),
+    diffusive_flux_ql = FT(0),
+    diffusive_flux_qi = FT(0),
+)
+face_aux_vars_edmf_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+face_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
+    turbconv = (;
+        bulk = (; w = FT(0)),
+        ρ_ae_KM = FT(0),
+        ρ_ae_KH = FT(0),
+        ρ_ae_K = FT(0),
+        en = (; w = FT(0)),
+        up = ntuple(i -> face_aux_vars_up(FT, local_geometry), Val(n_updrafts(edmf))),
+        massflux = FT(0),
+        massflux_h = FT(0),
+        massflux_qt = FT(0),
+        ϕ_temporary = FT(0),
+        diffusive_flux_h = FT(0),
+        diffusive_flux_qt = FT(0),
+        face_aux_vars_edmf_moisture(FT, edmf.moisture_model)...,
+        diffusive_flux_uₕ = CCG.Covariant3Vector(FT(0)) ⊗ CCG.Covariant12Vector(FT(0), FT(0)),
+    )
+)
+
+##### Diagnostic fields
+
+# Center only
+cent_diagnostic_vars_edmf(FT, local_geometry, edmf) = (;
+    turbconv = (;
+        asp_ratio = FT(0),
+        entr_sc = FT(0),
+        ε_nondim = FT(0),
+        detr_sc = FT(0),
+        δ_nondim = FT(0),
+        massflux = FT(0),
+        frac_turb_entr = FT(0),
+    )
+)
+
+# Face only
+face_diagnostic_vars_edmf(FT, local_geometry, edmf) = (;
+    turbconv = (; nh_pressure = FT(0), nh_pressure_adv = FT(0), nh_pressure_drag = FT(0), nh_pressure_b = FT(0)),
+    precip = (; rain_flux = FT(0), snow_flux = FT(0)),
+)
+
+# Single value per column diagnostic variables
+single_value_per_col_diagnostic_vars_edmf(FT, edmf) = (;
+    turbconv = (;
+        env_cloud_base = FT(0),
+        env_cloud_top = FT(0),
+        env_cloud_cover = FT(0),
+        env_lwp = FT(0),
+        env_iwp = FT(0),
+        updraft_cloud_cover = FT(0),
+        updraft_cloud_base = FT(0),
+        updraft_cloud_top = FT(0),
+        updraft_lwp = FT(0),
+        updraft_iwp = FT(0),
+        Hd = FT(0),
+    )
+)
+
+##### Prognostic fields
+
+# Center only
+cent_prognostic_vars_up_noisy_relaxation(::Type{FT}, ::PrognosticNoisyRelaxationProcess) where {FT} =
+    (; ε_nondim = FT(0), δ_nondim = FT(0))
+cent_prognostic_vars_up_noisy_relaxation(::Type{FT}, _) where {FT} = NamedTuple()
+cent_prognostic_vars_up_moisture(::Type{FT}, ::EquilibriumMoisture) where {FT} = NamedTuple()
+cent_prognostic_vars_up_moisture(::Type{FT}, ::NonEquilibriumMoisture) where {FT} = (; ρaq_liq = FT(0), ρaq_ice = FT(0))
+cent_prognostic_vars_up(::Type{FT}, edmf) where {FT} = (;
+    ρarea = FT(0),
+    ρaθ_liq_ice = FT(0),
+    ρaq_tot = FT(0),
+    cent_prognostic_vars_up_noisy_relaxation(FT, edmf.entr_closure)...,
+    cent_prognostic_vars_up_moisture(FT, edmf.moisture_model)...,
+)
+
+cent_prognostic_vars_en(::Type{FT}, edmf) where {FT} =
+    (; ρatke = FT(0), cent_prognostic_vars_en_thermo(FT, edmf.thermo_covariance_model)...)
+cent_prognostic_vars_en_thermo(::Type{FT}, ::DiagnosticThermoCovariances) where {FT} = NamedTuple()
+cent_prognostic_vars_en_thermo(::Type{FT}, ::PrognosticThermoCovariances) where {FT} =
+    (; ρaHvar = FT(0), ρaQTvar = FT(0), ρaHQTcov = FT(0))
+cent_prognostic_vars_edmf(::Type{FT}, edmf) where {FT} = (;
+    turbconv = (;
+        en = cent_prognostic_vars_en(FT, edmf),
+        up = ntuple(i -> cent_prognostic_vars_up(FT, edmf), Val(n_updrafts(edmf))),
+        pr = (; q_rai = FT(0), q_sno = FT(0)),
+    )
+)
+# cent_prognostic_vars_edmf(FT, edmf) = (;) # could also use this for empty model
+
+# Face only
+face_prognostic_vars_up(::Type{FT}, local_geometry) where {FT} = (; ρaw = FT(0))
+face_prognostic_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} =
+    (; turbconv = (; up = ntuple(i -> face_prognostic_vars_up(FT, local_geometry), Val(n_updrafts(edmf)))))

--- a/tc_driver/Artifacts.toml
+++ b/tc_driver/Artifacts.toml
@@ -1,0 +1,8 @@
+[LESDrivenSCM_output_dataset]
+git-tree-sha1 = "3d6bb62d803fb01908ffe85469a89933f28ced45"
+
+[PyCLES_output]
+git-tree-sha1 = "c2d323fb412d1250182be3aeadf9d94e816550a0"
+
+[SCAMPy_output]
+git-tree-sha1 = "6b82611f969d3cf99102baa7d898e3c759cf014c"

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -1,0 +1,1239 @@
+module Cases
+
+import NCDatasets as NC
+import OrdinaryDiffEq as ODE
+import Thermodynamics as TD
+
+import ClimaCore as CC
+import ClimaCore.Operators as CCO
+import ClimaCore.Geometry as CCG
+import DocStringExtensions
+
+import AtmosphericProfilesLibrary as APL
+
+import Dierckx
+import Statistics
+import Random
+import UnPack
+
+import ..TurbulenceConvection as TC
+import ..TurbulenceConvection.Parameters as TCP
+const APS = TCP.AbstractTurbulenceConvectionParameters
+
+using ..TurbulenceConvection: pyinterp
+using ..TurbulenceConvection: Grid
+using ..TurbulenceConvection: real_center_indices
+using ..TurbulenceConvection: real_face_indices
+using ..TurbulenceConvection: get_inversion
+
+#=
+    arr_type(x)
+We're keeping this around in case we need
+to move some initialized data to the GPU.
+In this case, we may be able to modify this
+function to do this.
+=#
+arr_type(x) = x
+
+#####
+##### Case types
+#####
+
+# For dispatching to inherited class
+struct BaseCase end
+
+abstract type AbstractCaseType end
+
+""" [Soares2004](@cite) """
+struct Soares <: AbstractCaseType end
+
+""" [Nieuwstadt1993](@cite) """
+struct Nieuwstadt <: AbstractCaseType end
+
+struct Bomex <: AbstractCaseType end
+
+""" [Tan2018](@cite) """
+struct life_cycle_Tan2018 <: AbstractCaseType end
+
+struct Rico <: AbstractCaseType end
+
+""" [Grabowski2006](@cite) """
+struct TRMM_LBA <: AbstractCaseType end
+
+""" [Brown2002](@cite) """
+struct ARM_SGP <: AbstractCaseType end
+
+""" [Khairoutdinov2009](@cite) """
+struct GATE_III <: AbstractCaseType end
+
+""" [Stevens2005](@cite) """
+struct DYCOMS_RF01 <: AbstractCaseType end
+
+""" [Ackerman2009](@cite) """
+struct DYCOMS_RF02 <: AbstractCaseType end
+
+struct GABLS <: AbstractCaseType end
+
+struct DryBubble <: AbstractCaseType end
+
+struct LES_driven_SCM <: AbstractCaseType end
+
+#####
+##### Radiation and forcing types
+#####
+
+struct ForcingNone end
+struct ForcingStandard end
+struct ForcingDYCOMS_RF01 end
+struct ForcingLES end
+
+struct RadiationNone end
+struct RadiationDYCOMS_RF01 end
+struct RadiationLES end
+struct RadiationTRMM_LBA end
+
+"""
+    ForcingBase
+
+LES-driven forcing
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct ForcingBase{T, FT}
+    "Coriolis parameter"
+    coriolis_param::FT = 0
+    "Wind relaxation timescale"
+    wind_nudge_τᵣ::FT = 0.0
+    "Scalar relaxation lower z"
+    scalar_nudge_zᵢ::FT = 0.0
+    "Scalar relaxation upper z"
+    scalar_nudge_zᵣ::FT = 0.0
+    "Scalar maximum relaxation timescale"
+    scalar_nudge_τᵣ::FT = 0.0
+    "Large-scale divergence (same as in RadiationBase)"
+    divergence::FT = 0
+end
+
+force_type(::ForcingBase{T}) where {T} = T
+
+Base.@kwdef struct RadiationBase{T, FT}
+    "Large-scale divergence (same as in ForcingBase)"
+    divergence::FT = 0
+    alpha_z::FT = 0
+    kappa::FT = 0
+    F0::FT = 0
+    F1::FT = 0
+end
+
+rad_type(::RadiationBase{T}) where {T} = T
+
+Base.@kwdef struct LESData
+    "Start time index of LES"
+    imin::Int = 0
+    "End time index of LES"
+    imax::Int = 0
+    "Path to LES stats file used to drive SCM"
+    les_filename::String = nothing
+    "Drive SCM with LES data from t = [end - t_interval_from_end_s, end]"
+    t_interval_from_end_s::Float64 = 6 * 3600.0
+    "Length of time to average over for SCM initialization"
+    initial_condition_averaging_window_s::Float64 = 3600.0
+end
+
+#####
+##### Radiation and forcing functions
+#####
+
+include("Radiation.jl")
+include("Forcing.jl")
+
+#####
+##### Case methods
+#####
+
+get_case(namelist::Dict) = get_case(namelist["meta"]["casename"])
+get_case(casename::String) = get_case(Val(Symbol(casename)))
+get_case(::Val{:Soares}) = Soares()
+get_case(::Val{:Nieuwstadt}) = Nieuwstadt()
+get_case(::Val{:Bomex}) = Bomex()
+get_case(::Val{:life_cycle_Tan2018}) = life_cycle_Tan2018()
+get_case(::Val{:Rico}) = Rico()
+get_case(::Val{:TRMM_LBA}) = TRMM_LBA()
+get_case(::Val{:ARM_SGP}) = ARM_SGP()
+get_case(::Val{:GATE_III}) = GATE_III()
+get_case(::Val{:DYCOMS_RF01}) = DYCOMS_RF01()
+get_case(::Val{:DYCOMS_RF02}) = DYCOMS_RF02()
+get_case(::Val{:GABLS}) = GABLS()
+get_case(::Val{:DryBubble}) = DryBubble()
+get_case(::Val{:LES_driven_SCM}) = LES_driven_SCM()
+
+get_case_name(case_type::AbstractCaseType) = string(case_type)
+
+#####
+##### Case configurations
+#####
+
+get_forcing_type(::AbstractCaseType) = ForcingStandard # default
+get_forcing_type(::Soares) = ForcingNone
+get_forcing_type(::Nieuwstadt) = ForcingNone
+get_forcing_type(::DYCOMS_RF01) = ForcingDYCOMS_RF01
+get_forcing_type(::DYCOMS_RF02) = ForcingDYCOMS_RF01
+get_forcing_type(::DryBubble) = ForcingNone
+get_forcing_type(::LES_driven_SCM) = ForcingLES
+get_forcing_type(::TRMM_LBA) = ForcingNone
+
+get_radiation_type(::AbstractCaseType) = RadiationNone # default
+get_radiation_type(::DYCOMS_RF01) = RadiationDYCOMS_RF01
+get_radiation_type(::DYCOMS_RF02) = RadiationDYCOMS_RF01
+get_radiation_type(::LES_driven_SCM) = RadiationLES
+get_radiation_type(::TRMM_LBA) = RadiationTRMM_LBA
+
+large_scale_divergence(::Union{DYCOMS_RF01, DYCOMS_RF02}) = 3.75e-6
+
+RadiationBase(case::AbstractCaseType, FT) = RadiationBase{Cases.get_radiation_type(case), FT}()
+
+forcing_kwargs(::AbstractCaseType, namelist) = (; coriolis_param = namelist["forcing"]["coriolis"])
+forcing_kwargs(case::DYCOMS_RF01, namelist) = (; divergence = large_scale_divergence(case))
+forcing_kwargs(case::DYCOMS_RF02, namelist) = (; divergence = large_scale_divergence(case))
+les_data_kwarg(::AbstractCaseType, namelist) = ()
+
+ForcingBase(case::AbstractCaseType, FT; kwargs...) = ForcingBase{get_forcing_type(case), FT}(; kwargs...)
+
+#####
+##### Default case behavior:
+#####
+
+initialize_radiation(::AbstractCaseType, radiation, grid, state, param_set) = nothing
+
+update_forcing(::AbstractCaseType, grid, state, t::Real, param_set) = nothing
+initialize_forcing(::AbstractCaseType, forcing, grid::Grid, state, param_set) = initialize(forcing, grid, state)
+
+#####
+##### Soares
+#####
+
+function surface_ref_state(::Soares, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1000.0 * 100.0
+    qtg::FT = 5.0e-3
+    Tg::FT = 300.0
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::Soares, grid::Grid, param_set, state; kwargs...)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    FT = TC.float_type(state)
+    prof_q_tot = APL.Soares_q_tot(FT)
+    prof_θ_liq_ice = APL.Soares_θ_liq_ice(FT)
+    prof_u = APL.Soares_u(FT)
+    prof_tke = APL.Soares_tke(FT)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.q_tot[k] = prof_q_tot(z)
+        aux_gm.θ_liq_ice[k] = prof_θ_liq_ice(z)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::Soares, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    zrough::FT = 0.16 #1.0e-4 0.16 is the value specified in the Nieuwstadt paper.
+    Tsurface::FT = 300.0
+    qsurface::FT = 5.0e-3
+    θ_flux::FT = 6.0e-2
+    qt_flux::FT = 2.5e-5
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
+    ustar::FT = 0.28 # just to initilize grid mean covariances
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
+end
+
+#####
+##### Nieuwstadt
+#####
+
+function surface_ref_state(::Nieuwstadt, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1000.0 * 100.0
+    Tg::FT = 300.0
+    qtg::FT = 0.0
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::Nieuwstadt, grid::Grid, param_set, state; kwargs...)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+
+    FT = TC.float_type(state)
+    prof_θ_liq_ice = APL.Nieuwstadt_θ_liq_ice(FT)
+    prof_u = APL.Nieuwstadt_u(FT)
+    prof_tke = APL.Nieuwstadt_tke(FT)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.θ_liq_ice[k] = prof_θ_liq_ice(z)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::Nieuwstadt, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    zrough::FT = 0.16 #1.0e-4 0.16 is the value specified in the Nieuwstadt paper.
+    Tsurface::FT = 300.0
+    qsurface::FT = 0.0
+    θ_flux::FT = 6.0e-2
+    lhf::FT = 0.0 # It would be 0.0 if we follow Nieuwstadt.
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
+    ustar::FT = 0.28 # just to initilize grid mean covariances
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
+end
+
+#####
+##### Bomex
+#####
+
+function surface_ref_state(::Bomex, param_set::APS, namelist)
+    FT = eltype(param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    Pg::FT = 1.015e5 #Pressure at ground
+    Tg::FT = 300.4 #Temperature at ground
+    qtg::FT = 0.02245#Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::Bomex, grid::Grid, param_set, state; kwargs...)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+
+    FT = TC.float_type(state)
+    prof_q_tot = APL.Bomex_q_tot(FT)
+    prof_θ_liq_ice = APL.Bomex_θ_liq_ice(FT)
+    prof_u = APL.Bomex_u(FT)
+    prof_tke = APL.Bomex_tke(FT)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.θ_liq_ice[k] = prof_θ_liq_ice(z)
+        aux_gm.q_tot[k] = prof_q_tot(z)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::Bomex, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    zrough::FT = 1.0e-4
+    qsurface::FT = 22.45e-3 # kg/kg
+    θ_surface::FT = 299.1
+    θ_flux::FT = 8.0e-3
+    qt_flux::FT = 5.2e-5
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
+    ustar::FT = 0.28 # m/s
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+function initialize_forcing(::Bomex, forcing, grid::Grid, state, param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    initialize(forcing, grid, state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    ts_gm = aux_gm.ts
+    p_c = aux_gm.p
+
+    FT = TC.float_type(state)
+    prof_ug = APL.Bomex_geostrophic_u(FT)
+    prof_dTdt = APL.Bomex_dTdt(FT)
+    prof_dqtdt = APL.Bomex_dqtdt(FT)
+    prof_subsidence = APL.Bomex_subsidence(FT)
+
+    z = CC.Fields.coordinate_field(axes(aux_gm.uₕ_g)).z
+    @. aux_gm.uₕ_g = CCG.Covariant12Vector(CCG.UVVector(prof_ug(z), FT(0)))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        # Geostrophic velocity profiles. vg = 0
+        Π = TD.exner(thermo_params, ts_gm[k])
+        # Set large-scale cooling
+        aux_gm.dTdt_hadv[k] = prof_dTdt(Π, z)
+        # Set large-scale drying
+        aux_gm.dqtdt_hadv[k] = prof_dqtdt(z)
+        #Set large scale subsidence
+        aux_gm.subsidence[k] = prof_subsidence(z)
+    end
+    return nothing
+end
+
+#####
+##### life_cycle_Tan2018
+#####
+
+function surface_ref_state(::life_cycle_Tan2018, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1.015e5  #Pressure at ground
+    Tg::FT = 300.4  #Temperature at ground
+    qtg::FT = 0.02245   #Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::life_cycle_Tan2018, grid::Grid, param_set, state; kwargs...)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+
+    FT = TC.float_type(state)
+    prof_q_tot = APL.LifeCycleTan2018_q_tot(FT)
+    prof_θ_liq_ice = APL.LifeCycleTan2018_θ_liq_ice(FT)
+    prof_u = APL.LifeCycleTan2018_u(FT)
+    prof_tke = APL.LifeCycleTan2018_tke(FT)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.θ_liq_ice[k] = prof_θ_liq_ice(z)
+        aux_gm.q_tot[k] = prof_q_tot(z)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::life_cycle_Tan2018, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    zrough::FT = 1.0e-4 # not actually used, but initialized to reasonable value
+    qsurface::FT = 22.45e-3 # kg/kg
+    θ_surface::FT = 299.1
+    θ_flux::FT = 8.0e-3
+    qt_flux::FT = 5.2e-5
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    lhf0 = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf0 = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
+
+    weight_factor(t) = FT(0.01) + FT(0.99) * (cos(2 * FT(π) * t / 3600) + 1) / 2
+    weight::FT = 1.0
+    lhf = t -> lhf0 * (weight * weight_factor(t))
+    shf = t -> shf0 * (weight * weight_factor(t))
+
+    ustar::FT = 0.28 # m/s
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+function initialize_forcing(::life_cycle_Tan2018, forcing, grid::Grid, state, param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    initialize(forcing, grid, state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    p_c = aux_gm.p
+    ts_gm = aux_gm.ts
+
+    FT = TC.float_type(state)
+    prof_ug = APL.LifeCycleTan2018_geostrophic_u(FT)
+    prof_dTdt = APL.LifeCycleTan2018_dTdt(FT)
+    prof_dqtdt = APL.LifeCycleTan2018_dqtdt(FT)
+    prof_subsidence = APL.LifeCycleTan2018_subsidence(FT)
+
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, prof_ug, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        # Geostrophic velocity profiles. vg = 0
+        Π = TD.exner(thermo_params, ts_gm[k])
+        # Set large-scale cooling
+        aux_gm.dTdt_hadv[k] = prof_dTdt(Π, z)
+        # Set large-scale drying
+        aux_gm.dqtdt_hadv[k] = prof_dqtdt(z)
+        #Set large scale subsidence
+        aux_gm.subsidence[k] = prof_subsidence(z)
+    end
+    return nothing
+end
+
+#####
+##### Rico
+#####
+
+function surface_ref_state(::Rico, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    molmass_ratio = TCP.molmass_ratio(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1.0154e5  #Pressure at ground
+    Tg::FT = 299.8  #Temperature at ground
+    pvg = TD.saturation_vapor_pressure(thermo_params, Tg, TD.Liquid())
+    qtg = (1 / molmass_ratio) * pvg / (Pg - pvg)   #Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::Rico, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_tc = TC.center_aux_turbconv(state)
+    p = aux_gm.p
+    ρ_c = prog_gm.ρ
+
+    FT = TC.float_type(state)
+    prof_u = APL.Rico_u(FT)
+    prof_v = APL.Rico_v(FT)
+    prof_q_tot = APL.Rico_q_tot(FT)
+    prof_θ_liq_ice = APL.Rico_θ_liq_ice(FT)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.θ_liq_ice[k] = prof_θ_liq_ice(z)
+        aux_gm.q_tot[k] = prof_q_tot(z)
+    end
+
+    # Need to get θ_virt
+    @inbounds for k in real_center_indices(grid)
+        # Thermo state field cache is not yet
+        # defined, so we can't use it yet.
+        ts = TD.PhaseEquil_pθq(thermo_params, p[k], aux_gm.θ_liq_ice[k], aux_gm.q_tot[k])
+        aux_gm.θ_virt[k] = TD.virtual_pottemp(thermo_params, ts)
+    end
+    zi = FT(0.6) * get_inversion(grid, state, param_set, FT(0.2))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.tke[k] = if z <= zi
+            1 - z / zi
+        else
+            FT(0)
+        end
+    end
+end
+
+function surface_params(case::Rico, surf_ref_state, param_set; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+
+    zrough::FT = 0.00015
+    cm0::FT = 0.001229
+    ch0::FT = 0.001094
+    cq0::FT = 0.001133
+    # Adjust for non-IC grid spacing
+    grid_adjust(zc_surf) = (log(20 / zrough) / log(zc_surf / zrough))^2
+    cm = zc_surf -> cm0 * grid_adjust(zc_surf)
+    ch = zc_surf -> ch0 * grid_adjust(zc_surf)
+    cq = zc_surf -> cq0 * grid_adjust(zc_surf) # TODO: not yet used..
+    Tsurface::FT = 299.8
+
+    # For Rico we provide values of transfer coefficients
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, FT(0)) # TODO: is this correct?
+    qsurface = TD.q_vap_saturation(thermo_params, ts)
+    kwargs = (; zrough, Tsurface, qsurface, cm, ch, kwargs...)
+    return TC.FixedSurfaceCoeffs(FT; kwargs...)
+end
+
+function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    initialize(forcing, grid, state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    ts_gm = aux_gm.ts
+    p_c = aux_gm.p
+
+    FT = TC.float_type(state)
+    prof_ug = APL.Rico_geostrophic_ug(FT)
+    prof_vg = APL.Rico_geostrophic_vg(FT)
+    prof_dTdt = APL.Rico_dTdt(FT)
+    prof_dqtdt = APL.Rico_dqtdt(FT)
+    prof_subsidence = APL.Rico_subsidence(FT)
+
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, prof_ug, prof_vg)
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        Π = TD.exner(thermo_params, ts_gm[k])
+        aux_gm.dTdt_hadv[k] = prof_dTdt(Π, z) # Set large-scale cooling
+        aux_gm.dqtdt_hadv[k] = prof_dqtdt(z) # Set large-scale moistening
+        aux_gm.subsidence[k] = prof_subsidence(z) #Set large scale subsidence
+    end
+    return nothing
+end
+
+#####
+##### TRMM_LBA
+#####
+
+function surface_ref_state(::TRMM_LBA, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    molmass_ratio = TCP.molmass_ratio(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 991.3 * 100  #Pressure at ground
+    Tg::FT = 296.85   # surface values for reference state (RS) which outputs p, ρ
+    pvg = TD.saturation_vapor_pressure(thermo_params, Tg, TD.Liquid())
+    qtg = (1 / molmass_ratio) * pvg / (Pg - pvg) #Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::TRMM_LBA, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    p = aux_gm.p
+
+    FT = TC.float_type(state)
+    # Get profiles from AtmosphericProfilesLibrary.jl
+    prof_p = APL.TRMM_LBA_p(FT)
+    prof_T = APL.TRMM_LBA_T(FT)
+    prof_RH = APL.TRMM_LBA_RH(FT)
+    prof_u = APL.TRMM_LBA_u(FT)
+    prof_v = APL.TRMM_LBA_v(FT)
+    prof_tke = APL.TRMM_LBA_tke(FT)
+
+    zc = grid.zc.z
+    molmass_ratio = TCP.molmass_ratio(param_set)
+    prog_gm = TC.center_prog_grid_mean(state)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    aux_gm.T .= prof_T.(zc)
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        pv_star = TD.saturation_vapor_pressure(thermo_params, aux_gm.T[k], TD.Liquid())
+        # eq. 37 in pressel et al and the def of RH
+        RH = prof_RH(z)
+        denom = (prof_p(z) - pv_star + (1 / molmass_ratio) * pv_star * RH / 100)
+        qv_star = pv_star * (1 / molmass_ratio) / denom
+        aux_gm.q_tot[k] = qv_star * RH / 100
+        phase_part = TD.PhasePartition(aux_gm.q_tot[k], FT(0), FT(0)) # initial state is not saturated
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(thermo_params, aux_gm.T[k], p[k], phase_part)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::TRMM_LBA, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    # zrough = 1.0e-4 # not actually used, but initialized to reasonable value
+    qsurface::FT = 22.45e-3 # kg/kg
+    θ_surface::FT = (273.15 + 23)
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    ustar::FT = 0.28 # this is taken from Bomex -- better option is to approximate from LES tke above the surface
+    lhf = t -> 554 * max(0, cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)))^FT(1.3)
+    shf = t -> 270 * max(0, cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)))^FT(1.5)
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit, zero_uv_fluxes = true)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+RadiationBase(case::TRMM_LBA, FT) = RadiationBase{Cases.get_radiation_type(case), FT}()
+
+initialize_radiation(::TRMM_LBA, radiation, grid::Grid, state, param_set) = initialize(radiation, grid, state)
+
+#####
+##### ARM_SGP
+#####
+
+function surface_ref_state(::ARM_SGP, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 970.0 * 100 #Pressure at ground
+    Tg::FT = 299.0   # surface values for reference state (RS) which outputs  p, ρ
+    qtg::FT = 15.2 / 1000 #Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::ARM_SGP, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    # ARM_SGP inputs
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    p = aux_gm.p
+
+    FT = TC.float_type(state)
+    prof_u = APL.ARM_SGP_u(FT)
+    prof_q_tot = APL.ARM_SGP_q_tot(FT)
+    prof_θ_liq_ice = APL.ARM_SGP_θ_liq_ice(FT)
+    prof_tke = APL.ARM_SGP_tke(FT)
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, x -> FT(0))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        # TODO figure out how to use ts here
+        phase_part = TD.PhasePartition(aux_gm.q_tot[k], aux_gm.q_liq[k], FT(0))
+        Π = TD.exner_given_pressure(thermo_params, p[k], phase_part)
+        aux_gm.q_tot[k] = prof_q_tot(z)
+        aux_gm.T[k] = prof_θ_liq_ice(z) * Π
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(thermo_params, aux_gm.T[k], p[k], phase_part)
+        aux_gm.tke[k] = prof_tke(z)
+    end
+end
+
+function surface_params(case::ARM_SGP, surf_ref_state, param_set; Ri_bulk_crit)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+    qsurface::FT = 15.2e-3 # kg/kg
+    θ_surface::FT = 299.0
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    ustar::FT = 0.28 # this is taken from Bomex -- better option is to approximate from LES tke above the surface
+
+    t_Sur_in = arr_type(FT[0.0, 4.0, 6.5, 7.5, 10.0, 12.5, 14.5]) .* 3600 #LES time is in sec
+    SH = arr_type(FT[-30.0, 90.0, 140.0, 140.0, 100.0, -10, -10]) # W/m^2
+    LH = arr_type(FT[5.0, 250.0, 450.0, 500.0, 420.0, 180.0, 0.0]) # W/m^2
+    shf = Dierckx.Spline1D(t_Sur_in, SH; k = 1)
+    lhf = Dierckx.Spline1D(t_Sur_in, LH; k = 1)
+
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit, zero_uv_fluxes = true)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+function initialize_forcing(::ARM_SGP, forcing, grid::Grid, state, param_set)
+    FT = TC.float_type(state)
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, FT(10), FT(0))
+    return nothing
+end
+
+function update_forcing(::ARM_SGP, grid, state, t::Real, param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    prog_gm = TC.center_prog_grid_mean(state)
+    p_c = prog_gm.ρ
+    FT = TC.float_type(state)
+    @inbounds for k in real_center_indices(grid)
+        Π = TD.exner(thermo_params, ts_gm[k])
+        z = grid.zc[k].z
+        aux_gm.dTdt_hadv[k] = APL.ARM_SGP_dTdt(FT)(t, z)
+        aux_gm.dqtdt_hadv[k] = APL.ARM_SGP_dqtdt(FT)(Π, t, z)
+
+    end
+end
+
+#####
+##### GATE_III
+#####
+
+function surface_ref_state(::GATE_III, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1013.0 * 100  #Pressure at ground
+    Tg::FT = 299.184   # surface values for reference state (RS) which outputs p, ρ
+    qtg::FT = 16.5 / 1000 #Total water mixing ratio at surface
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::GATE_III, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+
+    prof_u = APL.GATE_III_u(FT)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    p = aux_gm.p
+    ρ_c = prog_gm.ρ
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.q_tot[k] = APL.GATE_III_q_tot(FT)(z)
+        aux_gm.T[k] = APL.GATE_III_T(FT)(z)
+        ts = TD.PhaseEquil_pTq(thermo_params, p[k], aux_gm.T[k], aux_gm.q_tot[k])
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts)
+        aux_gm.tke[k] = APL.GATE_III_tke(FT)(z)
+    end
+end
+
+function surface_params(case::GATE_III, surf_ref_state, param_set; kwargs...)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    FT = eltype(p_f_surf)
+
+    qsurface::FT = 16.5 / 1000.0 # kg/kg
+    cm = zc_surf -> FT(0.0012)
+    ch = zc_surf -> FT(0.0034337)
+    cq = zc_surf -> FT(0.0034337)
+    Tsurface::FT = 299.184
+
+    # For GATE_III we provide values of transfer coefficients
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, Tsurface, qsurface)
+    qsurface = TD.q_vap_saturation(thermo_params, ts)
+    kwargs = (; Tsurface, qsurface, cm, ch, kwargs...)
+    return TC.FixedSurfaceCoeffs(FT; kwargs...)
+end
+
+function initialize_forcing(::GATE_III, forcing, grid::Grid, state, param_set)
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    for k in TC.real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.dqtdt_hadv[k] = APL.GATE_III_dqtdt(FT)(z)
+        aux_gm.dTdt_hadv[k] = APL.GATE_III_dTdt(FT)(z)
+    end
+end
+
+#####
+##### DYCOMS_RF01
+#####
+
+function surface_ref_state(::DYCOMS_RF01, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1017.8 * 100.0
+    qtg::FT = 9.0 / 1000.0
+    θ_surf::FT = 289.0
+    ts = TD.PhaseEquil_pθq(thermo_params, Pg, θ_surf, qtg)
+    Tg = TD.air_temperature(thermo_params, ts)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::DYCOMS_RF01, grid::Grid, param_set, state; kwargs...)
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+
+    prof_u = APL.Dycoms_RF01_u0(FT)
+    prof_v = APL.Dycoms_RF01_v0(FT)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    ρ_c = prog_gm.ρ
+    p = aux_gm.p
+    @inbounds for k in real_center_indices(grid)
+        # thetal profile as defined in DYCOMS
+        z = grid.zc[k].z
+        aux_gm.q_tot[k] = APL.Dycoms_RF01_q_tot(FT)(z)
+        aux_gm.θ_liq_ice[k] = APL.Dycoms_RF01_θ_liq_ice(FT)(z)
+
+        # velocity profile (geostrophic)
+        aux_gm.tke[k] = APL.Dycoms_RF01_tke(FT)(z)
+    end
+end
+
+function surface_params(case::DYCOMS_RF01, surf_ref_state, param_set; Ri_bulk_crit)
+    FT = eltype(surf_ref_state)
+    zrough::FT = 1.0e-4
+    ustar::FT = 0.28 # just to initialize grid mean covariances
+    shf::FT = 15.0 # sensible heat flux
+    lhf::FT = 115.0 # latent heat flux
+    Tsurface::FT = 292.5    # K      # i.e. the SST from DYCOMS setup
+    qsurface::FT = 13.84e-3 # kg/kg  # TODO - taken from Pycles, maybe it would be better to calculate the q_star(sst) for TurbulenceConvection?
+    #density_surface  = 1.22     # kg/m^3
+
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
+end
+
+function initialize_forcing(::DYCOMS_RF01, forcing, grid::Grid, state, param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    FT = TC.float_type(state)
+
+    # geostrophic velocity profiles
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, FT(7), FT(-5.5))
+
+    # large scale subsidence
+    divergence = forcing.divergence
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.subsidence[k] = -grid.zc[k].z * divergence
+    end
+
+    # no large-scale drying
+    parent(aux_gm.dqtdt_hadv) .= 0 #kg/(kg * s)
+end
+
+function RadiationBase(case::DYCOMS_RF01, FT)
+    return RadiationBase{Cases.get_radiation_type(case), FT}(;
+        divergence = large_scale_divergence(case),
+        alpha_z = 1.0,
+        kappa = 85.0,
+        F0 = 70.0,
+        F1 = 22.0,
+    )
+end
+
+function initialize_radiation(::DYCOMS_RF01, radiation, grid::Grid, state, param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+
+    # no large-scale drying
+    parent(aux_gm.dqtdt_rad) .= 0 #kg/(kg * s)
+
+    # Radiation based on eq. 3 in Stevens et. al., (2005)
+    # cloud-top cooling + cloud-base warming + cooling in free troposphere
+    update_radiation(radiation, grid, state, 0, param_set)
+end
+
+#####
+##### DYCOMS_RF02
+#####
+
+function surface_ref_state(::DYCOMS_RF02, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1017.8 * 100.0
+    qtg::FT = 9.0 / 1000.0
+    θ_surf::FT = 288.3
+    ts = TD.PhaseEquil_pθq(thermo_params, Pg, θ_surf, qtg)
+    Tg = TD.air_temperature(thermo_params, ts)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::DYCOMS_RF02, grid::Grid, param_set, state; kwargs...)
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+
+    prof_u = APL.Dycoms_RF02_u(FT)
+    prof_v = APL.Dycoms_RF02_v(FT)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    p = aux_gm.p
+    ρ_c = prog_gm.ρ
+    @inbounds for k in real_center_indices(grid)
+        # θ_liq_ice profile as defined in DYCOM RF02
+        z = grid.zc[k].z
+        aux_gm.q_tot[k] = APL.Dycoms_RF02_q_tot(FT)(z)
+        aux_gm.θ_liq_ice[k] = APL.Dycoms_RF02_θ_liq_ice(FT)(z)
+
+        # velocity profile
+        aux_gm.tke[k] = APL.Dycoms_RF02_tke(FT)(z)
+    end
+end
+
+function surface_params(case::DYCOMS_RF02, surf_ref_state, param_set; Ri_bulk_crit)
+    FT = eltype(surf_ref_state)
+    zrough::FT = 1.0e-4  #TODO - not needed?
+    ustar::FT = 0.25
+    shf::FT = 16.0 # sensible heat flux
+    lhf::FT = 93.0 # latent heat flux
+    Tsurface::FT = 292.5    # K      # i.e. the SST from DYCOMS setup
+    qsurface::FT = 13.84e-3 # kg/kg  # TODO - taken from Pycles, maybe it would be better to calculate the q_star(sst) for TurbulenceConvection?
+
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+function initialize_forcing(::DYCOMS_RF02, forcing, grid::Grid, state, param_set)
+    FT = TC.float_type(state)
+    # the same as in DYCOMS_RF01
+    aux_gm = TC.center_aux_grid_mean(state)
+
+    # geostrophic velocity profiles
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, FT(5), FT(-5.5))
+
+    # large scale subsidence
+    divergence = forcing.divergence
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.subsidence[k] = -grid.zc[k].z * divergence
+    end
+
+    # no large-scale drying
+    parent(aux_gm.dqtdt_hadv) .= 0 #kg/(kg * s)
+end
+
+function RadiationBase(case::DYCOMS_RF02, FT)
+    return RadiationBase{Cases.get_radiation_type(case), FT}(;
+        divergence = large_scale_divergence(case),
+        alpha_z = 1.0,
+        kappa = 85.0,
+        F0 = 70.0,
+        F1 = 22.0,
+    )
+end
+
+function initialize_radiation(::DYCOMS_RF02, radiation, grid::Grid, state, param_set)
+    # the same as in DYCOMS_RF01
+    aux_gm = TC.center_aux_grid_mean(state)
+
+    # no large-scale drying
+    parent(aux_gm.dqtdt_rad) .= 0 #kg/(kg * s)
+
+    # Radiation based on eq. 3 in Stevens et. al., (2005)
+    # cloud-top cooling + cloud-base warming + cooling in free troposphere
+    update_radiation(radiation, grid, state, 0, param_set)
+end
+
+#####
+##### GABLS
+#####
+
+function surface_ref_state(::GABLS, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1.0e5  #Pressure at ground,
+    Tg::FT = 265.0  #Temperature at ground,
+    qtg::FT = 0.0
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+function initialize_profiles(::GABLS, grid::Grid, param_set, state; kwargs...)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    FT = TC.float_type(state)
+
+    prof_u = APL.GABLS_u(FT)
+    prof_v = APL.GABLS_v(FT)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, prof_u, prof_v)
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        #Set wind velocity profile
+        aux_gm.θ_liq_ice[k] = APL.GABLS_θ_liq_ice(FT)(z)
+        aux_gm.q_tot[k] = APL.GABLS_q_tot(FT)(z)
+        aux_gm.tke[k] = APL.GABLS_tke(FT)(z)
+        aux_gm.Hvar[k] = aux_gm.tke[k]
+    end
+end
+
+function surface_params(case::GABLS, surf_ref_state, param_set; kwargs...)
+    FT = eltype(surf_ref_state)
+    Tsurface = t -> 265 - (FT(0.25) / 3600) * t
+    qsurface::FT = 0.0
+    zrough::FT = 0.1
+
+    kwargs = (; Tsurface, qsurface, zrough, kwargs...)
+    return TC.MoninObukhovSurface(FT; kwargs...)
+end
+
+function initialize_forcing(::GABLS, forcing, grid::Grid, state, param_set)
+    FT = TC.float_type(state)
+    initialize(forcing, grid, state)
+    aux_gm = TC.center_aux_grid_mean(state)
+
+    prof_ug = APL.GABLS_geostrophic_ug(FT)
+    prof_vg = APL.GABLS_geostrophic_vg(FT)
+
+    # Geostrophic velocity profiles.
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    TC.set_z!(aux_gm_uₕ_g, prof_ug, prof_vg)
+    return nothing
+end
+
+#####
+##### DryBubble
+#####
+
+function surface_ref_state(::DryBubble, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    Pg::FT = 1.0e5  #Pressure at ground
+    Tg::FT = 296.0
+    qtg::FT = 1.0e-5
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::DryBubble, grid::Grid, param_set, state; kwargs...)
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    TC.set_z!(prog_gm_uₕ, FT(0.01), FT(0))
+
+    # initialize Grid Mean Profiles of thetali and qt
+    zc_in = grid.zc.z
+    prof_θ_liq_ice = APL.DryBubble_θ_liq_ice(FT)
+    aux_gm.θ_liq_ice .= prof_θ_liq_ice.(zc_in)
+    parent(prog_gm.ρq_tot) .= 0
+    parent(aux_gm.q_tot) .= 0
+    parent(aux_gm.tke) .= 0
+    parent(aux_gm.Hvar) .= 0
+    parent(aux_gm.QTvar) .= 0
+    parent(aux_gm.HQTcov) .= 0
+end
+
+function surface_params(case::DryBubble, surf_ref_state, param_set; Ri_bulk_crit)
+    FT = eltype(surf_ref_state)
+    Tsurface::FT = 300.0
+    qsurface::FT = 0.0
+    shf::FT = 0.0001 # only prevent zero division in SF.jl lmo
+    lhf::FT = 0.0001 # only prevent zero division in SF.jl lmo
+    ustar::FT = 0.1
+
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
+end
+
+#####
+##### LES_driven_SCM
+#####
+
+function forcing_kwargs(::LES_driven_SCM, namelist)
+    coriolis_param = namelist["forcing"]["coriolis"]
+    les_filename = namelist["meta"]["lesfile"]
+    cfsite_number, forcing_model, month, experiment = TC.parse_les_path(les_filename)
+    LES_library = TC.get_LES_library()
+    les_type = LES_library[forcing_model][string(month, pad = 2)]["cfsite_numbers"][string(cfsite_number, pad = 2)]
+    if les_type == "shallow"
+        wind_nudge_τᵣ = 6.0 * 3600.0
+        scalar_nudge_zᵢ = 3000.0
+        scalar_nudge_zᵣ = 3500.0
+        scalar_nudge_τᵣ = 24.0 * 3600.0
+    elseif les_type == "deep"
+        wind_nudge_τᵣ = 3600.0
+        scalar_nudge_zᵢ = 16000.0
+        scalar_nudge_zᵣ = 20000.0
+        scalar_nudge_τᵣ = 2.0 * 3600.0
+    end
+
+    return (; wind_nudge_τᵣ, scalar_nudge_zᵢ, scalar_nudge_zᵣ, scalar_nudge_τᵣ, coriolis_param)
+end
+
+function les_data_kwarg(::LES_driven_SCM, namelist)
+    les_filename = namelist["meta"]["lesfile"]
+    # load data here
+    LESDat = NC.Dataset(les_filename, "r") do data
+        t = data.group["profiles"]["t"][:]
+        t_interval_from_end_s = namelist["t_interval_from_end_s"]
+        t_from_end_s = t .- t[end]
+        # find inds within time interval
+        time_interval_bool = findall(>(-t_interval_from_end_s), t_from_end_s)
+        imin = time_interval_bool[1]
+        imax = time_interval_bool[end]
+
+        LESData(imin, imax, les_filename, t_interval_from_end_s, namelist["initial_condition_averaging_window_s"])
+    end
+    return (; LESDat)
+end
+
+function surface_ref_state(::LES_driven_SCM, param_set::APS, namelist)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = eltype(param_set)
+    les_filename = namelist["meta"]["lesfile"]
+
+    Pg, Tg, qtg = NC.Dataset(les_filename, "r") do data
+        pg_str = haskey(data.group["reference"], "p0_full") ? "p0_full" : "p0"
+        Pg = data.group["reference"][pg_str][1] #Pressure at ground
+        Tg = data.group["reference"]["temperature0"][1] #Temperature at ground
+        ql_ground = data.group["reference"]["ql0"][1]
+        qv_ground = data.group["reference"]["qv0"][1]
+        qi_ground = data.group["reference"]["qi0"][1]
+        qtg = ql_ground + qv_ground + qi_ground #Total water mixing ratio at surface
+        (FT(Pg), FT(Tg), FT(qtg))
+    end
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
+end
+
+function initialize_profiles(::LES_driven_SCM, grid::Grid, param_set, state; LESDat)
+
+    FT = TC.float_type(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+
+    nt = NC.Dataset(LESDat.les_filename, "r") do data
+        t = data.group["profiles"]["t"][:]
+        # define time interval
+        half_window = LESDat.initial_condition_averaging_window_s / 2
+        t_window_start = (LESDat.t_interval_from_end_s + half_window)
+        t_window_end = (LESDat.t_interval_from_end_s - half_window)
+        t_from_end_s = Array(t) .- t[end]
+        # find inds within time interval
+        in_window(x) = -t_window_start <= x <= -t_window_end
+        time_interval_bool = findall(in_window, t_from_end_s)
+        imin = time_interval_bool[1]
+        imax = time_interval_bool[end]
+        zc_les = Array(TC.get_nc_data(data, "zc"))
+
+        getvar(var) = pyinterp(vec(grid.zc.z), zc_les, TC.mean_nc_data(data, "profiles", var, imin, imax))
+
+        θ_liq_ice_gm = getvar("thetali_mean")
+        q_tot_gm = getvar("qt_mean")
+        prog_gm_u_gm = getvar("u_mean")
+        prog_gm_v_gm = getvar("v_mean")
+        (; zc_les, θ_liq_ice_gm, q_tot_gm, prog_gm_u_gm, prog_gm_v_gm)
+    end
+
+    prog_gm_u = copy(aux_gm.q_tot)
+    prog_gm_v = copy(aux_gm.q_tot)
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.θ_liq_ice[k] = nt.θ_liq_ice_gm[k.i]
+        aux_gm.q_tot[k] = nt.q_tot_gm[k.i]
+        prog_gm_u[k] = nt.prog_gm_u_gm[k.i]
+        prog_gm_v[k] = nt.prog_gm_v_gm[k.i]
+    end
+
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    @. prog_gm_uₕ = CCG.Covariant12Vector(CCG.UVVector(prog_gm_u, prog_gm_v))
+
+    @inbounds for k in real_center_indices(grid)
+        z = grid.zc[k].z
+        aux_gm.tke[k] = if z <= 2500.0
+            1 - z / 3000
+        else
+            FT(0)
+        end
+    end
+end
+
+function surface_params(case::LES_driven_SCM, surf_ref_state, param_set; Ri_bulk_crit, LESDat)
+    FT = eltype(surf_ref_state)
+    nt = NC.Dataset(LESDat.les_filename, "r") do data
+        imin = LESDat.imin
+        imax = LESDat.imax
+
+        zrough = FT(1.0e-4)
+        Tsurface = Statistics.mean(data.group["timeseries"]["surface_temperature"][:][imin:imax], dims = 1)[1]
+        # get surface value of q
+        mean_qt_prof = Statistics.mean(data.group["profiles"]["qt_mean"][:][:, imin:imax], dims = 2)[:]
+        # TODO: this will need to be changed if/when we don't prescribe surface fluxes
+        qsurface = FT(0)
+        lhf = FT(Statistics.mean(data.group["timeseries"]["lhf_surface_mean"][:][imin:imax], dims = 1)[1])
+        shf = FT(Statistics.mean(data.group["timeseries"]["shf_surface_mean"][:][imin:imax], dims = 1)[1])
+        (; zrough, Tsurface, qsurface, lhf, shf)
+    end
+    UnPack.@unpack zrough, Tsurface, qsurface, lhf, shf = nt
+
+    ustar = FT(0) # TODO: why is initialization missing?
+    kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
+    return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
+end
+
+initialize_forcing(::LES_driven_SCM, forcing, grid::Grid, state, param_set; LESDat) =
+    initialize(forcing, grid, state, LESDat)
+
+initialize_radiation(::LES_driven_SCM, radiation, grid::Grid, state, param_set; LESDat) =
+    initialize(radiation, grid, state, LESDat)
+
+end # module Cases

--- a/tc_driver/Forcing.jl
+++ b/tc_driver/Forcing.jl
@@ -1,0 +1,34 @@
+initialize(::ForcingBase, grid, state) = nothing
+
+function initialize(::ForcingBase{ForcingLES}, grid, state, LESDat::LESData)
+    aux_gm = TC.center_aux_grid_mean(state)
+    nt = NC.Dataset(LESDat.les_filename, "r") do data
+        imin = LESDat.imin
+        imax = LESDat.imax
+
+        zc_les = Array(TC.get_nc_data(data, "zc"))
+        getvar(var) = TC.pyinterp(vec(grid.zc.z), zc_les, TC.mean_nc_data(data, "profiles", var, imin, imax))
+
+        dTdt_hadv = getvar("dtdt_hadv")
+        T_nudge = getvar("temperature_mean")
+        dTdt_fluc = getvar("dtdt_fluc")
+        dqtdt_hadv = getvar("dqtdt_hadv")
+        qt_nudge = getvar("qt_mean")
+        dqtdt_fluc = getvar("dqtdt_fluc")
+        subsidence = getvar("ls_subsidence")
+        u_nudge = getvar("u_mean")
+        v_nudge = getvar("v_mean")
+        (; dTdt_hadv, T_nudge, dTdt_fluc, dqtdt_hadv, qt_nudge, dqtdt_fluc, subsidence, u_nudge, v_nudge)
+    end
+    for k in TC.real_center_indices(grid)
+        aux_gm.dTdt_hadv[k] = nt.dTdt_hadv[k]
+        aux_gm.T_nudge[k] = nt.T_nudge[k]
+        aux_gm.dTdt_fluc[k] = nt.dTdt_fluc[k]
+        aux_gm.dqtdt_hadv[k] = nt.dqtdt_hadv[k]
+        aux_gm.qt_nudge[k] = nt.qt_nudge[k]
+        aux_gm.dqtdt_fluc[k] = nt.dqtdt_fluc[k]
+        aux_gm.subsidence[k] = nt.subsidence[k]
+        aux_gm.u_nudge[k] = nt.u_nudge[k]
+        aux_gm.v_nudge[k] = nt.v_nudge[k]
+    end
+end

--- a/tc_driver/NetCDFIO.jl
+++ b/tc_driver/NetCDFIO.jl
@@ -1,0 +1,178 @@
+import NCDatasets
+const NC = NCDatasets
+import JSON
+import TurbulenceConvection
+const TC = TurbulenceConvection
+
+# TODO: remove `vars` hack that avoids https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+
+function nc_fileinfo(namelist)
+
+    uuid = string(namelist["meta"]["uuid"])
+    simname = namelist["meta"]["simname"]
+    outpath = joinpath(namelist["output"]["output_root"], "Output.$simname.$uuid")
+    @info "Output folder: `$outpath`"
+    mkpath(outpath)
+
+    nc_filename = joinpath(outpath, namelist["stats_io"]["stats_dir"])
+    mkpath(nc_filename)
+    @info "NC filename path: `$nc_filename`"
+
+    nc_filename = joinpath(nc_filename, "Stats.$simname.nc")
+    @info "NC filename: `$nc_filename`"
+    return nc_filename, outpath
+end
+
+mutable struct NetCDFIO_Stats{FT}
+    root_grp::NC.NCDataset{Nothing}
+    profiles_grp::NC.NCDataset{NC.NCDataset{Nothing}}
+    ts_grp::NC.NCDataset{NC.NCDataset{Nothing}}
+    frequency::FT
+    nc_filename::String
+    vars::Dict{String, Any} # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+end
+
+# Convenience backward compatible outer constructor
+function NetCDFIO_Stats(nc_filename, frequency, grid::TC.Grid)
+    NetCDFIO_Stats(; nc_filename, frequency, z_faces = vec(grid.zf.z), z_centers = vec(grid.zc.z))
+end
+
+function NetCDFIO_Stats(; nc_filename, frequency, z_faces, z_centers)
+    # Initialize properties with valid type:
+    tmp = tempname()
+    root_grp = NC.Dataset(tmp, "c")
+    NC.defGroup(root_grp, "profiles")
+    NC.defGroup(root_grp, "timeseries")
+    profiles_grp = root_grp.group["profiles"]
+    ts_grp = root_grp.group["timeseries"]
+    close(root_grp)
+    FT = eltype(z_faces)
+
+    # Remove the NC file if it exists, in case it accidentally wasn't closed
+    isfile(nc_filename) && rm(nc_filename; force = true)
+
+    NC.Dataset(nc_filename, "c") do root_grp
+        # Set profile dimensions
+        profile_grp = NC.defGroup(root_grp, "profiles")
+        NC.defDim(profile_grp, "zf", length(z_faces))
+        NC.defDim(profile_grp, "zc", length(z_centers))
+        NC.defDim(profile_grp, "t", Inf)
+        NC.defVar(profile_grp, "zf", z_faces, ("zf",))
+        NC.defVar(profile_grp, "zc", z_centers, ("zc",))
+        NC.defVar(profile_grp, "t", FT, ("t",))
+
+        reference_grp = NC.defGroup(root_grp, "reference")
+        NC.defDim(reference_grp, "zf", length(z_faces))
+        NC.defDim(reference_grp, "zc", length(z_centers))
+        NC.defVar(reference_grp, "zf", z_faces, ("zf",))
+        NC.defVar(reference_grp, "zc", z_centers, ("zc",))
+
+        ts_grp = NC.defGroup(root_grp, "timeseries")
+        NC.defDim(ts_grp, "t", Inf)
+        NC.defVar(ts_grp, "t", FT, ("t",))
+    end
+    vars = Dict{String, Any}()
+    return NetCDFIO_Stats{FT}(root_grp, profiles_grp, ts_grp, frequency, nc_filename, vars)
+end
+
+
+function open_files(self::NetCDFIO_Stats)
+    self.root_grp = NC.Dataset(self.nc_filename, "a")
+    self.profiles_grp = self.root_grp.group["profiles"]
+    self.ts_grp = self.root_grp.group["timeseries"]
+    vars = self.vars
+
+    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+    vars["profiles"] = Dict{String, Any}()
+    for k in keys(self.profiles_grp)
+        vars["profiles"][k] = self.profiles_grp[k]
+    end
+    vars["timeseries"] = Dict{String, Any}()
+    for k in keys(self.ts_grp)
+        vars["timeseries"][k] = self.ts_grp[k]
+    end
+end
+
+function close_files(self::NetCDFIO_Stats)
+    close(self.root_grp)
+end
+
+#####
+##### Generic field
+#####
+
+function add_field(ds, var_name::String, dims, group, ::Type{FT}) where {FT <: AbstractFloat}
+    profile_grp = ds.group[group]
+    new_var = NC.defVar(profile_grp, var_name, FT, dims)
+    return nothing
+end
+
+#####
+##### Time-series data
+#####
+
+function add_ts(ds, var_name::String, ::Type{FT}) where {FT <: AbstractFloat}
+    ts_grp = ds.group["timeseries"]
+    new_var = NC.defVar(ts_grp, var_name, FT, ("t",))
+    return nothing
+end
+
+#####
+##### Performance critical IO
+#####
+
+write_field(
+    self::NetCDFIO_Stats,
+    var_name::String,
+    data::T,
+    group,
+) where {FT <: ForwardDiff.Dual, T <: AbstractArray{FT}} = write_field(self, var_name, ForwardDiff.value.(data), group)
+function write_field(
+    self::NetCDFIO_Stats,
+    var_name::String,
+    data::T,
+    group,
+) where {FT <: AbstractFloat, T <: AbstractArray{FT, 1}}
+    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+    @inbounds self.vars[group][var_name][:, end] = data
+    # Ideally, we remove self.vars and use:
+    # var = self.profiles_grp[var_name]
+    # Not sure why `end` instead of `end+1`, but `end+1` produces garbage output
+    # @inbounds var[end, :] = data :: T
+end
+
+add_write_field(ds, var_name::String, data::T, args...) where {FT <: ForwardDiff.Dual, T <: AbstractArray{FT}} =
+    add_write_field(ds, var_name, ForwardDiff.value.(data), args...)
+function add_write_field(
+    ds,
+    var_name::String,
+    data::T,
+    group,
+    dims,
+) where {FT <: AbstractFloat, T <: AbstractArray{FT, 1}}
+    grp = ds.group[group]
+    NC.defVar(grp, var_name, FT, dims)
+    var = grp[var_name]
+    var .= data::T
+    return nothing
+end
+
+write_ts(self, var_name, data::ForwardDiff.Dual) = write_ts(self, var_name, ForwardDiff.value(data))
+function write_ts(self::NetCDFIO_Stats, var_name::String, data::FT) where {FT <: AbstractFloat}
+    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+    @inbounds self.vars["timeseries"][var_name][end] = data::FT
+    # Ideally, we remove self.vars and use:
+    # var = self.ts_grp[var_name]
+    # @inbounds var[end+1] = data :: FT
+end
+
+write_simulation_time(self, t::ForwardDiff.Dual) = write_simulation_time(self, ForwardDiff.value(t))
+function write_simulation_time(self::NetCDFIO_Stats, t::FT) where {FT <: AbstractFloat}
+    # # Write to profiles group
+    profile_t = self.profiles_grp["t"]
+    @inbounds profile_t[end + 1] = t::FT
+
+    # # Write to timeseries group
+    ts_t = self.ts_grp["t"]
+    @inbounds ts_t[end + 1] = t::FT
+end

--- a/tc_driver/NetCDFIO.jl
+++ b/tc_driver/NetCDFIO.jl
@@ -1,7 +1,7 @@
 import NCDatasets
 const NC = NCDatasets
 import JSON
-import TurbulenceConvection
+import ClimaAtmos.TurbulenceConvection
 const TC = TurbulenceConvection
 
 # TODO: remove `vars` hack that avoids https://github.com/Alexander-Barth/NCDatasets.jl/issues/135

--- a/tc_driver/Radiation.jl
+++ b/tc_driver/Radiation.jl
@@ -1,0 +1,105 @@
+update_radiation(self::RadiationBase, grid, state, t::Real, param_set) = nothing
+initialize(self::RadiationBase{RadiationNone}, grid, state) = nothing
+
+"""
+see eq. 3 in Stevens et. al. 2005 DYCOMS paper
+"""
+function update_radiation(self::RadiationBase{RadiationDYCOMS_RF01}, grid, state, t::Real, param_set)
+    cp_d = TCP.cp_d(param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    q_tot_f = TC.face_aux_turbconv(state).ϕ_temporary
+    ρ_f = aux_gm_f.ρ
+    ρ_c = prog_gm.ρ
+    # find zi (level of 8.0 g/kg isoline of qt)
+    # TODO: report bug: zi and ρ_i are not initialized
+    FT = TC.float_type(state)
+    zi = FT(0)
+    ρ_i = FT(0)
+    kc_surf = TC.kc_surface(grid)
+    q_tot_surf = aux_gm.q_tot[kc_surf]
+    If = CCO.InterpolateC2F(; bottom = CCO.SetValue(q_tot_surf), top = CCO.Extrapolate())
+    @. q_tot_f .= If(aux_gm.q_tot)
+    @inbounds for k in TC.real_face_indices(grid)
+        if (q_tot_f[k] < 8.0 / 1000)
+            idx_zi = k
+            # will be used at cell faces
+            zi = grid.zf[k].z
+            ρ_i = ρ_f[k]
+            break
+        end
+    end
+
+    ρ_z = Dierckx.Spline1D(vec(grid.zc.z), vec(ρ_c); k = 1)
+    q_liq_z = Dierckx.Spline1D(vec(grid.zc.z), vec(aux_gm.q_liq); k = 1)
+
+    integrand(ρq_l, params, z) = params.κ * ρ_z(z) * q_liq_z(z)
+    rintegrand(ρq_l, params, z) = -integrand(ρq_l, params, z)
+
+    z_span = (grid.zmin, grid.zmax)
+    rz_span = (grid.zmax, grid.zmin)
+    params = (; κ = self.kappa)
+
+    Δz = TC.get_Δz(prog_gm.ρ)[1]
+    rprob = ODE.ODEProblem(rintegrand, 0.0, rz_span, params; dt = Δz)
+    rsol = ODE.solve(rprob, ODE.Tsit5(), reltol = 1e-12, abstol = 1e-12)
+    q_0 = rsol.(vec(grid.zf.z))
+
+    prob = ODE.ODEProblem(integrand, 0.0, z_span, params; dt = Δz)
+    sol = ODE.solve(prob, ODE.Tsit5(), reltol = 1e-12, abstol = 1e-12)
+    q_1 = sol.(vec(grid.zf.z))
+    parent(aux_gm_f.f_rad) .= self.F0 .* exp.(-q_0)
+    parent(aux_gm_f.f_rad) .+= self.F1 .* exp.(-q_1)
+
+    # cooling in free troposphere
+    @inbounds for k in TC.real_face_indices(grid)
+        if grid.zf[k].z > zi
+            cbrt_z = cbrt(grid.zf[k].z - zi)
+            aux_gm_f.f_rad[k] += ρ_i * cp_d * self.divergence * self.alpha_z * (cbrt_z^4 / 4 + zi * cbrt_z)
+        end
+    end
+
+    ∇c = CCO.DivergenceF2C()
+    wvec = CC.Geometry.WVector
+    @. aux_gm.dTdt_rad = -∇c(wvec(aux_gm_f.f_rad)) / ρ_c / cp_d
+
+    return
+end
+
+function initialize(self::RadiationBase{RadiationLES}, grid, state, LESDat::LESData)
+    # load from LES
+    aux_gm = TC.center_aux_grid_mean(state)
+    dTdt = NC.Dataset(LESDat.les_filename, "r") do data
+        imin = LESDat.imin
+        imax = LESDat.imax
+
+        # interpolate here
+        zc_les = Array(TC.get_nc_data(data, "zc"))
+        meandata = TC.mean_nc_data(data, "profiles", "dtdt_rad", imin, imax)
+        pyinterp(vec(grid.zc.z), zc_les, meandata)
+    end
+    @inbounds for k in TC.real_center_indices(grid)
+        aux_gm.dTdt_rad[k] = dTdt[k]
+    end
+    return
+end
+
+
+function initialize(self::RadiationBase{RadiationTRMM_LBA}, grid, state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    rad = APL.TRMM_LBA_radiation(eltype(grid))
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.dTdt_rad[k] = rad(0, grid.zc[k].z)
+    end
+    return nothing
+end
+
+function update_radiation(self::RadiationBase{RadiationTRMM_LBA}, grid, state, t::Real, param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    rad = APL.TRMM_LBA_radiation(eltype(grid))
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.dTdt_rad[k] = rad(t, grid.zc[k].z)
+    end
+    return nothing
+end

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -1,0 +1,193 @@
+import StaticArrays as SA
+import SurfaceFluxes as SF
+import SurfaceFluxes.UniversalFunctions as UF
+
+function get_surface(
+    surf_params::TC.FixedSurfaceFlux,
+    grid::TC.Grid,
+    state::TC.State,
+    t::Real,
+    param_set::TCP.AbstractTurbulenceConvectionParameters,
+)
+    FT = TC.float_type(state)
+    surf_flux_params = TCP.surface_fluxes_params(param_set)
+    kc_surf = TC.kc_surface(grid)
+    kf_surf = TC.kf_surface(grid)
+    z_sfc = FT(0)
+    z_in = grid.zc[kc_surf].z
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    p_f_surf = aux_gm_f.p[kf_surf]
+    Tsurface = TC.surface_temperature(surf_params, t)
+    qsurface = TC.surface_q_tot(surf_params, t)
+    shf = TC.sensible_heat_flux(surf_params, t)
+    lhf = TC.latent_heat_flux(surf_params, t)
+    Ri_bulk_crit = surf_params.Ri_bulk_crit
+    zrough = surf_params.zrough
+    thermo_params = TCP.thermodynamics_params(param_set)
+
+    ts_sfc = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    ts_in = aux_gm.ts[kc_surf]
+    scheme = SF.FVScheme()
+
+    bflux = SF.compute_buoyancy_flux(surf_flux_params, shf, lhf, ts_in, ts_sfc, scheme)
+    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    convective_vel = TC.get_wstar(bflux, zi) # yair here zi in TRMM should be adjusted
+
+    u_sfc = SA.SVector{2, FT}(0, 0)
+    # TODO: make correct with topography
+    uₕ_gm_surf = TC.physical_grid_mean_uₕ(state)[kc_surf]
+    u_in = SA.SVector{2, FT}(uₕ_gm_surf.u, uₕ_gm_surf.v)
+    vals_sfc = SF.SurfaceValues(z_sfc, u_sfc, ts_sfc)
+    vals_int = SF.InteriorValues(z_in, u_in, ts_in)
+    kwargs = (;
+        state_in = vals_int,
+        state_sfc = vals_sfc,
+        shf = shf,
+        lhf = lhf,
+        z0m = zrough,
+        z0b = zrough,
+        gustiness = convective_vel,
+    )
+    sc = if TC.fixed_ustar(surf_params)
+        SF.FluxesAndFrictionVelocity{FT}(; kwargs..., ustar = surf_params.ustar)
+    else
+        SF.Fluxes{FT}(; kwargs...)
+    end
+    result = SF.surface_conditions(surf_flux_params, sc, scheme)
+    return TC.SurfaceBase{FT}(;
+        shf = shf,
+        lhf = lhf,
+        ustar = TC.fixed_ustar(surf_params) ? surf_params.ustar : result.ustar,
+        bflux = bflux,
+        obukhov_length = result.L_MO,
+        cm = result.Cd,
+        ch = result.Ch,
+        ρu_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτxz,
+        ρv_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτyz,
+        ρe_tot_flux = shf + lhf,
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
+        wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
+    )
+end
+
+function get_surface(
+    surf_params::TC.FixedSurfaceCoeffs,
+    grid::TC.Grid,
+    state::TC.State,
+    t::Real,
+    param_set::TCP.AbstractTurbulenceConvectionParameters,
+)
+    FT = TC.float_type(state)
+    surf_flux_params = TCP.surface_fluxes_params(param_set)
+    kc_surf = TC.kc_surface(grid)
+    kf_surf = TC.kf_surface(grid)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    Tsurface = TC.surface_temperature(surf_params, t)
+    qsurface = TC.surface_q_tot(surf_params, t)
+    p_f_surf = aux_gm_f.p[kf_surf]
+    zrough = surf_params.zrough
+    zc_surf = grid.zc[kc_surf].z
+    cm = surf_params.cm(zc_surf)
+    ch = surf_params.ch(zc_surf)
+    Ri_bulk_crit = surf_params.Ri_bulk_crit
+    thermo_params = TCP.thermodynamics_params(param_set)
+
+    scheme = SF.FVScheme()
+    z_sfc = FT(0)
+    z_in = grid.zc[kc_surf].z
+    ts_sfc = TD.PhaseEquil_pθq(thermo_params, p_f_surf, Tsurface, qsurface)
+    ts_in = aux_gm.ts[kc_surf]
+    u_sfc = SA.SVector{2, FT}(0, 0)
+    # TODO: make correct with topography
+    uₕ_gm_surf = TC.physical_grid_mean_uₕ(state)[kc_surf]
+    u_in = SA.SVector{2, FT}(uₕ_gm_surf.u, uₕ_gm_surf.v)
+    vals_sfc = SF.SurfaceValues(z_sfc, u_sfc, ts_sfc)
+    vals_int = SF.InteriorValues(z_in, u_in, ts_in)
+    sc = SF.Coefficients{FT}(state_in = vals_int, state_sfc = vals_sfc, Cd = cm, Ch = ch, z0m = zrough, z0b = zrough)
+    result = SF.surface_conditions(surf_flux_params, sc, scheme)
+    lhf = result.lhf
+    shf = result.shf
+
+    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    convective_vel = TC.get_wstar(result.buoy_flux, zi)
+    return TC.SurfaceBase{FT}(;
+        cm = result.Cd,
+        ch = result.Ch,
+        obukhov_length = result.L_MO,
+        lhf = lhf,
+        shf = shf,
+        ustar = result.ustar,
+        ρu_flux = result.ρτxz,
+        ρv_flux = result.ρτyz,
+        ρe_tot_flux = shf + lhf,
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
+        bflux = result.buoy_flux,
+        wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
+    )
+end
+
+function get_surface(
+    surf_params::TC.MoninObukhovSurface,
+    grid::TC.Grid,
+    state::TC.State,
+    t::Real,
+    param_set::TCP.AbstractTurbulenceConvectionParameters,
+)
+    surf_flux_params = TCP.surface_fluxes_params(param_set)
+    kc_surf = TC.kc_surface(grid)
+    kf_surf = TC.kf_surface(grid)
+    FT = TC.float_type(state)
+    z_sfc = FT(0)
+    z_in = grid.zc[kc_surf].z
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    p_f_surf = aux_gm_f.p[kf_surf]
+    ts_gm = aux_gm.ts
+    Tsurface = TC.surface_temperature(surf_params, t)
+    qsurface = TC.surface_q_tot(surf_params, t)
+    zrough = surf_params.zrough
+    Ri_bulk_crit = surf_params.Ri_bulk_crit
+    thermo_params = TCP.thermodynamics_params(param_set)
+
+    scheme = SF.FVScheme()
+    ts_sfc = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    ts_in = ts_gm[kc_surf]
+
+    u_sfc = SA.SVector{2, FT}(0, 0)
+    # TODO: make correct with topography
+    uₕ_gm_surf = TC.physical_grid_mean_uₕ(state)[kc_surf]
+    u_in = SA.SVector{2, FT}(uₕ_gm_surf.u, uₕ_gm_surf.v)
+    vals_sfc = SF.SurfaceValues(z_sfc, u_sfc, ts_sfc)
+    vals_int = SF.InteriorValues(z_in, u_in, ts_in)
+    sc = SF.ValuesOnly{FT}(state_in = vals_int, state_sfc = vals_sfc, z0m = zrough, z0b = zrough)
+    result = SF.surface_conditions(surf_flux_params, sc, scheme)
+    lhf = result.lhf
+    shf = result.shf
+    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    convective_vel = TC.get_wstar(result.buoy_flux, zi)
+    return TC.SurfaceBase{FT}(;
+        cm = result.Cd,
+        ch = result.Ch,
+        obukhov_length = result.L_MO,
+        lhf = lhf,
+        shf = shf,
+        ustar = result.ustar,
+        ρu_flux = result.ρτxz,
+        ρv_flux = result.ρτyz,
+        ρe_tot_flux = shf + lhf,
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
+        bflux = result.buoy_flux,
+        wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
+    )
+end

--- a/tc_driver/TimeStepping.jl
+++ b/tc_driver/TimeStepping.jl
@@ -1,0 +1,25 @@
+mutable struct TimeStepping{FT}
+    dt::FT
+    t_max::FT
+    t::FT
+    nstep::Int
+    cfl_limit::FT
+    dt_max::FT
+    dt_max_edmf::FT
+    dt_io::FT
+end
+
+function TimeStepping(::Type{FT}, namelist) where {FT}
+    dt = TC.parse_namelist(namelist, "time_stepping", "dt_min"; default = FT(1.0))
+    t_max = TC.parse_namelist(namelist, "time_stepping", "t_max"; default = FT(7200.0))
+    cfl_limit = TC.parse_namelist(namelist, "time_stepping", "cfl_limit"; default = FT(0.5))
+    dt_max = TC.parse_namelist(namelist, "time_stepping", "dt_max"; default = FT(10.0))
+    dt_max_edmf = FT(0)
+
+    # set time
+    t = FT(0)
+    dt_io = FT(0)
+    nstep = 0
+
+    return TimeStepping{FT}(dt, t_max, t, nstep, cfl_limit, dt_max, dt_max_edmf, dt_io)
+end

--- a/tc_driver/artifact_funcs.jl
+++ b/tc_driver/artifact_funcs.jl
@@ -1,0 +1,59 @@
+#! format: off
+
+import ArtifactWrappers
+const AW = ArtifactWrappers
+
+function pycles_output_dataset_folder(lazy_download = true)
+    PyCLES_output_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        lazy_download,
+        "PyCLES_output",
+        AW.ArtifactFile[
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc", filename = "DYCOMS_RF01.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/dgie1774uw5ot8mmrmp46nauhb3ervgp.nc", filename = "DYCOMS_RF02.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/ivo4751camlph6u3k68ftmb1dl4z7uox.nc", filename = "TRMM_LBA.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/4osqp0jpt4cny8fq2ukimgfnyi787vsy.nc", filename = "ARM_SGP.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/jci8l11qetlioab4cxf5myr1r492prk6.nc", filename = "Bomex.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/pzuu6ii99by2s356ij69v5cb615200jq.nc", filename = "Soares.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/7upt639siyc2umon8gs6qsjiqavof5cq.nc", filename = "Nieuwstadt.nc",),
+        ],
+    )
+    return AW.get_data_folder(PyCLES_output_dataset)
+end
+
+function scampy_output_dataset_folder(lazy_download = true)
+    SCAMPy_output_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        lazy_download,
+        "SCAMPy_output",
+        AW.ArtifactFile[
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/1dzpydqiagjvzfpyv9lbic3atvca93hl.nc", filename = "Rico.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/agkycoum93bd6xjduyaeo3oqg6asoru5.nc", filename = "GABLS.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/fqpq1q74uxfh1e8018hwhqogw1htn2lq.nc", filename = "DYCOMS_RF01.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/wevi0rqiwo6sgkqdhcddr72u5ylt0tqp.nc", filename = "TRMM_LBA.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/fis6n0g9x9lts70m0zmve5ullqnw0pzq.nc", filename = "ARM_SGP.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/t6qq6plt2oxcmmy40r1szgokahykqggp.nc", filename = "Bomex.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/wp8k4m7ta1hs0c6e4j2fpsp3kj05wdip.nc", filename = "Soares.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/vbuxzg85scwy9mg0ziiuzy6fimo0e389.nc", filename = "Nieuwstadt.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/72t6fr1gq10tg3jjputtp35nfzex0o4k.nc", filename = "DryBubble.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/7axeussneeg8g3k0ndvagsn0pkmbij3e.nc", filename = "life_cycle_Tan2018.nc",),
+        ],
+    )
+    return AW.get_data_folder(SCAMPy_output_dataset)
+end
+
+function les_driven_scm_data_folder(lazy_download = true)
+    LESDrivenSCM_output_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        lazy_download,
+        "LESDrivenSCM_output_dataset",
+        AW.ArtifactFile[
+            AW.ArtifactFile(url = "https://caltech.box.com/shared/static/0hnf7nkttueraaqf9tpkqsx38gjqx41p.nc", filename = "Stats.cfsite23_HadGEM2-A_amip_2004-2008.07.nc",),
+        ],
+    )
+    return AW.get_data_folder(LESDrivenSCM_output_dataset)
+end
+
+#! format: on

--- a/tc_driver/callbacks.jl
+++ b/tc_driver/callbacks.jl
@@ -1,0 +1,192 @@
+function condition_io(u, t, integrator)
+    UnPack.@unpack TS, Stats = integrator.p
+    TS.dt_io += TS.dt
+    io_flag = false
+    if TS.dt_io > Stats[1].frequency
+        TS.dt_io = 0
+        io_flag = true
+    end
+    return io_flag || t ≈ 0 || t ≈ TS.t_max
+end
+
+condition_every_iter(u, t, integrator) = true
+
+function affect_io!(integrator)
+    UnPack.@unpack edmf, calibrate_io, precip_model, aux, io_nt, diagnostics, surf_params, param_set, Stats, skip_io =
+        integrator.p
+    skip_io && return nothing
+    t = integrator.t
+    prog = integrator.u
+
+    for inds in TC.iterate_columns(prog.cent)
+        stats = Stats[inds...]
+        # TODO: remove `vars` hack that avoids
+        # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+        # opening/closing files every step should be okay. #removeVarsHack
+        # TurbulenceConvection.io(sim) # #removeVarsHack
+        write_simulation_time(stats, t) # #removeVarsHack
+
+        state = TC.column_prog_aux(prog, aux, inds...)
+        grid = TC.Grid(state)
+        diag_col = TC.column_diagnostics(diagnostics, inds...)
+
+        # TODO: is this the best location to call diagnostics?
+        compute_diagnostics!(edmf, precip_model, param_set, grid, state, diag_col, stats, surf_params, t, calibrate_io)
+
+        cent = TC.Cent(1)
+        diag_svpc = svpc_diagnostics_grid_mean(diag_col)
+        diag_tc_svpc = svpc_diagnostics_turbconv(diag_col)
+        write_ts(stats, "lwp_mean", diag_svpc.lwp_mean[cent])
+        write_ts(stats, "iwp_mean", diag_svpc.iwp_mean[cent])
+        write_ts(stats, "rwp_mean", diag_svpc.rwp_mean[cent])
+        write_ts(stats, "swp_mean", diag_svpc.swp_mean[cent])
+
+        if !calibrate_io
+            write_ts(stats, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
+            write_ts(stats, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])
+            write_ts(stats, "updraft_cloud_top", diag_tc_svpc.updraft_cloud_top[cent])
+            write_ts(stats, "env_cloud_cover", diag_tc_svpc.env_cloud_cover[cent])
+            write_ts(stats, "env_cloud_base", diag_tc_svpc.env_cloud_base[cent])
+            write_ts(stats, "env_cloud_top", diag_tc_svpc.env_cloud_top[cent])
+            write_ts(stats, "env_lwp", diag_tc_svpc.env_lwp[cent])
+            write_ts(stats, "env_iwp", diag_tc_svpc.env_iwp[cent])
+            write_ts(stats, "Hd", diag_tc_svpc.Hd[cent])
+            write_ts(stats, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
+            write_ts(stats, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
+
+            write_ts(stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
+            write_ts(stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
+            write_ts(stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
+            write_ts(stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
+        end
+
+        io(io_nt.aux, stats, state)
+        io(io_nt.diagnostics, stats, diag_col)
+
+        surf = get_surface(surf_params, grid, state, t, param_set)
+        io(surf, surf_params, grid, state, stats, t)
+    end
+
+    ODE.u_modified!(integrator, false) # We're legitamately not mutating `u` (the state vector)
+end
+
+function affect_filter!(integrator)
+    UnPack.@unpack edmf, param_set, aux, case, surf_params = integrator.p
+    t = integrator.t
+    prog = integrator.u
+    prog = integrator.u
+
+    for inds in TC.iterate_columns(prog.cent)
+        state = TC.column_prog_aux(prog, aux, inds...)
+        grid = TC.Grid(state)
+        surf = get_surface(surf_params, grid, state, t, param_set)
+        TC.affect_filter!(edmf, grid, state, param_set, surf, t)
+    end
+
+    # We're lying to OrdinaryDiffEq.jl, in order to avoid
+    # paying for an additional `∑tendencies!` call, which is required
+    # to support supplying a continuous representation of the
+    # solution.
+    ODE.u_modified!(integrator, false)
+end
+
+function adaptive_dt!(integrator)
+    UnPack.@unpack edmf, TS, dt_min = integrator.p
+    TS.dt = min(TS.dt_max, max(TS.dt_max_edmf, dt_min))
+    SciMLBase.set_proposed_dt!(integrator, TS.dt)
+    ODE.u_modified!(integrator, false)
+end
+
+function compute_dt_max(state::TC.State, edmf::TC.EDMFModel, dt_max::FT, CFL_limit::FT) where {FT <: Real}
+    grid = TC.Grid(state)
+
+    prog_gm = TC.center_prog_grid_mean(state)
+    prog_gm_f = TC.face_prog_grid_mean(state)
+    Δzc = TC.get_Δz(prog_gm.ρ)
+    Δzf = TC.get_Δz(prog_gm_f.w)
+    N_up = TC.n_updrafts(edmf)
+
+    aux_tc = TC.center_aux_turbconv(state)
+    aux_up_f = TC.face_aux_updrafts(state)
+    aux_en_f = TC.face_aux_environment(state)
+    KM = aux_tc.KM
+    KH = aux_tc.KH
+
+    # helper to calculate the rain velocity
+    # TODO: assuming w_gm = 0
+    # TODO: verify translation
+    term_vel_rain = aux_tc.term_vel_rain
+    term_vel_snow = aux_tc.term_vel_snow
+    ε = FT(eps(FT))
+
+    @inbounds for k in TC.real_face_indices(grid)
+        TC.is_surface_face(grid, k) && continue
+        @inbounds for i in 1:N_up
+            dt_max = min(dt_max, CFL_limit * Δzf[k] / (abs(aux_up_f[i].w[k]) + ε))
+        end
+        dt_max = min(dt_max, CFL_limit * Δzf[k] / (abs(aux_en_f.w[k]) + ε))
+    end
+    @inbounds for k in TC.real_center_indices(grid)
+        vel_max = max(term_vel_rain[k], term_vel_snow[k])
+        # Check terminal rain/snow velocity CFL
+        dt_max = min(dt_max, CFL_limit * Δzc[k] / (vel_max + ε))
+        # Check diffusion CFL (i.e., Fourier number)
+        dt_max = min(dt_max, CFL_limit * Δzc[k]^2 / (max(KH[k], KM[k]) + ε))
+    end
+    return dt_max
+end
+
+function dt_max!(integrator)
+    UnPack.@unpack edmf, aux, TS = integrator.p
+    prog = integrator.u
+
+    dt_max = TS.dt_max # initialize dt_max
+    for inds in TC.iterate_columns(prog.cent)
+        state = TC.column_prog_aux(prog, aux, inds...)
+        dt_max = compute_dt_max(state, edmf, dt_max, TS.cfl_limit)
+    end
+    to_float(f) = f isa ForwardDiff.Dual ? ForwardDiff.value(f) : f
+    TS.dt_max_edmf = to_float(dt_max)
+
+    ODE.u_modified!(integrator, false)
+end
+
+function monitor_cfl!(integrator)
+    UnPack.@unpack edmf, aux, TS = integrator.p
+    prog = integrator.u
+
+    for inds in TC.iterate_columns(prog.cent)
+        state = TC.column_prog_aux(prog, aux, inds...)
+        grid = TC.Grid(state)
+        prog_gm = TC.center_prog_grid_mean(state)
+        Δz = TC.get_Δz(prog_gm.ρ)
+        Δt = TS.dt
+        CFL_limit = TS.cfl_limit
+
+        aux_tc = TC.center_aux_turbconv(state)
+
+        # helper to calculate the rain velocity
+        # TODO: assuming w_gm = 0
+        # TODO: verify translation
+        term_vel_rain = aux_tc.term_vel_rain
+        term_vel_snow = aux_tc.term_vel_snow
+
+        @inbounds for k in TC.real_center_indices(grid)
+            # check stability criterion
+            CFL_out_rain = Δt / Δz[k] * term_vel_rain[k]
+            CFL_out_snow = Δt / Δz[k] * term_vel_snow[k]
+            if TC.is_toa_center(grid, k)
+                CFL_in_rain = 0.0
+                CFL_in_snow = 0.0
+            else
+                CFL_in_rain = Δt / Δz[k] * term_vel_rain[k + 1]
+                CFL_in_snow = Δt / Δz[k] * term_vel_snow[k + 1]
+            end
+            if max(CFL_in_rain, CFL_in_snow, CFL_out_rain, CFL_out_snow) > CFL_limit
+                error("Time step is too large for rain fall velocity!")
+            end
+        end
+    end
+
+    ODE.u_modified!(integrator, false)
+end

--- a/tc_driver/common_spaces.jl
+++ b/tc_driver/common_spaces.jl
@@ -1,0 +1,123 @@
+import ClimaCore
+const CC = ClimaCore
+
+function periodic_line_mesh(; x_max, x_elem)
+    domain = CC.Domains.IntervalDomain(CCG.XPoint(zero(x_max)), CCG.XPoint(x_max); periodic = true)
+    return CC.Meshes.IntervalMesh(domain; nelems = x_elem)
+end
+
+function periodic_rectangle_mesh(; x_max, y_max, x_elem, y_elem)
+    x_domain = CC.Domains.IntervalDomain(CCG.XPoint(zero(x_max)), CCG.XPoint(x_max); periodic = true)
+    y_domain = CC.Domains.IntervalDomain(CCG.YPoint(zero(y_max)), CCG.YPoint(y_max); periodic = true)
+    domain = CC.Domains.RectangleDomain(x_domain, y_domain)
+    return CC.Meshes.RectilinearMesh(domain, x_elem, y_elem)
+end
+
+# h_elem is the number of elements per side of every panel (6 panels in total)
+function cubed_sphere_mesh(; radius, h_elem)
+    domain = CC.Domains.SphereDomain(radius)
+    return CC.Meshes.EquiangularCubedSphere(domain, h_elem)
+end
+
+function make_horizontal_space(mesh, quad)
+    if mesh isa CC.Meshes.AbstractMesh1D
+        topology = CC.Topologies.IntervalTopology(mesh)
+        space = CC.Spaces.SpectralElementSpace1D(topology, quad)
+    elseif mesh isa CC.Meshes.AbstractMesh2D
+        topology = CC.Topologies.Topology2D(mesh)
+        space = CC.Spaces.SpectralElementSpace2D(topology, quad)
+    end
+    return space
+end
+
+function make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
+    FT = eltype(z_max)
+    z_domain = CC.Domains.IntervalDomain(CCG.ZPoint(zero(z_max)), CCG.ZPoint(z_max); boundary_tags = (:bottom, :top))
+    z_mesh = CC.Meshes.IntervalMesh(z_domain, z_stretch; nelems = z_elem)
+    @info "z heights" z_mesh.faces
+    z_topology = CC.Topologies.IntervalTopology(z_mesh)
+    z_space = CC.Spaces.CenterFiniteDifferenceSpace(z_topology)
+    center_space = CC.Spaces.ExtrudedFiniteDifferenceSpace(h_space, z_space)
+    face_space = CC.Spaces.FaceExtrudedFiniteDifferenceSpace(center_space)
+
+    svpc_domain =
+        CC.Domains.IntervalDomain(CC.Geometry.ZPoint{FT}(0), CC.Geometry.ZPoint{FT}(1), boundary_tags = (:bottom, :top))
+    svpc_mesh = CC.Meshes.IntervalMesh(svpc_domain, nelems = 1)
+    svpc_space = CC.Spaces.CenterFiniteDifferenceSpace(svpc_mesh)
+
+    return center_space, face_space, svpc_space
+end
+
+function construct_mesh(namelist; FT = Float64)
+
+    truncated_gcm_mesh = TC.parse_namelist(namelist, "grid", "stretch", "flag"; default = false)
+
+    if Cases.get_case(namelist) == Cases.LES_driven_SCM()
+        Δz = get(namelist["grid"], "dz", nothing)
+        nz = get(namelist["grid"], "nz", nothing)
+        @assert isnothing(Δz) ⊻ isnothing(nz) string(
+            "LES_driven_SCM supports nz or Δz, not both.",
+            "The domain height is enforced to be the same as in LES.",
+        )
+
+        les_filename = namelist["meta"]["lesfile"]
+        TC.valid_lespath(les_filename)
+        zmax = NC.Dataset(les_filename, "r") do data
+            Array(TC.get_nc_data(data, "zf"))[end]
+        end
+        nz = isnothing(nz) ? Int(zmax ÷ Δz) : Int(nz)
+        Δz = isnothing(Δz) ? FT(zmax ÷ nz) : FT(Δz)
+    else
+        Δz = FT(namelist["grid"]["dz"])
+        nz = namelist["grid"]["nz"]
+    end
+
+    z₀, z₁ = FT(0), FT(nz * Δz)
+    z_stretch = CC.Meshes.Uniform()
+    return (; z_stretch, z_max = z₁, z_elem = nz)
+end
+
+
+function get_spaces(namelist, param_set, FT)
+    center_space, face_space, svpc_space = if namelist["config"] == "sphere"
+        h_elem = 1
+        quad = CC.Spaces.Quadratures.GLL{2}()
+        horizontal_mesh = cubed_sphere_mesh(; radius = FT(TCP.planet_radius(param_set)), h_elem)
+        h_space = make_horizontal_space(horizontal_mesh, quad)
+        (; z_stretch, z_max, z_elem) = construct_mesh(namelist; FT = FT)
+        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
+        center_space, face_space, svpc_space
+    elseif namelist["config"] == "column" # single column (default)
+        Δx = FT(1) # Note: This value shouldn't matter, since we only have 1 column.
+        quad = CC.Spaces.Quadratures.GL{1}()
+        horizontal_mesh = periodic_rectangle_mesh(; x_max = Δx, y_max = Δx, x_elem = 1, y_elem = 1)
+        h_space = make_horizontal_space(horizontal_mesh, quad)
+        (; z_stretch, z_max, z_elem) = construct_mesh(namelist; FT = FT)
+        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
+        center_space, face_space, svpc_space
+    end
+    # if truncated_gcm_mesh
+    #     nzₛ = namelist["grid"]["stretch"]["nz"]
+    #     Δzₛ_surf = FT(namelist["grid"]["stretch"]["dz_surf"])
+    #     Δzₛ_top = FT(namelist["grid"]["stretch"]["dz_toa"])
+    #     zₛ_toa = FT(namelist["grid"]["stretch"]["z_toa"])
+    #     stretch = CC.Meshes.GeneralizedExponentialStretching(Δzₛ_surf, Δzₛ_top)
+    #     domain = CC.Domains.IntervalDomain(
+    #         CC.Geometry.ZPoint{FT}(z₀),
+    #         CC.Geometry.ZPoint{FT}(zₛ_toa),
+    #         boundary_tags = (:bottom, :top),
+    #     )
+    #     gcm_mesh = CC.Meshes.IntervalMesh(domain, stretch; nelems = nzₛ)
+    #     mesh = TC.TCMeshFromGCMMesh(gcm_mesh; z_max = z₁)
+    # else
+    #     CC.Meshes.Uniform()
+    #     domain = CC.Domains.IntervalDomain(
+    #         CC.Geometry.ZPoint{FT}(z₀),
+    #         CC.Geometry.ZPoint{FT}(z₁),
+    #         boundary_tags = (:bottom, :top),
+    #     )
+    #     mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
+    # end
+    # @info "z heights" mesh.faces
+    # return TC.Grid(mesh)
+end

--- a/tc_driver/compute_diagnostics.jl
+++ b/tc_driver/compute_diagnostics.jl
@@ -1,0 +1,342 @@
+# TODO: should this live in its own module?
+
+import StatsBase
+
+import ClimaCore
+const CC = ClimaCore
+const CCO = CC.Operators
+
+import CLIMAParameters as CP
+import TurbulenceConvection.Parameters as TCP
+const APS = TCP.AbstractTurbulenceConvectionParameters
+
+""" Purely diagnostic fields for the host model """
+diagnostics(state, fl) = getproperty(state, TC.field_loc(fl))
+
+center_diagnostics_grid_mean(state) = diagnostics(state, TC.CentField())
+center_diagnostics_turbconv(state) = diagnostics(state, TC.CentField()).turbconv
+face_diagnostics_turbconv(state) = diagnostics(state, TC.FaceField()).turbconv
+face_diagnostics_precip(state) = diagnostics(state, TC.FaceField()).precip
+
+svpc_diagnostics_grid_mean(state) = diagnostics(state, TC.SingleValuePerColumn())
+svpc_diagnostics_turbconv(state) = diagnostics(state, TC.SingleValuePerColumn()).turbconv
+
+#=
+    io_dictionary_diagnostics()
+
+These functions return a dictionary whose
+ - `keys` are the nc variable names
+ - `values` are NamedTuples corresponding to
+    - `dims` (`("z")`  or `("z", "t")`) and
+    - `group` (`"reference"` or `"profiles"`)
+
+This dictionary is for purely diagnostic quantities--which
+are not required to compute in order to run a simulation.
+=#
+
+#! format: off
+function io_dictionary_diagnostics()
+    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
+    io_dict = Dict{String, DT}(
+        "nh_pressure" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure),
+        "nh_pressure_adv" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_adv,),
+        "nh_pressure_drag" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_drag,),
+        "nh_pressure_b" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_b,),
+        "turbulent_entrainment" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).frac_turb_entr,),
+        "entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).entr_sc),
+        "nondim_entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).ε_nondim),
+        "detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).detr_sc),
+        "nondim_detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).δ_nondim),
+        "asp_ratio" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).asp_ratio),
+        "massflux" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).massflux),
+        "rain_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_precip(state).rain_flux),
+        "snow_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_precip(state).snow_flux,),
+    )
+    return io_dict
+end
+#! format: on
+
+function io(surf::TC.SurfaceBase, surf_params, grid, state, Stats::NetCDFIO_Stats, t::Real)
+    write_ts(Stats, "Tsurface", TC.surface_temperature(surf_params, t))
+    write_ts(Stats, "shf", surf.shf)
+    write_ts(Stats, "lhf", surf.lhf)
+    write_ts(Stats, "ustar", surf.ustar)
+    write_ts(Stats, "wstar", surf.wstar)
+end
+function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
+    for var in keys(io_dict)
+        write_field(Stats, var, vec(io_dict[var].field(state)), io_dict[var].group)
+    end
+end
+
+
+function initialize_io(nc_filename, FT, ts_list)
+    NC.Dataset(nc_filename, "a") do ds
+        for var_name in ts_list
+            add_ts(ds, var_name, FT)
+        end
+    end
+    return nothing
+end
+
+function initialize_io(nc_filename, FT, io_dicts::Dict...)
+    NC.Dataset(nc_filename, "a") do ds
+        for io_dict in io_dicts
+            for var_name in keys(io_dict)
+                add_field(ds, var_name, io_dict[var_name].dims, io_dict[var_name].group, FT)
+            end
+        end
+    end
+end
+
+#=
+    compute_diagnostics!
+
+Computes diagnostic quantities. The state _should not_ depend
+on any quantities here. I.e., we should be able to shut down
+diagnostics and still run, at which point we'll be able to export
+the state, auxiliary fields (which the state does depend on), and
+tendencies.
+=#
+function compute_diagnostics!(
+    edmf::TC.EDMFModel,
+    precip_model::TC.AbstractPrecipitationModel,
+    param_set::APS,
+    grid::TC.Grid,
+    state::TC.State,
+    diagnostics::D,
+    Stats::NetCDFIO_Stats,
+    surf_params,
+    t::Real,
+    calibrate_io::Bool,
+) where {D <: CC.Fields.FieldVector}
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = TC.float_type(state)
+    N_up = TC.n_updrafts(edmf)
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_en = TC.center_aux_environment(state)
+    aux_up = TC.center_aux_updrafts(state)
+    aux_up_f = TC.face_aux_updrafts(state)
+    aux_tc_f = TC.face_aux_turbconv(state)
+    aux_tc = TC.center_aux_turbconv(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    prog_pr = TC.center_prog_precipitation(state)
+    aux_bulk = TC.center_aux_bulk(state)
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    ts_en = TC.center_aux_environment(state).ts
+    a_up_bulk = aux_bulk.area
+    kc_toa = TC.kc_top_of_atmos(grid)
+    prog_gm = TC.center_prog_grid_mean(state)
+    diag_tc = center_diagnostics_turbconv(diagnostics)
+    diag_tc_f = face_diagnostics_turbconv(diagnostics)
+    diag_tc_f_precip = face_diagnostics_precip(diagnostics)
+    ρ_c = prog_gm.ρ
+    p_c = aux_gm.p
+
+    diag_tc_svpc = svpc_diagnostics_turbconv(diagnostics)
+    diag_svpc = svpc_diagnostics_grid_mean(diagnostics)
+
+    surf = get_surface(surf_params, grid, state, t, param_set)
+
+    @. aux_gm.s = TD.specific_entropy(thermo_params, ts_gm)
+    @. aux_en.s = TD.specific_entropy(thermo_params, ts_en)
+
+    @inbounds for k in TC.real_center_indices(grid)
+        @inbounds for i in 1:N_up
+            aux_up[i].s[k] = if aux_up[i].area[k] > 0.0
+                thermo_args = if edmf.moisture_model isa TC.EquilibriumMoisture
+                    ()
+                elseif edmf.moisture_model isa TC.NonEquilibriumMoisture
+                    (aux_up[i].q_liq[k], aux_up[i].q_ice[k])
+                end
+                ts_up = TC.thermo_state_pθq(
+                    param_set,
+                    p_c[k],
+                    aux_up[i].θ_liq_ice[k],
+                    aux_up[i].q_tot[k],
+                    thermo_args...,
+                )
+                TD.specific_entropy(thermo_params, ts_up)
+            else
+                FT(0)
+            end
+        end
+    end
+
+    # TODO(ilopezgp): Fix bottom gradient
+    wvec = CC.Geometry.WVector
+    m_bcs = (; bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
+    # ∇0_bcs = (; bottom = CCO.SetDivergence(wvec(FT(0))), top = CCO.SetDivergence(wvec(FT(0))))
+    ∇0_bcs = (; bottom = CCO.SetDivergence(FT(0)), top = CCO.SetDivergence(FT(0)))
+    If = CCO.InterpolateC2F(; m_bcs...)
+    ∇f = CCO.DivergenceC2F(; ∇0_bcs...)
+    massflux_s = aux_gm_f.massflux_s
+    parent(massflux_s) .= 0
+    @. aux_gm_f.diffusive_flux_s = -aux_tc_f.ρ_ae_KH * ∇f(wvec(aux_en.s))
+    @inbounds for i in 1:N_up
+        @. massflux_s += aux_up_f[i].massflux * (If(aux_up[i].s) - If(aux_en.s))
+    end
+
+    # Mean water paths for calibration
+    cent = TC.Cent(1)
+    diag_svpc.lwp_mean[cent] = sum(ρ_c .* aux_gm.q_liq)
+    diag_svpc.iwp_mean[cent] = sum(ρ_c .* aux_gm.q_ice)
+    diag_svpc.rwp_mean[cent] = sum(ρ_c .* prog_pr.q_rai)
+    diag_svpc.swp_mean[cent] = sum(ρ_c .* prog_pr.q_sno)
+
+    #####
+    ##### Cloud base, top and cover
+    #####
+    # TODO: write this in a mutating-free way using findfirst/findlast/map
+
+    cloud_base_up = Vector{FT}(undef, N_up)
+    cloud_top_up = Vector{FT}(undef, N_up)
+    cloud_cover_up = Vector{FT}(undef, N_up)
+
+    @inbounds for i in 1:N_up
+        cloud_base_up[i] = TC.zc_toa(grid).z
+        cloud_top_up[i] = FT(0)
+        cloud_cover_up[i] = FT(0)
+
+        @inbounds for k in TC.real_center_indices(grid)
+            if aux_up[i].area[k] > 1e-3
+                if TD.has_condensate(aux_up[i].q_liq[k] + aux_up[i].q_ice[k])
+                    cloud_base_up[i] = min(cloud_base_up[i], grid.zc[k].z)
+                    cloud_top_up[i] = max(cloud_top_up[i], grid.zc[k].z)
+                    cloud_cover_up[i] = max(cloud_cover_up[i], aux_up[i].area[k])
+                end
+            end
+        end
+    end
+    # Note definition of cloud cover : each updraft is associated with
+    # a cloud cover equal to the maximum area fraction of the updraft
+    # where ql > 0. Each updraft is assumed to have maximum overlap with
+    # respect to itup (i.e. no consideration of tilting due to shear)
+    # while the updraft classes are assumed to have no overlap at all.
+    # Thus total updraft cover is the sum of each updraft's cover
+
+    diag_tc_svpc.updraft_cloud_cover[cent] = sum(cloud_cover_up)
+    diag_tc_svpc.updraft_cloud_base[cent] = minimum(abs.(cloud_base_up))
+    diag_tc_svpc.updraft_cloud_top[cent] = maximum(abs.(cloud_top_up))
+
+    cloud_top_en = FT(0)
+    cloud_base_en = TC.zc_toa(grid).z
+    cloud_cover_en = FT(0)
+    @inbounds for k in TC.real_center_indices(grid)
+        if TD.has_condensate(aux_en.q_liq[k] + aux_en.q_ice[k]) && aux_en.area[k] > 1e-6
+            cloud_base_en = min(cloud_base_en, grid.zc[k].z)
+            cloud_top_en = max(cloud_top_en, grid.zc[k].z)
+            cloud_cover_en = max(cloud_cover_en, aux_en.area[k] * aux_en.cloud_fraction[k])
+        end
+    end
+    # Assuming amximum overlap in environmental clouds
+    diag_tc_svpc.env_cloud_cover[cent] = cloud_cover_en
+    diag_tc_svpc.env_cloud_base[cent] = cloud_base_en
+    diag_tc_svpc.env_cloud_top[cent] = cloud_top_en
+
+    cloud_cover_gm = min(cloud_cover_en + sum(cloud_cover_up), 1)
+    cloud_base_gm = grid.zc[kc_toa].z
+    cloud_top_gm = FT(0)
+    @inbounds for k in TC.real_center_indices(grid)
+        if TD.has_condensate(aux_gm.q_liq[k] + aux_gm.q_ice[k])
+            cloud_base_gm = min(cloud_base_gm, grid.zc[k].z)
+            cloud_top_gm = max(cloud_top_gm, grid.zc[k].z)
+        end
+    end
+
+    diag_svpc.cloud_cover_mean[cent] = cloud_cover_gm
+    diag_svpc.cloud_base_mean[cent] = cloud_base_gm
+    diag_svpc.cloud_top_mean[cent] = cloud_top_gm
+
+    #####
+    ##### Fluxes
+    #####
+    Ic = CCO.InterpolateF2C()
+    parent(diag_tc.massflux) .= 0
+    @inbounds for i in 1:N_up
+        @. diag_tc.massflux += Ic(aux_up_f[i].massflux)
+    end
+
+    @inbounds for k in TC.real_center_indices(grid)
+        a_up_bulk_k = a_up_bulk[k]
+        diag_tc.entr_sc[k] = 0
+        diag_tc.ε_nondim[k] = 0
+        diag_tc.detr_sc[k] = 0
+        diag_tc.δ_nondim[k] = 0
+        diag_tc.asp_ratio[k] = 0
+        diag_tc.frac_turb_entr[k] = 0
+        if a_up_bulk_k > 0.0
+            @inbounds for i in 1:N_up
+                aux_up_i = aux_up[i]
+                diag_tc.entr_sc[k] += aux_up_i.area[k] * aux_up_i.entr_sc[k] / a_up_bulk_k
+                diag_tc.ε_nondim[k] += aux_up_i.area[k] * aux_up_i.ε_nondim[k] / a_up_bulk_k
+                diag_tc.detr_sc[k] += aux_up_i.area[k] * aux_up_i.detr_sc[k] / a_up_bulk_k
+                diag_tc.δ_nondim[k] += aux_up_i.area[k] * aux_up_i.δ_nondim[k] / a_up_bulk_k
+                diag_tc.asp_ratio[k] += aux_up_i.area[k] * aux_up_i.asp_ratio[k] / a_up_bulk_k
+                diag_tc.frac_turb_entr[k] += aux_up_i.area[k] * aux_up_i.frac_turb_entr[k] / a_up_bulk_k
+            end
+        end
+    end
+
+    a_bulk_bcs = TC.a_bulk_boundary_conditions(surf, edmf)
+    Ifabulk = CCO.InterpolateC2F(; a_bulk_bcs...)
+    a_up_bulk_f = @. Ifabulk(a_up_bulk)
+
+    RB_precip = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
+
+    @inbounds for i in 1:N_up
+        a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
+        Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
+        a_up_f = @. Ifaup(aux_up[i].area)
+        @inbounds for k in TC.real_face_indices(grid)
+            diag_tc_f.nh_pressure[k] = 0
+            diag_tc_f.nh_pressure_b[k] = 0
+            diag_tc_f.nh_pressure_adv[k] = 0
+            diag_tc_f.nh_pressure_drag[k] = 0
+            if a_up_bulk_f[k] > 0.0
+                diag_tc_f.nh_pressure[k] += a_up_f[k] * aux_up_f[i].nh_pressure[k] / a_up_bulk_f[k]
+                diag_tc_f.nh_pressure_b[k] += a_up_f[k] * aux_up_f[i].nh_pressure_b[k] / a_up_bulk_f[k]
+                diag_tc_f.nh_pressure_adv[k] += a_up_f[k] * aux_up_f[i].nh_pressure_adv[k] / a_up_bulk_f[k]
+                diag_tc_f.nh_pressure_drag[k] += a_up_f[k] * aux_up_f[i].nh_pressure_drag[k] / a_up_bulk_f[k]
+            end
+        end
+    end
+    @. diag_tc_f_precip.rain_flux = RB_precip(ρ_c * prog_pr.q_rai * aux_tc.term_vel_rain)
+    @. diag_tc_f_precip.snow_flux = RB_precip(ρ_c * prog_pr.q_sno * aux_tc.term_vel_snow)
+
+    TC.GMV_third_m(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:H_third_m))
+    TC.GMV_third_m(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:QT_third_m))
+    TC.GMV_third_m(edmf, grid, state, Val(:tke), Val(:w), Val(:W_third_m))
+
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
+
+    TC.update_cloud_frac(edmf, grid, state)
+
+    diag_tc_svpc.env_lwp[cent] = sum(ρ_c .* aux_en.q_liq .* aux_en.area)
+    diag_tc_svpc.env_iwp[cent] = sum(ρ_c .* aux_en.q_ice .* aux_en.area)
+
+    #TODO - change to rain rate that depends on rain model choice
+    ρ_cloud_liq = TCP.ρ_cloud_liq(param_set)
+    if (precip_model isa TC.Clima0M)
+        f =
+            (aux_en.qt_tendency_precip_formation .+ aux_bulk.qt_tendency_precip_formation) .* ρ_c ./ ρ_cloud_liq .*
+            FT(3.6) .* 1e6
+        diag_svpc.cutoff_precipitation_rate[cent] = sum(f)
+    end
+
+    lwp = sum(i -> sum(ρ_c .* aux_up[i].q_liq .* aux_up[i].area .* (aux_up[i].area .> 1e-3)), 1:N_up)
+    iwp = sum(i -> sum(ρ_c .* aux_up[i].q_ice .* aux_up[i].area .* (aux_up[i].area .> 1e-3)), 1:N_up)
+
+    plume_scale_height = map(1:N_up) do i
+        TC.compute_plume_scale_height(grid, state, edmf.H_up_min, i)
+    end
+
+    diag_tc_svpc.updraft_lwp[cent] = lwp
+    diag_tc_svpc.updraft_iwp[cent] = iwp
+    diag_tc_svpc.Hd[cent] = StatsBase.mean(plume_scale_height)
+
+    return
+end

--- a/tc_driver/compute_diagnostics.jl
+++ b/tc_driver/compute_diagnostics.jl
@@ -7,7 +7,7 @@ const CC = ClimaCore
 const CCO = CC.Operators
 
 import CLIMAParameters as CP
-import TurbulenceConvection.Parameters as TCP
+import ClimaAtmos.TurbulenceConvection.Parameters as TCP
 const APS = TCP.AbstractTurbulenceConvectionParameters
 
 """ Purely diagnostic fields for the host model """

--- a/tc_driver/download_artifacts.jl
+++ b/tc_driver/download_artifacts.jl
@@ -1,0 +1,10 @@
+include(joinpath(@__DIR__, "..", "integration_tests", "artifact_funcs.jl"))
+
+# Trigger download if data doesn't exist locally
+function trigger_download(lazy_download = true)
+    @info "pycles Artifact folder:`$(pycles_output_dataset_folder(lazy_download))`"
+    @info "scampy Artifact folder:`$(scampy_output_dataset_folder(lazy_download))`"
+    @info "LES_driven_SCM Artifact folder:`$(les_driven_scm_data_folder(lazy_download))`"
+    return nothing
+end
+trigger_download()

--- a/tc_driver/download_artifacts.jl
+++ b/tc_driver/download_artifacts.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "integration_tests", "artifact_funcs.jl"))
+include(joinpath(@__DIR__, "artifact_funcs.jl"))
 
 # Trigger download if data doesn't exist locally
 function trigger_download(lazy_download = true)

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -1,0 +1,455 @@
+import UnPack
+import LinearAlgebra as LA
+import LinearAlgebra: ×
+
+import TurbulenceConvection as TC
+import TurbulenceConvection.Parameters as TCP
+const APS = TCP.AbstractTurbulenceConvectionParameters
+import Thermodynamics as TD
+import ClimaCore as CC
+import ClimaCore.Geometry as CCG
+import OrdinaryDiffEq as ODE
+
+import CLIMAParameters as CP
+
+include(joinpath(@__DIR__, "dycore_variables.jl"))
+
+#####
+##### Methods
+#####
+
+####
+#### Reference state
+####
+
+"""
+    compute_ref_state!(
+        state,
+        grid::Grid,
+        param_set::PS;
+        ts_g,
+    ) where {PS}
+
+TODO: add better docs once the API converges
+
+The reference profiles, given
+ - `grid` the grid
+ - `param_set` the parameter set
+ - `ts_g` the surface reference state (a thermodynamic state)
+"""
+function compute_ref_state!(state, grid::TC.Grid, param_set::PS; ts_g) where {PS}
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    p_f = aux_gm_f.p
+    ρ_f = aux_gm_f.ρ
+    compute_ref_state!(p_c, ρ_c, p_f, ρ_f, grid, param_set; ts_g)
+end
+
+function compute_ref_state!(
+    p_c::CC.Fields.Field,
+    ρ_c::CC.Fields.Field,
+    p_f::CC.Fields.Field,
+    ρ_f::CC.Fields.Field,
+    grid::TC.Grid,
+    param_set::PS;
+    ts_g,
+) where {PS}
+    thermo_params = TCP.thermodynamics_params(param_set)
+    FT = TC.float_type(p_c)
+    kf_surf = TC.kf_surface(grid)
+    qtg = TD.total_specific_humidity(thermo_params, ts_g)
+    Φ = TC.geopotential(param_set, grid.zf[kf_surf].z)
+    mse_g = TD.moist_static_energy(thermo_params, ts_g, Φ)
+    Pg = TD.air_pressure(thermo_params, ts_g)
+
+    # We are integrating the log pressure so need to take the log of the
+    # surface pressure
+    logp = log(Pg)
+
+    # Form a right hand side for integrating the hydrostatic equation to
+    # determine the reference pressure
+    function minus_inv_scale_height(logp, u, z)
+        p_ = exp(logp)
+        grav = FT(TCP.grav(param_set))
+        Φ = TC.geopotential(param_set, z)
+        h = TC.enthalpy(mse_g, Φ)
+        ts = TD.PhaseEquil_phq(thermo_params, p_, h, qtg)
+        R_m = TD.gas_constant_air(thermo_params, ts)
+        T = TD.air_temperature(thermo_params, ts)
+        return -FT(TCP.grav(param_set)) / (T * R_m)
+    end
+
+    # Perform the integration
+    z_span = (grid.zmin, grid.zmax)
+    prob = ODE.ODEProblem(minus_inv_scale_height, logp, z_span)
+    sol = ODE.solve(prob, ODE.Tsit5(), reltol = 1e-12, abstol = 1e-12)
+    parent(p_f) .= sol.(vec(grid.zf.z))
+    parent(p_c) .= sol.(vec(grid.zc.z))
+
+    p_f .= exp.(p_f)
+    p_c .= exp.(p_c)
+
+    # Compute reference state thermodynamic profiles
+    @inbounds for k in TC.real_center_indices(grid)
+        Φ = TC.geopotential(param_set, grid.zc[k].z)
+        h = TC.enthalpy(mse_g, Φ)
+        ts = TD.PhaseEquil_phq(thermo_params, p_c[k], h, qtg)
+        ρ_c[k] = TD.air_density(thermo_params, ts)
+    end
+
+    @inbounds for k in TC.real_face_indices(grid)
+        Φ = TC.geopotential(param_set, grid.zf[k].z)
+        h = TC.enthalpy(mse_g, Φ)
+        ts = TD.PhaseEquil_phq(thermo_params, p_f[k], h, qtg)
+        ρ_f[k] = TD.air_density(thermo_params, ts)
+    end
+    return nothing
+end
+
+
+function set_thermo_state_peq!(state, grid, moisture_model, param_set)
+    Ic = CCO.InterpolateF2C()
+    thermo_params = TCP.thermodynamics_params(param_set)
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    prog_gm = TC.center_prog_grid_mean(state)
+    prog_gm_f = TC.face_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    C123 = CCG.Covariant123Vector
+    @. aux_gm.e_kin = LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(prog_gm_f.w))) / 2
+
+    @inbounds for k in TC.real_center_indices(grid)
+        thermo_args = if moisture_model isa TC.EquilibriumMoisture
+            ()
+        elseif moisture_model isa TC.NonEquilibriumMoisture
+            (prog_gm.q_liq[k], prog_gm.q_ice[k])
+        else
+            error("Something went wrong. The moisture_model options are equilibrium or nonequilibrium")
+        end
+        e_pot = TC.geopotential(param_set, grid.zc.z[k])
+        e_int = prog_gm.ρe_tot[k] / ρ_c[k] - aux_gm.e_kin[k] - e_pot
+        ts_gm[k] = TC.thermo_state_peq(param_set, p_c[k], e_int, prog_gm.ρq_tot[k] / ρ_c[k], thermo_args...)
+    end
+    return nothing
+end
+
+function set_thermo_state_pθq!(state, grid, moisture_model, param_set)
+    Ic = CCO.InterpolateF2C()
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    p_c = aux_gm.p
+    @inbounds for k in TC.real_center_indices(grid)
+        thermo_args = if moisture_model isa TC.EquilibriumMoisture
+            ()
+        elseif moisture_model isa TC.NonEquilibriumMoisture
+            (prog_gm.q_liq[k], prog_gm.q_ice[k])
+        else
+            error("Something went wrong. The moisture_model options are equilibrium or nonequilibrium")
+        end
+        ts_gm[k] = TC.thermo_state_pθq(param_set, p_c[k], aux_gm.θ_liq_ice[k], aux_gm.q_tot[k], thermo_args...)
+    end
+    return nothing
+end
+
+function set_grid_mean_from_thermo_state!(param_set, state, grid)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    Ic = CCO.InterpolateF2C()
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    prog_gm = TC.center_prog_grid_mean(state)
+    prog_gm_f = TC.face_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    ρ_c = prog_gm.ρ
+    C123 = CCG.Covariant123Vector
+    @. prog_gm.ρe_tot =
+        ρ_c * TD.total_energy(
+            thermo_params,
+            ts_gm,
+            LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(prog_gm_f.w))) / 2,
+            TC.geopotential(param_set, grid.zc.z),
+        )
+    @. prog_gm.ρq_tot = ρ_c * aux_gm.q_tot
+
+    return nothing
+end
+
+function assign_thermo_aux!(state, grid, moisture_model, param_set)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ts_gm = TC.center_aux_grid_mean(state).ts
+    ρ_c = prog_gm.ρ
+    @inbounds for k in TC.real_center_indices(grid)
+        ts = ts_gm[k]
+        aux_gm.q_tot[k] = prog_gm.ρq_tot[k] / ρ_c[k]
+        aux_gm.q_liq[k] = TD.liquid_specific_humidity(thermo_params, ts)
+        aux_gm.q_ice[k] = TD.ice_specific_humidity(thermo_params, ts)
+        aux_gm.T[k] = TD.air_temperature(thermo_params, ts)
+        aux_gm.RH[k] = TD.relative_humidity(thermo_params, ts)
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts)
+        aux_gm.h_tot[k] = TC.total_enthalpy(param_set, prog_gm.ρe_tot[k] / ρ_c[k], ts)
+    end
+    return
+end
+
+function ∑stoch_tendencies!(tendencies::FV, prog::FV, params::NT, t::Real) where {NT, FV <: CC.Fields.FieldVector}
+    UnPack.@unpack edmf, param_set, surf_params, aux = params
+
+    # set all tendencies to zero
+    tends_face = tendencies.face
+    tends_cent = tendencies.cent
+    parent(tends_face) .= 0
+    parent(tends_cent) .= 0
+
+    for inds in TC.iterate_columns(prog.cent)
+
+        state = TC.column_state(prog, aux, tendencies, inds...)
+        grid = TC.Grid(state)
+        surf = get_surface(surf_params, grid, state, t, param_set)
+
+        # compute updraft stochastic tendencies
+        TC.compute_up_stoch_tendencies!(edmf, grid, state, param_set, surf)
+    end
+end
+
+# Compute the sum of tendencies for the scheme
+function ∑tendencies!(tendencies::FV, prog::FV, params::NT, t::Real) where {NT, FV <: CC.Fields.FieldVector}
+    UnPack.@unpack edmf, precip_model, param_set, case = params
+    UnPack.@unpack surf_params, radiation, forcing, aux, TS = params
+
+    thermo_params = TCP.thermodynamics_params(param_set)
+    tends_face = tendencies.face
+    tends_cent = tendencies.cent
+    parent(tends_face) .= 0
+    parent(tends_cent) .= 0
+
+    for inds in TC.iterate_columns(prog.cent)
+        state = TC.column_state(prog, aux, tendencies, inds...)
+        grid = TC.Grid(state)
+
+        set_thermo_state_peq!(state, grid, edmf.moisture_model, param_set)
+        assign_thermo_aux!(state, grid, edmf.moisture_model, param_set)
+
+        aux_gm = TC.center_aux_grid_mean(state)
+
+        @. aux_gm.θ_virt = TD.virtual_pottemp(thermo_params, aux_gm.ts)
+
+        Δt = TS.dt
+        surf = get_surface(surf_params, grid, state, t, param_set)
+
+        TC.affect_filter!(edmf, grid, state, param_set, surf, t)
+
+        # Update aux / pre-tendencies filters. TODO: combine these into a function that minimizes traversals
+        # Some of these methods should probably live in `compute_tendencies`, when written, but we'll
+        # treat them as auxiliary variables for now, until we disentangle the tendency computations.
+        Cases.update_forcing(case, grid, state, t, param_set)
+        Cases.update_radiation(radiation, grid, state, t, param_set)
+
+        TC.update_aux!(edmf, grid, state, surf, param_set, t, Δt)
+
+        # compute tendencies
+        # causes division error in dry bubble first time step
+        TC.compute_precipitation_sink_tendencies(precip_model, edmf, grid, state, param_set, Δt)
+        TC.compute_precipitation_advection_tendencies(precip_model, edmf, grid, state, param_set)
+
+        TC.compute_turbconv_tendencies!(edmf, grid, state, param_set, surf, Δt)
+        compute_gm_tendencies!(edmf, grid, state, surf, radiation, forcing, param_set)
+    end
+
+    return nothing
+end
+
+function compute_les_Γᵣ(z::FT, τᵣ::FT = 24.0 * 3600.0, zᵢ::FT = 3000.0, zᵣ::FT = 3500.0) where {FT <: Real}
+    # returns height-dependent relaxation timescale from eqn. 9 in `Shen et al. 2021`
+    if z < zᵢ
+        return FT(0)
+    elseif zᵢ <= z <= zᵣ
+        cos_arg = pi * ((z - zᵢ) / (zᵣ - zᵢ))
+        return (FT(0.5) / τᵣ) * (1 - cos(cos_arg))
+    elseif z > zᵣ
+        return (1 / τᵣ)
+    end
+end
+
+function compute_gm_tendencies!(
+    edmf::TC.EDMFModel,
+    grid::TC.Grid,
+    state::TC.State,
+    surf::TC.SurfaceBase,
+    radiation::Cases.RadiationBase,
+    force::Cases.ForcingBase,
+    param_set::APS,
+)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    Ic = CCO.InterpolateF2C()
+    R_d = TCP.R_d(param_set)
+    T_0 = TCP.T_0(param_set)
+    Lv_0 = TCP.LH_v0(param_set)
+    tendencies_gm = TC.center_tendencies_grid_mean(state)
+    kc_toa = TC.kc_top_of_atmos(grid)
+    kf_surf = TC.kf_surface(grid)
+    FT = TC.float_type(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    prog_gm_f = TC.face_prog_grid_mean(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    ∇MSE_gm = TC.center_aux_grid_mean(state).∇MSE_gm
+    ∇q_tot_gm = TC.center_aux_grid_mean(state).∇q_tot_gm
+    aux_en = TC.center_aux_environment(state)
+    aux_en_f = TC.face_aux_environment(state)
+    aux_up = TC.center_aux_updrafts(state)
+    aux_bulk = TC.center_aux_bulk(state)
+    ρ_f = aux_gm_f.ρ
+    p_c = aux_gm.p
+    ρ_c = prog_gm.ρ
+    aux_tc = TC.center_aux_turbconv(state)
+    ts_gm = TC.center_aux_grid_mean(state).ts
+
+    MSE_gm_toa = aux_gm.h_tot[kc_toa] - aux_gm.e_kin[kc_toa]
+    q_tot_gm_toa = prog_gm.ρq_tot[kc_toa] / ρ_c[kc_toa]
+    RBe = CCO.RightBiasedC2F(; top = CCO.SetValue(MSE_gm_toa))
+    RBq = CCO.RightBiasedC2F(; top = CCO.SetValue(q_tot_gm_toa))
+    wvec = CC.Geometry.WVector
+    ∇c = CCO.DivergenceF2C()
+    @. ∇MSE_gm = ∇c(wvec(RBe(aux_gm.h_tot - aux_gm.e_kin)))
+    @. ∇q_tot_gm = ∇c(wvec(RBq(prog_gm.ρq_tot / ρ_c)))
+
+    if edmf.moisture_model isa TC.NonEquilibriumMoisture
+        ∇q_liq_gm = TC.center_aux_grid_mean(state).∇q_liq_gm
+        ∇q_ice_gm = TC.center_aux_grid_mean(state).∇q_ice_gm
+        q_liq_gm_toa = prog_gm.q_liq[kc_toa]
+        q_ice_gm_toa = prog_gm.q_ice[kc_toa]
+        RBq_liq = CCO.RightBiasedC2F(; top = CCO.SetValue(q_liq_gm_toa))
+        RBq_ice = CCO.RightBiasedC2F(; top = CCO.SetValue(q_ice_gm_toa))
+        @. ∇q_liq_gm = ∇c(wvec(RBq(prog_gm.q_liq)))
+        @. ∇q_ice_gm = ∇c(wvec(RBq(prog_gm.q_ice)))
+    end
+
+    # Apply forcing and radiation
+    prog_gm_uₕ = TC.grid_mean_uₕ(state)
+    aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
+    # prog_gm_v = TC.grid_mean_v(state)
+    tendencies_gm_uₕ = TC.tendencies_grid_mean_uₕ(state)
+    # tendencies_gm_v = TC.tendencies_grid_mean_v(state)
+    prog_gm_u = TC.physical_grid_mean_u(state)
+    prog_gm_v = TC.physical_grid_mean_v(state)
+
+    # Coriolis
+    coriolis_param = force.coriolis_param
+    # TODO: union split over sphere or box
+    # lat = CC.Fields.coordinate_field(axes(ρ_c)).lat
+    coords = CC.Fields.coordinate_field(axes(ρ_c))
+    coriolis_fn(coord) = CCG.WVector(coriolis_param)
+    f = @. CCG.Contravariant3Vector(coriolis_fn(coords))
+
+    C123 = CCG.Covariant123Vector
+    C12 = CCG.Contravariant12Vector
+    lg = CC.Fields.local_geometry_field(axes(ρ_c))
+    @. tendencies_gm_uₕ -= f × (C12(C123(prog_gm_uₕ)) - C12(C123(aux_gm_uₕ_g)))
+
+
+    @inbounds for k in TC.real_center_indices(grid)
+        cp_m = TD.cp_m(thermo_params, ts_gm[k])
+        cp_v = TCP.cp_v(param_set)
+        cv_v = TCP.cv_v(param_set)
+        R_v = TCP.R_v(param_set)
+        cv_m = TD.cv_m(thermo_params, ts_gm[k])
+        h_v = cv_v * (aux_gm.T[k] - T_0) + Lv_0 - R_v * T_0
+
+        # LS Subsidence
+        tendencies_gm.ρe_tot[k] -= ρ_c[k] * aux_gm.subsidence[k] * ∇MSE_gm[k]
+        tendencies_gm.ρq_tot[k] -= ρ_c[k] * aux_gm.subsidence[k] * ∇q_tot_gm[k]
+        if edmf.moisture_model isa TC.NonEquilibriumMoisture
+            tendencies_gm.q_liq[k] -= ∇q_liq_gm[k] * aux_gm.subsidence[k]
+            tendencies_gm.q_ice[k] -= ∇q_ice_gm[k] * aux_gm.subsidence[k]
+        end
+        # Radiation
+        if Cases.rad_type(radiation) <: Union{Cases.RadiationDYCOMS_RF01, Cases.RadiationLES, Cases.RadiationTRMM_LBA}
+            tendencies_gm.ρe_tot[k] += ρ_c[k] * cv_m * aux_gm.dTdt_rad[k]
+        end
+        # LS advection
+        tendencies_gm.ρq_tot[k] += ρ_c[k] * aux_gm.dqtdt_hadv[k]
+        if !(Cases.force_type(force) <: Cases.ForcingDYCOMS_RF01)
+            tendencies_gm.ρe_tot[k] += ρ_c[k] * (cp_m * aux_gm.dTdt_hadv[k] + h_v * aux_gm.dqtdt_hadv[k])
+        end
+        if edmf.moisture_model isa TC.NonEquilibriumMoisture
+            tendencies_gm.q_liq[k] += aux_gm.dqldt[k]
+            tendencies_gm.q_ice[k] += aux_gm.dqidt[k]
+        end
+
+        # LES specific forcings
+        if Cases.force_type(force) <: Cases.ForcingLES
+            T_fluc = aux_gm.dTdt_fluc[k]
+
+            gm_U_nudge_k = (aux_gm.u_nudge[k] - prog_gm_u[k]) / force.wind_nudge_τᵣ
+            gm_V_nudge_k = (aux_gm.v_nudge[k] - prog_gm_v[k]) / force.wind_nudge_τᵣ
+
+            Γᵣ = compute_les_Γᵣ(grid.zc[k].z, force.scalar_nudge_τᵣ, force.scalar_nudge_zᵢ, force.scalar_nudge_zᵣ)
+            gm_T_nudge_k = Γᵣ * (aux_gm.T_nudge[k] - aux_gm.T[k])
+            gm_q_tot_nudge_k = Γᵣ * (aux_gm.qt_nudge[k] - aux_gm.q_tot[k])
+            if edmf.moisture_model isa TC.NonEquilibriumMoisture
+                gm_q_liq_nudge_k = Γᵣ * (aux_gm.ql_nudge[k] - prog_gm.q_liq[k])
+                gm_q_ice_nudge_k = Γᵣ * (aux_gm.qi_nudge[k] - prog_gm.q_ice[k])
+            end
+
+            tendencies_gm.ρq_tot[k] += ρ_c[k] * (gm_q_tot_nudge_k + aux_gm.dqtdt_fluc[k])
+            tendencies_gm.ρe_tot[k] +=
+                ρ_c[k] * (cv_m * (gm_T_nudge_k + T_fluc) + h_v * (gm_q_tot_nudge_k + aux_gm.dqtdt_fluc[k]))
+            tendencies_gm_uₕ[k] += CCG.Covariant12Vector(CCG.UVVector(gm_U_nudge_k, gm_V_nudge_k), lg[k])
+            if edmf.moisture_model isa TC.NonEquilibriumMoisture
+                tendencies_gm.q_liq[k] += aux_gm.dqldt_hadv[k] + gm_q_liq_nudge_k + aux_gm.dqldt_fluc[k]
+                tendencies_gm.q_ice[k] += aux_gm.dqidt_hadv[k] + gm_q_ice_nudge_k + aux_gm.dqidt_fluc[k]
+            end
+        end
+
+        # Apply precipitation tendencies
+        tendencies_gm.ρq_tot[k] +=
+            ρ_c[k] * (
+                aux_bulk.qt_tendency_precip_formation[k] +
+                aux_en.qt_tendency_precip_formation[k] +
+                aux_tc.qt_tendency_precip_sinks[k]
+            )
+
+        tendencies_gm.ρe_tot[k] +=
+            ρ_c[k] * (
+                aux_bulk.e_tot_tendency_precip_formation[k] +
+                aux_en.e_tot_tendency_precip_formation[k] +
+                aux_tc.e_tot_tendency_precip_sinks[k]
+            )
+
+        if edmf.moisture_model isa TC.NonEquilibriumMoisture
+            tendencies_gm.q_liq[k] += aux_bulk.ql_tendency_precip_formation[k] + aux_en.ql_tendency_precip_formation[k]
+            tendencies_gm.q_ice[k] += aux_bulk.qi_tendency_precip_formation[k] + aux_en.qi_tendency_precip_formation[k]
+        end
+    end
+    TC.compute_sgs_flux!(edmf, grid, state, surf, param_set)
+    sgs_flux_h_tot = aux_gm_f.sgs_flux_h_tot
+    sgs_flux_q_tot = aux_gm_f.sgs_flux_q_tot
+    sgs_flux_uₕ = aux_gm_f.sgs_flux_uₕ
+    tends_ρe_tot = tendencies_gm.ρe_tot
+    tends_ρq_tot = tendencies_gm.ρq_tot
+    tends_uₕ = TC.tendencies_grid_mean_uₕ(state)
+
+    ∇sgs = CCO.DivergenceF2C()
+    @. tends_ρe_tot += -∇sgs(wvec(sgs_flux_h_tot))
+    @. tends_ρq_tot += -∇sgs(wvec(sgs_flux_q_tot))
+    @. tends_uₕ += -∇sgs(sgs_flux_uₕ) / ρ_c
+
+    if edmf.moisture_model isa TC.NonEquilibriumMoisture
+        sgs_flux_q_liq = aux_gm_f.sgs_flux_q_liq
+        sgs_flux_q_ice = aux_gm_f.sgs_flux_q_ice
+
+        tends_q_liq = tendencies_gm.q_liq
+        tends_q_ice = tendencies_gm.q_ice
+        @. tends_q_liq += -∇sgs(wvec(sgs_flux_q_liq)) / ρ_c
+        @. tends_q_ice += -∇sgs(wvec(sgs_flux_q_ice)) / ρ_c
+    end
+
+    return nothing
+end

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -2,8 +2,8 @@ import UnPack
 import LinearAlgebra as LA
 import LinearAlgebra: ×
 
-import TurbulenceConvection as TC
-import TurbulenceConvection.Parameters as TCP
+import ClimaAtmos.TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection.Parameters as TCP
 const APS = TCP.AbstractTurbulenceConvectionParameters
 import Thermodynamics as TD
 import ClimaCore as CC

--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -2,7 +2,7 @@
 ##### Fields
 #####
 
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection as TC
 import ClimaCore as CC
 import ClimaCore.Geometry as CCG
 import ClimaCore.Geometry: ⊗

--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -1,0 +1,140 @@
+#####
+##### Fields
+#####
+
+import TurbulenceConvection as TC
+import ClimaCore as CC
+import ClimaCore.Geometry as CCG
+import ClimaCore.Geometry: ⊗
+
+##### Auxiliary fields
+
+# Center only
+cent_aux_vars_gm_moisture(FT, ::TC.NonEquilibriumMoisture) = (;
+    ∇q_liq_gm = FT(0),
+    ∇q_ice_gm = FT(0),
+    dqldt_rad = FT(0),
+    dqidt_rad = FT(0),
+    dqldt = FT(0),
+    dqidt = FT(0),
+    dqldt_hadv = FT(0),
+    dqidt_hadv = FT(0),
+    ql_nudge = FT(0),
+    qi_nudge = FT(0),
+    dqldt_fluc = FT(0),
+    dqidt_fluc = FT(0),
+)
+cent_aux_vars_gm_moisture(FT, ::TC.EquilibriumMoisture) = NamedTuple()
+cent_aux_vars_gm(FT, local_geometry, edmf) = (;
+    ts = TC.thermo_state(FT, edmf.moisture_model),
+    tke = FT(0),
+    Hvar = FT(0),
+    QTvar = FT(0),
+    HQTcov = FT(0),
+    q_liq = FT(0),
+    q_ice = FT(0),
+    RH = FT(0),
+    s = FT(0),
+    T = FT(0),
+    buoy = FT(0),
+    cloud_fraction = FT(0),
+    H_third_m = FT(0),
+    W_third_m = FT(0),
+    QT_third_m = FT(0),
+    # From RadiationBase
+    dTdt_rad = FT(0), # horizontal advection temperature tendency
+    dqtdt_rad = FT(0), # horizontal advection moisture tendency
+    # From ForcingBase
+    subsidence = FT(0), #Large-scale subsidence
+    dTdt_hadv = FT(0), #Horizontal advection of temperature
+    dqtdt_hadv = FT(0), #Horizontal advection of moisture
+    T_nudge = FT(0), #Reference T profile for relaxation tendency
+    qt_nudge = FT(0), #Reference qt profile for relaxation tendency
+    dTdt_fluc = FT(0), #Vertical turbulent advection of temperature
+    dqtdt_fluc = FT(0), #Vertical turbulent advection of moisture
+    u_nudge = FT(0), #Reference u profile for relaxation tendency
+    v_nudge = FT(0), #Reference v profile for relaxation tendency
+    uₕ_g = CCG.Covariant12Vector(CCG.UVVector(FT(0), FT(0)), local_geometry), #Geostrophic u velocity
+    ∇MSE_gm = FT(0),
+    ∇q_tot_gm = FT(0),
+    cent_aux_vars_gm_moisture(FT, edmf.moisture_model)...,
+    θ_virt = FT(0),
+    Ri = FT(0),
+    θ_liq_ice = FT(0),
+    q_tot = FT(0),
+    p = FT(0),
+    e_kin = FT(0),
+    h_tot = FT(0),
+)
+cent_aux_vars(FT, local_geometry, edmf) =
+    (; cent_aux_vars_gm(FT, local_geometry, edmf)..., TC.cent_aux_vars_edmf(FT, local_geometry, edmf)...)
+
+# Face only
+face_aux_vars_gm_moisture(FT, ::TC.NonEquilibriumMoisture) = (; sgs_flux_q_liq = FT(0), sgs_flux_q_ice = FT(0))
+face_aux_vars_gm_moisture(FT, ::TC.EquilibriumMoisture) = NamedTuple()
+face_aux_vars_gm(FT, local_geometry, edmf) = (;
+    massflux_s = FT(0),
+    diffusive_flux_s = FT(0),
+    total_flux_s = FT(0),
+    f_rad = FT(0),
+    sgs_flux_h_tot = FT(0),
+    sgs_flux_q_tot = FT(0),
+    face_aux_vars_gm_moisture(FT, edmf.moisture_model)...,
+    sgs_flux_uₕ = CCG.Covariant3Vector(FT(0)) ⊗ CCG.Covariant12Vector(FT(0), FT(0)),
+    p = FT(0),
+    ρ = FT(0),
+)
+face_aux_vars(FT, local_geometry, edmf) =
+    (; face_aux_vars_gm(FT, local_geometry, edmf)..., TC.face_aux_vars_edmf(FT, local_geometry, edmf)...)
+
+##### Diagnostic fields
+
+# Center only
+cent_diagnostic_vars_gm(FT, local_geometry) = NamedTuple()
+cent_diagnostic_vars(FT, local_geometry, edmf) =
+    (; cent_diagnostic_vars_gm(FT, local_geometry)..., TC.cent_diagnostic_vars_edmf(FT, local_geometry, edmf)...)
+
+# Face only
+face_diagnostic_vars_gm(FT, local_geometry) = NamedTuple()
+face_diagnostic_vars(FT, local_geometry, edmf) =
+    (; face_diagnostic_vars_gm(FT, local_geometry)..., TC.face_diagnostic_vars_edmf(FT, local_geometry, edmf)...)
+
+# Single value per column diagnostic variables
+single_value_per_col_diagnostic_vars_gm(FT) = (;
+    Tsurface = FT(0),
+    shf = FT(0),
+    lhf = FT(0),
+    ustar = FT(0),
+    wstar = FT(0),
+    lwp_mean = FT(0),
+    iwp_mean = FT(0),
+    rwp_mean = FT(0),
+    swp_mean = FT(0),
+    cutoff_precipitation_rate = FT(0),
+    cloud_base_mean = FT(0),
+    cloud_top_mean = FT(0),
+    cloud_cover_mean = FT(0),
+)
+single_value_per_col_diagnostic_vars(FT, edmf) =
+    (; single_value_per_col_diagnostic_vars_gm(FT)..., TC.single_value_per_col_diagnostic_vars_edmf(FT, edmf)...)
+
+##### Prognostic fields
+
+# Center only
+cent_prognostic_vars(::Type{FT}, local_geometry, edmf) where {FT} =
+    (; cent_prognostic_vars_gm(FT, local_geometry, edmf)..., TC.cent_prognostic_vars_edmf(FT, edmf)...)
+cent_prognostic_vars_gm_moisture(::Type{FT}, ::TC.NonEquilibriumMoisture) where {FT} = (; q_liq = FT(0), q_ice = FT(0))
+cent_prognostic_vars_gm_moisture(::Type{FT}, ::TC.EquilibriumMoisture) where {FT} = NamedTuple()
+cent_prognostic_vars_gm(::Type{FT}, local_geometry, edmf) where {FT} = (;
+    ρ = FT(0),
+    uₕ = CCG.Covariant12Vector(CCG.UVVector(FT(0), FT(0)), local_geometry),
+    ρe_tot = FT(0),
+    ρq_tot = FT(0),
+    cent_prognostic_vars_gm_moisture(FT, edmf.moisture_model)...,
+)
+
+# Face only
+face_prognostic_vars(::Type{FT}, local_geometry, edmf) where {FT} =
+    (; w = CCG.Covariant3Vector(FT(0)), TC.face_prognostic_vars_edmf(FT, local_geometry, edmf)...)
+
+# TC.face_prognostic_vars_edmf(FT, edmf) = (;) # could also use this for empty model

--- a/tc_driver/generate_namelist.jl
+++ b/tc_driver/generate_namelist.jl
@@ -1,0 +1,636 @@
+module NameList
+# See Table 2 of Cohen et al, 2020
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_factor"] = 0.13
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["detrainment_factor"] = 0.51
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_massflux_div_factor"] = 0.0
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["turbulent_entrainment_factor"] = 0.075
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_smin_tke_coeff"] = 0.3
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_mixing_frac"] = 0.25
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_scale"] = 0.0004
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["sorting_power"] = 2.0
+
+# See Table 1 of Lopez Gomez et al, 2020
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_ed_coeff"] = 0.14
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_diss_coeff"] = 0.22
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["static_stab_coeff"] = 0.4 # Square of value in the paper
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_surf_scale"] = 3.75 # Square of value in the paper
+# namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"] = 0.74
+
+# See Table ? of He et al, 2021
+# namelist["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_buoy_coeff1"] = 0.12 ==> alpha_b (scaling constant for virtual mass term)
+# namelist["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_buoy_coeff2"] = 0.0 ==> alpha_b (scaling constant for virtual mass term)
+# namelist["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_adv_coeff"] = 0.1 alpha_a (scaling constant for advection term)
+# namelist["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_drag_coeff"] = 10.0 ==> alpha_d (scaling constant for drag term)
+# namelist["turbulence"]["EDMF_PrognosticTKE"]["pressure_plume_spacing"] ==> r_d (horizontal length scale of plume spacing)
+
+#NB: except for Bomex and life_cycle_Tan2018 cases, the parameters listed have not been thoroughly tuned/tested
+# and should be regarded as placeholders only. Optimal parameters may also depend on namelist options, such as
+# entrainment/detrainment rate formulation, diagnostic vs. prognostic updrafts, and vertical resolution
+export default_namelist
+
+using ArgParse
+
+import StaticArrays
+const SA = StaticArrays
+
+include(joinpath(@__DIR__, "..", "integration_tests", "artifact_funcs.jl"))
+
+import Random
+
+import JSON
+
+function parse_commandline()
+    s = ArgParseSettings(; description = "namelist Generator")
+
+    @add_arg_table! s begin
+        "case_name"
+        help = "The case name"
+        arg_type = String
+        required = true
+    end
+
+    return parse_args(s)
+end
+
+function default_namelist(::Nothing)
+
+    args = parse_commandline()
+    case_name = args["case_name"]
+    return default_namelist(case_name)
+end
+
+function default_namelist(
+    case_name::String;
+    root::String = ".",
+    write::Bool = true,
+    set_seed::Bool = true,
+    seed::Int = 2022,
+    truncate_stack_trace::Bool = false,
+)
+
+    if set_seed
+        Random.seed!(seed)
+    end
+
+    namelist_defaults = Dict()
+    namelist_defaults["meta"] = Dict()
+    namelist_defaults["meta"]["uuid"] = basename(tempname())
+
+    namelist_defaults["config"] = "column"
+    namelist_defaults["set_src_seed"] = false
+    namelist_defaults["test_duals"] = false
+
+    namelist_defaults["logging"] = Dict()
+    namelist_defaults["logging"]["truncate_stack_trace"] = truncate_stack_trace
+
+    namelist_defaults["float_type"] = "Float64"
+
+    namelist_defaults["turbulence"] = Dict()
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"] = Dict()
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["max_area"] = 0.9
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["min_area"] = 1e-5
+
+    # mixing_length
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_ed_coeff"] = 0.14
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_diss_coeff"] = 0.22
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["static_stab_coeff"] = 0.4
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_surf_scale"] = 3.75
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_scale"] = 53.0 / 13.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"] = 0.74
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"] = 0.25
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_ub"] = 0.1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_rm"] = 1.5
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["l_max"] = 1.0e6
+    # entrainment
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_factor"] = 0.13
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["detrainment_factor"] = 0.51
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_massflux_div_factor"] = 0.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["turbulent_entrainment_factor"] = 0.075
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_smin_tke_coeff"] = 0.3
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_mixing_frac"] = 0.25
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["area_limiter_scale"] = 10.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["area_limiter_power"] = 4.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_scale"] = 0.0004
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["sorting_power"] = 2.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["min_upd_velocity"] = 0.001
+    # pressure
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["min_updraft_top"] = 500.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_buoy_coeff1"] = 0.12
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_buoy_coeff2"] = 0.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_adv_coeff"] = 0.1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_drag_coeff"] = 10.0
+
+    # From namelist
+    namelist_defaults["grid"] = Dict()
+    namelist_defaults["grid"]["dims"] = 1
+    namelist_defaults["grid"]["stretch"] = Dict()
+    namelist_defaults["grid"]["stretch"]["flag"] = false
+    namelist_defaults["grid"]["stretch"]["nz"] = 55
+    namelist_defaults["grid"]["stretch"]["dz_surf"] = 30.0
+    namelist_defaults["grid"]["stretch"]["dz_toa"] = 8000.0
+    namelist_defaults["grid"]["stretch"]["z_toa"] = 45000.0
+
+    namelist_defaults["forcing"] = Dict()
+    namelist_defaults["forcing"]["coriolis"] = 0.0
+
+    namelist_defaults["thermodynamics"] = Dict()
+    namelist_defaults["thermodynamics"]["moisture_model"] = "equilibrium" #"nonequilibrium"
+    namelist_defaults["thermodynamics"]["thermo_covariance_model"] = "diagnostic" #"prognostic" or "diagnostic"
+    namelist_defaults["thermodynamics"]["diagnostic_covar_limiter"] = 1e-3 # this controls the magnitude of the spike in covariance
+    namelist_defaults["thermodynamics"]["sgs"] = "mean" # "quadrature" or "mean"
+    namelist_defaults["thermodynamics"]["quadrature_order"] = 3
+    namelist_defaults["thermodynamics"]["quadrature_type"] = "log-normal" #"gaussian" or "log-normal"
+
+    namelist_defaults["time_stepping"] = Dict()
+    namelist_defaults["time_stepping"]["dt_max"] = 12.0
+    namelist_defaults["time_stepping"]["dt_min"] = 1.0
+    namelist_defaults["time_stepping"]["adapt_dt"] = true
+    namelist_defaults["time_stepping"]["cfl_limit"] = 0.5
+
+    namelist_defaults["microphysics"] = Dict()
+    namelist_defaults["microphysics"]["precipitation_model"] = "None"
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "NN_nonlocal", "Linear", "FNO", "RF"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = "buoy_vel" # {"buoy_vel", "inv_z", "none"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["detr_dim_scale"] = "buoy_vel" # {"buoy_vel", "inv_z", "none"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_pi_subset"] = ntuple(i -> i, 6) # or, e.g., (1, 3, 6)
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pi_norm_consts"] = [478.298, 1.0, 1.0, 1.0, 1.0, 1.0] # normalization constants for Pi groups
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = "deterministic"  # {"deterministic", "noisy_relaxation_process", "lognormal_scaling", "prognostic_noisy_relaxation_process"}
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_buoy"] = "normalmode"
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_drag"] = "normalmode"
+
+    namelist_defaults["output"] = Dict()
+    namelist_defaults["output"]["output_root"] = "./"
+
+    namelist_defaults["stats_io"] = Dict()
+    namelist_defaults["stats_io"]["stats_dir"] = "stats"
+    namelist_defaults["stats_io"]["frequency"] = 60.0
+    namelist_defaults["stats_io"]["skip"] = false
+    namelist_defaults["stats_io"]["calibrate_io"] = false # limit io for calibration when `true`
+
+    # nn parameters
+    #! format: off
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["nn_arc"] = (6, 5, 4, 2) # [#inputs, #neurons in L1, #neurons in L2, ...., #outputs]
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["nn_ent_params"] =
+        [-1.2791038,
+        -1.1564382,
+        1.2115442,
+        0.3241886,
+        0.4968626,
+        -1.1304279,
+        0.1335658,
+        -1.5348452,
+        -0.661436,
+        -1.7114845,
+        0.5861781,
+        -0.0008509,
+        1.8417425,
+        -0.0692783,
+        -0.1800616,
+        0.4822386,
+        0.1193081,
+        0.4175962,
+        -1.7491715,
+        0.0331383,
+        -1.1470715,
+        0.1166774,
+        -0.5425564,
+        -0.3332106,
+        -1.3615489,
+        -0.2109712,
+        -0.1836716,
+        -1.7316646,
+        -0.5677241,
+        1.5717871,
+        -0.2886485,
+        0.2341374,
+        -1.1329331,
+        -0.5656705,
+        -0.7084822,
+        0.0904796,
+        -0.2447465,
+        -0.8655097,
+        0.1487832,
+        1.737286,
+        0.3335405,
+        1.2600883,
+        0.1105,
+        -0.9467368,
+        -0.1319687,
+        -0.3314595,
+        1.2015113,
+        -0.5082856,
+        -1.3685998,
+        -1.6377497,
+        0.0398038,
+        0.6748809,
+        1.1398398,
+        -1.1689684,
+        -0.9930153,
+        0.8116707,
+        -0.006826,
+        0.0822948,
+        -0.7905997,
+        -0.3131524,
+        -0.4061444,
+        1.6651008,
+        1.555821,
+        0.1941005,
+        1.0823169,
+        -0.3608865,
+        0.7003173,
+        0.2197592,
+        -0.1367713]
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["nn_ent_biases"] = true
+
+    # m=100 random features, d=6 input Pi groups
+    # RF: parameters to optimize, 2 x (m + 1 + d)
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["rf_opt_ent_params"] =
+        vec(cat(randn(2,100), # vec(cat(randn(2, m),
+                    ones(2,7), dims=2)) # ones(2, d + 1), dims=2))
+
+    # RF: fixed realizations of random variables, 2 x m x (1 + d)
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["rf_fix_ent_params"] =
+        vec(cat(2*pi*rand(2,100,1), # vec(cat(2*pi*rand(2, m, 1),
+                    randn(2,100,6), dims=3)) # randn(2, m, d), dims=3))
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["linear_ent_params"] =
+        SA.SVector{14}(rand(14))
+
+    # General stochastic entrainment/detrainment parameters
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["general_stochastic_ent_params"] =
+    SA.SVector(
+        0.1, 0.1,   # ε_σ², δ_σ²
+        0.05, 0.05  # ε_λ, δ_λ
+    )
+
+    # For FNO add here
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["fno_ent_width"] = 2
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["fno_ent_n_modes"] = 2
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["fno_ent_params"] =
+        SA.SVector{50}(rand(50))
+
+    #! format: on
+
+    if case_name == "Soares"
+        namelist = Soares(namelist_defaults)
+    elseif case_name == "Nieuwstadt"
+        namelist = Nieuwstadt(namelist_defaults)
+    elseif case_name == "Bomex"
+        namelist = Bomex(namelist_defaults)
+    elseif case_name == "life_cycle_Tan2018"
+        namelist = life_cycle_Tan2018(namelist_defaults)
+    elseif case_name == "Rico"
+        namelist = Rico(namelist_defaults)
+    elseif case_name == "TRMM_LBA"
+        namelist = TRMM_LBA(namelist_defaults)
+    elseif case_name == "ARM_SGP"
+        namelist = ARM_SGP(namelist_defaults)
+    elseif case_name == "GATE_III"
+        namelist = GATE_III(namelist_defaults)
+    elseif case_name == "DYCOMS_RF01"
+        namelist = DYCOMS_RF01(namelist_defaults)
+    elseif case_name == "DYCOMS_RF02"
+        namelist = DYCOMS_RF02(namelist_defaults)
+    elseif case_name == "GABLS"
+        namelist = GABLS(namelist_defaults)
+    elseif case_name == "DryBubble"
+        namelist = DryBubble(namelist_defaults)
+    elseif case_name == "LES_driven_SCM"
+        namelist = LES_driven_SCM(namelist_defaults)
+    else
+        error("Not a valid case name")
+    end
+
+    if write
+        write_file(namelist, root)
+    end
+    return namelist
+end
+function Soares(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "Soares"
+
+    namelist["grid"]["nz"] = 75
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["time_stepping"]["t_max"] = 8 * 3600.0
+    namelist["time_stepping"]["dt_min"] = 1.0
+
+    namelist["meta"]["simname"] = "Soares"
+    namelist["meta"]["casename"] = "Soares"
+
+    return namelist
+end
+function Nieuwstadt(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "Nieuwstadt"
+
+    namelist["grid"]["nz"] = 75
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["time_stepping"]["t_max"] = 8 * 3600.0
+    namelist["time_stepping"]["dt_min"] = 1.2
+
+    namelist["meta"]["simname"] = "Nieuwstadt"
+    namelist["meta"]["casename"] = "Nieuwstadt"
+
+    return namelist
+end
+function Bomex(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "Bomex"
+
+    namelist["grid"]["nz"] = 60
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["forcing"]["coriolis"] = 0.376e-4
+
+    namelist["time_stepping"]["t_max"] = 21600.0
+    namelist["time_stepping"]["dt_min"] = 6.0
+
+    namelist["meta"]["simname"] = "Bomex"
+    namelist["meta"]["casename"] = "Bomex"
+
+    return namelist
+end
+function life_cycle_Tan2018(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "life_cycle_Tan2018"
+
+    namelist["grid"]["nz"] = 75
+    namelist["grid"]["dz"] = 40.0
+
+    namelist["forcing"]["coriolis"] = 0.376e-4
+
+    namelist["time_stepping"]["t_max"] = 6 * 3600.0
+    namelist["time_stepping"]["dt_min"] = 10.0
+    namelist["meta"]["simname"] = "life_cycle_Tan2018"
+    namelist["meta"]["casename"] = "life_cycle_Tan2018"
+
+    return namelist
+end
+function Rico(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "Rico"
+
+    namelist["grid"]["nz"] = 80
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["time_stepping"]["adapt_dt"] = false
+    namelist["time_stepping"]["t_max"] = 86400.0
+    #namelist["time_stepping"]["dt_max"] = 5.0
+    namelist["time_stepping"]["dt_min"] = 1.5
+
+    namelist["forcing"]["latitude"] = 18.0
+    namelist["forcing"]["coriolis"] = 4.5e-5
+
+    namelist["microphysics"]["precipitation_model"] = "clima_1m"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
+    namelist["microphysics"]["τ_acnv_rai"] = 2500.0
+    namelist["microphysics"]["τ_acnv_sno"] = 100.0
+    namelist["microphysics"]["q_liq_threshold"] = 0.5e-3
+    namelist["microphysics"]["q_ice_threshold"] = 1e-6
+    namelist["microphysics"]["microph_scaling"] = 1.0
+    namelist["microphysics"]["microph_scaling_dep_sub"] = 1.0
+    namelist["microphysics"]["microph_scaling_melt"] = 1.0
+    namelist["microphysics"]["E_liq_rai"] = 0.8
+    namelist["microphysics"]["E_liq_sno"] = 0.1
+    namelist["microphysics"]["E_ice_rai"] = 1.0
+    namelist["microphysics"]["E_ice_sno"] = 0.1
+    namelist["microphysics"]["E_rai_sno"] = 1.0
+
+    namelist["meta"]["simname"] = "Rico"
+    namelist["meta"]["casename"] = "Rico"
+    return namelist
+end
+function TRMM_LBA(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "TRMM_LBA"
+
+    namelist["grid"]["nz"] = 82
+    namelist["grid"]["dz"] = 200
+
+    namelist["time_stepping"]["adapt_dt"] = true
+    namelist["time_stepping"]["t_max"] = 60 * 60 * 6.0
+    namelist["time_stepping"]["dt_max"] = 5.0
+    namelist["time_stepping"]["dt_min"] = 1.0
+
+    namelist["microphysics"]["precipitation_model"] = "clima_1m" # "cutoff"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
+    namelist["microphysics"]["τ_acnv_rai"] = 2500.0
+    namelist["microphysics"]["τ_acnv_sno"] = 100.0
+    namelist["microphysics"]["q_liq_threshold"] = 0.5e-3
+    namelist["microphysics"]["q_ice_threshold"] = 1e-6
+    namelist["microphysics"]["microph_scaling"] = 1.0
+    namelist["microphysics"]["microph_scaling_dep_sub"] = 1.0
+    namelist["microphysics"]["microph_scaling_melt"] = 1.0
+    namelist["microphysics"]["E_liq_rai"] = 0.8
+    namelist["microphysics"]["E_liq_sno"] = 0.1
+    namelist["microphysics"]["E_ice_rai"] = 1.0
+    namelist["microphysics"]["E_ice_sno"] = 0.1
+    namelist["microphysics"]["E_rai_sno"] = 1.0
+
+    namelist["meta"]["simname"] = "TRMM_LBA"
+    namelist["meta"]["casename"] = "TRMM_LBA"
+
+    return namelist
+end
+function ARM_SGP(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "ARM_SGP"
+
+    namelist["grid"]["nz"] = 88
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["forcing"]["coriolis"] = 8.5e-5
+
+    namelist["time_stepping"]["t_max"] = 3600.0 * 14.5
+    namelist["time_stepping"]["dt_min"] = 2.0
+
+    namelist["meta"]["simname"] = "ARM_SGP"
+    namelist["meta"]["casename"] = "ARM_SGP"
+
+    return namelist
+end
+function GATE_III(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "GATE_III"
+
+    namelist["grid"]["nz"] = 200 # 1700
+    namelist["grid"]["dz"] = 85  # 10
+
+    namelist["time_stepping"]["adapt_dt"] = false
+    namelist["time_stepping"]["t_max"] = 3600.0 * 24.0
+    namelist["time_stepping"]["dt_max"] = 5.0
+    namelist["time_stepping"]["dt_min"] = 2.0
+
+    namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+
+    namelist["meta"]["simname"] = "GATE_III"
+    namelist["meta"]["casename"] = "GATE_III"
+
+    return namelist
+end
+function DYCOMS_RF01(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "DYCOMS_RF01"
+
+    namelist["grid"]["nz"] = 30
+    namelist["grid"]["dz"] = 50
+
+    namelist["time_stepping"]["t_max"] = 60 * 60 * 16.0
+    namelist["time_stepping"]["dt_min"] = 6.0
+
+    namelist["meta"]["simname"] = "DYCOMS_RF01"
+    namelist["meta"]["casename"] = "DYCOMS_RF01"
+
+    return namelist
+end
+function DYCOMS_RF02(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "DYCOMS_RF02"
+
+    namelist["grid"]["nz"] = 30
+    namelist["grid"]["dz"] = 50
+
+    namelist["time_stepping"]["adapt_dt"] = true
+    namelist["time_stepping"]["t_max"] = 60 * 60 * 6.0
+    namelist["time_stepping"]["dt_max"] = 4.0
+    namelist["time_stepping"]["dt_min"] = 1.0
+
+    namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
+    namelist["microphysics"]["τ_acnv_rai"] = 2500.0
+    namelist["microphysics"]["τ_acnv_sno"] = 100.0
+    namelist["microphysics"]["q_liq_threshold"] = 0.5e-3
+    namelist["microphysics"]["q_ice_threshold"] = 1e-6
+    namelist["microphysics"]["microph_scaling"] = 1.0
+    namelist["microphysics"]["microph_scaling_dep_sub"] = 1.0
+    namelist["microphysics"]["microph_scaling_melt"] = 1.0
+    namelist["microphysics"]["E_liq_rai"] = 0.8
+    namelist["microphysics"]["E_liq_sno"] = 0.1
+    namelist["microphysics"]["E_ice_rai"] = 1.0
+    namelist["microphysics"]["E_ice_sno"] = 0.1
+    namelist["microphysics"]["E_rai_sno"] = 1.0
+
+    namelist["meta"]["simname"] = "DYCOMS_RF02"
+    namelist["meta"]["casename"] = "DYCOMS_RF02"
+
+    return namelist
+end
+function GABLS(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "GABLS"
+
+    namelist["grid"]["nz"] = 8
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["forcing"]["coriolis"] = 1.39e-4
+
+    namelist["time_stepping"]["t_max"] = 9 * 3600.0
+    namelist["time_stepping"]["dt_min"] = 4.0
+    namelist["time_stepping"]["dt_max"] = 8.0
+    namelist["meta"]["simname"] = "GABLS"
+    namelist["meta"]["casename"] = "GABLS"
+
+    return namelist
+end
+
+function DryBubble(namelist_defaults)
+    namelist = deepcopy(namelist_defaults)
+    namelist["meta"]["casename"] = "DryBubble"
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.0
+
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_buoy_coeff1"] = 0.12
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_adv_coeff"] = 0.25
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_normalmode_drag_coeff"] = 0.1
+
+    namelist["grid"]["nz"] = 200
+    namelist["grid"]["dz"] = 50.0
+
+    namelist["stats_io"]["frequency"] = 10.0
+    namelist["time_stepping"]["t_max"] = 1000.0
+    namelist["time_stepping"]["dt_min"] = 0.5
+
+    namelist["meta"]["simname"] = "DryBubble"
+    namelist["meta"]["casename"] = "DryBubble"
+
+    namelist["turbulence"]["EDMF_PrognosticTKE"]["entrainment_massflux_div_factor"] = 0.4
+
+    return namelist
+end
+
+function LES_driven_SCM(namelist_defaults)
+    namelist = deepcopy(namelist_defaults)
+    # Only one can be defined by user
+    # namelist["grid"]["dz"] = 50.0
+    namelist["grid"]["nz"] = 80
+
+    namelist["stats_io"]["frequency"] = 10.0
+    namelist["time_stepping"]["t_max"] = 3600.0 * 6
+    namelist["time_stepping"]["dt_min"] = 1.0
+
+    # use last 6 hours of LES simulation to drive LES
+    namelist["t_interval_from_end_s"] = 3600.0 * 6
+    # average in 1 hour interval around `t_interval_from_end_s`
+    namelist["initial_condition_averaging_window_s"] = 3600.0
+
+    # LES filename should follow pattern:
+    # Stats.cfsite<SITE-NUMBER>_<FORCING-MODEL>_<EXPERIMENT>_2004-2008.<MONTH>.nc
+    namelist["meta"]["lesfile"] =
+        joinpath(les_driven_scm_data_folder(), "Stats.cfsite23_HadGEM2-A_amip_2004-2008.07.nc")
+    namelist["meta"]["simname"] = "LES_driven_SCM"
+    namelist["meta"]["casename"] = "LES_driven_SCM"
+
+    return namelist
+end
+
+function write_file(namelist, root::String = ".")
+    mkpath(root)
+
+    @assert haskey(namelist, "meta")
+    @assert haskey(namelist["meta"], "simname")
+
+    casename = namelist["meta"]["casename"]
+    open(joinpath(root, "namelist_$casename.in"), "w") do io
+        JSON.print(io, namelist, 4)
+    end
+
+    return
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    default_namelist(nothing)
+end
+
+end

--- a/tc_driver/generate_namelist.jl
+++ b/tc_driver/generate_namelist.jl
@@ -33,7 +33,7 @@ using ArgParse
 import StaticArrays
 const SA = StaticArrays
 
-include(joinpath(@__DIR__, "..", "integration_tests", "artifact_funcs.jl"))
+include(joinpath(@__DIR__, "artifact_funcs.jl"))
 
 import Random
 

--- a/tc_driver/initial_conditions.jl
+++ b/tc_driver/initial_conditions.jl
@@ -1,0 +1,148 @@
+import TurbulenceConvection as TC
+import TurbulenceConvection.Parameters as TCP
+const APS = TCP.AbstractTurbulenceConvectionParameters
+
+import Thermodynamics as TD
+
+function initialize_edmf(edmf::TC.EDMFModel, grid::TC.Grid, state::TC.State, surf_params, param_set::APS, t::Real, case)
+    thermo_params = TCP.thermodynamics_params(param_set)
+    initialize_covariance(edmf, grid, state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    ts_gm = aux_gm.ts
+    @. aux_gm.θ_virt = TD.virtual_pottemp(thermo_params, ts_gm)
+    surf = get_surface(surf_params, grid, state, t, param_set)
+    if case isa Cases.DryBubble
+        initialize_updrafts_DryBubble(edmf, grid, state)
+    else
+        initialize_updrafts(edmf, grid, state, surf)
+    end
+    TC.set_edmf_surface_bc(edmf, grid, state, surf, param_set)
+    return
+end
+
+function initialize_covariance(edmf::TC.EDMFModel, grid::TC.Grid, state::TC.State)
+
+    kc_surf = TC.kc_surface(grid)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_en = TC.center_prog_environment(state)
+    aux_en = TC.center_aux_environment(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    ρ_c = prog_gm.ρ
+    aux_bulk = TC.center_aux_bulk(state)
+    ae = 1 .- aux_bulk.area # area of environment
+
+    aux_en.tke .= aux_gm.tke
+    aux_en.Hvar .= aux_gm.Hvar
+    aux_en.QTvar .= aux_gm.QTvar
+    aux_en.HQTcov .= aux_gm.HQTcov
+
+    prog_en.ρatke .= aux_en.tke .* ρ_c .* ae
+    if edmf.thermo_covariance_model isa TC.PrognosticThermoCovariances
+        prog_en.ρaHvar .= aux_gm.Hvar .* ρ_c .* ae
+        prog_en.ρaQTvar .= aux_gm.QTvar .* ρ_c .* ae
+        prog_en.ρaHQTcov .= aux_gm.HQTcov .* ρ_c .* ae
+    end
+    return
+end
+
+function initialize_updrafts(edmf, grid, state, surf)
+    N_up = TC.n_updrafts(edmf)
+    kc_surf = TC.kc_surface(grid)
+    aux_up = TC.center_aux_updrafts(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    aux_up = TC.center_aux_updrafts(state)
+    aux_up_f = TC.face_aux_updrafts(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    prog_up = TC.center_prog_updrafts(state)
+    prog_up_f = TC.face_prog_updrafts(state)
+    ρ_c = prog_gm.ρ
+    @inbounds for i in 1:N_up
+        @inbounds for k in TC.real_face_indices(grid)
+            aux_up_f[i].w[k] = 0
+            prog_up_f[i].ρaw[k] = 0
+        end
+
+        @inbounds for k in TC.real_center_indices(grid)
+            aux_up[i].buoy[k] = 0
+            # Simple treatment for now, revise when multiple updraft closures
+            # become more well defined
+            aux_up[i].area[k] = 0
+            aux_up[i].q_tot[k] = aux_gm.q_tot[k]
+            aux_up[i].θ_liq_ice[k] = aux_gm.θ_liq_ice[k]
+            aux_up[i].q_liq[k] = aux_gm.q_liq[k]
+            aux_up[i].q_ice[k] = aux_gm.q_ice[k]
+            aux_up[i].T[k] = aux_gm.T[k]
+            prog_up[i].ρarea[k] = 0
+            prog_up[i].ρaq_tot[k] = 0
+            prog_up[i].ρaθ_liq_ice[k] = 0
+        end
+        if edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess
+            @. prog_up[i].ε_nondim = 0
+            @. prog_up[i].δ_nondim = 0
+        end
+
+        a_surf = TC.area_surface_bc(surf, edmf, i)
+        aux_up[i].area[kc_surf] = a_surf
+        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
+    end
+    return
+end
+
+import AtmosphericProfilesLibrary
+const APL = AtmosphericProfilesLibrary
+function initialize_updrafts_DryBubble(edmf, grid, state)
+
+    # criterion 2: b>1e-4
+    aux_up = TC.center_aux_updrafts(state)
+    aux_up_f = TC.face_aux_updrafts(state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    prog_up = TC.center_prog_updrafts(state)
+    prog_up_f = TC.face_prog_updrafts(state)
+    ρ_0_c = prog_gm.ρ
+    ρ_0_f = aux_gm_f.ρ
+    N_up = TC.n_updrafts(edmf)
+    FT = TC.float_type(state)
+    z_in = APL.DryBubble_updrafts_z(FT)
+    z_min, z_max = first(z_in), last(z_in)
+    prof_θ_liq_ice = APL.DryBubble_updrafts_θ_liq_ice(FT)
+    prof_area = APL.DryBubble_updrafts_area(FT)
+    prof_w = APL.DryBubble_updrafts_w(FT)
+    prof_T = APL.DryBubble_updrafts_T(FT)
+    face_bcs = (; bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
+    If = CCO.InterpolateC2F(; face_bcs...)
+    @inbounds for i in 1:N_up
+        @inbounds for k in TC.real_face_indices(grid)
+            if z_min <= grid.zf[k].z <= z_max
+                aux_up_f[i].w[k] = eps(FT) # non zero value to aviod zeroing out fields in the filter
+            end
+        end
+
+        @inbounds for k in TC.real_center_indices(grid)
+            z = grid.zc[k].z
+            if z_min <= z <= z_max
+                aux_up[i].area[k] = prof_area(z)
+                aux_up[i].θ_liq_ice[k] = prof_θ_liq_ice(z)
+                aux_up[i].q_tot[k] = 0.0
+                aux_up[i].q_liq[k] = 0.0
+                aux_up[i].q_ice[k] = 0.0
+
+                # for now temperature is provided as diagnostics from LES
+                aux_up[i].T[k] = prof_T(z)
+                prog_up[i].ρarea[k] = ρ_0_c[k] * aux_up[i].area[k]
+                prog_up[i].ρaθ_liq_ice[k] = prog_up[i].ρarea[k] * aux_up[i].θ_liq_ice[k]
+                prog_up[i].ρaq_tot[k] = prog_up[i].ρarea[k] * aux_up[i].q_tot[k]
+            else
+                aux_up[i].area[k] = 0.0
+                aux_up[i].θ_liq_ice[k] = aux_gm.θ_liq_ice[k]
+                aux_up[i].T[k] = aux_gm.T[k]
+                prog_up[i].ρarea[k] = 0.0
+                prog_up[i].ρaθ_liq_ice[k] = 0.0
+                prog_up[i].ρaq_tot[k] = 0.0
+            end
+        end
+        @. prog_up_f[i].ρaw = If(prog_up[i].ρarea) * aux_up_f[i].w
+    end
+    return nothing
+end

--- a/tc_driver/initial_conditions.jl
+++ b/tc_driver/initial_conditions.jl
@@ -1,5 +1,5 @@
-import TurbulenceConvection as TC
-import TurbulenceConvection.Parameters as TCP
+import ClimaAtmos.TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection.Parameters as TCP
 const APS = TCP.AbstractTurbulenceConvectionParameters
 
 import Thermodynamics as TD

--- a/tc_driver/main.jl
+++ b/tc_driver/main.jl
@@ -6,7 +6,8 @@ Logging.global_logger(TerminalLoggers.TerminalLogger())
 import UnPack
 import JSON
 import ArgParse
-import TurbulenceConvection
+import ClimaAtmos
+import ClimaAtmos.TurbulenceConvection
 
 import CloudMicrophysics as CM
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
@@ -20,16 +21,16 @@ import OrdinaryDiffEq as ODE
 import StochasticDiffEq as SDE
 import StaticArrays: SVector
 
-const tc_dir = pkgdir(TurbulenceConvection)
+const ca_dir = pkgdir(ClimaAtmos)
 
-include(joinpath(tc_dir, "driver", "NetCDFIO.jl"))
-include(joinpath(tc_dir, "driver", "initial_conditions.jl"))
-include(joinpath(tc_dir, "driver", "compute_diagnostics.jl"))
-include(joinpath(tc_dir, "driver", "parameter_set.jl"))
-include(joinpath(tc_dir, "driver", "Cases.jl"))
-include(joinpath(tc_dir, "driver", "dycore.jl"))
-include(joinpath(tc_dir, "driver", "TimeStepping.jl"))
-include(joinpath(tc_dir, "driver", "Surface.jl"))
+include(joinpath(tc_dir, "tc_driver", "NetCDFIO.jl"))
+include(joinpath(tc_dir, "tc_driver", "initial_conditions.jl"))
+include(joinpath(tc_dir, "tc_driver", "compute_diagnostics.jl"))
+include(joinpath(tc_dir, "tc_driver", "parameter_set.jl"))
+include(joinpath(tc_dir, "tc_driver", "Cases.jl"))
+include(joinpath(tc_dir, "tc_driver", "dycore.jl"))
+include(joinpath(tc_dir, "tc_driver", "TimeStepping.jl"))
+include(joinpath(tc_dir, "tc_driver", "Surface.jl"))
 import .Cases
 
 import DiffEqNoiseProcess

--- a/tc_driver/main.jl
+++ b/tc_driver/main.jl
@@ -1,0 +1,454 @@
+import Logging
+import ForwardDiff
+import TerminalLoggers
+Logging.global_logger(TerminalLoggers.TerminalLogger())
+
+import UnPack
+import JSON
+import ArgParse
+import TurbulenceConvection
+
+import CloudMicrophysics as CM
+import CloudMicrophysics.MicrophysicsNonEq as CMNe
+import CloudMicrophysics.Microphysics0M as CM0
+import CloudMicrophysics.Microphysics1M as CM1
+
+import ClimaCore as CC
+import SciMLBase
+
+import OrdinaryDiffEq as ODE
+import StochasticDiffEq as SDE
+import StaticArrays: SVector
+
+const tc_dir = pkgdir(TurbulenceConvection)
+
+include(joinpath(tc_dir, "driver", "NetCDFIO.jl"))
+include(joinpath(tc_dir, "driver", "initial_conditions.jl"))
+include(joinpath(tc_dir, "driver", "compute_diagnostics.jl"))
+include(joinpath(tc_dir, "driver", "parameter_set.jl"))
+include(joinpath(tc_dir, "driver", "Cases.jl"))
+include(joinpath(tc_dir, "driver", "dycore.jl"))
+include(joinpath(tc_dir, "driver", "TimeStepping.jl"))
+include(joinpath(tc_dir, "driver", "Surface.jl"))
+import .Cases
+
+import DiffEqNoiseProcess
+import Random
+function DiffEqNoiseProcess.wiener_randn!(rng::Random.AbstractRNG, rand_vec::CC.Fields.FieldVector)
+    # TODO: fix this hack. ClimaCore's axes(::FieldVector) cannot
+    #       return a space (since it has multiple spaces)
+    parent(rand_vec.cent) .= Random.randn.()
+    parent(rand_vec.face) .= Random.randn.()
+end
+
+struct Simulation1d{IONT, P, A, C, F, R, SM, EDMF, PM, D, TIMESTEPPING, STATS, PS, SRS, LESDK}
+    io_nt::IONT
+    prog::P
+    aux::A
+    case::C
+    forcing::F
+    radiation::R
+    surf_params::SM
+    edmf::EDMF
+    precip_model::PM
+    diagnostics::D
+    TS::TIMESTEPPING
+    Stats::STATS
+    param_set::PS
+    skip_io::Bool
+    calibrate_io::Bool
+    adapt_dt::Bool
+    cfl_limit::Float64
+    dt_min::Float64
+    truncate_stack_trace::Bool
+    surf_ref_state::SRS
+    les_data_kwarg::LESDK
+end
+
+function open_files(sim::Simulation1d)
+    for inds in TC.iterate_columns(sim.prog.cent)
+        open_files(sim.Stats[inds...])
+    end
+end
+function close_files(sim::Simulation1d)
+    for inds in TC.iterate_columns(sim.prog.cent)
+        close_files(sim.Stats[inds...])
+    end
+end
+
+include("common_spaces.jl")
+
+function Simulation1d(namelist)
+    TC = TurbulenceConvection
+
+    FT = namelist["float_type"] == "Float32" ? Float32 : Float64
+    # This is used for testing Duals
+    FTD = namelist["test_duals"] ? typeof(ForwardDiff.Dual{Nothing}(FT(1), FT(0))) : FT
+
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    # TODO: the namelist should override whatever
+    # we need to override for calibration
+
+    param_set = create_parameter_set(namelist, toml_dict, FTD)
+
+    skip_io = namelist["stats_io"]["skip"]
+    calibrate_io = namelist["stats_io"]["calibrate_io"]
+    adapt_dt = namelist["time_stepping"]["adapt_dt"]
+    cfl_limit = namelist["time_stepping"]["cfl_limit"]
+    dt_min = namelist["time_stepping"]["dt_min"]
+    truncate_stack_trace = namelist["logging"]["truncate_stack_trace"]
+
+    cspace, fspace, svpc_space = get_spaces(namelist, param_set, FT)
+
+    # Create the class for precipitation
+
+    precip_name = TC.parse_namelist(
+        namelist,
+        "microphysics",
+        "precipitation_model";
+        default = "None",
+        valid_options = ["None", "cutoff", "clima_1m"],
+    )
+
+    precip_model = if precip_name == "None"
+        TC.NoPrecipitation()
+    elseif precip_name == "cutoff"
+        TC.Clima0M()
+    elseif precip_name == "clima_1m"
+        TC.Clima1M()
+    else
+        error("Invalid precip_name $(precip_name)")
+    end
+
+    edmf = TC.EDMFModel(FTD, namelist, precip_model)
+    if isbits(edmf)
+        @info "edmf = \n$(summary(edmf))"
+    else
+        @show edmf
+        error("Something non-isbits was added to edmf and needs to be fixed.")
+    end
+    N_up = TC.n_updrafts(edmf)
+
+    cent_prog_fields = TC.FieldFromNamedTuple(cspace, cent_prognostic_vars, FT, edmf)
+    face_prog_fields = TC.FieldFromNamedTuple(fspace, face_prognostic_vars, FT, edmf)
+    aux_cent_fields = TC.FieldFromNamedTuple(cspace, cent_aux_vars, FT, edmf)
+    aux_face_fields = TC.FieldFromNamedTuple(fspace, face_aux_vars, FT, edmf)
+    diagnostic_cent_fields = TC.FieldFromNamedTuple(cspace, cent_diagnostic_vars, FT, edmf)
+    diagnostic_face_fields = TC.FieldFromNamedTuple(fspace, face_diagnostic_vars, FT, edmf)
+    diagnostics_single_value_per_col =
+        TC.FieldFromNamedTuple(svpc_space, single_value_per_col_diagnostic_vars(FT, edmf))
+
+    prog = CC.Fields.FieldVector(cent = cent_prog_fields, face = face_prog_fields)
+    aux = CC.Fields.FieldVector(cent = aux_cent_fields, face = aux_face_fields)
+    diagnostics = CC.Fields.FieldVector(;
+        cent = diagnostic_cent_fields,
+        face = diagnostic_face_fields,
+        svpc = diagnostics_single_value_per_col,
+    )
+
+    if namelist["test_duals"]
+        prog = ForwardDiff.Dual{Nothing}.(prog, 1.0)
+        aux = ForwardDiff.Dual{Nothing}.(aux, 1.0)
+        diagnostics = ForwardDiff.Dual{Nothing}.(diagnostics, 1.0)
+    end
+
+    # TODO: clean up
+    frequency = namelist["stats_io"]["frequency"]
+    nc_filename, outpath = nc_fileinfo(namelist)
+    nc_filename_suffix = if namelist["config"] == "column"
+        (fn, inds) -> fn
+    elseif namelist["config"] == "sphere"
+        (fn, inds) -> first(split(fn, ".nc")) * "_col=$(inds).nc"
+    end
+
+    Stats = if skip_io
+        nothing
+    else
+        map(TC.iterate_columns(prog.cent)) do inds
+            col_state = TC.column_prog_aux(prog, aux, inds...)
+            grid = TC.Grid(col_state)
+            ncfn = nc_filename_suffix(nc_filename, inds)
+            NetCDFIO_Stats(ncfn, frequency, grid)
+        end
+    end
+    casename = namelist["meta"]["casename"]
+    open(joinpath(outpath, "namelist_$casename.in"), "w") do io
+        JSON.print(io, namelist, 4)
+    end
+
+    case = Cases.get_case(namelist)
+    surf_ref_state = Cases.surface_ref_state(case, param_set, namelist)
+
+    forcing = Cases.ForcingBase(case, FT; Cases.forcing_kwargs(case, namelist)...)
+
+    radiation = Cases.RadiationBase(case, FT)
+    TS = TimeStepping(FT, namelist)
+
+    Ri_bulk_crit::FTD = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
+    les_data_kwarg = Cases.les_data_kwarg(case, namelist)
+    surf_params = Cases.surface_params(case, surf_ref_state, param_set; Ri_bulk_crit = Ri_bulk_crit, les_data_kwarg...)
+
+    calibrate_io = namelist["stats_io"]["calibrate_io"]
+    aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate() : TC.io_dictionary_aux()
+    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics()
+
+    io_nt = (; aux = aux_dict, diagnostics = diagnostics_dict)
+
+    return Simulation1d(
+        io_nt,
+        prog,
+        aux,
+        case,
+        forcing,
+        radiation,
+        surf_params,
+        edmf,
+        precip_model,
+        diagnostics,
+        TS,
+        Stats,
+        param_set,
+        skip_io,
+        calibrate_io,
+        adapt_dt,
+        cfl_limit,
+        dt_min,
+        truncate_stack_trace,
+        surf_ref_state,
+        les_data_kwarg,
+    )
+end
+
+function initialize(sim::Simulation1d)
+    TC = TurbulenceConvection
+
+    (; prog, aux, edmf, case, forcing, radiation, surf_params, param_set, surf_ref_state) = sim
+    (; les_data_kwarg, skip_io, Stats, io_nt, diagnostics, truncate_stack_trace) = sim
+
+    ts_gm = ["Tsurface", "shf", "lhf", "ustar", "wstar", "lwp_mean", "iwp_mean"]
+    ts_edmf = [
+        "cloud_base_mean",
+        "cloud_top_mean",
+        "cloud_cover_mean",
+        "env_cloud_base",
+        "env_cloud_top",
+        "env_cloud_cover",
+        "env_lwp",
+        "env_iwp",
+        "updraft_cloud_cover",
+        "updraft_cloud_base",
+        "updraft_cloud_top",
+        "updraft_lwp",
+        "updraft_iwp",
+        "rwp_mean",
+        "swp_mean",
+        "cutoff_precipitation_rate",
+        "Hd",
+    ]
+    ts_list = vcat(ts_gm, ts_edmf)
+
+    # `nothing` goes into State because OrdinaryDiffEq.jl owns tendencies.
+    for inds in TC.iterate_columns(prog.cent)
+        state = TC.column_prog_aux(prog, aux, inds...)
+        diagnostics_col = TC.column_diagnostics(diagnostics, inds...)
+        grid = TC.Grid(state)
+        FT = TC.float_type(state)
+        t = FT(0)
+        compute_ref_state!(state, grid, param_set; ts_g = surf_ref_state)
+        if !skip_io
+            stats = Stats[inds...]
+            NC.Dataset(stats.nc_filename, "a") do ds
+                group = "reference"
+                add_write_field(ds, "ρ_f", vec(TC.face_aux_grid_mean(state).ρ), group, ("zf",))
+                add_write_field(ds, "ρ_c", vec(TC.center_prog_grid_mean(state).ρ), group, ("zc",))
+                add_write_field(ds, "p_f", vec(TC.face_aux_grid_mean(state).p), group, ("zf",))
+                add_write_field(ds, "p_c", vec(TC.center_aux_grid_mean(state).p), group, ("zc",))
+            end
+        end
+        Cases.initialize_profiles(case, grid, param_set, state; les_data_kwarg...)
+        set_thermo_state_pθq!(state, grid, edmf.moisture_model, param_set)
+        set_grid_mean_from_thermo_state!(param_set, state, grid)
+        assign_thermo_aux!(state, grid, edmf.moisture_model, param_set)
+        Cases.initialize_forcing(case, forcing, grid, state, param_set; les_data_kwarg...)
+        Cases.initialize_radiation(case, radiation, grid, state, param_set; les_data_kwarg...)
+        initialize_edmf(edmf, grid, state, surf_params, param_set, t, case)
+        if !skip_io
+            stats = Stats[inds...]
+            initialize_io(stats.nc_filename, eltype(grid), io_nt.aux, io_nt.diagnostics)
+            initialize_io(stats.nc_filename, eltype(grid), ts_list)
+        end
+    end
+
+    (prob, alg, kwargs) = solve_args(sim)
+    integrator = ODE.init(prob, alg; kwargs...)
+    skip_io && return (integrator, :success)
+
+    open_files(sim)
+    try
+        affect_io!(integrator)
+    catch e
+        if truncate_stack_trace
+            @warn "IO during initialization failed."
+        else
+            @warn "IO during initialization failed." exception = (e, catch_backtrace())
+        end
+        return (integrator, :simulation_crashed)
+    finally
+        close_files(sim)
+    end
+
+    return (integrator, :success)
+end
+
+include("callbacks.jl")
+
+function solve_args(sim::Simulation1d)
+    TC = TurbulenceConvection
+    calibrate_io = sim.calibrate_io
+    prog = sim.prog
+    aux = sim.aux
+    TS = sim.TS
+    diagnostics = sim.diagnostics
+
+    t_span = (0.0, sim.TS.t_max)
+    params = (;
+        calibrate_io,
+        edmf = sim.edmf,
+        precip_model = sim.precip_model,
+        param_set = sim.param_set,
+        aux = aux,
+        io_nt = sim.io_nt,
+        case = sim.case,
+        forcing = sim.forcing,
+        surf_params = sim.surf_params,
+        radiation = sim.radiation,
+        diagnostics = diagnostics,
+        TS = sim.TS,
+        Stats = sim.Stats,
+        skip_io = sim.skip_io,
+        cfl_limit = sim.cfl_limit,
+        dt_min = sim.dt_min,
+    )
+
+    callback_io = ODE.DiscreteCallback(condition_io, affect_io!; save_positions = (false, false))
+    callback_io = sim.skip_io ? () : (callback_io,)
+    callback_cfl = ODE.DiscreteCallback(condition_every_iter, monitor_cfl!; save_positions = (false, false))
+    callback_cfl = sim.precip_model isa TC.Clima1M ? (callback_cfl,) : ()
+    callback_dtmax = ODE.DiscreteCallback(condition_every_iter, dt_max!; save_positions = (false, false))
+    callback_filters = ODE.DiscreteCallback(condition_every_iter, affect_filter!; save_positions = (false, false))
+    callback_adapt_dt = ODE.DiscreteCallback(condition_every_iter, adaptive_dt!; save_positions = (false, false))
+    callback_adapt_dt = sim.adapt_dt ? (callback_adapt_dt,) : ()
+    if sim.edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess && sim.adapt_dt
+        @warn("The prognostic noisy relaxation process currently uses a Euler-Maruyama time stepping method,
+              which does not support adaptive time stepping. Adaptive time stepping disabled.")
+        callback_adapt_dt = ()
+    end
+
+    callbacks = ODE.CallbackSet(callback_adapt_dt..., callback_dtmax, callback_cfl..., callback_filters, callback_io...)
+
+    if sim.edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess
+        prob = SDE.SDEProblem(∑tendencies!, ∑stoch_tendencies!, prog, t_span, params; dt = sim.TS.dt)
+        alg = SDE.EM()
+    else
+        prob = ODE.ODEProblem(∑tendencies!, prog, t_span, params; dt = sim.TS.dt)
+        alg = ODE.Euler()
+    end
+
+    kwargs = (;
+        progress_steps = 100,
+        save_start = false,
+        saveat = last(t_span),
+        callback = callbacks,
+        progress = true,
+        progress_message = (dt, u, p, t) -> t,
+    )
+    return (prob, alg, kwargs)
+end
+
+function run(sim::Simulation1d, integrator; time_run = true)
+    TC = TurbulenceConvection
+    sim.skip_io || open_files(sim)
+
+    local sol
+    try
+        if time_run
+            sol = @timev ODE.solve!(integrator)
+        else
+            sol = ODE.solve!(integrator)
+        end
+    catch e
+        if sim.truncate_stack_trace
+            @error "TurbulenceConvection simulation crashed. $(e)"
+        else
+            @error "TurbulenceConvection simulation crashed. Stacktrace for failed simulation" exception =
+                (e, catch_backtrace())
+        end
+        # "Stacktrace for failed simulation" exception = (e, catch_backtrace())
+        return (integrator, :simulation_crashed)
+    finally
+        sim.skip_io || close_files(sim)
+    end
+
+    if first(sol.t) == sim.TS.t_max
+        return (integrator, :success)
+    else
+        return (integrator, :simulation_aborted)
+    end
+end
+
+main(namelist; kwargs...) = @timev main1d(namelist; kwargs...)
+
+nc_results_file(stats) = map(x -> x.nc_filename, stats)
+nc_results_file(stats::NetCDFIO_Stats) = stats.nc_filename
+function nc_results_file(::Nothing)
+    @info "The simulation was run without IO, so no nc files were exported"
+    return ""
+end
+
+to_svec(x::AbstractArray) = SA.SVector{length(x)}(x)
+to_svec(x::Tuple) = SA.SVector{length(x)}(x)
+
+function main1d(namelist; time_run = true)
+    edmf_turb_dict = namelist["turbulence"]["EDMF_PrognosticTKE"]
+    for key in keys(edmf_turb_dict)
+        entry = edmf_turb_dict[key]
+        if entry isa AbstractArray || entry isa Tuple
+            edmf_turb_dict[key] = to_svec(entry)
+        end
+    end
+    sim = Simulation1d(namelist)
+    (integrator, return_init) = initialize(sim)
+    return_init == :success && @info "The initialization has completed."
+    if time_run
+        (Y, return_code) = @timev run(sim, integrator; time_run)
+    else
+        (Y, return_code) = run(sim, integrator; time_run)
+    end
+    return_code == :success && @info "The simulation has completed."
+    return Y, nc_results_file(sim.Stats), return_code
+end
+
+
+function parse_commandline()
+    s = ArgParse.ArgParseSettings(; description = "Run case input")
+
+    ArgParse.@add_arg_table! s begin
+        "case_name"
+        help = "The case name"
+        arg_type = String
+        required = true
+    end
+
+    return ArgParse.parse_args(s)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+
+    args = parse_commandline()
+    case_name = args["case_name"]
+
+    namelist = open("namelist_" * "$case_name.in", "r") do io
+        JSON.parse(io; dicttype = Dict, inttype = Int64)
+    end
+    main(namelist)
+end

--- a/tc_driver/parameter_set.jl
+++ b/tc_driver/parameter_set.jl
@@ -1,10 +1,10 @@
-import TurbulenceConvection as TC
+import ClimaAtmos.TurbulenceConvection as TC
 import CLIMAParameters as CP
 import CloudMicrophysics as CM
 import SurfaceFluxes as SF
 import SurfaceFluxes.UniversalFunctions as UF
 import Thermodynamics as TD
-import TurbulenceConvection.Parameters as TCP
+import ClimaAtmos.TurbulenceConvection.Parameters as TCP
 
 #! format: off
 function create_parameter_set(namelist, toml_dict_default::CP.AbstractTOMLDict, FTD = CP.float_type(toml_dict_default))

--- a/tc_driver/parameter_set.jl
+++ b/tc_driver/parameter_set.jl
@@ -1,0 +1,64 @@
+import TurbulenceConvection as TC
+import CLIMAParameters as CP
+import CloudMicrophysics as CM
+import SurfaceFluxes as SF
+import SurfaceFluxes.UniversalFunctions as UF
+import Thermodynamics as TD
+import TurbulenceConvection.Parameters as TCP
+
+#! format: off
+function create_parameter_set(namelist, toml_dict_default::CP.AbstractTOMLDict, FTD = CP.float_type(toml_dict_default))
+    FT = CP.float_type(toml_dict_default)
+    _, out_dir = nc_fileinfo(namelist)
+    override_file = joinpath(out_dir, "override_dict.toml")
+    open(override_file, "w") do io
+        println(io, "[mean_sea_level_pressure]")
+        println(io, "alias = \"MSLP\"")
+        println(io, "value = 100000.0")
+        println(io, "type = \"float\"")
+    end
+    toml_dict = CP.create_toml_dict(FT; override_file, dict_type="alias")
+    isfile(override_file) && rm(override_file; force=true)
+
+    aliases = string.(fieldnames(TD.Parameters.ThermodynamicsParameters))
+    param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
+    thermo_params = TD.Parameters.ThermodynamicsParameters{FTD}(; param_pairs...)
+    # logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
+    # CP.log_parameter_information(toml_dict, logfilepath)
+    TP = typeof(thermo_params)
+
+    aliases = string.(fieldnames(CM.Parameters.CloudMicrophysicsParameters))
+    aliases = setdiff(aliases, ["thermo_params"])
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "CloudMicrophysics")
+    microphys_params = CM.Parameters.CloudMicrophysicsParameters{FTD, TP}(;
+        pairs...,
+        thermo_params,
+    )
+    MP = typeof(microphys_params)
+
+    aliases = ["Pr_0_Businger", "a_m_Businger", "a_h_Businger"]
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "UniversalFunctions")
+    pairs = (; pairs...) # convert to NamedTuple
+    pairs = (; Pr_0 = pairs.Pr_0_Businger, a_m = pairs.a_m_Businger, a_h = pairs.a_h_Businger)
+    ufp = UF.BusingerParams{FTD}(; pairs...)
+    UFP = typeof(ufp)
+
+    pairs = CP.get_parameter_values!(toml_dict, ["von_karman_const"], "SurfaceFluxesParameters")
+    surf_flux_params = SF.Parameters.SurfaceFluxesParameters{FTD, UFP, TP}(; pairs..., ufp, thermo_params)
+
+    aliases = [
+    "microph_scaling_dep_sub",
+    "microph_scaling_melt",
+    "microph_scaling",
+    "Omega",
+    "planet_radius"]
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "TurbulenceConvection")
+
+    SFP = typeof(surf_flux_params)
+    param_set = TCP.TurbulenceConvectionParameters{FTD, MP, SFP}(; pairs..., microphys_params, surf_flux_params)
+    if !isbits(param_set)
+        @warn "The parameter set SHOULD be isbits in order to be stack-allocated."
+    end
+    return param_set
+end
+#! format: on


### PR DESCRIPTION
There was a decision made in the recent EDMF meeting to port TurbulenceConvection into ClimaAtmos in order to smooth development of several pieces that need to be updated together:

 - Using consistent energy between grid mean and updraft variables
 - Using a fully compressible model
 - Using an implicit solver

These pieces cannot be (easily) done in TC alone because TC has a built-in anelastic assumption, which is incompatible with the energy formulation.

If what I've wrote is somehow inaccurate, please chime in, @yairchn, @tapios.

Once we merge this, we can add a note/warning in the TC readme indicating that development has been moved to this repo.