### PR TITLE
Add perf target bk job, update benchmarks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -225,6 +225,21 @@ steps:
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_clearsky/*"
 
 
+  - group: "Performance targets"
+    steps:
+
+      # TODO: add/exercise edmf code
+      - label: ":computer: Unthreaded performance target"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_unthreaded/*"
+
+      - label: ":computer: Threaded performance target"
+        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --job_id perf_target_threaded --enable_threading true --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_threaded/*"
+        agents:
+          slurm_nodes: 1
+          slurm_tasks_per_node: 8
+
   - group: "TurbulenceConvection"
     steps:
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -295,21 +295,22 @@ parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
 include("examples/hybrid/driver.jl")
 ```
 """
-function parsed_args_per_job_id()
+function parsed_args_per_job_id(; trigger = "driver.jl")
     ca_dir = joinpath(@__DIR__, "..", "..")
     buildkite_yaml = joinpath(ca_dir, ".buildkite", "pipeline.yml")
-    parsed_args_per_job_id(buildkite_yaml)
+    parsed_args_per_job_id(buildkite_yaml; trigger)
 end
 
-function parsed_args_per_job_id(buildkite_yaml)
+function parsed_args_per_job_id(buildkite_yaml; trigger = "driver.jl")
     buildkite_commands = readlines(buildkite_yaml)
-    filter!(x -> occursin("driver.jl", x), buildkite_commands)
+    filter!(x -> occursin(trigger, x), buildkite_commands)
 
     @assert length(buildkite_commands) > 0 # sanity check
     result = Dict()
     for bkcs in buildkite_commands
         (s, default_parsed_args) = parse_commandline()
         job_id = first(split(last(split(bkcs, "--job_id ")), " "))
+        job_id = strip(job_id, '\"')
         result[job_id] =
             parsed_args_from_command_line_flags(bkcs, default_parsed_args)
     end

--- a/examples/hybrid/utilities.jl
+++ b/examples/hybrid/utilities.jl
@@ -1,3 +1,6 @@
+time_to_seconds(t::Number) =
+    t == Inf ? t : error("Uncaught case in computing time from given string.")
+
 function time_to_seconds(s::String)
     factor = Dict(
         "secs" => 1,

--- a/perf/benchmark_utils.jl
+++ b/perf/benchmark_utils.jl
@@ -1,0 +1,70 @@
+import StatsBase
+import PrettyTables
+import BenchmarkTools
+
+#####
+##### BenchmarkTools's trial utils
+#####
+
+get_summary(trial) = (;
+    # Using some BenchmarkTools internals :/
+    mem = BenchmarkTools.prettymemory(trial.memory),
+    nalloc = trial.allocs,
+    t_min = BenchmarkTools.prettytime(minimum(trial.times)),
+    t_max = BenchmarkTools.prettytime(maximum(trial.times)),
+    t_mean = BenchmarkTools.prettytime(StatsBase.mean(trial.times)),
+    t_med = BenchmarkTools.prettytime(StatsBase.median(trial.times)),
+    n_samples = length(trial),
+)
+
+function tabulate_summary(summary)
+    summary_keys = collect(keys(summary))
+    mem = map(k -> summary[k].mem, summary_keys)
+    nalloc = map(k -> summary[k].nalloc, summary_keys)
+    t_mean = map(k -> summary[k].t_mean, summary_keys)
+    t_min = map(k -> summary[k].t_min, summary_keys)
+    t_max = map(k -> summary[k].t_max, summary_keys)
+    t_med = map(k -> summary[k].t_med, summary_keys)
+    n_samples = map(k -> summary[k].n_samples, summary_keys)
+
+    table_data = hcat(
+        string.(collect(keys(summary))),
+        mem,
+        nalloc,
+        t_min,
+        t_max,
+        t_mean,
+        t_med,
+        n_samples,
+    )
+
+    header = (
+        [
+            "Function",
+            "Memory",
+            "allocs",
+            "Time",
+            "Time",
+            "Time",
+            "Time",
+            "N-samples",
+        ],
+        [" ", "estimate", "estimate", "min", "max", "mean", "median", ""],
+    )
+
+    PrettyTables.pretty_table(
+        table_data;
+        header,
+        crop = :none,
+        alignment = vcat(:l, repeat([:r], length(header[1]) - 1)),
+    )
+end
+
+function get_trial(f, args, name)
+    sample_limit = 10
+    f(args...) # compile first
+    b = BenchmarkTools.@benchmarkable $f($(args)...)
+    println("Benchmarking $name...")
+    trial = BenchmarkTools.run(b, samples = sample_limit)
+    return trial
+end

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -1,12 +1,14 @@
-example_dir = joinpath(dirname(@__DIR__), "examples")
-
-import Profile
+ca_dir = joinpath(dirname(@__DIR__));
+include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"));
 
 ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
 
-filename = joinpath(example_dir, "hybrid", "driver.jl")
+filename = joinpath(ca_dir, "examples", "hybrid", "driver.jl")
+dict = parsed_args_per_job_id(; trigger = "benchmark.jl")
+parsed_args = dict["perf_target_unthreaded"];
 
-try
+
+try # capture integrator
     include(filename)
 catch err
     if err.error !== :exit_profile
@@ -15,9 +17,10 @@ catch err
 end
 
 OrdinaryDiffEq.step!(integrator) # compile first
+import Profile
 Profile.clear_malloc_data()
 prof = Profile.@profile begin
-    for _ in 1:5
+    for _ in 1:10
         OrdinaryDiffEq.step!(integrator)
     end
 end


### PR DESCRIPTION
This PR

 - Addresses @cmbengue's request to polish / automate a performance analysis report for single processor (unthreaded + multithreaded) for our nearest neighbor to amip. At the moment, the performance targets are missing edmf-- which I'll try to fix in a subsequent PR, after which the performance report will auto-update.

 - Adds/uses some benchmark utilities developed in Thermodynamics
 - Adds two benchmarks: unthreaded (adjusted existing benchmark script) + multithreaded (new script)

For now, we're explicitly avoiding IO, however, we should revisit this soon. Also, our benchmark for `step!` is not "robust" to callbacks-- we may call some of the callbacks depending on the interval / frequency specified. This should also be revisited.

Here's an example output (for the unthreaded):

```
Benchmarking Wfact...
Benchmarking linsolve...
Benchmarking implicit_tendency!...
Benchmarking remaining_tendency!...
Benchmarking step!...
┌─────────────────────┬────────────┬──────────┬────────────┬────────────┬────────────┬────────────┬───────────┐
│ Function            │     Memory │   allocs │       Time │       Time │       Time │       Time │ N-samples │
│                     │   estimate │ estimate │        min │        max │       mean │     median │           │
├─────────────────────┼────────────┼──────────┼────────────┼────────────┼────────────┼────────────┼───────────┤
│ Wfact               │ 335.53 MiB │   259207 │ 528.069 ms │ 731.836 ms │ 605.385 ms │ 592.255 ms │         8 │
│ linsolve            │ 205.67 MiB │   280806 │ 277.099 ms │ 405.817 ms │ 316.950 ms │ 287.764 ms │        10 │
│ implicit_tendency!  │  13.67 KiB │       51 │ 649.578 ms │ 674.674 ms │ 658.891 ms │ 657.224 ms │         8 │
│ remaining_tendency! │  13.82 MiB │    43442 │    2.690 s │    2.697 s │    2.693 s │    2.693 s │         2 │
│ step!               │ 838.18 MiB │   951620 │   13.180 s │   13.180 s │   13.180 s │   13.180 s │         1 │
└─────────────────────┴────────────┴──────────┴────────────┴────────────┴────────────┴────────────┴───────────┘
```

Note that some of these functions call other functions, so there's a scope understanding that's required for interpreting results. `step!` is the outer-most call and can be considered the wall time per timestep (note that a single `step!` performs multiple `wfact`, `linsolve`, `implicit_tendency!` and `remaining_tendency!` calls).

These results will be available on every merged PR in the "performance targets" jobs (threaded / unthreaded).

I'm using BenchmarkTools to perform the benchmarks, we could call multiple times to force a larger sample size, but the existing config will automatically increase the sample size as we improve performance.