### PR TITLE
Add edmf consistency test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -354,6 +354,13 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":dart: EDMF Consistency test Bomex"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex --dt 6secs --t_end 6hours --anelastic_dycore true --apply_limiter false --test_edmf_consistency true --debugging_tc true --dt_save_to_disk 6hours"
+        artifact_paths: "edmf_bomex/*"
+        agents:
+          slurm_mem: 20GB
+        soft_fail: true
+
   - group: "Performance"
     steps:
 

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -226,6 +226,10 @@ function parse_commandline()
         help = "Save most of the tc aux state to HDF5 file [`false` (default), `true`]"
         arg_type = Bool
         default = false
+        "--test_edmf_consistency"
+        help = "Test edmf equation consistency [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--non_orographic_gravity_wave"
         help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow"
         arg_type = Bool


### PR DESCRIPTION
This PR adds an edmf consistency test. It works by running Bomex and first setting all the edmf auxiliary variables to NaNs, which should work so long we compute everything in the correct order.

Since it's not yet working, I've labeled the job as a `soft_fail`, so that we can chip away until it's working and change it to a test proper.