### PR TITLE
Fix edmf types

### DIFF
--- a/src/TurbulenceConvection/variables.jl
+++ b/src/TurbulenceConvection/variables.jl
@@ -92,7 +92,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         ),
         en = (;
             ts = thermo_state(FT, edmf.moisture_model),
-            w = FT(0),
+            w = CCG.Covariant3Vector(FT(0)),
             area = FT(0),
             q_tot = FT(0),
             q_liq = FT(0),
@@ -150,8 +150,8 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         prandtl_nvec = FT(0),
         # Variable Prandtl number initialized as neutral value.
         b_exch = FT(0),
-        w_up_c = FT(0),
-        w_en_c = FT(0),
+        w_up_c = CCG.Covariant3Vector(FT(0)),
+        w_en_c = CCG.Covariant3Vector(FT(0)),
         Shear² = FT(0),
         ∂θv∂z = FT(0),
         ∂qt∂z = FT(0),
@@ -168,7 +168,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
 
 # Face only
 face_aux_vars_up(FT, local_geometry) =
-    (; w = FT(0), nh_pressure = FT(0), massflux = FT(0))
+    (; w = CCG.Covariant3Vector(FT(0)), nh_pressure = FT(0), massflux = FT(0))
 face_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
     massflux_en = FT(0), # TODO: is this the right place for this?
     massflux_ql = FT(0),
@@ -179,11 +179,11 @@ face_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
 face_aux_vars_edmf_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
 face_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
     turbconv = (;
-        bulk = (; w = FT(0)),
+        bulk = (; w = CCG.Covariant3Vector(FT(0))),
         ρ_ae_KM = FT(0),
         ρ_ae_KH = FT(0),
         ρ_ae_K = FT(0),
-        en = (; w = FT(0)),
+        en = (; w = CCG.Covariant3Vector(FT(0))),
         up = ntuple(
             i -> face_aux_vars_up(FT, local_geometry),
             Val(n_updrafts(edmf)),


### PR DESCRIPTION
This PR fixes some edmf types by converting scalars to `Covariant3Vector`s in order to help fix things for our sphere example.