### PR TITLE
Add unthreaded version of linsolve

### DIFF
--- a/examples/hybrid/linsolve_test.jl
+++ b/examples/hybrid/linsolve_test.jl
@@ -1,7 +1,7 @@
 
 function verify_matrix(x, A, b, update_matrix = false; kwargs...)
     (; dtγ_ref, S, S_column_arrays) = A
-    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple) = A
+    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_field) = A
     dtγ = dtγ_ref[]
     dtγ² = dtγ^2
     FT = eltype(eltype(S))
@@ -40,7 +40,7 @@ function verify_matrix(x, A, b, update_matrix = false; kwargs...)
                 DataLayouts.fieldtypeoffset(FT, eltype(x.c), ᶜ𝕋_position)
             ᶜ𝕋_indices = (Nv * ᶜ𝕋_offset + 1):(Nv * (ᶜ𝕋_offset + 1))
             ᶜ𝕋_name = propertynames(x.c)[ᶜ𝕋_position]
-            ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple, ᶜ𝕋_name)
+            ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
             J_col[ᶜ𝕋_indices, ᶠ𝕄_indices] .=
                 matrix_column(∂ᶜ𝕋ₜ∂ᶠ𝕄, axes(x.f), i, j, h)
         end

--- a/examples/hybrid/schur_complement_W.jl
+++ b/examples/hybrid/schur_complement_W.jl
@@ -39,7 +39,7 @@ struct SchurComplementW{F, FT, J1, J2, J3, J4, J5, S, A}
     ∂ᶠ𝕄ₜ∂ᶜ𝔼::J3
     ∂ᶠ𝕄ₜ∂ᶜρ::J3
     ∂ᶠ𝕄ₜ∂ᶠ𝕄::J4
-    ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple::J5
+    ∂ᶜ𝕋ₜ∂ᶠ𝕄_field::J5
 
     # cache for the Schur complement linear solve
     S::S
@@ -82,7 +82,7 @@ function SchurComplementW(Y, transform, flags, test = false)
     ∂ᶠ𝕄ₜ∂ᶜρ = Fields.Field(bidiag_type, axes(Y.f))
     ∂ᶠ𝕄ₜ∂ᶠ𝕄 = Fields.Field(tridiag_type, axes(Y.f))
     ᶜ𝕋_names = filter(is_tracer_var, propertynames(Y.c))
-    ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple =
+    ∂ᶜ𝕋ₜ∂ᶠ𝕄_field =
         FieldFromNamedTuple(axes(Y.c), tracer_variables(FT, ᶜ𝕋_names))
 
     S = Fields.Field(tridiag_type, axes(Y.f))
@@ -102,7 +102,7 @@ function SchurComplementW(Y, transform, flags, test = false)
         typeof(∂ᶜ𝔼ₜ∂ᶠ𝕄),
         typeof(∂ᶠ𝕄ₜ∂ᶜρ),
         typeof(∂ᶠ𝕄ₜ∂ᶠ𝕄),
-        typeof(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple),
+        typeof(∂ᶜ𝕋ₜ∂ᶠ𝕄_field),
         typeof(S),
         typeof(S_column_arrays),
     }(
@@ -114,7 +114,7 @@ function SchurComplementW(Y, transform, flags, test = false)
         ∂ᶠ𝕄ₜ∂ᶜ𝔼,
         ∂ᶠ𝕄ₜ∂ᶜρ,
         ∂ᶠ𝕄ₜ∂ᶠ𝕄,
-        ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple,
+        ∂ᶜ𝕋ₜ∂ᶠ𝕄_field,
         S,
         S_column_arrays,
         test,
@@ -184,7 +184,7 @@ call_verify_matrix() = false
 
 function _linsolve!(x, A, b, update_matrix = false; kwargs...)
     (; dtγ_ref, S, S_column_arrays, transform) = A
-    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple) = A
+    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_field) = A
     dtγ = dtγ_ref[]
     cond = Operators.bandwidths(eltype(∂ᶜ𝔼ₜ∂ᶠ𝕄)) != (-half, half)
     if cond
@@ -197,22 +197,42 @@ function _linsolve!(x, A, b, update_matrix = false; kwargs...)
     @nvtx "linsolve" color = colorant"lime" begin
 
         # Compute Schur complement
-        Fields.bycolumn(axes(x.c)) do colidx
+        if enable_threading()
+            Fields.bycolumn(axes(x.c)) do colidx
+                _linsolve_serial!(
+                    x.c[colidx],
+                    x.f[colidx],
+                    b.c[colidx],
+                    b.f[colidx],
+                    dtγ,
+                    transform,
+                    cond,
+                    ∂ᶜρₜ∂ᶠ𝕄[colidx],
+                    ∂ᶜ𝔼ₜ∂ᶠ𝕄[colidx],
+                    ∂ᶠ𝕄ₜ∂ᶜ𝔼[colidx],
+                    ∂ᶠ𝕄ₜ∂ᶜρ[colidx],
+                    ∂ᶠ𝕄ₜ∂ᶠ𝕄[colidx],
+                    ∂ᶜ𝕋ₜ∂ᶠ𝕄_field[colidx],
+                    S[colidx],
+                    S_column_arrays[Threads.threadid()], # can / should this be colidx?
+                )
+            end
+        else
             _linsolve_serial!(
-                x.c[colidx],
-                x.f[colidx],
-                b.c[colidx],
-                b.f[colidx],
+                x.c,
+                x.f,
+                b.c,
+                b.f,
                 dtγ,
                 transform,
                 cond,
-                ∂ᶜρₜ∂ᶠ𝕄[colidx],
-                ∂ᶜ𝔼ₜ∂ᶠ𝕄[colidx],
-                ∂ᶠ𝕄ₜ∂ᶜ𝔼[colidx],
-                ∂ᶠ𝕄ₜ∂ᶜρ[colidx],
-                ∂ᶠ𝕄ₜ∂ᶠ𝕄[colidx],
-                ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple[colidx],
-                S[colidx],
+                ∂ᶜρₜ∂ᶠ𝕄,
+                ∂ᶜ𝔼ₜ∂ᶠ𝕄,
+                ∂ᶠ𝕄ₜ∂ᶜ𝔼,
+                ∂ᶠ𝕄ₜ∂ᶜρ,
+                ∂ᶠ𝕄ₜ∂ᶠ𝕄,
+                ∂ᶜ𝕋ₜ∂ᶠ𝕄_field,
+                S,
                 S_column_arrays[Threads.threadid()], # can / should this be colidx?
             )
         end
@@ -237,7 +257,7 @@ function _linsolve_serial!(
     ∂ᶠ𝕄ₜ∂ᶜ𝔼,
     ∂ᶠ𝕄ₜ∂ᶜρ,
     ∂ᶠ𝕄ₜ∂ᶠ𝕄,
-    ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple,
+    ∂ᶜ𝕋ₜ∂ᶠ𝕄_field,
     S_column,
     S_column_array,
 )
@@ -285,7 +305,7 @@ function _linsolve_serial!(
     for ᶜ𝕋_name in filter(is_tracer_var, propertynames(xc))
         xᶜ𝕋 = getproperty(xc, ᶜ𝕋_name)
         bᶜ𝕋 = getproperty(bc, ᶜ𝕋_name)
-        ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple, ᶜ𝕋_name)
+        ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
         @. xᶜ𝕋 = -bᶜ𝕋 + dtγ * apply(∂ᶜ𝕋ₜ∂ᶠ𝕄, xᶠ𝕄)
     end
     for var_name in filter(is_edmf_var, propertynames(xc))

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -602,7 +602,7 @@ function Wfact_special!(W, Y, p, dtγ, t)
     (; apply_moisture_filter) = p
     apply_moisture_filter && affect_filter!(Y)
     (; flags, dtγ_ref) = W
-    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple) = W
+    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_field) = W
     ᶜρ = Y.c.ρ
     ᶜuₕ = Y.c.uₕ
     ᶠw = Y.f.w
@@ -717,7 +717,7 @@ function Wfact_special!(W, Y, p, dtγ, t)
 
             for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
                 ᶜ𝕋 = getproperty(Y.c, ᶜ𝕋_name)
-                ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple, ᶜ𝕋_name)
+                ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
                 if isnothing(ᶠupwind_product)
                     # ᶜ𝕋ₜ = -ᶜdivᵥ(ᶠinterp(ᶜ𝕋) * ᶠw)
                     # ∂(ᶜ𝕋ₜ)/∂(ᶠw_data) = -ᶜdivᵥ_stencil(ᶠinterp(ᶜ𝕋) * ᶠw_unit)
@@ -746,7 +746,7 @@ function Wfact_generic!(W, Y, p, dtγ, t)
     (; apply_moisture_filter) = p
     apply_moisture_filter && affect_filter!(Y)
     (; flags, dtγ_ref) = W
-    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple) = W
+    (; ∂ᶜρₜ∂ᶠ𝕄, ∂ᶜ𝔼ₜ∂ᶠ𝕄, ∂ᶠ𝕄ₜ∂ᶜ𝔼, ∂ᶠ𝕄ₜ∂ᶜρ, ∂ᶠ𝕄ₜ∂ᶠ𝕄, ∂ᶜ𝕋ₜ∂ᶠ𝕄_field) = W
     ᶜρ = Y.c.ρ
     ᶜuₕ = Y.c.uₕ
     ᶠw = Y.f.w
@@ -1075,7 +1075,7 @@ function Wfact_generic!(W, Y, p, dtγ, t)
 
         for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
             ᶜ𝕋 = getproperty(Y.c, ᶜ𝕋_name)
-            ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple, ᶜ𝕋_name)
+            ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
             if isnothing(ᶠupwind_product)
                 # ᶜ𝕋ₜ = -ᶜdivᵥ(ᶠinterp(ᶜ𝕋) * ᶠw)
                 # ∂(ᶜ𝕋ₜ)/∂(ᶠw_data) = -ᶜdivᵥ_stencil(ᶠinterp(ᶜ𝕋) * ᶠw_unit)
@@ -1112,7 +1112,7 @@ function Wfact_generic!(W, Y, p, dtγ, t)
             @assert matrix_column(∂ᶠ𝕄ₜ∂ᶠ𝕄, axes(Y.f), i, j, h) ≈
                     exact_column_jacobian_block(args..., (:f, :w), (:f, :w))
             for ᶜ𝕋_name in filter(is_tracer_var, propertynames(Y.c))
-                ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_named_tuple, ᶜ𝕋_name)
+                ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
                 ᶜ𝕋_tuple = (:c, ᶜ𝕋_name)
                 @assert matrix_column(∂ᶜ𝕋ₜ∂ᶠ𝕄, axes(Y.f), i, j, h) ≈
                         exact_column_jacobian_block(args..., ᶜ𝕋_tuple, (:f, :w))


### PR DESCRIPTION
This PR:
 - Adds an unthreaded version of `linsolve` (to close #737)
 - Renames `ᶠ𝕄_named_tuple` to `∂ᶜ𝕋ₜ∂ᶠ𝕄_field`, since that's now more appropriate (should have been incorporated in #779).