### PR TITLE
restart with mpi runs

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -76,7 +76,7 @@ function get_callbacks(parsed_args, simulation, model_spec, params)
 
     return ODE.CallbackSet(
         dss_cb,
-        saveto_disk_callback,
+        save_to_disk_callback,
         save_restart_callback,
         additional_callbacks...,
     )

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -191,6 +191,10 @@ function parse_commandline()
         help = "Define the surface elevation profile [`NoWarp`,`Earth`,`DCMIP200`]"
         arg_type = String
         default = "NoWarp"
+        "--dt_save_restart"
+        help = "Time between saving restart files to disk. Examples: [`10secs`, `1hours`, `Inf` (do not save)]"
+        arg_type = String
+        default = "Inf"
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR enables the restart functionality for mpi runs. 
- [x] Switching on restart thru cli allows for Y saved separate jld2 files per processor;
- [ ] Specifying `RESTART_FILE` as an environmental variable initializes the simulation by reading from the jld2 files.


## Benefits and Risks
(State concisely the benefits to be derived from and the risks associated with this PR)

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
