### PR TITLE
Update perf target and cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -237,11 +237,13 @@ steps:
 
       # TODO: add/exercise edmf code
       - label: ":computer: Unthreaded performance target"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_unthreaded/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: Threaded performance target"
-        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --job_id perf_target_threaded --enable_threading true --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --job_id perf_target_threaded --enable_threading true --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_threaded/*"
         agents:
           slurm_ntasks: 8

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -96,7 +96,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
     default_remaining_tendency! = if model_spec.anelastic_dycore
         (Yₜ, Y, p, t) -> nothing
     else
-        if :ρe_tot in propertynames(Y.c)
+        if :ρe_tot in propertynames(Y.c) && enable_threading()
             default_remaining_tendency_special!
         else
             default_remaining_tendency_generic!

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -551,22 +551,10 @@ function vertical_diffusion_boundary_layer_cache(
             zeros(axes(z_bottom)),
             zeros(axes(z_bottom)),
         )
-    if :ρq_tot in propertynames(Y.c)
-        dif_flux_ρq_tot = similar(z_bottom, Geometry.WVector{FT})
+    dif_flux_ρq_tot = if :ρq_tot in propertynames(Y.c)
+        similar(z_bottom, Geometry.WVector{FT})
     else
-        dif_flux_ρq_tot = Ref(Geometry.WVector(FT(0)))
-    end
-
-    if (
-        :ρq_liq in propertynames(Y.c) &&
-        :ρq_ice in propertynames(Y.c) &&
-        :ρq_tot in propertynames(Y.c)
-    )
-        ts_type = TD.PhaseNonEquil{FT}
-    elseif :ρq_tot in propertynames(Y.c)
-        ts_type = TD.PhaseEquil{FT}
-    else
-        ts_type = TD.PhaseDry{FT}
+        Ref(Geometry.WVector(FT(0)))
     end
 
     cond_type = NamedTuple{(:shf, :lhf, :E, :ρτxz, :ρτyz), NTuple{5, FT}}

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -285,7 +285,8 @@ function ode_config(Y, parsed_args, model_spec)
         Wfact! =
             if :ρe_tot in propertynames(Y.c) &&
                W.flags.∂ᶜ𝔼ₜ∂ᶠ𝕄_mode == :no_∂ᶜp∂ᶜK &&
-               W.flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact
+               W.flags.∂ᶠ𝕄ₜ∂ᶜρ_mode == :exact &&
+               enable_threading()
                 Wfact_special!
             else
                 Wfact_generic!
@@ -320,7 +321,7 @@ function get_integrator(parsed_args, Y, p, tspan, jac_kwargs, callback)
     show_progress_bar = isinteractive()
     additional_solver_kwargs = () # e.g., abstol and reltol
 
-    if :ρe_tot in propertynames(Y.c)
+    if :ρe_tot in propertynames(Y.c) && enable_threading()
         implicit_tendency! = implicit_tendency_special!
     else
         implicit_tendency! = implicit_tendency_generic!

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -25,6 +25,7 @@ end
 do_work!(integrator) # compile first
 import Profile
 Profile.clear_malloc_data()
+Profile.clear()
 prof = Profile.@profile begin
     do_work!(integrator)
 end


### PR DESCRIPTION
This PR:
 - Avoids threaded functions when threading is disabled
 - Adds held suarez forcing to the perf target (I noticed allocations in Held Suarez forcing, so it could be costing us)
 - Adds a call to `Profile.clear()` in the flame graph script (I'm hoping that this may clear out global scope calls)
 - Cleans up some unused functions