### PR TITLE
CLI option: nh_poly help string

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -151,7 +151,7 @@ function parse_commandline()
         arg_type = Int
         default = 10
         "--nh_poly"
-        help = "Horizontal polynomial order"
+        help = "Horizontal polynomial degree. Note: The number of quadrature points in 1D within each horizontal element is then Nq = <--nh_poly> + 1"
         arg_type = Int
         default = 3
         "--z_max"


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
I don't know if this was discussed with the recent changes when we lowered the default value. This can be considered a small nuance by some, but it can be really confusing for other people (like me). 

See the polynomial [degree](https://en.wikipedia.org/wiki/Degree_of_a_polynomial#:~:text=For%20a%20univariate%20polynomial%2C%20the,a%20polynomial%20(disambiguation)).) definition, which we represent by the current `nh_poly` option. In some contexts, especially finite and spectral elements (and I would say in general, in approximation theory) the word "order" is usually referred to either the degree+1 of the polynomials defining the basis function or the number of knot points used to determine it (see this [ref](https://en.wikipedia.org/wiki/Order_of_a_polynomial)). 

## Benefits and Risks
Improve the help string of the `--nh_poly` CLI option


## Linked Issues


## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
