### PR TITLE
Move rayleigh sponge to the implicit solver and only damp w

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -139,6 +139,18 @@ steps:
         artifact_paths: "longrun_hs_rhoe_hightop_third/*"
         agents:
           slurm_cpus_per_task: 8
+      
+      - label: ":computer: held suarez (ρe_tot) equilmoist hightop"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --z_max 45e3 --z_elem 25 --dt 200secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_equil_hightop --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        artifact_paths: "longrun_hs_rhoe_equil_hightop/*"
+        agents:
+          slurm_cpus_per_task: 8
+      
+      - label: ":computer: held suarez (ρe_tot) equilmoist hightop sponge"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --z_max 45e3 --z_elem 25 --rayleigh_sponge true --zd_rayleigh 30e3 --alpha_rayleigh_uh 0 --dt 200secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_equil_hightop_sponge --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        artifact_paths: "longrun_hs_rhoe_equil_hightop_sponge/*"
+        agents:
+          slurm_cpus_per_task: 8
 
   - group: "Targeted resolution AMIP long runs"
   

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -167,6 +167,14 @@ function parse_commandline()
         help = "Rayleigh sponge height"
         arg_type = Float64
         default = Float64(15e3)
+        "alpha_rayleigh_uh"
+        help = "Rayleigh sponge coefficient for horizontal velocity"
+        arg_type = Float64
+        default = Float64(1e-4)
+        "alpha_rayleigh_w"
+        help = "Rayleigh sponge coefficient for vertical velocity"
+        arg_type = Float64
+        default = Float64(1)
         "--zd_viscous"
         help = "Viscous sponge height"
         arg_type = Float64

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -28,6 +28,8 @@ case_name = parsed_args["turbconv_case"]
 rayleigh_sponge = parsed_args["rayleigh_sponge"]
 viscous_sponge = parsed_args["viscous_sponge"]
 zd_rayleigh = parsed_args["zd_rayleigh"]
+α_rayleigh_uₕ = parsed_args["alpha_rayleigh_uh"]
+α_rayleigh_w = parsed_args["alpha_rayleigh_w"]
 zd_viscous = parsed_args["zd_viscous"]
 κ₂_sponge = parsed_args["kappa_2_sponge"]
 
@@ -114,8 +116,13 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
             disable_qt_hyperdiffusion,
         ),
         rayleigh_sponge ?
-        rayleigh_sponge_cache(Y, dt; zd_rayleigh = FT(zd_rayleigh)) :
-        NamedTuple(),
+        rayleigh_sponge_cache(
+            Y,
+            dt;
+            zd_rayleigh = FT(zd_rayleigh),
+            α_rayleigh_uₕ = FT(α_rayleigh_uₕ),
+            α_rayleigh_w = FT(α_rayleigh_w),
+        ) : NamedTuple(),
         viscous_sponge ?
         viscous_sponge_cache(
             Y;

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -318,23 +318,28 @@ end
 
 # Rayleigh sponge
 
-function rayleigh_sponge_cache(Y, dt; zd_rayleigh = FT(15e3))
+function rayleigh_sponge_cache(
+    Y,
+    dt;
+    zd_rayleigh = FT(15e3),
+    α_rayleigh_uₕ = FT(1e-4),
+    α_rayleigh_w = FT(1),
+)
     ᶜz = Fields.coordinate_field(Y.c).z
     ᶠz = Fields.coordinate_field(Y.f).z
-    ᶜαₘ = @. ifelse(ᶜz > zd_rayleigh, 1 / (20 * dt), FT(0))
-    ᶠαₘ = @. ifelse(ᶠz > zd_rayleigh, 1 / (20 * dt), FT(0))
+    ᶜαₘ_uₕ = @. ifelse(ᶜz > zd_rayleigh, α_rayleigh_uₕ, FT(0))
+    ᶠαₘ_w = @. ifelse(ᶠz > zd_rayleigh, α_rayleigh_w, FT(0))
     zmax = maximum(ᶠz)
-    ᶜβ_rayleigh =
-        @. ᶜαₘ * sin(FT(π) / 2 * (ᶜz - zd_rayleigh) / (zmax - zd_rayleigh))^2
-    ᶠβ_rayleigh =
-        @. ᶠαₘ * sin(FT(π) / 2 * (ᶠz - zd_rayleigh) / (zmax - zd_rayleigh))^2
-    return (; ᶜβ_rayleigh, ᶠβ_rayleigh)
+    ᶜβ_rayleigh_uₕ =
+        @. ᶜαₘ_uₕ * sin(FT(π) / 2 * (ᶜz - zd_rayleigh) / (zmax - zd_rayleigh))^2
+    ᶠβ_rayleigh_w =
+        @. ᶠαₘ_w * sin(FT(π) / 2 * (ᶠz - zd_rayleigh) / (zmax - zd_rayleigh))^2
+    return (; ᶜβ_rayleigh_uₕ, ᶠβ_rayleigh_w)
 end
 
 function rayleigh_sponge_tendency!(Yₜ, Y, p, t)
-    (; ᶜβ_rayleigh, ᶠβ_rayleigh) = p
-    @. Yₜ.c.uₕ -= ᶜβ_rayleigh * Y.c.uₕ
-    @. Yₜ.f.w -= ᶠβ_rayleigh * Y.f.w
+    (; ᶜβ_rayleigh_uₕ) = p
+    @. Yₜ.c.uₕ -= ᶜβ_rayleigh_uₕ * Y.c.uₕ
 end
 
 # Viscous sponge

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -222,6 +222,10 @@ function implicit_tendency_special!(Yₜ, Y, p, t)
                 ᶠgradᵥ(ᶜK[colidx] + ᶜΦ[colidx])
             )
 
+            if p.tendency_knobs.rayleigh_sponge
+                @. Yₜ.f.w[colidx] -= p.ᶠβ_rayleigh_w[colidx] * Y.f.w[colidx]
+            end
+
             for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
                 ᶜ𝕋 = getproperty(Y.c, ᶜ𝕋_name)
                 ᶜ𝕋ₜ = getproperty(Yₜ.c, ᶜ𝕋_name)
@@ -316,6 +320,10 @@ function implicit_tendency_generic!(Yₜ, Y, p, t)
         Yₜ.c.uₕ .= Ref(zero(eltype(Yₜ.c.uₕ)))
 
         @. Yₜ.f.w = -(ᶠgradᵥ(ᶜp) / ᶠinterp(ᶜρ) + ᶠgradᵥ(ᶜK + ᶜΦ))
+
+        if p.tendency_knobs.rayleigh_sponge
+            @. Yₜ.f.w -= p.ᶠβ_rayleigh_w * Y.f.w
+        end
 
         for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
             ᶜ𝕋 = getproperty(Y.c, ᶜ𝕋_name)
@@ -643,6 +651,10 @@ function Wfact_special!(W, Y, p, dtγ, t)
                     ∂ᶜK∂ᶠw_data[colidx],
                 ),
             )
+
+            if p.tendency_knobs.rayleigh_sponge
+                @. ∂ᶠ𝕄ₜ∂ᶠ𝕄.coefs.:2[colidx] -= p.ᶠβ_rayleigh_w[colidx]
+            end
 
             for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
                 ᶜ𝕋 = getproperty(Y.c, ᶜ𝕋_name)
@@ -1005,6 +1017,10 @@ function Wfact_generic!(W, Y, p, dtγ, t)
                     ∂ᶜK∂ᶠw_data,
                 ),
             )
+        end
+
+        if p.tendency_knobs.rayleigh_sponge
+            @. ∂ᶠ𝕄ₜ∂ᶠ𝕄.coefs.:2 -= p.ᶠβ_rayleigh_w
         end
 
         for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

- Separate the relaxation coefficient for horizontal and vertical velocities in rayleigh sponge
- Move the relaxation of vertical velocity into implicit tendency

## Benefits and Risks
(State concisely the benefits to be derived from and the risks associated with this PR)

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #
- Closes #

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
