### PR TITLE
Make get_simulation not depend on ArgParseSettings

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -69,7 +69,7 @@ params = create_parameter_set(FT, parsed_args, namelist)
 
 model_spec = get_model_spec(FT, parsed_args, namelist)
 numerics = get_numerics(parsed_args)
-simulation = get_simulation(s, parsed_args)
+simulation = get_simulation(parsed_args)
 
 diffuse_momentum = vert_diff && !(model_spec.forcing_type isa HeldSuarezForcing)
 

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -123,9 +123,10 @@ function get_numerics(parsed_args)
     return numerics
 end
 
-function get_simulation(s, parsed_args)
+function get_simulation(parsed_args)
 
     job_id = if isnothing(parsed_args["job_id"])
+        (s, default_parsed_args) = parse_commandline()
         job_id_from_parsed_args(s, parsed_args)
     else
         parsed_args["job_id"]


### PR DESCRIPTION
This was making working with `parsed_args_per_job_id` easier.