### PR TITLE
change default post processing

### DIFF
--- a/examples/hybrid/classify_case.jl
+++ b/examples/hybrid/classify_case.jl
@@ -5,6 +5,13 @@ is_baro_wave(parsed_args) = all((
     parsed_args["perturb_initstate"] == true,
 ))
 
+is_solid_body(parsed_args) = all((
+    parsed_args["config"] == "sphere",
+    parsed_args["forcing"] == nothing,
+    parsed_args["rad"] == nothing,
+    parsed_args["perturb_initstate"] == false,
+))
+
 is_column_without_edmf(parsed_args) = all((
     parsed_args["config"] == "column",
     parsed_args["turbconv"] == nothing,

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -310,7 +310,9 @@ if !simulation.is_distributed && parsed_args["post_process"]
         custom_postprocessing(sol, simulation.output_dir)
     elseif is_column_edmf(parsed_args)
         postprocessing_edmf(sol, simulation.output_dir, fps)
-    elseif model_spec.forcing_type isa HeldSuarezForcing
+    elseif is_solid_body(parsed_args)
+        postprocessing(sol, simulation.output_dir, fps)
+    else
         paperplots_held_suarez(
             model_spec,
             sol,
@@ -319,8 +321,6 @@ if !simulation.is_distributed && parsed_args["post_process"]
             FT(90),
             FT(180),
         )
-    else
-        postprocessing(sol, simulation.output_dir, fps)
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Changes default post processing to held suarez paper plots because those are more helpful

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

- Use `paperplots_held_suarez` for most of the experiments
- Add a case `is_solid_body` which uses `postprocessing`, so we exercise the code in the ci

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
