### PR TITLE
Add and fix some Aqua tests

### DIFF
--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -372,7 +372,7 @@ function FixedSurfaceCoeffs(
     ch::FloatOrFunc{FT},
     cm::FloatOrFunc{FT},
     kwargs...,
-) where {FT, FVT}
+) where {FT}
     TS = typeof(Tsurface)
     QS = typeof(qsurface)
     CH = typeof(ch)
@@ -399,7 +399,7 @@ function MoninObukhovSurface(
     Tsurface::FloatOrFunc{FT},
     qsurface::FloatOrFunc{FT},
     kwargs...,
-) where {FT, FVT}
+) where {FT}
     TS = typeof(Tsurface)
     QS = typeof(qsurface)
     return MoninObukhovSurface{FT, TS, QS}(; Tsurface, qsurface, kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 AtmosphericProfilesLibrary = "86bc3604-9858-485a-bdbe-831ec50de11d"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,14 @@ group = get(ENV, "TEST_GROUP", :all) |> Symbol
     end
 end
 
+using Test
+import ClimaAtmos
+using Aqua
+
+@testset "Aqua tests - unbound args" begin
+    # This tests that we don't accidentally run into
+    # https://github.com/JuliaLang/julia/issues/29393
+    Aqua.test_unbound_args(ClimaAtmos)
+end
+
 nothing


### PR DESCRIPTION
This is a peel off from #896, which first adds and tackles the unbound type parameters