### PR TITLE
add hs with AMIP targeted resolution to longrun

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -116,3 +116,22 @@ steps:
         agents:
           slurm_cpus_per_task: 8
 
+  - group: "Targeted resolution AMIP long runs"
+  
+    steps:
+
+      - label: ":computer: held suarez (ρe_tot) high resolution"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 12 --kappa_4 7e15 --dt 200secs --t_end 600days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres"
+        artifact_paths: "longrun_hs_rhoe_highres/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 128
+
+      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 12 --kappa_4 7e15 --dt 50secs --t_end 150days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres"
+        artifact_paths: "longrun_hs_rhoe_equil_highres/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 256


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR adds high resolution hs simulations to longrun buildkite.
It sets up mpi with 128 tasks.

## Benefits and Risks
(State concisely the benefits to be derived from and the risks associated with this PR)

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
