### PR TITLE
Make sure mse values are reset when incrementing ref counter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,6 +100,12 @@ steps:
         command: "julia --color=yes --project=test test/test_cases/run_3d_baroclinic_wave.jl"
         artifact_paths: "test/test_cases/run_3d_baroclinic_wave/*"
 
+  - group: "Regression tests"
+    steps:
+
+      - label: ":computer: Ensure mse tables are reset when necessary"
+        command: "julia --color=yes --project=examples regression_tests/test_reset.jl"
+
   - group: "Column Examples"
     steps:
 

--- a/regression_tests/test_reset.jl
+++ b/regression_tests/test_reset.jl
@@ -1,0 +1,14 @@
+import OrderedCollections
+
+# Get cases from JobIDs in mse_tables file:
+include(joinpath(@__DIR__, "self_reference_or_path.jl"))
+self_reference = self_reference_or_path() == :self_reference
+include(joinpath(@__DIR__, "mse_tables.jl"))
+
+#### Test that mse values are all zero if ref counter is incremented
+mse_vals = collect(Iterators.flatten(map(x -> values(x), values(all_best_mse))))
+if self_reference && !all(mse_vals .== 0)
+    error(
+        "All mse values in `regression_tests/mse_tables.jl` must be set to zero when the reference counter is incremented",
+    )
+end


### PR DESCRIPTION
This PR adds an error for when the reference counter is incremented and the mse values are not updated. Doing so results in subsequent PRs to break because the mse and reference values are mismatched, putting the burden of future PR authors to fix the issue. This should help our workflow a bit.