### PR TITLE
Rm no longer needed jobs, + moist / dry compare

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -48,10 +48,6 @@ steps:
         agents:
           slurm_cpus_per_task: 8
 
-      - label: ":computer: held suarez (ρe_tot, unthreaded)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --enable_threading false --forcing held_suarez --t_end 1200days --fps 30 --job_id longrun_hs_rhoe_unthreaded --dt_save_to_sol 1days --dt_save_to_disk 10days"
-        artifact_paths: "longrun_hs_rhoe_unthreaded/*"
-
       - label: ":computer: held suarez (ρe_tot) equilmoist"
         command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --dt 250secs --t_end 800days --fps 30 --job_id longrun_hs_rhoe_equil --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_hs_rhoe_equil/*"
@@ -63,16 +59,10 @@ steps:
         artifact_paths: "longrun_hs_rhoe_equil_ARS343/*"
         agents:
           slurm_cpus_per_task: 8
-      
+
       - label: ":computer: held suarez (ρe_tot) equilmoist ARS343 dt200"
         command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --dt 200secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_equil_ARS343_dt200 --ode_algo ARS343 --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_hs_rhoe_equil_ARS343_dt200/*"
-        agents:
-          slurm_cpus_per_task: 8
-
-      - label: ":computer: held suarez (ρe_tot) equilmoist no_save_to_sol"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --microphy 0M --dt 250secs --t_end 800days --fps 30 --job_id longrun_hs_rhoe_equil_nosavetosol --dt_save_to_sol Inf --dt_save_to_disk 10days --post_process false"
-        artifact_paths: "longrun_hs_rhoe_equil_nosavetosol/*"
         agents:
           slurm_cpus_per_task: 8
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -242,7 +242,7 @@ steps:
       - label: ":computer: held suarez (ρe_tot) equilmoist"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 200secs --t_end 3days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
-      
+
       - label: ":computer: held suarez (ρe_tot) equilmoist monin_obukhov"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist_mo --dt 200secs --t_end 3days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_mo/*"
@@ -250,7 +250,7 @@ steps:
       - label: ":computer: held suarez (ρe_tot) equilmoist monin_obukhov Float64"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist_mo_ft64 --dt 200secs --t_end 3days --FLOAT_TYPE Float64"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_mo_ft64/*"
-      
+
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation monin_obukhov"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky_mo --dt 200secs --t_end 2.5days"
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_clearsky_mo/*"
@@ -348,22 +348,6 @@ steps:
           slurm_mem: 20GB
         env:
           CI_PERF_CPUPROFILE: "true"
-
-      - label: ":rocket: flame graph: perf target (ρe_tot) disabled vert_diff"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_no_vert_diff --vert_diff false"
-        artifact_paths: "flame_perf_target_rhoe_no_vert_diff/*"
-        agents:
-          slurm_mem: 20GB
-        env:
-          CI_PERF_CPUPROFILE: "true"
-
-      - label: ":rocket: flame graph: perf target (ρe_int)" # vert_diff true not supported for rhoe_int..
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_int --energy_name rhoe_int --vert_diff false"
-        artifact_paths: "flame_perf_target_rhoe_int/*"
-        env:
-          CI_PERF_CPUPROFILE: "true"
-        agents:
-          slurm_mem: 20GB
 
       - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"


### PR DESCRIPTION
This PR:
 - Removes the unthreaded longrun, it's helped us identify the threading issue and I think is no longer really needed
 - Removes the `no_save_to_sol` longrun job, since that also wasn't the source of allocations
 - Removes the internal energy flame graph, since there's no longer a discrepancy between internal and total energy long runs