### PR TITLE
Change default max_newton_iters=1 and dt for longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -59,7 +59,7 @@ steps:
           slurm_ntasks: 8
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution ars343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_ars343"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_ars343"
         artifact_paths: "longrun_bw_rhoe_equil_highres_ars343/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -67,7 +67,7 @@ steps:
           slurm_ntasks: 8
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution zalesak ars343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --tracer_upwinding zalesak --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_zalesak_ars343"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --tracer_upwinding zalesak --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_zalesak_ars343"
         artifact_paths: "longrun_bw_rhoe_equil_highres_zalesak_ars343/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -83,7 +83,7 @@ steps:
           slurm_ntasks: 64
 
       - label: ":computer: held suarez (ρe_tot) high resolution ARS343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --ode_algo ARS343 --dt 200secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres_ars343"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --ode_algo ARS343 --dt 400secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres_ars343"
         artifact_paths: "longrun_hs_rhoe_highres_ars343/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -111,7 +111,7 @@ function parse_commandline()
         "--max_newton_iters"
         help = "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)"
         arg_type = Int
-        default = 3
+        default = 1
         "--split_ode"
         help = "Use split of ODE problem. Examples: [`true` (implicit, default), `false` (explicit)]"
         arg_type = Bool


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR updates some longrun CI jobs to use a higher `dt` and fewer Newton iterations for the `ARS343` scheme.

## Benefits and Risks
~~This allows us to use the newly fixed ARS343 algorithm as default time-stepping scheme and we should see a factor of 2 increase in the `dt`.~~ EDIT: For now, until perf analysis is cleared, it was deemed safer to not change the default algorithm but only increase the `dt` and decrease the number of Newtown iterations for the longruns that use `ARS343`

## Linked Issues
- This is an incremental step towards #863 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
