### PR TITLE
Add printing of basic time info

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -27,7 +27,6 @@ viscous_sponge = parsed_args["viscous_sponge"]
 zd_rayleigh = parsed_args["zd_rayleigh"]
 zd_viscous = parsed_args["zd_viscous"]
 κ₂_sponge = parsed_args["kappa_2_sponge"]
-t_end = FT(time_to_seconds(parsed_args["t_end"]))
 
 @assert idealized_insolation in (true, false)
 @assert idealized_clouds in (true, false)
@@ -236,7 +235,7 @@ end
 include("callbacks.jl")
 
 callback = get_callbacks(parsed_args, simulation, model_spec, params)
-tspan = (t_start, t_end)
+tspan = (t_start, simulation.t_end)
 @info "tspan = `$tspan`"
 integrator = get_integrator(parsed_args, Y, p, tspan, jac_kwargs, callback)
 
@@ -253,7 +252,7 @@ else
     sol = @timev OrdinaryDiffEq.solve!(integrator)
 end
 
-@assert last(sol.t) == t_end
+@assert last(sol.t) == simulation.t_end
 
 verify_callbacks(sol.t)
 

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -152,6 +152,14 @@ function get_simulation(::Type{FT}, parsed_args) where {FT}
         job_id,
         dt = FT(time_to_seconds(parsed_args["dt"])),
         start_date = DateTime(parsed_args["start_date"], dateformat"yyyymmdd"),
+        t_end = FT(time_to_seconds(parsed_args["t_end"])),
+    )
+    n_steps = floor(Int, sim.t_end / sim.dt)
+    @info(
+        "Time info:",
+        dt = parsed_args["dt"],
+        t_end = parsed_args["t_end"],
+        floor_n_steps = n_steps,
     )
 
     return sim


### PR DESCRIPTION
This PR adds printing for some basic time information (`t_end`, `dt`, `n_steps`), and removes `t_end` from global scope.