### PR TITLE
Upload flame graph to GCP

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -51,14 +51,12 @@ if !isempty(get(ENV, "CI_PERF_CPUPROFILE", ""))
         gs_profile_uri = "gs://clima-ci/$profile_uri"
         dl_profile_uri = "https://storage.googleapis.com/clima-ci/$profile_uri"
 
-        #=
         # sync to bucket
         run(`gsutil cp $(joinpath(output_path, cpufile)) $gs_profile_uri`)
 
         # print link
         println("+++ Profiler link for '$profile_uri': ")
         print_link_url(profiler_url(dl_profile_uri))
-        =#
     end
 else
     import PProf


### PR DESCRIPTION
This is an attempt to fix uploading the flame graph to GCP so that we can load it into [Firefox profiler](https://profiler.firefox.com/).

cc @simonbyrne 