### PR TITLE
Make sure overloading, hack `calc_tderivative!`

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -3,6 +3,9 @@ if !(@isdefined parsed_args)
     (s, parsed_args) = parse_commandline()
 end
 
+include("../implicit_solver_debugging_tools.jl")
+include("../ordinary_diff_eq_bug_fixes.jl")
+include("../common_spaces.jl")
 include("classify_case.jl")
 include("utilities.jl")
 include("nvtx.jl")
@@ -204,9 +207,6 @@ import ClimaCore
 if parsed_args["trunc_stack_traces"]
     ClimaCore.Fields.truncate_printing_field_types() = true
 end
-include("../implicit_solver_debugging_tools.jl")
-include("../ordinary_diff_eq_bug_fixes.jl")
-include("../common_spaces.jl")
 
 include(joinpath("sphere", "baroclinic_wave_utilities.jl"))
 

--- a/examples/ordinary_diff_eq_bug_fixes.jl
+++ b/examples/ordinary_diff_eq_bug_fixes.jl
@@ -19,6 +19,22 @@ using OrdinaryDiffEq.SciMLBase: RECOMPILE_BY_DEFAULT
 
 import OrdinaryDiffEq: nlsolve!
 import OrdinaryDiffEq.SciMLBase: SplitFunction
+import OrdinaryDiffEq as ODE
+using DiffEqBase: @..
+
+# TODO: remove this hack after updating to ClimaTimeSteppers.jl
+function ODE.calc_tderivative!(
+    integrator::ODE.ODEIntegrator,
+    cache,
+    dtd1,
+    repeat_step,
+)
+    @inbounds begin
+        @unpack fsalfirst, linsolve_tmp = cache
+        @.. linsolve_tmp = fsalfirst
+    end
+    return nothing
+end
 
 #=
 Issue: calc_W! attempts to access f.Wfact when has_Wfact(f) and f.Wfact_t when


### PR DESCRIPTION
This PR:
 - Moves some code loading, to make sure that we're overloading some OrdinaryDiffEq methods (`SplitFunction`). It turns out that it was, but moving this code up is also good because it confirms that there's no closures in these functions.
 - Hacks `OrdinaryDiffEq.calc_tderivative!` to skip calling `f` (this presumably is not needed when no explicit time derivatives exist).

It looks like:
 - All of our regression tests are passing, which is great
 - One additional RHS eval is eliminated (so we get a ~30% speedup)