### PR TITLE
Mv print output dir to after logging config

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -289,6 +289,7 @@ if parsed_args["turbconv"] == "edmf"
 end
 
 # Print tendencies:
+@info "Output directory: `$(simulation.output_dir)`"
 for key in keys(p.tendency_knobs)
     @info "`$(key)`:$(getproperty(p.tendency_knobs, key))"
 end

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -133,7 +133,6 @@ function get_simulation(parsed_args)
     end
     default_output = haskey(ENV, "CI") ? job_id : joinpath("output", job_id)
     output_dir = parse_arg(parsed_args, "output_dir", default_output)
-    @info "Output directory: `$output_dir`"
     mkpath(output_dir)
 
     sim = (;


### PR DESCRIPTION
Everything printed before MPI logging is configured will print for all processors, which is noisy. This PR moves the output printing to after the MPI logging is configured.