### PR TITLE
fix Nq vs nh_poly

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -134,7 +134,7 @@ function parse_commandline()
         "--nh_poly"
         help = "Horizontal polynomial order"
         arg_type = Int
-        default = 5
+        default = 4
         "--z_max"
         help = "Model top height. Default: 30km"
         arg_type = Float64

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -186,7 +186,7 @@ function get_spaces(parsed_args, params, comms_ctx)
     radius = CAP.planet_radius(params)
     center_space, face_space = if parsed_args["config"] == "sphere"
         nh_poly = parsed_args["nh_poly"]
-        quad = Spaces.Quadratures.GLL{nh_poly}()
+        quad = Spaces.Quadratures.GLL{nh_poly + 1}()
         horizontal_mesh = cubed_sphere_mesh(; radius, h_elem)
         h_space = make_horizontal_space(horizontal_mesh, quad, comms_ctx)
         z_stretch = if parsed_args["z_stretch"]


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Fix:
`nh_poly` is given in command line while `Nq` is needed in computing quadrature points `Spaces.Quadratures.GLL{Nq}()`. They satisfies `Nq = nh_poly + 1`.

## Benefits and Risks
(State concisely the benefits to be derived from and the risks associated with this PR)

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
