### PR TITLE
CI: double dt

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -35,7 +35,7 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe_tot) high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres"
         artifact_paths: "longrun_bw_rhoe_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -43,7 +43,7 @@ steps:
           slurm_ntasks: 32
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres"
         artifact_paths: "longrun_bw_rhoe_equil_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -58,40 +58,24 @@ steps:
         agents:
           slurm_ntasks: 8
 
-      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution ars343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_ars343"
-        artifact_paths: "longrun_bw_rhoe_equil_highres_ars343/*"
-        env:
-          CLIMACORE_DISTRIBUTED: "MPI"
-        agents:
-          slurm_ntasks: 8
-
-      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution zalesak ars343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --ode_algo ARS343 --moist equil --microphy 0M --tracer_upwinding zalesak --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_zalesak_ars343"
-        artifact_paths: "longrun_bw_rhoe_equil_highres_zalesak_ars343/*"
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_ars343"
+        artifact_paths: "longrun_bw_rhoe_equil_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 8
 
       - label: ":computer: held suarez (ρe_tot) high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres"
         artifact_paths: "longrun_hs_rhoe_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 64
 
-      - label: ":computer: held suarez (ρe_tot) high resolution ARS343"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --ode_algo ARS343 --dt 400secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_highres_ars343"
-        artifact_paths: "longrun_hs_rhoe_highres_ars343/*"
-        env:
-          CLIMACORE_DISTRIBUTED: "MPI"
-        agents:
-          slurm_ntasks: 64
-
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 75secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres"
         artifact_paths: "longrun_hs_rhoe_equil_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -99,7 +83,7 @@ steps:
           slurm_ntasks: 64
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution monin obukhov Float64"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 75secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov_FLoat64 --FLOAT_TYPE Float64"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov_FLoat64 --FLOAT_TYPE Float64"
         artifact_paths: "longrun_hs_rhoe_equil_highres_monin_obukhov_Float64/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -131,7 +115,7 @@ steps:
           slurm_cpus_per_task: 8
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation monin_obukhov Float64"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 200secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_clearsky_mo_ft64 --dt_save_to_sol 1days --dt_save_to_disk 10days --FLOAT_TYPE Float64"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 400secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_clearsky_mo_ft64 --dt_save_to_sol 1days --dt_save_to_disk 10days --FLOAT_TYPE Float64"
         artifact_paths: "longrun_aquaplanet_rhoe_equil_clearsky_mo_ft64/*"
         agents:
           slurm_cpus_per_task: 8
@@ -143,13 +127,13 @@ steps:
           slurm_cpus_per_task: 8
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 200secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_clearsky --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 400secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_clearsky --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_aquaplanet_rhoe_equil_clearsky/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist allsky radiation"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 200secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_allsky --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --viscous_sponge true --kappa_2_sponge 1e7 --dt 300secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_allsky --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_aquaplanet_rhoe_equil_allsky/*"
         agents:
           slurm_cpus_per_task: 8
@@ -165,7 +149,7 @@ steps:
     steps:
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution monin obukhov"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 75secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov"
+        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --microphy 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov"
         artifact_paths: "longrun_hs_rhoe_equil_highres_monin_obukhov/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -173,13 +157,13 @@ steps:
           slurm_ntasks: 32
 
       - label: ":computer: held suarez (ρe_tot) hightop"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --z_max 45e3 --z_elem 25 --dt 300secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_hightop --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --z_max 45e3 --z_elem 25 --dt 600secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_hightop --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_hs_rhoe_hightop/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: held suarez (ρe_tot) equilmoist hightop sponge"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --microphy 0M --z_max 45e3 --z_elem 25 --rayleigh_sponge true --zd_rayleigh 30e3 --alpha_rayleigh_uh 0 --dt 200secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_equil_hightop_sponge --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --microphy 0M --z_max 45e3 --z_elem 25 --rayleigh_sponge true --zd_rayleigh 30e3 --alpha_rayleigh_uh 0 --dt 400secs --t_end 600days --fps 30 --job_id longrun_hs_rhoe_equil_hightop_sponge --dt_save_to_sol 1days --dt_save_to_disk 10days"
         artifact_paths: "longrun_hs_rhoe_equil_hightop_sponge/*"
         agents:
           slurm_cpus_per_task: 8
@@ -188,7 +172,7 @@ steps:
     steps:
 
       - label: ":balloon: Compressible single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case TRMM_LBA --dt_save_to_sol 5mins --z_elem 90 --z_stretch false --z_max 17000 --rayleigh_sponge true --zd_rayleigh 15000 --job_id longrun_compressible_edmf_trmm --dt 0.1secs --t_end 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case TRMM_LBA --dt_save_to_sol 5mins --z_elem 90 --z_stretch false --z_max 17000 --rayleigh_sponge true --zd_rayleigh 15000 --job_id longrun_compressible_edmf_trmm --dt 0.2secs --t_end 6hours"
         artifact_paths: "longrun_compressible_edmf_trmm/*"
         agents:
           slurm_mem: 20GB

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,10 +135,10 @@ steps:
         agents:
           slurm_ntasks: 2
 
-      - label: ":computer: MPI baroclinic wave (ρe_tot) ARS343"
+      - label: ":computer: MPI baroclinic wave (ρe_tot)"
         key: "mpi_baro_wave_ARS343"
-        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --job_id mpi_baroclinic_wave_rhoe_ARS343 --ode_algo ARS343 --dt 580secs"
-        artifact_paths: "mpi_baroclinic_wave_rhoe_ARS343/*"
+        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --job_id mpi_baroclinic_wave_rhoe --dt 580secs"
+        artifact_paths: "mpi_baroclinic_wave_rhoe/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
@@ -159,7 +159,7 @@ steps:
           automatic: true
 
       - label: ":computer: MPI aquaplanet (ρe_tot) equilmoist clearsky radiation"
-        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --job_id mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 200secs --t_end 4days"
+        command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --job_id mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 400secs --t_end 4days"
         artifact_paths: "mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -177,13 +177,13 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhoe_Float64 --t_end 9days"
         artifact_paths: "sphere_baroclinic_wave_rhoe_Float64/*"
 
-      - label: ":computer: baroclinic wave (ρe_tot) ARS343"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe_ARS343 --ode_algo ARS343 --dt 580secs"
-        artifact_paths: "sphere_baroclinic_wave_rhoe_ARS343/*"
+      - label: ":computer: baroclinic wave (ρe_tot)"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --dt 580secs"
+        artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
-      - label: ":computer: baroclinic wave (ρe_tot) equilmoist ARS343"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist_ARS343 --ode_algo ARS343 --t_end 4days"
-        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_ARS343/*"
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --microphy 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --t_end 4days"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: baroclinic wave (ρθ) Float64"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --energy_name rhotheta --FLOAT_TYPE Float64 --job_id sphere_baroclinic_wave_rhotheta_Float64 --dt 500secs"
@@ -198,7 +198,7 @@ steps:
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge/*"
 
       - label: ":computer: held suarez (ρe_tot) equilmoist FCT Zalesak on moisture"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --microphy 0M --tracer_upwinding zalesak --kappa_4 4e17 --job_id sphere_held_suarez_rhoe_equilmoist_zalesak --dt 200secs --t_end 3days"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --microphy 0M --tracer_upwinding zalesak --kappa_4 4e17 --job_id sphere_held_suarez_rhoe_equilmoist_zalesak --dt 400secs --t_end 3days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_zalesak/*"
         agents:
           slurm_mem: 20GB
@@ -253,11 +253,11 @@ steps:
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
 
       - label: ":computer: held suarez (ρe_tot) equilmoist monin_obukhov"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist_mo --dt 300secs --t_end 3days"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --forcing held_suarez --microphy 0M --job_id sphere_held_suarez_rhoe_equilmoist_mo --dt 600secs --t_end 3days"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_mo/*"
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation monin_obukhov"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky_mo --dt 200secs --t_end 2.5days"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky_mo --dt 400secs --t_end 2.5days"
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_clearsky_mo/*"
         agents:
           slurm_mem: 20GB
@@ -267,7 +267,7 @@ steps:
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_gray/*"
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 200secs --t_end 2.5days"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --microphy 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 400secs --t_end 2.5days"
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_clearsky/*"
 
       # The following tests used to work with upwinding on both energy and tracers, but they fail with upwinding on only tracers. They will be re-enabled after updates to topography.
@@ -298,14 +298,14 @@ steps:
 
       # TODO: add/exercise edmf code
       - label: ":computer: Unthreaded performance target (Rosenbrock)"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded/*"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_unthreaded_rosenbrock/*"
         agents:
           slurm_mem: 20GB
 
-      - label: ":computer: Unthreaded performance target ARS343"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_ARS343 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --ode_algo ARS343 --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded_ARS343/*"
+      - label: ":computer: Unthreaded performance target"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_unthreaded/*"
         agents:
           slurm_mem: 20GB
 
@@ -391,9 +391,9 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: flame graph: perf target (ρe_tot) ARS343"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_ARS343 --ode_algo ARS343"
-        artifact_paths: "flame_perf_target_rhoe_ARS343/*"
+      - label: ":rocket: flame graph: perf target (ρe_tot) (Rosenbrock)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_rosenbrock --ode_algo ODE.Rosenbrock23"
+        artifact_paths: "flame_perf_target_rhoe_rosenbrock/*"
         agents:
           slurm_mem: 20GB
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -297,11 +297,12 @@ steps:
     steps:
 
       # TODO: add/exercise edmf code
-      - label: ":computer: Unthreaded performance target (Rosenbrock)"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded_rosenbrock/*"
-        agents:
-          slurm_mem: 20GB
+      # Comment out the following job for now, until flame graph w/ changing ID is cleared
+      # - label: ":computer: Unthreaded performance target (Rosenbrock)"
+      #   command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+      #   artifact_paths: "perf_target_unthreaded_rosenbrock/*"
+      #   agents:
+      #     slurm_mem: 20GB
 
       - label: ":computer: Unthreaded performance target"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
@@ -391,11 +392,12 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: flame graph: perf target (ρe_tot) (Rosenbrock)"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_rosenbrock --ode_algo ODE.Rosenbrock23"
-        artifact_paths: "flame_perf_target_rhoe_rosenbrock/*"
-        agents:
-          slurm_mem: 20GB
+      # Comment out the following job for now, until flame graph w/ changing ID is cleared
+      # - label: ":rocket: flame graph: perf target (ρe_tot) (Rosenbrock)"
+      #   command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_rosenbrock --ode_algo ODE.Rosenbrock23"
+      #   artifact_paths: "flame_perf_target_rhoe_rosenbrock/*"
+      #   agents:
+      #     slurm_mem: 20GB
 
       - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -67,10 +67,10 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 @info "`allocs ($job_id)`: $(allocs)"
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target_rhoe"] = 10575616
-allocs_limit["flame_perf_target_rhoe_threaded"] = 12183888
-allocs_limit["flame_perf_target_rhoe_callbacks"] = 21775759
-allocs_limit["flame_perf_target_rhoe_ARS343"] = 24056711
+allocs_limit["flame_perf_target_rhoe"] = 21096624
+allocs_limit["flame_perf_target_rhoe_threaded"] = 24548384
+allocs_limit["flame_perf_target_rhoe_callbacks"] = 32385176
+allocs_limit["flame_perf_target_rhoe_rosenbrock"] = 10575616
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -70,7 +70,6 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 21096624
 allocs_limit["flame_perf_target_rhoe_threaded"] = 24548384
 allocs_limit["flame_perf_target_rhoe_callbacks"] = 32385176
-allocs_limit["flame_perf_target_rhoe_rosenbrock"] = 10575616
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR attempts at doubling `dt` in our CI jobs now that we have switched to ARS343 as default time-steppers (if there are jobs that fail, `dt` will be lowered back to find optimal value). I also cleaned up a bunch or CLI options and job names specifying the algorithm that are not needed anymore since the default has changed.

## Benefits and Risks
A larger `dt` will allows to have a better time-to-solution :rocket:  

## Linked Issues
- Closes #863 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
