### PR TITLE
Make up_deps script more robust

### DIFF
--- a/.dev/up_deps.jl
+++ b/.dev/up_deps.jl
@@ -7,6 +7,7 @@ root = dirname(@__DIR__)
 dirs = (
     root,
     joinpath(root, "test"),
+    joinpath(root, ".dev"),
     joinpath(root, "perf"),
     joinpath(root, "docs"),
     joinpath(root, "examples"),
@@ -14,8 +15,15 @@ dirs = (
 
 cd(root) do
     for dir in dirs
-        @info "Updating environment `$dir`"
-        cmd = `$(Base.julia_cmd()) --project=$dir -e 'import Pkg; Pkg.update()'`
+        reldir = relpath(dir, root)
+        @info "Updating environment `$reldir`"
+        cmd = if dir == root
+            `$(Base.julia_cmd()) --project -e """import Pkg; Pkg.update()"""`
+        elseif dir == joinpath(root, ".dev")
+            `$(Base.julia_cmd()) --project=$reldir -e """import Pkg; Pkg.update()"""`
+        else
+            `$(Base.julia_cmd()) --project=$reldir -e """import Pkg; Pkg.develop(;path=\".\"); Pkg.update()"""`
+        end
         run(cmd)
     end
 end


### PR DESCRIPTION
This changes our `.dev/up_deps.jl` script more robust by developing ClimaAtmos.jl in all environments first, to avoid the  situation where `instantiate`, or `resolve` is called in the `test` environment, which has `ClimaAtmos.jl` as a dep.