### PR TITLE
remove covar dissipation

### DIFF
--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -1104,34 +1104,6 @@ function compute_covariance_entr(
     return nothing
 end
 
-function compute_covariance_dissipation(
-    edmf::EDMFModel,
-    grid::Grid,
-    state::State,
-    ::Val{covar_sym},
-    param_set::APS,
-) where {covar_sym}
-    FT = float_type(state)
-    c_d = mixing_length_params(edmf).c_d
-    aux_tc = center_aux_turbconv(state)
-    prog_en = center_prog_environment(state)
-    prog_gm = center_prog_grid_mean(state)
-    aux_en = center_aux_environment(state)
-    ρ_c = prog_gm.ρ
-    aux_en_2m = center_aux_environment_2m(state)
-    aux_covar = getproperty(aux_en_2m, covar_sym)
-    covar = getproperty(aux_en, covar_sym)
-    dissipation = aux_covar.dissipation
-    area_en = aux_en.area
-    tke_en = aux_en.tke
-    mixing_length = aux_tc.mixing_length
-
-    @. dissipation =
-        ρ_c * area_en * covar * max(tke_en, 0)^FT(0.5) /
-        max(mixing_length, FT(1.0e-3)) * c_d
-    return nothing
-end
-
 function compute_en_tendencies!(
     edmf::EDMFModel,
     grid::Grid,

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -609,11 +609,6 @@ function update_aux!(
         Val(:θ_liq_ice),
         Val(:q_tot),
     )
-    compute_covariance_dissipation(edmf, grid, state, Val(:tke), param_set)
-    compute_covariance_dissipation(edmf, grid, state, Val(:Hvar), param_set)
-    compute_covariance_dissipation(edmf, grid, state, Val(:QTvar), param_set)
-    compute_covariance_dissipation(edmf, grid, state, Val(:HQTcov), param_set)
-
     # TODO defined again in compute_covariance_shear and compute_covaraince
     @inbounds for k in real_center_indices(grid)
         aux_en_2m.tke.rain_src[k] = 0

--- a/src/TurbulenceConvection/variables.jl
+++ b/src/TurbulenceConvection/variables.jl
@@ -12,7 +12,6 @@ thermo_state(FT, ::NonEquilibriumMoisture) =
 
 # Center only
 cent_aux_vars_en_2m(FT) = (;
-    dissipation = FT(0),
     shear = FT(0),
     entr_gain = FT(0),
     detr_loss = FT(0),


### PR DESCRIPTION
 covar dissipation is used only for diagnostics, as the equation is solved implicitly 