### PR TITLE
Print zeros in mse tables when ref counter is incremented

### DIFF
--- a/post_processing/compute_mse.jl
+++ b/post_processing/compute_mse.jl
@@ -1,21 +1,8 @@
 import NCRegressionTests
 import NCDatasets
-import Dates
-import ClimaCoreTempestRemap
-const CCTR = ClimaCoreTempestRemap
+import ClimaCoreTempestRemap as CCTR
 
-function sorted_dataset_folder(; dir = pwd())
-    matching_paths = String[]
-    for file in readdir(dir)
-        !ispath(joinpath(dir, file)) && continue
-        push!(matching_paths, joinpath(dir, file))
-    end
-    isempty(matching_paths) && return ""
-    # sort by timestamp
-    sorted_paths =
-        sort(matching_paths; by = f -> Dates.unix2datetime(stat(f).mtime))
-    return sorted_paths
-end
+include("self_reference_or_path.jl")
 
 """
     regression_test(;
@@ -39,62 +26,9 @@ from the latest merged dataset on Caltech central.
 function regression_test(; job_id, reference_mse, ds_filename_computed, varname)
     local ds_filename_reference
 
-    # Note: cluster_data_prefix is also defined in move_output.jl
     if haskey(ENV, "BUILDKITE_COMMIT")
-        cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
-        # Get (sorted) array of paths, `pop!(sorted_paths)`
-        # is the most recent merged folder.
-        sorted_paths = sorted_dataset_folder(; dir = cluster_data_prefix)
-        if isempty(sorted_paths)
-            @warn "No paths on main found, assuming self-reference"
-            @info "Please review output results before merging."
-            return reference_mse
-        end
-        # Find oldest path in main with the same reference
-        # counter as the one in the PR. If none exists,
-        # then assume self reference.
-
-        ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl")
-        @assert isfile(ref_counter_file_PR)
-        ref_counter_PR = parse(Int, first(readlines(ref_counter_file_PR)))
-
-        ref_counters_main = Vector{Int}(undef, length(sorted_paths))
-        ref_counters_main .= -1
-        for (i, path) in enumerate(sorted_paths)
-            ref_counter_file_main = joinpath(path, "ref_counter.jl")
-            !isfile(ref_counter_file_main) && continue
-            ref_counters_main[i] =
-                parse(Int, first(readlines(ref_counter_file_main)))
-        end
-        i_oldest_reference = findfirst(ref_counters_main) do ref_counter_main
-            ref_counter_main == ref_counter_PR
-        end
-        if i_oldest_reference == nothing
-            @warn "`ref_counter.jl` not found on main, assuming self-reference"
-            @info "Please review output results before merging."
-            return reference_mse
-        end
-        # Oldest reference path:
-        path = sorted_paths[i_oldest_reference]
-        ref_counter_file_main = joinpath(path, "ref_counter.jl")
-
-        @info "Files on main:" # for debugging
-        for file_on_main in readdir(path)
-            @info "   File:`$file_on_main`"
-        end
-        @assert isfile(ref_counter_file_main)
-        ref_counter_main = parse(Int, first(readlines(ref_counter_file_main)))
-        if ref_counter_PR == ref_counter_main + 1 # new reference
-            @warn "`ref_counter.jl` incremented, assuming self-reference"
-            @info "Please review output results before merging."
-            return reference_mse
-        elseif ref_counter_PR == ref_counter_main # unchanged reference
-            @info "Comparing results against main path:$path"
-        else
-            error(
-                "Unexpected reference. Please open an issue pointing to this build.",
-            )
-        end
+        path = self_reference_or_path()
+        path == :self_reference && return reference_mse
         ds_filename_reference = joinpath(path, ds_filename_computed)
         @info "`ds_filename_computed`: `$ds_filename_computed`"
         @info "`ds_filename_reference`: `$ds_filename_reference`"

--- a/post_processing/print_new_mse.jl
+++ b/post_processing/print_new_mse.jl
@@ -2,6 +2,9 @@ import OrderedCollections
 import JSON
 
 # Get cases from JobIDs in mse_tables file:
+include(joinpath(@__DIR__, "self_reference_or_path.jl"))
+self_reference = self_reference_or_path() == :self_reference
+
 all_lines = readlines(joinpath(@__DIR__, "mse_tables.jl"))
 lines = deepcopy(all_lines)
 filter!(x -> occursin("] = OrderedCollections", x), lines)
@@ -43,6 +46,7 @@ for job_id in keys(computed_mse)
                 "all_best_mse[\"$job_id\"][$(var)] = \"$(computed_mse[job_id][var])\"",
             )
         else
+            self_reference && (computed_mse[job_id][var] .= 0)
             println(
                 "all_best_mse[\"$job_id\"][$(var)] = $(computed_mse[job_id][var])",
             )
@@ -55,6 +59,14 @@ println("#! format: on")
 println("#################################")
 println("#################################")
 println("#################################")
+
+if self_reference
+    @warn string(
+        "The printed `all_best_mse` values have",
+        "been set to zero, due to self-reference,",
+        "for copy-paste convenience.",
+    )
+end
 
 # Cleanup
 for job_id in job_ids

--- a/post_processing/self_reference_or_path.jl
+++ b/post_processing/self_reference_or_path.jl
@@ -1,0 +1,74 @@
+import Dates
+
+function sorted_dataset_folder(; dir = pwd())
+    matching_paths = String[]
+    for file in readdir(dir)
+        !ispath(joinpath(dir, file)) && continue
+        push!(matching_paths, joinpath(dir, file))
+    end
+    isempty(matching_paths) && return ""
+    # sort by timestamp
+    sorted_paths =
+        sort(matching_paths; by = f -> Dates.unix2datetime(stat(f).mtime))
+    return sorted_paths
+end
+
+function self_reference_or_path()
+
+    # Note: cluster_data_prefix is also defined in move_output.jl
+    cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
+    # Get (sorted) array of paths, `pop!(sorted_paths)`
+    # is the most recent merged folder.
+    sorted_paths = sorted_dataset_folder(; dir = cluster_data_prefix)
+    if isempty(sorted_paths)
+        @warn "No paths on main found, assuming self-reference"
+        @info "Please review output results before merging."
+        return :self_reference
+    end
+    # Find oldest path in main with the same reference
+    # counter as the one in the PR. If none exists,
+    # then assume self reference.
+
+    ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl")
+    @assert isfile(ref_counter_file_PR)
+    ref_counter_PR = parse(Int, first(readlines(ref_counter_file_PR)))
+
+    ref_counters_main = Vector{Int}(undef, length(sorted_paths))
+    ref_counters_main .= -1
+    for (i, path) in enumerate(sorted_paths)
+        ref_counter_file_main = joinpath(path, "ref_counter.jl")
+        !isfile(ref_counter_file_main) && continue
+        ref_counters_main[i] =
+            parse(Int, first(readlines(ref_counter_file_main)))
+    end
+    i_oldest_reference = findfirst(ref_counters_main) do ref_counter_main
+        ref_counter_main == ref_counter_PR
+    end
+    if i_oldest_reference == nothing
+        @warn "`ref_counter.jl` not found on main, assuming self-reference"
+        @info "Please review output results before merging."
+        return :self_reference
+    end
+    # Oldest reference path:
+    path = sorted_paths[i_oldest_reference]
+    ref_counter_file_main = joinpath(path, "ref_counter.jl")
+
+    @info "Files on main:" # for debugging
+    for file_on_main in readdir(path)
+        @info "   File:`$file_on_main`"
+    end
+    @assert isfile(ref_counter_file_main)
+    ref_counter_main = parse(Int, first(readlines(ref_counter_file_main)))
+    if ref_counter_PR == ref_counter_main + 1 # new reference
+        @warn "`ref_counter.jl` incremented, assuming self-reference"
+        @info "Please review output results before merging."
+        return :self_reference
+    elseif ref_counter_PR == ref_counter_main # unchanged reference
+        @info "Comparing results against main path:$path"
+    else
+        error(
+            "Unexpected reference. Please open an issue pointing to this build.",
+        )
+    end
+    return path
+end


### PR DESCRIPTION
This PR splits out the logic that gets the reference data path into a separate file so that we can determine if a PR triggers a self reference. This allows us to print mse tables that are (appropriately) filled with zeros when the reference counter is incremented.