### PR TITLE
Always move performance benchmarks

### DIFF
--- a/regression_tests/move_output.jl
+++ b/regression_tests/move_output.jl
@@ -9,9 +9,7 @@ job_ids = getindex.(split.(lines, "\""), 2)
 @assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
 @assert length(job_ids) ≠ 0 # safety net
 
-if haskey(ENV, "BUILDKITE_COMMIT") &&
-   haskey(ENV, "BUILDKITE_BRANCH") &&
-   self_reference
+if haskey(ENV, "BUILDKITE_COMMIT") && haskey(ENV, "BUILDKITE_BRANCH")
     commit = ENV["BUILDKITE_COMMIT"]
     branch = ENV["BUILDKITE_BRANCH"]
     # Note: cluster_data_prefix is also defined in compute_mse.jl
@@ -28,15 +26,18 @@ if haskey(ENV, "BUILDKITE_COMMIT") &&
         mkpath(cluster_data_prefix)
         path = joinpath(cluster_data_prefix, commit_sha)
         mkpath(path)
-        for folder_name in job_ids
-            src = folder_name
-            dst = joinpath(path, folder_name)
-            @info "Moving $src to $dst"
-            mv(src, dst; force = true)
+        # Only move regression data if self reference:
+        if self_reference
+            for folder_name in job_ids
+                src = folder_name
+                dst = joinpath(path, folder_name)
+                @info "Moving $src to $dst"
+                mv(src, dst; force = true)
+            end
+            ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl")
+            ref_counter_file_main = joinpath(path, "ref_counter.jl")
+            mv(ref_counter_file_PR, ref_counter_file_main; force = true)
         end
-        ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl")
-        ref_counter_file_main = joinpath(path, "ref_counter.jl")
-        mv(ref_counter_file_PR, ref_counter_file_main; force = true)
         perf_benchmarks_PR = joinpath(dirname(@__DIR__), "perf_benchmarks.json")
         perf_benchmarks_main = joinpath(path, "perf_benchmarks.json")
         mv(perf_benchmarks_PR, perf_benchmarks_main; force = true)


### PR DESCRIPTION
#611 resulted in a minor performance monitoring history lapse, since data from PRs since have not been moved for comparison. This PR fixes this issue so that our perf history should be maintained.