### PR TITLE
Narrow scope of allocation table

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -19,14 +19,14 @@ dirs_to_monitor = [
     joinpath(example_dir, "hybrid"),
     joinpath(example_dir, "hybrid", "sphere"),
     pkgdir(ClimaCore),
-    pkgdir(SciMLBase),
-    pkgdir(DiffEqBase),
-    pkgdir(OrdinaryDiffEq),
+    # pkgdir(SciMLBase),
+    # pkgdir(DiffEqBase),
+    # pkgdir(OrdinaryDiffEq),
     pkgdir(ClimaTimeSteppers),
-    pkgdir(Thermodynamics),
-    pkgdir(SurfaceFluxes),
-    pkgdir(CloudMicrophysics),
-    pkgdir(DiffEqOperators),
+    # pkgdir(Thermodynamics),
+    # pkgdir(SurfaceFluxes),
+    # pkgdir(CloudMicrophysics),
+    # pkgdir(DiffEqOperators),
 ]
 @info "`dirs_to_monitor` (Pre)  = $dirs_to_monitor"
 dirs_to_monitor_filtered = filter(x -> x isa String, dirs_to_monitor)


### PR DESCRIPTION
This PR narrows the scope of the allocation table in hopes to speed up CI times, while still keeping an eye on the remaining top allocation sites