### PR TITLE
Add job with check bounds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -183,6 +183,13 @@ steps:
         agents:
           slurm_ntasks: 2
 
+      - label: ":computer: performance target checkbounds"
+        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_cb --enable_threading false --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_unthreaded_cb/*"
+        soft_fail: true
+        agents:
+          slurm_mem: 20GB
+
   - group: "Milestones"
     steps:
 


### PR DESCRIPTION
This PR adds a job that runs our perf target with `--check-bounds=yes` to make sure that we're not accidentally accessing invalid memory.