### PR TITLE
separate vertical diffusion and surface flux

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -171,6 +171,14 @@ steps:
         agents:
           slurm_ntasks: 128
 
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist vertdiff high resolution zalesak ars343"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --vert_diff true --surface_scheme nothing --microphy 0M --tracer_upwinding zalesak --z_elem 45 --dz_bottom 30 --h_elem 12 --kappa_4 14e15 --dt 50secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_vdiff_highres_zalesak_ars343"
+        artifact_paths: "longrun_bw_rhoe_equil_vdiff_highres_zalesak_ars343/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 128
+
       - label: ":computer: held suarez (ρe_tot) high resolution"
         command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 12 --kappa_4 7e15 --dt 200secs --t_end 600days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres"
         artifact_paths: "longrun_hs_rhoe_highres/*"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -49,7 +49,7 @@ function parse_commandline()
         arg_type = Bool
         default = false
         "--surface_scheme"
-        help = "Surface flux scheme [`bulk` (default), `monin_obukhov`]"
+        help = "Surface flux scheme [`nothing`, `bulk` (default), `monin_obukhov`]"
         arg_type = String
         default = "bulk"
         "--C_E"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -36,7 +36,7 @@ zd_viscous = parsed_args["zd_viscous"]
 @assert idealized_insolation in (true, false)
 @assert idealized_clouds in (true, false)
 @assert vert_diff in (true, false)
-@assert surface_scheme in ("bulk", "monin_obukhov")
+@assert surface_scheme in (nothing, "bulk", "monin_obukhov")
 @assert hyperdiff in (true, false)
 @assert parsed_args["config"] in ("sphere", "column")
 @assert rayleigh_sponge in (true, false)
@@ -67,7 +67,10 @@ model_spec = get_model_spec(FT, parsed_args, namelist)
 numerics = get_numerics(parsed_args)
 simulation = get_simulation(FT, parsed_args)
 
-diffuse_momentum = vert_diff && !(model_spec.forcing_type isa HeldSuarezForcing)
+diffuse_momentum =
+    vert_diff &&
+    !(model_spec.forcing_type isa HeldSuarezForcing) &&
+    !isnothing(surface_scheme)
 
 # TODO: use import istead of using
 using Colors

--- a/examples/hybrid/sphere/baroclinic_wave_utilities.jl
+++ b/examples/hybrid/sphere/baroclinic_wave_utilities.jl
@@ -273,6 +273,8 @@ function vertical_diffusion_boundary_layer_cache(
         (; Cd = FT(0.0044), Ch = FT(0.0044))
     elseif surface_scheme == "monin_obukhov"
         (; z0m = FT(1e-5), z0b = FT(1e-5))
+    elseif isnothing(surface_scheme)
+        NamedTuple()
     end
     return (;
         surface_scheme,
@@ -484,9 +486,13 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
 
     if :ρe_tot in propertynames(Y.c)
         if !coupled
-            @. dif_flux_energy = Geometry.WVector(
-                surface_conditions.shf + surface_conditions.lhf,
-            )
+            if isnothing(p.surface_scheme)
+                @. dif_flux_energy *= 0
+            else
+                @. dif_flux_energy = Geometry.WVector(
+                    surface_conditions.shf + surface_conditions.lhf,
+                )
+            end
         end
         ᶜdivᵥ = Operators.DivergenceF2C(
             top = Operators.SetValue(Geometry.WVector(FT(0))),
@@ -498,7 +504,11 @@ function vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
 
     if :ρq_tot in propertynames(Y.c)
         if !coupled
-            @. dif_flux_ρq_tot = Geometry.WVector(surface_conditions.E)
+            if isnothing(p.surface_scheme)
+                @. dif_flux_ρq_tot *= 0
+            else
+                @. dif_flux_ρq_tot = Geometry.WVector(surface_conditions.E)
+            end
         end
         ᶜdivᵥ = Operators.DivergenceF2C(
             top = Operators.SetValue(Geometry.WVector(FT(0))),


### PR DESCRIPTION
This PR adds an option `nothing` to surface_scheme, so we can run simulations with vertical diffusion only.