### PR TITLE
Updated if statement to work with the coupler driver

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,5 +1,5 @@
-include("cli_options.jl")
 if !(@isdefined parsed_args)
+    include("cli_options.jl")
     (s, parsed_args) = parse_commandline()
 end
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
The coupler driver file is also run with command line arguments. Currently, the coupler cli arguments are specified in `cli_options.jl`. They are a set which include the exact same arguments of the atmosphere `cli_options.jl`, but include additional coupler specific args. 

In the current setup, the coupler driver reads in cli_options.jl (coupler version), and reads in the parsed args correctly. Later on, we include the clima atmos examples/driver.jl file. This file includes the atmos cli_options.jl, which redefines the parse_command_line function. This function then errors on the parsed_args which include the coupler args as well - when called within the atmos script.



## Benefits and Risks
Benefits: this lets the coupler run with command line arguments
Risks: This is a hacky solution. A better solution would be some sort of simulations function which takes in parsed_args and sets up the simulation (and integrator). in a clima atmos driver file, this function could be called with clima atmos parsed_args, and the simulation ran. In a clima coupler driver file, this function would be called with coupler+clima atmos parsed args, and the returned integrator could be used for the coupled simulation. Is this the right time to implement something like this? What other fixes are there?

Note that it also means we have essentially two copies of clima atmos cli_options.jl - one in the coupler, and one in clima atmos, that need to be manually kept consistent, so this is part of a broader issue.

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [X] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [X] All classes, modules, and function contain docstrings OR N/A.
- [X] Documentation has been added/updated OR N/A.
