### PR TITLE
Refactor surface flux calculation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,9 +169,6 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --vert_diff true --moist equil --forcing held_suarez --microphy 0M --rayleigh_sponge true --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_held_suarez_rhoe_equilmoist_hightop_sponge --dt 200secs --t_end 1days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge/*"
 
-      - label: ":computer: held suarez (ρe_int) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --energy_name rhoe_int --forcing held_suarez --moist equil --microphy 0M --job_id sphere_held_suarez_rhoe_int_equilmoist --regression_test true --dt 200secs --t_end 2.5days"
-        artifact_paths: "sphere_held_suarez_rhoe_int_equilmoist/*"
 
   - group: "Configs"
     steps:

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -566,17 +566,14 @@ function vertical_diffusion_boundary_layer_cache(
     else
         ts_type = TD.PhaseDry{FT}
     end
-    coef_type = SF.Coefficients{
-        FT,
-        SF.InteriorValues{FT, Tuple{FT, FT}, ts_type},
-        SF.SurfaceValues{FT, Tuple{FT, FT}, TD.PhaseEquil{FT}},
-    }
+
+    cond_type = NamedTuple{(:shf, :lhf, :E, :ρτxz, :ρτyz), NTuple{5, FT}}
 
     return (;
         ᶠv_a = similar(Y.f, eltype(Y.c.uₕ)),
         ᶠz_a,
         ᶠK_E = similar(Y.f, FT),
-        flux_coefficients = similar(z_bottom, coef_type),
+        surface_conditions = similar(z_bottom, cond_type),
         dif_flux_uₕ,
         dif_flux_energy = similar(z_bottom, Geometry.WVector{FT}),
         dif_flux_ρq_tot,
@@ -596,7 +593,7 @@ function eddy_diffusivity_coefficient(norm_v_a, z_a, p)
     return p > p_pbl ? K_E : K_E * exp(-((p_pbl - p) / p_strato)^2)
 end
 
-function constant_T_saturated_surface_coefs(
+function constant_T_saturated_surface_conditions(
     T_sfc,
     ts_int,
     uₕ_int,
@@ -606,22 +603,42 @@ function constant_T_saturated_surface_coefs(
     Ch,
     params,
 )
+    # parameters
     thermo_params = CAP.thermodynamics_params(params)
+    sf_params = CAP.surface_fluxes_params(params)
+
+    # get the near-surface thermal state
     T_int = TD.air_temperature(thermo_params, ts_int)
     Rm_int = TD.gas_constant_air(thermo_params, ts_int)
     ρ_sfc =
         TD.air_density(thermo_params, ts_int) *
         (T_sfc / T_int)^(TD.cv_m(thermo_params, ts_int) / Rm_int)
+
     q_sfc =
         TD.q_vap_saturation_generic(thermo_params, T_sfc, ρ_sfc, TD.Liquid())
     ts_sfc = TD.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
-    return SF.Coefficients{FT}(;
+
+    # wrap state values
+    sc = SF.Coefficients{FT}(;
         state_in = SF.InteriorValues(z_int, (uₕ_int.u, uₕ_int.v), ts_int),
         state_sfc = SF.SurfaceValues(z_sfc, (FT(0), FT(0)), ts_sfc),
-        Cd,
-        Ch,
         z0m = FT(0),
         z0b = FT(0),
+        Cd = Cd, #FT(0.001),
+        Ch = Ch, #FT(0.0001),
+    )
+
+    # calculate all fluxes
+    tsf = SF.surface_conditions(sf_params, sc, SF.FVScheme())
+
+    E = SF.evaporation(sc, sf_params, tsf.Ch)
+
+    return (;
+        shf = tsf.shf,
+        lhf = tsf.lhf,
+        E = E,
+        ρτxz = tsf.ρτxz,
+        ρτyz = tsf.ρτyz,
     )
 end
 
@@ -643,18 +660,11 @@ function sensible_heat_flux_ρe_int(param_set, Ch, sc, scheme)
     return -ρ_sfc * Ch * SF.windspeed(sc) * (cp_m * ΔT) - (hd_sfc) * E
 end
 
-function get_momentum_fluxes(params, Cd, flux_coefficients, nothing)
-    surf_flux_params = CAP.surface_fluxes_params(params)
-    ρτxz, ρτyz =
-        SF.momentum_fluxes(surf_flux_params, Cd, flux_coefficients, nothing)
-    return (; ρτxz = ρτxz, ρτyz = ρτyz)
-end
-
 function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     ᶜρ = Y.c.ρ
     (; z_sfc, ᶜts, ᶜp, T_sfc, ᶠv_a, ᶠz_a, ᶠK_E) = p # assume ᶜts and ᶜp have been updated
     (;
-        flux_coefficients,
+        surface_conditions,
         dif_flux_uₕ,
         dif_flux_energy,
         dif_flux_ρq_tot,
@@ -680,8 +690,8 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     z_surface = Fields.field_values(z_sfc)
 
     if !coupled
-        flux_coefficients .=
-            constant_T_saturated_surface_coefs.(
+        surface_conditions .=
+            constant_T_saturated_surface_conditions.(
                 T_sfc,
                 Spaces.level(ᶜts, 1),
                 Geometry.UVVector.(Spaces.level(Y.c.uₕ, 1)),
@@ -695,8 +705,8 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
 
     if diffuse_momentum
         if !coupled
-            (; ρτxz, ρτyz) =
-                get_momentum_fluxes.(params, Cd, flux_coefficients, nothing)
+            ρτxz = surface_conditions.ρτxz
+            ρτyz = surface_conditions.ρτyz
             u_space = axes(ρτxz) # TODO: delete when "space not the same instance" error is dealt with 
             normal = Geometry.WVector.(ones(u_space)) # TODO: this will need to change for topography
             ρ_1 = Fields.Field(
@@ -724,17 +734,7 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
     if :ρe_tot in propertynames(Y.c)
         if !coupled
             @. dif_flux_energy = Geometry.WVector(
-                SF.sensible_heat_flux(
-                    surf_flux_params,
-                    Ch,
-                    flux_coefficients,
-                    nothing,
-                ) + SF.latent_heat_flux(
-                    surf_flux_params,
-                    Ch,
-                    flux_coefficients,
-                    nothing,
-                ),
+                surface_conditions.shf + surface_conditions.lhf,
             )
         end
         ᶜdivᵥ = Operators.DivergenceF2C(
@@ -743,35 +743,11 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
         )
         @. Yₜ.c.ρe_tot +=
             ᶜdivᵥ(ᶠK_E * ᶠinterp(ᶜρ) * ᶠgradᵥ((Y.c.ρe_tot + ᶜp) / ᶜρ))
-    elseif :ρe_int in propertynames(Y.c)
-        if !coupled
-            @. dif_flux_energy = Geometry.WVector(
-                sensible_heat_flux_ρe_int(
-                    params,
-                    Ch,
-                    flux_coefficients,
-                    nothing,
-                ) + SF.latent_heat_flux(
-                    surf_flux_params,
-                    Ch,
-                    flux_coefficients,
-                    nothing,
-                ),
-            )
-        end
-        ᶜdivᵥ = Operators.DivergenceF2C(
-            top = Operators.SetValue(Geometry.WVector(FT(0))),
-            bottom = Operators.SetValue(.-dif_flux_energy),
-        )
-        @. Yₜ.c.ρe_int +=
-            ᶜdivᵥ(ᶠK_E * ᶠinterp(ᶜρ) * ᶠgradᵥ((Y.c.ρe_int + ᶜp) / ᶜρ))
     end
 
     if :ρq_tot in propertynames(Y.c)
         if !coupled
-            @. dif_flux_ρq_tot = Geometry.WVector(
-                SF.evaporation(flux_coefficients, surf_flux_params, Ch),
-            )
+            @. dif_flux_ρq_tot = Geometry.WVector(surface_conditions.E)
         end
         ᶜdivᵥ = Operators.DivergenceF2C(
             top = Operators.SetValue(Geometry.WVector(FT(0))),

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -29,6 +29,10 @@ struct InternalEnergy <: AbstractEnergyFormulation end
 function energy_form(parsed_args)
     energy_name = parse_arg(parsed_args, "energy_name", "rhoe")
     @assert energy_name in ("rhoe", "rhoe_int", "rhotheta")
+    vert_diff = parsed_args["vert_diff"]
+    if vert_diff
+        @assert energy_name == "rhoe"
+    end
     return if energy_name == "rhoe"
         TotalEnergy()
     elseif energy_name == "rhoe_int"
@@ -37,7 +41,6 @@ function energy_form(parsed_args)
         PotentialTemperature()
     end
 end
-
 
 function radiation_model(parsed_args)
     radiation_name = parsed_args["rad"]

--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -49,14 +49,6 @@ all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] 
 all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 0
 all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 0
 #
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρ)] = 0
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρe_int)] = 0
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:c, :ρq_tot)] = 0
-all_best_mse["sphere_held_suarez_rhoe_int_equilmoist"][(:f, :w, :components, :data, 1)] = 0
-#
 all_best_mse["edmf_bomex"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_bomex"][(:c, :ρ)] = 0
 all_best_mse["edmf_bomex"][(:c, :ρe_tot)] = 0


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Refactors the surface flux calculation to use surface_conditions

## Benefits and Risks
This makes the surface flux calculation cleaner, and is a step towards using Monin Obukhov

## Linked Issues

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.

co-authored-by: @szy21 