### PR TITLE
Remove w ( = 0) from compressible edmf trmm

### DIFF
--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -127,7 +127,6 @@ all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :en, :ρatke)] = 0.0
 all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρarea)] = 0.0
 all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaθ_liq_ice)] = 0.0
 all_best_mse["compressible_edmf_trmm"][(:c, :turbconv, :up, 1, :ρaq_tot)] = 0.0
-all_best_mse["compressible_edmf_trmm"][(:f, :turbconv, :up, 1, :w)] = 0.0
 #
 all_best_mse["edmf_gabls"] = OrderedCollections.OrderedDict()
 all_best_mse["edmf_gabls"][(:c, :ρ)] = 0.0


### PR DESCRIPTION
This PR fixes the regression tests for the compressible edmf TRMM job. See this [build](https://buildkite.com/clima/climaatmos-ci/builds/4275#0183c8f3-ebcf-4dba-8b00-07f4fc234d8e)