### PR TITLE
Increase memory request for GWP 3D test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,6 +126,8 @@ steps:
       - label: ":computer: non-orographic gravity wave parameterization unit test 3d"
         command: "julia --color=yes --project=examples examples/hybrid/gravitywave_parameterization/gw_test_3d.jl"
         artifact_paths: "nonorographic_gravity_wave_test_3d/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: non-orographic gravity wave parameterization unit test single column"
         command: "julia --color=yes --project=examples examples/hybrid/gravitywave_parameterization/gw_test_single_column.jl"


### PR DESCRIPTION
This [build](https://buildkite.com/clima/climaatmos-ci/builds/4260#0183c7d9-1c07-48b0-b792-7c5d4e05ec45) shows that our gravity wave parameterization 3D test seems to need more memory, so this PR increases the memory request for this job.