### PR TITLE
Add a simulation without dt_save_to_sol to the longrun

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -47,6 +47,12 @@ steps:
         artifact_paths: "longrun_hs_rhoe_equil/*"
         agents:
           slurm_cpus_per_task: 8
+      
+      - label: ":computer: held suarez (ρe_tot) equilmoist no_save_to_sol"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --dt 250secs --t_end 800days --fps 30 --job_id longrun_hs_rhoe_equil_nosavetosol --dt_save_to_sol Inf --dt_save_to_disk 10days --post_process false"
+        artifact_paths: "longrun_hs_rhoe_equil_nosavetosol/*"
+        agents:
+          slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_tot) equilmoist monin_obukhov Float64"
         command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --microphy 0M --dt 250secs --t_end 800days --fps 30 --job_id longrun_hs_rhoe_equil_mo_ft64 --dt_save_to_sol 1days --dt_save_to_disk 10days --FLOAT_TYPE Float64"

--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -93,11 +93,11 @@ all_best_mse["edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 4.9268887644192
 all_best_mse["edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 8.50032654518012
 #
 all_best_mse["compressible_edmf_gabls"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 4.888486165219538e-5
-all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 0.10337336544741292
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 0.18166174637526528
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 5.5710914785660925
-all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 12.062732246091889
+all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 3.282277731315681e-5
+all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 0.06899554058935968
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 0.21674773274526996
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 4.4632729650903435
+all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 10.081131490997622
 #
 #! format: on
 #################################


### PR DESCRIPTION
Adds a simulation without saving to sol to check the performance. Also updates the MSE table (This PR shouldn't affect the MSE, so probably the MSE table was not updated correctly before).