### PR TITLE
Fuse some bycolumn loops

### DIFF
--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -177,16 +177,17 @@ function rrtmgp_model_cache(
         rrtmgp_model,
     )
 end
-function rrtmgp_model_tendency!(Yₜ, Y, p, t)
+function rrtmgp_model_tendency!(Yₜ, Y, p, t, colidx)
     (; ᶠradiation_flux) = p
     ᶜdivᵥ = Operators.DivergenceF2C()
     if :ρθ in propertynames(Y.c)
         error("rrtmgp_model_tendency! not implemented for ρθ")
     elseif :ρe_tot in propertynames(Y.c)
-        @. Yₜ.c.ρe_tot -= ᶜdivᵥ(ᶠradiation_flux)
+        @. Yₜ.c.ρe_tot[colidx] -= ᶜdivᵥ(ᶠradiation_flux[colidx])
     elseif :ρe_int in propertynames(Y.c)
-        @. Yₜ.c.ρe_int -= ᶜdivᵥ(ᶠradiation_flux)
+        @. Yₜ.c.ρe_int[colidx] -= ᶜdivᵥ(ᶠradiation_flux[colidx])
     end
+    return nothing
 end
 function rrtmgp_model_callback!(integrator)
     Y = integrator.u


### PR DESCRIPTION
This PR fuses some bycolumn loops. This is the direction I see things moving for the gpu / improving thread scaling.

This improved threaded allocations inside `additional_tendency!` by ~50% and `step!` by ~19%. This does however slow down the unthreaded `step!` by ~10%. Some of that may be variation, but it's unclear.