### PR TITLE
Dy/move k term

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -141,9 +141,9 @@ function save_to_disk_func(integrator)
     Y = u
 
     if :ρq_tot in propertynames(Y.c)
-        (; ᶜts, ᶜp, ᶜS_ρq_tot, params, ᶜK, ᶜΦ) = p
+        (; ᶜts, ᶜp, ᶜS_ρq_tot, params, ᶜK) = p
     else
-        (; ᶜts, ᶜp, params, ᶜK, ᶜΦ) = p
+        (; ᶜts, ᶜp, params, ᶜK) = p
     end
     thermo_params = CAP.thermodynamics_params(params)
     cm_params = CAP.microphysics_params(params)

--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -317,7 +317,7 @@ end
 
 # plots for moist baroclinic wave: https://www.cesm.ucar.edu/events/wg-meetings/2018/presentations/amwg/jablonowski.pdf
 function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, ᶜp, params, ᶜK, ᶜΦ) = p
+    (; ᶜts, ᶜp, params, ᶜK) = p
     last_day = floor(Int, sol.t[end] / (24 * 3600))
     days = [last_day - 2, last_day]
     thermo_params = CAP.thermodynamics_params(params)
@@ -772,7 +772,7 @@ function postprocessing_edmf(sol, output_dir, fps)
 end
 
 function paperplots_moist_held_suarez_ρe(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, params, ᶜK, ᶜΦ) = p
+    (; ᶜts, params, ᶜK) = p
     thermo_params = CAP.thermodynamics_params(params)
 
     ### save raw data into nc -> in preparation for remapping

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -193,7 +193,7 @@ function rrtmgp_model_callback!(integrator)
     p = integrator.p
     t = integrator.t
 
-    (; ᶜK, ᶜΦ, ᶜts, T_sfc, params) = p
+    (; ᶜK, ᶜts, T_sfc, params) = p
     (; idealized_insolation, idealized_h2o, idealized_clouds) = p
     (; insolation_tuple, ᶠradiation_flux, rrtmgp_model) = p
     thermo_params = CAP.thermodynamics_params(params)

--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -6,48 +6,48 @@
 all_best_mse = OrderedCollections.OrderedDict()
 #
 all_best_mse["sphere_held_suarez_rhotheta"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 1.6809275386800948e-7
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 6.262375765923583e-9
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 0.005848683042811358
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 0.33720431316147
-all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 7.58846246682216
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 1.6193573169208953e-7
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 5.794432690544718e-9
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 0.0052961737378325715
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 0.2856815462764704
+all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 6.957987065930084
 #
 all_best_mse["sphere_held_suarez_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 3.791803395333096e-9
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe_tot)] = 7.129459043178872e-7
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0012773046132519982
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.04058715617543107
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 2.5524901161530087e-5
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 34.39483489419334
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 4.329258333233513e-9
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe_tot)] = 9.352547534007653e-7
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0014573739605400694
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.046279574860332344
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 3.2809699936140647e-5
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 37.47881884168757
 #
 all_best_mse["sphere_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe_tot)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 1.0540531930506877e-6
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe_tot)] = 1.6479850411795196e-5
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0006089219530418976
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 1.4327093799483166
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 3.1477667218306444
 #
 all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 2.0942300316958478e-8
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 1.131278772934838e-6
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 3.005029752396643e-5
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0068174150497760065
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 8.593085124564406e-6
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 4.04818736970874
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 1.008574490686853e-7
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 3.447703103549545e-6
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.005183137972018408
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.7771387614169974
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 2.4719041998861164e-5
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 6.3519623066828546
 #
 all_best_mse["sphere_held_suarez_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 4.6643303671829996e-9
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe_tot)] = 7.986314717737867e-8
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0005123580120576744
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.014815985887276211
-all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 2.9196460681211165
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 6.639342599624274e-9
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe_tot)] = 1.118138182095686e-7
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0006746573435171093
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.014597642126239123
+all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 3.188673657097964
 #
 all_best_mse["sphere_held_suarez_rhoe_int"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 1.6571910948917722e-8
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 2.320213200956851e-6
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 0.0009642264833738182
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 0.014393560048110174
-all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 2.5413488484983864
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 1.7198435477405778e-8
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 2.6354668436730466e-6
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 0.0009629275043504053
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 0.015243579327998148
+all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 3.0699616990859373
 #
 all_best_mse["edmf_bomex"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_bomex"][(:c, :ρ)] = 2.8522353213044766e-17
@@ -75,15 +75,15 @@ all_best_mse["edmf_dycoms_rf01"][(:f, :turbconv, :up, 1, :ρaw)] = 3.38243686130
 #
 all_best_mse["edmf_trmm"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_trmm"][(:c, :ρ)] = 4.128691267630159e-15
-all_best_mse["edmf_trmm"][(:c, :ρe_tot)] = 1.885109594812877e-14
-all_best_mse["edmf_trmm"][(:c, :uₕ, :components, :data, 1)] = 7.209727706937545e-14
-all_best_mse["edmf_trmm"][(:c, :uₕ, :components, :data, 2)] = 7.883385322388729e-14
-all_best_mse["edmf_trmm"][(:c, :ρq_tot)] = 2.816674211914342e-13
-all_best_mse["edmf_trmm"][(:c, :turbconv, :en, :ρatke)] = 3.3661227756901374e-12
-all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρarea)] = 8.333829223739702e-13
-all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 9.279063933589412e-13
-all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 1.6864875679316793e-12
-all_best_mse["edmf_trmm"][(:f, :turbconv, :up, 1, :ρaw)] = 2.4745277425294757e-13
+all_best_mse["edmf_trmm"][(:c, :ρe_tot)] = 1.8851082932363716e-14
+all_best_mse["edmf_trmm"][(:c, :uₕ, :components, :data, 1)] = 7.20895479279743e-14
+all_best_mse["edmf_trmm"][(:c, :uₕ, :components, :data, 2)] = 7.883295084687389e-14
+all_best_mse["edmf_trmm"][(:c, :ρq_tot)] = 2.816671570667443e-13
+all_best_mse["edmf_trmm"][(:c, :turbconv, :en, :ρatke)] = 3.3660553414560265e-12
+all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρarea)] = 8.337273447946508e-13
+all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 9.283206947395169e-13
+all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 1.6864846874739997e-12
+all_best_mse["edmf_trmm"][(:f, :turbconv, :up, 1, :ρaw)] = 2.4745516465347836e-13
 #
 all_best_mse["edmf_gabls"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_gabls"][(:c, :ρ)] = 0.0
@@ -93,11 +93,11 @@ all_best_mse["edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 0.0
 all_best_mse["edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 0.0
 #
 all_best_mse["compressible_edmf_gabls"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 2.31669141627373e-20
-all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 5.530777000234495e-17
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 3.083858688471818e-16
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 1.3870892916453092e-15
-all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 1.1684973737743386e-8
+all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 1.8711190181319758e-16
+all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 4.4172261486579754e-13
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 2.7566317385055272e-12
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 1.2284531527859584e-11
+all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 4.0037094639860584e-12
 #
 #! format: on
 #################################


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Move `ᶠgradᵥ.(ᶜK)` from the implicit tendency to the explicit tendency (both the special and generic versions), and make appropriate changes to the Jacobian. Since this replaces `ᶠgradᵥ.(ᶜK + ᶜΦ)` with `ᶠgradᵥ.(ᶜΦ)` in the implicit tendency, the constant `Field` `ᶠgradᵥ_ᶜΦ = ᶠgradᵥ.(ᶜΦ)` is now stored in the cache along with `ᶜΦ`.

## Benefits and Risks
This PR will improve numerical stability for IMEX methods like ARS343, allowing them to achieve larger maximum timesteps.

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
