### PR TITLE
Add ARS343 flame graph

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -381,6 +381,12 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":rocket: flame graph: perf target (ρe_tot) ARS343"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_ARS343 --ode_algo ARS343"
+        artifact_paths: "flame_perf_target_rhoe_ARS343/*"
+        agents:
+          slurm_mem: 20GB
+
       - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"
 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -70,6 +70,7 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 13675232
 allocs_limit["flame_perf_target_rhoe_threaded"] = 27219952
 allocs_limit["flame_perf_target_rhoe_callbacks"] = 24841304
+allocs_limit["flame_perf_target_rhoe_ARS343"] = 33318672
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"


### PR DESCRIPTION
This PR adds a flame graph for the perf target when using the ARS343 time stepper