### PR TITLE
Centralize thermo state field dispatching

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -505,23 +505,9 @@ function make_save_to_disk_func(output_dir, p)
                 cm_params = CAP.microphysics_params(params)
                 # kinetic energy
                 global_ᶜK = @. norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
-                global_ᶜΦ =
-                    FT(CAP.grav(params)) .* Fields.coordinate_field(Y.c).z
 
                 # pressure, temperature, potential temperature
-                if :ρθ in propertynames(Y.c)
-                    global_ᶜts = @. thermo_state_ρθ(Y.c.ρθ, Y.c, params)
-                elseif :ρe_tot in propertynames(Y.c)
-                    global_ᶜts = @. thermo_state_ρe(
-                        Y.c.ρe_tot,
-                        Y.c,
-                        global_ᶜK,
-                        global_ᶜΦ,
-                        params,
-                    )
-                elseif :ρe_int in propertynames(Y.c)
-                    global_ᶜts = @. thermo_state_ρe_int(Y.c.ρe_int, Y.c, params)
-                end
+                global_ᶜts = thermo_state(Y, params, ᶜinterp, global_ᶜK)
                 global_ᶜp = @. TD.air_pressure(thermo_params, global_ᶜts)
                 global_ᶜT = @. TD.air_temperature(thermo_params, global_ᶜts)
                 global_ᶜθ = @. TD.dry_pottemp(thermo_params, global_ᶜts)
@@ -696,18 +682,11 @@ function make_save_to_disk_func(output_dir, p)
 
             ᶜuₕ = Y.c.uₕ
             ᶠw = Y.f.w
-
-            # kinetic energy
+            # kinetic
             @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
 
-            # pressure, temperature, potential temperature
-            if :ρθ in propertynames(Y.c)
-                @. ᶜts = thermo_state_ρθ(Y.c.ρθ, Y.c, params)
-            elseif :ρe_tot in propertynames(Y.c)
-                @. ᶜts = thermo_state_ρe(Y.c.ρe_tot, Y.c, ᶜK, ᶜΦ, params)
-            elseif :ρe_int in propertynames(Y.c)
-                @. ᶜts = thermo_state_ρe_int(Y.c.ρe_int, Y.c, params)
-            end
+            # thermo state
+            thermo_state!(ᶜts, Y, params, ᶜinterp, ᶜK)
             @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -54,14 +54,7 @@ function rrtmgp_model_cache(
         # kinetic energy to 0 when computing the pressure using total energy)
         pressure2ozone =
             Spline1D(input_center_pressure, input_center_volume_mixing_ratio_o3)
-        if :ρθ in propertynames(Y.c)
-            ᶜts = @. thermo_state_ρθ(Y.c.ρθ, Y.c, params)
-        elseif :ρe_tot in propertynames(Y.c)
-            ᶜΦ = FT(CAP.grav(params)) .* Fields.coordinate_field(Y.c).z
-            ᶜts = @. thermo_state_ρe(Y.c.ρe_tot, Y.c, 0, ᶜΦ, params)
-        elseif :ρe_int in propertynames(Y.c)
-            ᶜts = @. thermo_state_ρe_int(Y.c.ρe_int, Y.c, params)
-        end
+        ᶜts = thermo_state(Y, params, ᶜinterp, 0)
         ᶜp = @. TD.air_pressure(thermo_params, ᶜts)
         center_volume_mixing_ratio_o3 =
             RRTMGPI.field2array(@. FT(pressure2ozone(ᶜp)))
@@ -206,14 +199,8 @@ function rrtmgp_model_callback!(integrator)
 
     ᶜp = RRTMGPI.array2field(rrtmgp_model.center_pressure, axes(Y.c))
     ᶜT = RRTMGPI.array2field(rrtmgp_model.center_temperature, axes(Y.c))
-    if :ρθ in propertynames(Y.c)
-        @. ᶜts = thermo_state_ρθ(Y.c.ρθ, Y.c, params)
-    elseif :ρe_tot in propertynames(Y.c)
-        @. ᶜK = norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
-        @. ᶜts = thermo_state_ρe(Y.c.ρe_tot, Y.c, ᶜK, ᶜΦ, params)
-    elseif :ρe_int in propertynames(Y.c)
-        @. ᶜts = thermo_state_ρe_int(Y.c.ρe_int, Y.c, params)
-    end
+    @. ᶜK = norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+    thermo_state!(ᶜts, Y, params, ᶜinterp, ᶜK)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     @. ᶜT = TD.air_temperature(thermo_params, ᶜts)
 

--- a/examples/hybrid/thermo_state.jl
+++ b/examples/hybrid/thermo_state.jl
@@ -1,0 +1,141 @@
+import ClimaCore.Geometry as Geometry
+import ClimaCore.Fields as Fields
+
+function thermo_state_type(Yc::Fields.Field, ::Type{FT}) where {FT}
+    pns = propertynames(Yc)
+    return if (:ρq_liq in pns && :ρq_ice in pns && :ρq_tot in pns)
+        TD.PhaseNonEquil{FT}
+    elseif :ρq_tot in pns
+        TD.PhaseEquil{FT}
+    else
+        TD.PhaseDry{FT}
+    end
+end
+
+function get_moisture_model(Yc::Fields.Field)
+    pns = propertynames(Yc)
+    if (:ρq_liq in pns && :ρq_ice in pns && :ρq_tot in pns)
+        return NonEquilMoistModel()
+    elseif :ρq_tot in pns
+        return EquilMoistModel()
+    else
+        return DryModel()
+    end
+end
+
+function get_energy_model(Yc::Fields.Field)
+    pns = propertynames(Yc)
+    if :ρθ in pns
+        return PotentialTemperature()
+    elseif :ρe_tot in pns
+        return TotalEnergy()
+    elseif :ρe_int in pns
+        return InternalEnergy()
+    else
+        error("Could not determine energy model")
+    end
+end
+
+#=
+
+    thermo_state!(ᶜts, Y, params, ᶜinterp)
+
+Populate the thermodynamic state, `ᶜts`, given
+`FieldVector` `Y` and parameters `params`. Interpolation
+`ᶜinterp` is used to interpolate vertical velocity
+when computing kinetic energy (assuming it's not given)
+when using the total energy formulation.
+=#
+function thermo_state!(ᶜts, Y::Fields.FieldVector, params, ᶜinterp, K = nothing)
+    # Sometimes we want to zero out kinetic energy
+    Yc = Y.c
+    moisture_model = get_moisture_model(Yc)
+    energy_model = get_energy_model(Yc)
+    thermo_params = CAP.thermodynamics_params(params)
+    if energy_model isa TotalEnergy
+        if isnothing(K)
+            C123 = Geometry.Covariant123Vector
+            K = @. norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+        end
+        z = Fields.local_geometry_field(Yc).coordinates.z
+        thermo_state_ρe_tot!(ᶜts, Yc, thermo_params, moisture_model, z, K)
+    elseif energy_model isa InternalEnergy
+        thermo_state_ρe_int!(ᶜts, Yc, thermo_params, moisture_model)
+    elseif energy_model isa PotentialTemperature
+        thermo_state_ρθ!(ᶜts, Yc, thermo_params, moisture_model)
+    else
+        error("Could not determine energy model")
+    end
+    return nothing
+end
+
+function thermo_state(Y::Fields.FieldVector, params, ᶜinterp, K = nothing)
+    FT = eltype(Y)
+    ts_type = thermo_state_type(Y.c, FT)
+    ts = similar(Y.c, ts_type)
+    thermo_state!(ts, Y, params, ᶜinterp, K)
+    return ts
+end
+
+function thermo_state_ρθ!(ts, Yc, thermo_params, ::DryModel)
+    @. ts = TD.PhaseDry_ρθ(thermo_params, Yc.ρ, Yc.ρθ / Yc.ρ)
+end
+function thermo_state_ρθ!(ts, Yc, thermo_params, ::EquilMoistModel)
+    @. ts =
+        TD.PhaseEquil_ρθq(thermo_params, Yc.ρ, Yc.ρθ / Yc.ρ, Yc.ρq_tot / Yc.ρ)
+end
+function thermo_state_ρθ!(ts, Yc, thermo_params, ::NonEquilMoistModel)
+    @. ts = TD.PhaseNonEquil_ρθq(
+        thermo_params,
+        Yc.ρ,
+        Yc.ρθ / Yc.ρ,
+        TD.PhasePartition(Yc.ρq_tot / Yc.ρ, Yc.ρq_liq / Yc.ρ, Yc.ρq_ice / Yc.ρ),
+    )
+end
+
+internal_energy(Yc, K, g, z) = Yc.ρe_tot - Yc.ρ * (K + g * z)
+
+function thermo_state_ρe_tot!(ts, Yc, thermo_params, ::DryModel, z, K)
+    g = TD.Parameters.grav(thermo_params)
+    @. ts =
+        TD.PhaseDry(thermo_params, internal_energy(Yc, K, g, z) / Yc.ρ, Yc.ρ)
+end
+function thermo_state_ρe_tot!(ts, Yc, thermo_params, ::EquilMoistModel, z, K)
+    g = TD.Parameters.grav(thermo_params)
+    @. ts = TD.PhaseEquil_ρeq(
+        thermo_params,
+        Yc.ρ,
+        internal_energy(Yc, K, g, z) / Yc.ρ,
+        Yc.ρq_tot / Yc.ρ,
+    )
+end
+
+function thermo_state_ρe_tot!(ts, Yc, thermo_params, ::NonEquilMoistModel, z, K)
+    g = TD.Parameters.grav(thermo_params)
+    @. ts = TD.PhaseNonEquil(
+        thermo_params,
+        internal_energy(Yc, K, g, z) / Yc.ρ,
+        Yc.ρ,
+        TD.PhasePartition(Yc.ρq_tot / Yc.ρ, Yc.ρq_liq / Yc.ρ, Yc.ρq_ice / Yc.ρ),
+    )
+end
+
+function thermo_state_ρe_int!(ts, Yc, thermo_params, ::DryModel)
+    @. ts = TD.PhaseDry(thermo_params, Yc.ρe_int / Yc.ρ, Yc.ρ)
+end
+function thermo_state_ρe_int!(ts, Yc, thermo_params, ::EquilMoistModel)
+    @. ts = TD.PhaseEquil_ρeq(
+        thermo_params,
+        Yc.ρ,
+        Yc.ρe_int / Yc.ρ,
+        Yc.ρq_tot / Yc.ρ,
+    )
+end
+function thermo_state_ρe_int!(ts, Yc, thermo_params, ::NonEquilMoistModel)
+    @. ts = TD.PhaseNonEquil(
+        thermo_params,
+        Yc.ρe_int / Yc.ρ,
+        Yc.ρ,
+        TD.PhasePartition(Yc.ρq_tot / Yc.ρ, Yc.ρq_liq / Yc.ρ, Yc.ρq_ice / Yc.ρ),
+    )
+end


### PR DESCRIPTION
This PR centralizes the computation of thermodynamic states using dispatch, so that we can extract some of this logic that is spread around in many places. While this eliminates the possibility to fuse multiple expressions, we can still apply threading per slab/column, and these computations will typically be cached.

I've retained the capability to make thermo states in place, or allocate new ones (since we're doing that right now in a few places).