### PR TITLE
Fix threading performance target

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -237,8 +237,9 @@ steps:
         command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --job_id perf_target_threaded --enable_threading true --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_threaded/*"
         agents:
-          slurm_nodes: 1
-          slurm_tasks_per_node: 8
+          slurm_ntasks: 8
+          slurm_ntasks_per_node: 8
+
 
   - group: "TurbulenceConvection"
     steps:


### PR DESCRIPTION
This PR corrects the threading flags for the performance target job. There's several options that can / should be used together, and from [these docs](https://slurm.schedmd.com/cpu_management.html#Overview):

> Some experimentation may be required to discover the exact combination of options needed to produce a desired outcome.

So, I've experimented a bit to understand what needs to be defined. Here's what I found:

```yaml
  agents: # works
    slurm_nodes: 1
    slurm_ntasks: 8
    slurm_ntasks_per_node: 8

  agents: # does not work
    slurm_nodes: 1
    slurm_ntasks_per_node: 8

  agents: # works
    slurm_ntasks: 8
    slurm_ntasks_per_node: 8

  agents: # works
    slurm_nodes: 1
    slurm_ntasks: 8
```

The takeaway is: `slurm_ntasks` _must_ be specified, _along with_ either `slurm_nodes` or `slurm_ntasks_per_node`.

We need to apply corrections to the threading specification in #657. I think that PR also needs fixes with how we specify the distributed configuration (maybe a similar job like this would be useful for breaking down the problem with a distributed config). Also, @sriharshakandala, it looks like there's a typo in ClimaCore.jl's scaling pipeline:
 - [`slurm_tasks_per_node`](https://github.com/CliMA/ClimaCore.jl/blob/d1d73c92869047b7d44e2ab3c68fa3685ab7e1ed/.buildkite/scaling/pipeline.yml#L41) should be [`slurm_ntasks_per_node`](https://www.hpc.caltech.edu/documentation/slurm-commands)