### PR TITLE
Delete iterate_columns, use bycolumn

### DIFF
--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -79,13 +79,13 @@ function get_edmf_cache(Y, namelist, param_set, parsed_args)
     )
 end
 
-function tc_column_state(prog, aux, tendencies, inds...)
-    prog_cent_column = CC.column(prog.c, inds...)
-    prog_face_column = CC.column(prog.f, inds...)
-    aux_cent_column = CC.column(aux.cent, inds...)
-    aux_face_column = CC.column(aux.face, inds...)
-    tends_cent_column = CC.column(tendencies.c, inds...)
-    tends_face_column = CC.column(tendencies.f, inds...)
+function tc_column_state(prog, aux, tendencies, colidx)
+    prog_cent_column = CC.column(prog.c, colidx)
+    prog_face_column = CC.column(prog.f, colidx)
+    aux_cent_column = CC.column(aux.cent, colidx)
+    aux_face_column = CC.column(aux.face, colidx)
+    tends_cent_column = CC.column(tendencies.c, colidx)
+    tends_face_column = CC.column(tendencies.f, colidx)
     prog_column =
         CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
     aux_column =
@@ -98,11 +98,11 @@ function tc_column_state(prog, aux, tendencies, inds...)
     return TC.State(prog_column, aux_column, tends_column)
 end
 
-function tc_column_state(prog, aux, tendencies::Nothing, inds...)
-    prog_cent_column = CC.column(prog.c, inds...)
-    prog_face_column = CC.column(prog.f, inds...)
-    aux_cent_column = CC.column(aux.cent, inds...)
-    aux_face_column = CC.column(aux.face, inds...)
+function tc_column_state(prog, aux, tendencies::Nothing, colidx)
+    prog_cent_column = CC.column(prog.c, colidx)
+    prog_face_column = CC.column(prog.f, colidx)
+    aux_cent_column = CC.column(aux.cent, colidx)
+    aux_face_column = CC.column(aux.face, colidx)
     prog_column =
         CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
     aux_column =
@@ -130,9 +130,9 @@ function init_tc!(Y, p, param_set, namelist)
     FT = eltype(edmf)
     N_up = TC.n_updrafts(edmf)
 
-    for inds in TC.iterate_columns(Y.c)
+    CC.Fields.bycolumn(axes(Y.c)) do colidx
         # `nothing` goes into State because OrdinaryDiffEq.jl owns tendencies.
-        state = tc_column_state(Y, aux, nothing, inds...)
+        state = tc_column_state(Y, aux, nothing, colidx)
 
         grid = TC.Grid(state)
         FT = eltype(grid)
@@ -165,8 +165,8 @@ function sgs_flux_tendency!(Yₜ, Y, p, t)
     tc_params = CAP.turbconv_params(param_set)
 
     # TODO: write iterator for this
-    for inds in TC.iterate_columns(Y.c)
-        state = tc_column_state(Y, aux, Yₜ, inds...)
+    CC.Fields.bycolumn(axes(Y.c)) do colidx
+        state = tc_column_state(Y, aux, Yₜ, colidx)
         grid = TC.Grid(state)
 
         set_thermo_state_peq!(

--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -136,8 +136,8 @@ function turb_conv_affect_filter!(integrator)
     Y = integrator.u
     tc_params = CAP.turbconv_params(param_set)
 
-    for inds in TC.iterate_columns(Y.c)
-        state = TCU.tc_column_state(Y, aux, nothing, inds...)
+    Fields.bycolumn(axes(Y.c)) do colidx
+        state = TCU.tc_column_state(Y, aux, nothing, colidx)
         grid = TC.Grid(state)
         surf = TCU.get_surface(surf_params, grid, state, t, tc_params)
         TC.affect_filter!(edmf, grid, state, tc_params, surf, t)

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -69,7 +69,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 10575616
 allocs_limit["flame_perf_target_rhoe_threaded"] = 12078608
-allocs_limit["flame_perf_target_rhoe_callbacks"] = 21740792
+allocs_limit["flame_perf_target_rhoe_callbacks"] = 21775759
 allocs_limit["flame_perf_target_rhoe_ARS343"] = 24056711
 
 if allocs < allocs_limit[job_id] * buffer

--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -1121,28 +1121,28 @@ struct State{P, A, T}
 end
 
 """
-    column_state(prog, aux, tendencies, inds...)
+    column_state(prog, aux, tendencies, colidx)
 
 Create a columnar state given full 3D states
  - `prog` prognostic state
  - `aux` auxiliary state
  - `tendencies` tendencies state
- - `inds` indices
+ - `colidx` column index
 
 ## Example
 ```julia
-for inds in TC.iterate_columns(prog.cent)
-    state = TC.column_state(prog, aux, tendencies, inds...)
+Fields.bycolumn(axes(Y.c)) do colidx
+    state = TC.column_state(prog, aux, tendencies, colidx)
     ...
 end
 """
-function column_state(prog, aux, tendencies, inds...)
-    prog_cent_column = CC.column(prog.cent, inds...)
-    prog_face_column = CC.column(prog.face, inds...)
-    aux_cent_column = CC.column(aux.cent, inds...)
-    aux_face_column = CC.column(aux.face, inds...)
-    tends_cent_column = CC.column(tendencies.cent, inds...)
-    tends_face_column = CC.column(tendencies.face, inds...)
+function column_state(prog, aux, tendencies, colidx)
+    prog_cent_column = CC.column(prog.cent, colidx)
+    prog_face_column = CC.column(prog.face, colidx)
+    aux_cent_column = CC.column(aux.cent, colidx)
+    aux_face_column = CC.column(aux.face, colidx)
+    tends_cent_column = CC.column(tendencies.cent, colidx)
+    tends_face_column = CC.column(tendencies.face, colidx)
     prog_column =
         CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
     aux_column =
@@ -1155,11 +1155,11 @@ function column_state(prog, aux, tendencies, inds...)
     return State(prog_column, aux_column, tends_column)
 end
 
-function column_prog_aux(prog, aux, inds...)
-    prog_cent_column = CC.column(prog.cent, inds...)
-    prog_face_column = CC.column(prog.face, inds...)
-    aux_cent_column = CC.column(aux.cent, inds...)
-    aux_face_column = CC.column(aux.face, inds...)
+function column_prog_aux(prog, aux, colidx)
+    prog_cent_column = CC.column(prog.cent, colidx)
+    prog_face_column = CC.column(prog.face, colidx)
+    aux_cent_column = CC.column(aux.cent, colidx)
+    aux_face_column = CC.column(aux.face, colidx)
     prog_column =
         CC.Fields.FieldVector(cent = prog_cent_column, face = prog_face_column)
     aux_column =
@@ -1168,10 +1168,10 @@ function column_prog_aux(prog, aux, inds...)
     return State(prog_column, aux_column, nothing)
 end
 
-function column_diagnostics(diagnostics, inds...)
-    diag_cent_column = CC.column(diagnostics.cent, inds...)
-    diag_face_column = CC.column(diagnostics.face, inds...)
-    diag_svpc_column = CC.column(diagnostics.svpc, inds...)
+function column_diagnostics(diagnostics, colidx)
+    diag_cent_column = CC.column(diagnostics.cent, colidx)
+    diag_face_column = CC.column(diagnostics.face, colidx)
+    diag_svpc_column = CC.column(diagnostics.svpc, colidx)
     return CC.Fields.FieldVector(
         cent = diag_cent_column,
         face = diag_face_column,

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -263,9 +263,9 @@ function ∑stoch_tendencies!(
     parent(tends_face) .= 0
     parent(tends_cent) .= 0
 
-    for inds in TC.iterate_columns(prog.cent)
+    Fields.bycolumn(axes(prog.cent)) do colidx
 
-        state = TC.column_state(prog, aux, tendencies, inds...)
+        state = TC.column_state(prog, aux, tendencies, colidx)
         grid = TC.Grid(state)
         surf = get_surface(surf_params, grid, state, t, param_set)
 
@@ -288,8 +288,8 @@ function ∑tendencies!(
     parent(tendencies.face) .= 0
     parent(tendencies.cent) .= 0
 
-    for inds in TC.iterate_columns(prog.cent)
-        state = TC.column_state(prog, aux, tendencies, inds...)
+    Fields.bycolumn(axes(prog.cent)) do colidx
+        state = TC.column_state(prog, aux, tendencies, colidx)
         grid = TC.Grid(state)
 
         set_thermo_state_peq!(


### PR DESCRIPTION
This PR deletes `iterate_columns` and replaces it with `ClimaCore.Fields.bycolumn`. One advantage is that we can now leverage multithreading with TC.

(the ClimaAtmos analog to [TC#1285](https://github.com/CliMA/TurbulenceConvection.jl/pull/1285)).