### PR TITLE
Add at-time to distributed solve

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -270,7 +270,13 @@ end
 if simulation.is_distributed
     OrdinaryDiffEq.step!(integrator)
     ClimaComms.barrier(comms_ctx)
-    walltime = @elapsed sol = OrdinaryDiffEq.solve!(integrator)
+    if ClimaComms.iamroot(comms_ctx)
+        @timev begin
+            walltime = @elapsed sol = OrdinaryDiffEq.solve!(integrator)
+        end
+    else
+        walltime = @elapsed sol = OrdinaryDiffEq.solve!(integrator)
+    end
     ClimaComms.barrier(comms_ctx)
 else
     sol = @timev OrdinaryDiffEq.solve!(integrator)

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -68,7 +68,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 
 allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 13675232
-allocs_limit["flame_perf_target_rhoe_threaded"] = 27219952
+allocs_limit["flame_perf_target_rhoe_threaded"] = 27249159
 allocs_limit["flame_perf_target_rhoe_callbacks"] = 24841304
 allocs_limit["flame_perf_target_rhoe_ARS343"] = 33318672
 


### PR DESCRIPTION
This PR adds a `@timev` to the distributed `solve!`