### PR TITLE
Cache flux BCs

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -67,7 +67,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 @info "`allocs ($job_id)`: $(allocs)"
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target_rhoe"] = 2958640
+allocs_limit["flame_perf_target_rhoe"] = 2529584
 allocs_limit["flame_perf_target_rhoe_threaded"] = 6474592
 allocs_limit["flame_perf_target_rhoe_callbacks"] = 14247192
 


### PR DESCRIPTION
This PR caches flux boundary conditions, for 
 - `dif_flux_uₕ`
 - `dif_flux_energy`
 - `dif_flux_ρq_tot`
to address [this comment](https://github.com/CliMA/ClimaAtmos.jl/issues/686#issuecomment-1260282007) (`Operators.SetValue(.-dif_flux_uₕ)` is allocating).

Note that it seems that the coupler may be impacted by this, due to the `coupled` flag. cc @LenkaNovak

A step towards #686.