### PR TITLE
Change default ode solver to ARS343

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -297,8 +297,8 @@ steps:
     steps:
 
       # TODO: add/exercise edmf code
-      - label: ":computer: Unthreaded performance target"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+      - label: ":computer: Unthreaded performance target (Rosenbrock)"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_unthreaded/*"
         agents:
           slurm_mem: 20GB

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -105,9 +105,9 @@ function parse_commandline()
         arg_type = Symbol
         default = :none # TODO: change to :zalesak
         "--ode_algo"
-        help = "ODE algorithm [`ARS343`, `IMKG343a`, `ODE.Euler`, `ODE.IMEXEuler`, `ODE.Rosenbrock23` (default), etc.]"
+        help = "ODE algorithm [`ARS343` (default), `IMKG343a`, `ODE.Euler`, `ODE.IMEXEuler`, `ODE.Rosenbrock23`, etc.]"
         arg_type = String
-        default = "ODE.Rosenbrock23"
+        default = "ARS343"
         "--max_newton_iters"
         help = "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)"
         arg_type = Int

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -68,7 +68,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 
 allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 10575616
-allocs_limit["flame_perf_target_rhoe_threaded"] = 12183312
+allocs_limit["flame_perf_target_rhoe_threaded"] = 12183888
 allocs_limit["flame_perf_target_rhoe_callbacks"] = 21775759
 allocs_limit["flame_perf_target_rhoe_ARS343"] = 24056711
 

--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -6,48 +6,48 @@
 all_best_mse = OrderedCollections.OrderedDict()
 #
 all_best_mse["sphere_held_suarez_rhotheta"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.0
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρ)] = 0.0014160167797316022
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :ρθ)] = 0.0006785155545801942
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 1)] = 1.0414821005891117
+all_best_mse["sphere_held_suarez_rhotheta"][(:c, :uₕ, :components, :data, 2)] = 19.641956774316224
+all_best_mse["sphere_held_suarez_rhotheta"][(:f, :w, :components, :data, 1)] = 64.06908717701455
 #
 all_best_mse["sphere_held_suarez_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe_tot)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρ)] = 0.003101683183546888
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρe_tot)] = 1.5420405610532801
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 133.8827739277012
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 1697.2744391129359
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:c, :ρq_tot)] = 60.27545568649035
+all_best_mse["sphere_held_suarez_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 31063.345588122716
 #
 all_best_mse["sphere_baroclinic_wave_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe_tot)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρ)] = 0.009687398744043245
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :ρe_tot)] = 0.08251793681019542
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 1)] = 58.56662260136159
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:c, :uₕ, :components, :data, 2)] = 60213.809290550824
+all_best_mse["sphere_baroclinic_wave_rhoe"][(:f, :w, :components, :data, 1)] = 48869.70353079549
 #
 all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.0
-all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0.00393354078275072
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 0.07133770822179655
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 147.29198860359278
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 15924.444234337836
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.2319449134153841
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 28794.924027545498
 #
 all_best_mse["sphere_held_suarez_rhoe"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe_tot)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρ)] = 0.005089655050263376
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :ρe_tot)] = 0.12063509205027237
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 1)] = 6.385687800824341
+all_best_mse["sphere_held_suarez_rhoe"][(:c, :uₕ, :components, :data, 2)] = 364.49716835554966
+all_best_mse["sphere_held_suarez_rhoe"][(:f, :w, :components, :data, 1)] = 1568.5382607340387
 #
 all_best_mse["sphere_held_suarez_rhoe_int"] = OrderedCollections.OrderedDict()
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 0.0
-all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 0.0
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρ)] = 0.005783913816720229
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :ρe_int)] = 2.038134438731988
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 1)] = 7.734961880580791
+all_best_mse["sphere_held_suarez_rhoe_int"][(:c, :uₕ, :components, :data, 2)] = 785.6911273364601
+all_best_mse["sphere_held_suarez_rhoe_int"][(:f, :w, :components, :data, 1)] = 1922.1261575133015
 #
 all_best_mse["edmf_bomex"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_bomex"][(:c, :ρ)] = 0.0
@@ -62,16 +62,16 @@ all_best_mse["edmf_bomex"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.0762819118562
 all_best_mse["edmf_bomex"][(:f, :turbconv, :up, 1, :ρaw)] = 0.1986205964380295
 #
 all_best_mse["compressible_edmf_bomex"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_bomex"][(:c, :ρ)] = 6.1005941889145366e-9
-all_best_mse["compressible_edmf_bomex"][(:c, :ρe_tot)] = 3.6147449288250086e-6
-all_best_mse["compressible_edmf_bomex"][(:c, :uₕ, :components, :data, 1)] = 5.209012942066034e-6
-all_best_mse["compressible_edmf_bomex"][(:c, :uₕ, :components, :data, 2)] = 0.0008870059639948838
-all_best_mse["compressible_edmf_bomex"][(:c, :ρq_tot)] = 2.2979869717303335e-5
-all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :en, :ρatke)] = 0.009646161773108276
-all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρarea)] = 0.008790268219271225
-all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 0.008798067005380716
-all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.008362797239014091
-all_best_mse["compressible_edmf_bomex"][(:f, :turbconv, :up, 1, :ρaw)] = 0.015939017060384524
+all_best_mse["compressible_edmf_bomex"][(:c, :ρ)] = 3.0939494648664425e-5
+all_best_mse["compressible_edmf_bomex"][(:c, :ρe_tot)] = 0.01925029787268622
+all_best_mse["compressible_edmf_bomex"][(:c, :uₕ, :components, :data, 1)] = 0.0002551077896303604
+all_best_mse["compressible_edmf_bomex"][(:c, :uₕ, :components, :data, 2)] = 0.008198524326962603
+all_best_mse["compressible_edmf_bomex"][(:c, :ρq_tot)] = 0.12438594020333466
+all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :en, :ρatke)] = 1.8495115120746723
+all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρarea)] = 1.3220243258676938
+all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 1.3375746741121528
+all_best_mse["compressible_edmf_bomex"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.8199446863241217
+all_best_mse["compressible_edmf_bomex"][(:f, :turbconv, :up, 1, :ρaw)] = 1.1880011200295955
 #
 all_best_mse["edmf_dycoms_rf01"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_dycoms_rf01"][(:c, :ρ)] = 0.0
@@ -86,16 +86,16 @@ all_best_mse["edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 9.2528802
 all_best_mse["edmf_dycoms_rf01"][(:f, :turbconv, :up, 1, :ρaw)] = 2.34153275805621e-5
 #
 all_best_mse["compressible_edmf_dycoms_rf01"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρ)] = 1.0944896365999254e-8
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρe_tot)] = 2.6690957663835314e-7
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :uₕ, :components, :data, 1)] = 1.202198245020051e-7
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :uₕ, :components, :data, 2)] = 1.2021982450238426e-7
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρq_tot)] = 2.4204093395001364e-6
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :en, :ρatke)] = 0.0008117430893245465
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρarea)] = 0.0009020955562455605
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 0.0009021278767540738
-all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.0009081318907653152
-all_best_mse["compressible_edmf_dycoms_rf01"][(:f, :turbconv, :up, 1, :ρaw)] = 0.0006499759652456001
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρ)] = 2.323280596479405e-8
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρe_tot)] = 4.7615988844529175e-7
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :uₕ, :components, :data, 1)] = 3.06186349634114e-6
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :uₕ, :components, :data, 2)] = 3.0618634963192573e-6
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :ρq_tot)] = 6.81794164316145e-6
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :en, :ρatke)] = 0.006162437510461917
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρarea)] = 0.0520571660747721
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 0.05203262712296469
+all_best_mse["compressible_edmf_dycoms_rf01"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.049294430552673685
+all_best_mse["compressible_edmf_dycoms_rf01"][(:f, :turbconv, :up, 1, :ρaw)] = 2.062455440574323
 #
 all_best_mse["edmf_trmm"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_trmm"][(:c, :ρ)] = 0.0
@@ -110,16 +110,16 @@ all_best_mse["edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.00088525863095
 all_best_mse["edmf_trmm"][(:f, :turbconv, :up, 1, :ρaw)] = 0.00385834647179069
 #
 all_best_mse["compressible_edmf_trmm"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_trmm"][(:c, :ρ)] = 1.690660184952545e-11
-all_best_mse["compressible_edmf_trmm"][(:c, :ρe_tot)] = 1.0160571925648023e-9
-all_best_mse["compressible_edmf_trmm"][(:c, :uₕ, :components, :data, 1)] = 1.986933787122021e-9
-all_best_mse["compressible_edmf_trmm"][(:c, :uₕ, :components, :data, 2)] = 5.5999522186158147e-8
-all_best_mse["compressible_edmf_trmm"][(:c, :ρq_tot)] = 4.247534848203897e-8
-all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :en, :ρatke)] = 8.203205111308456e-6
-all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρarea)] = 1.5869379574132405e-8
-all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 5.169446771056764e-10
-all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 4.552554312409156e-6
-all_best_mse["compressible_edmf_trmm"][(:f, :turbconv, :up, 1, :ρaw)] = 0.004253906713943052
+all_best_mse["compressible_edmf_trmm"][(:c, :ρ)] = 1.719468889452787e-11
+all_best_mse["compressible_edmf_trmm"][(:c, :ρe_tot)] = 1.0205757372356625e-9
+all_best_mse["compressible_edmf_trmm"][(:c, :uₕ, :components, :data, 1)] = 1.9995295051394103e-9
+all_best_mse["compressible_edmf_trmm"][(:c, :uₕ, :components, :data, 2)] = 5.6033035905900835e-8
+all_best_mse["compressible_edmf_trmm"][(:c, :ρq_tot)] = 4.244150244269476e-8
+all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :en, :ρatke)] = 8.520020088098778e-6
+all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρarea)] = 1.6067527399461942e-8
+all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 3.3243495690452557e-10
+all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 4.6708271098049195e-6
+all_best_mse["compressible_edmf_trmm"][(:f, :turbconv, :up, 1, :ρaw)] = 6889.0
 #
 all_best_mse["edmf_gabls"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_gabls"][(:c, :ρ)] = 0.0
@@ -129,11 +129,11 @@ all_best_mse["edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 4.0817276301219
 all_best_mse["edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 1.7893976631737016e-5
 #
 all_best_mse["compressible_edmf_gabls"] = OrderedCollections.OrderedDict()
-all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 8.594108353858545e-11
-all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 1.1232940371213663e-7
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 9.786880624905995e-7
-all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 2.4719912917168085e-6
-all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 1.3695372955163653e-5
+all_best_mse["compressible_edmf_gabls"][(:c, :ρ)] = 6.007154159742451e-11
+all_best_mse["compressible_edmf_gabls"][(:c, :ρe_tot)] = 7.90942061764338e-8
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 1)] = 9.281809725932665e-7
+all_best_mse["compressible_edmf_gabls"][(:c, :uₕ, :components, :data, 2)] = 2.3322891140919147e-6
+all_best_mse["compressible_edmf_gabls"][(:c, :turbconv, :en, :ρatke)] = 0.0015960927930047594
 #
 #! format: on
 #################################


### PR DESCRIPTION
This PR changes the default ODE solver to ARS343, a continuation of #864.