### PR TITLE
add start_date as a command line argument and use it in radiation

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -167,6 +167,10 @@ function parse_commandline()
         help = "Disable the hyperdiffusion of specific humidity [`true`, `false` (default)] (TODO: reconcile this with ρe_tot or remove if instability fixed with limiters)"
         arg_type = Bool
         default = false
+        "--start_date"
+        help = "Start date of the simulation"
+        arg_type = String
+        default = "19790101"
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -1,7 +1,7 @@
 import ClimaAtmos.Parameters as CAP
 using Statistics: mean
 using Dierckx: Spline1D
-using Dates: Second, DateTime
+using Dates: Second
 using Insolation: instantaneous_zenith_angle
 
 function rrtmgp_model_cache(
@@ -241,7 +241,7 @@ function rrtmgp_model_callback!(integrator)
     end
 
     if !idealized_insolation
-        date_time = DateTime(2022) + Second(round(Int, t)) # t secs into 2022
+        current_datetime = p.simulation.start_date + Second(round(Int, t)) # current time
         max_zenith_angle = FT(π) / 2 - eps(FT)
         irradiance = FT(CAP.tot_solar_irrad(params))
         au = FT(CAP.astro_unit(params))
@@ -257,7 +257,7 @@ function rrtmgp_model_callback!(integrator)
                 axes(bottom_coords),
             )
             @. insolation_tuple = instantaneous_zenith_angle(
-                date_time,
+                current_datetime,
                 Float64(bottom_coords.long),
                 Float64(bottom_coords.lat),
                 insolation_params,
@@ -269,7 +269,7 @@ function rrtmgp_model_callback!(integrator)
         else
             # assume that the latitude and longitude are both 0 for flat space
             insolation_tuple = instantaneous_zenith_angle(
-                date_time,
+                current_datetime,
                 0.0,
                 0.0,
                 insolation_params,

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -1,3 +1,5 @@
+using Dates: DateTime, @dateformat_str
+
 abstract type AbstractMoistureModel end
 struct DryModel <: AbstractMoistureModel end
 struct EquilMoistModel <: AbstractMoistureModel end
@@ -141,6 +143,7 @@ function get_simulation(::Type{FT}, parsed_args) where {FT}
         restart = haskey(ENV, "RESTART_FILE"),
         job_id,
         dt = FT(time_to_seconds(parsed_args["dt"])),
+        start_date = DateTime(parsed_args["start_date"], dateformat"yyyymmdd"),
     )
 
     return sim


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Adds start date as a command line argument and uses it in insolation calculation for radiation.

## Benefits and Risks
Benefits: We will have real insolation
Risks: We need to manually modify it for restarting simulations. It would be better to save it in restart files?

## Linked Issues


## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
