### PR TITLE
Declutter global scope

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -261,40 +261,8 @@ for key in keys(p.tendency_knobs)
     @info "`$(key)`:$(getproperty(p.tendency_knobs, key))"
 end
 
-ode_algorithm = getproperty(OrdinaryDiffEq, Symbol(parsed_args["ode_algo"]))
-
-ode_algorithm_type =
-    ode_algorithm isa Function ? typeof(ode_algorithm()) : ode_algorithm
-if ode_algorithm_type <: Union{
-    OrdinaryDiffEq.OrdinaryDiffEqImplicitAlgorithm,
-    OrdinaryDiffEq.OrdinaryDiffEqAdaptiveImplicitAlgorithm,
-}
-    use_transform = !(ode_algorithm_type in (Rosenbrock23, Rosenbrock32))
-    W = SchurComplementW(Y, use_transform, jacobian_flags, test_implicit_solver)
-    if :ρe_tot in propertynames(Y.c) &&
-       W.flags.∂ᶜ𝔼ₜ∂ᶠ𝕄_mode == :no_∂ᶜp∂ᶜK &&
-       W.flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
-        Wfact! = Wfact_special!
-    else
-        Wfact! = Wfact_generic!
-    end
-    jac_kwargs =
-        use_transform ? (; jac_prototype = W, Wfact_t = Wfact!) :
-        (; jac_prototype = W, Wfact = Wfact!)
-
-    alg_kwargs = (; linsolve = linsolve!)
-    if ode_algorithm_type <: Union{
-        OrdinaryDiffEq.OrdinaryDiffEqNewtonAlgorithm,
-        OrdinaryDiffEq.OrdinaryDiffEqNewtonAdaptiveAlgorithm,
-    }
-        alg_kwargs = (;
-            alg_kwargs...,
-            nlsolve = NLNewton(; κ = newton_κ, max_iter = max_newton_iters),
-        )
-    end
-else
-    jac_kwargs = alg_kwargs = ()
-end
+(; jac_kwargs, alg_kwargs, ode_algorithm) =
+    ode_config(Y, parsed_args, model_spec)
 
 include("callbacks.jl")
 


### PR DESCRIPTION
This PR moves some variable definitions into a new function, `ode_config`, to help further declutter the global scope.