### PR TITLE
Skip folders without the reference counter

### DIFF
--- a/regression_tests/print_new_ref_counter.jl
+++ b/regression_tests/print_new_ref_counter.jl
@@ -4,6 +4,8 @@ function find_latest_dataset_folder(; dir = pwd())
     matching_paths = String[]
     for file in readdir(dir)
         !ispath(joinpath(dir, file)) && continue
+        # Skip folders without the ref_counter
+        isfile(joinpath(dir, "ref_counter.jl")) || continue
         push!(matching_paths, joinpath(dir, file))
     end
     isempty(matching_paths) && return ""


### PR DESCRIPTION
This is a followup to #814, if we conditionally move the reference data (when the reference counter is incremented), then we need to filter the folders on main based on whether the ref counter file exists. This PR fixes this issue.

Related PRs:
 - #814
 - #611

If this continues to open/result in issues, we can revert this PR, #814 and #611 to bring things back to normal.