### PR TITLE
Re-enable GC callbacks

### DIFF
--- a/.buildkite/scaling/pipeline.sh
+++ b/.buildkite/scaling/pipeline.sh
@@ -8,7 +8,7 @@ FT="Float32"
 resolutions=("low" "mid" "high")
 max_procs_per_node=16 # limit this artificially for profiling
 profiling=enable
-exclusive=false
+exclusive=true
 mpi_impl="openmpi"
 
 # set up environment and agents

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -262,6 +262,8 @@ end
 
 if simulation.is_distributed
     OrdinaryDiffEq.step!(integrator)
+    #GC.enable(false)
+    GC.gc()
     ClimaComms.barrier(comms_ctx)
     if ClimaComms.iamroot(comms_ctx)
         @timev begin
@@ -271,6 +273,7 @@ if simulation.is_distributed
         walltime = @elapsed sol = OrdinaryDiffEq.solve!(integrator)
     end
     ClimaComms.barrier(comms_ctx)
+    GC.enable(true)
 else
     sol = @timev OrdinaryDiffEq.solve!(integrator)
 end

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -262,7 +262,7 @@ end
 
 if simulation.is_distributed
     OrdinaryDiffEq.step!(integrator)
-    #GC.enable(false)
+    # GC.enable(false) # disabling GC causes a memory leak
     GC.gc()
     ClimaComms.barrier(comms_ctx)
     if ClimaComms.iamroot(comms_ctx)

--- a/examples/hybrid/nvtx.jl
+++ b/examples/hybrid/nvtx.jl
@@ -3,6 +3,12 @@ using NVTX, Colors
 if NVTX.isactive()
     NVTX.enable_gc_hooks()
     const nvtx_domain = NVTX.Domain("ClimaAtmos")
+    # makes output on buildkite a bit nicer
+    if ClimaComms.iamroot(comms_ctx)
+        atexit() do
+            println("--- Saving profiler information")
+        end
+    end
 end
 macro nvtx(message, args...)
     block = args[end]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds GC callbacks. Behavior can be controlled by an environment variable `CLIMAATMOS_GC_NSTEPS` (default = every 1000 steps).

Unlike #821, this doesn't disable the GC, but by manually calling it we should be able to avoid the runtime needing to call it.

## To-do
- waiting on https://buildkite.com/clima/climaatmos-scaling/builds/332

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
