### PR TITLE
Refactor radiation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Climate Modeling Alliance"]
 version = "0.5.0"
 
 [deps]
+AtmosphericProfilesLibrary = "86bc3604-9858-485a-bdbe-831ec50de11d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaCorePlots = "cf7c7e5a-b407-4c48-9047-11a94a308626"
 ClimaCoreVTK = "c8b6d40d-e815-466f-95ae-c48aefa668fa"

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -33,7 +33,7 @@ function get_model_spec(::Type{FT}, parsed_args, namelist) where {FT}
         energy_form = CA.energy_form(parsed_args),
         perturb_initstate = parsed_args["perturb_initstate"],
         idealized_h2o,
-        radiation_model = CA.radiation_model(parsed_args),
+        radiation_mode = CA.radiation_mode(parsed_args, FT),
         microphysics_model = CA.microphysics_model(parsed_args),
         precip_model,
         forcing_type = CA.forcing_type(parsed_args),

--- a/src/RRTMGPInterface.jl
+++ b/src/RRTMGPInterface.jl
@@ -92,11 +92,11 @@ import ClimaCore.DataLayouts: parent_array_type
 parent_array_type(::Type{<:Base.ReshapedArray{T, N, P}}) where {T, N, P} =
     parent_array_type(P)
 
-abstract type AbstractRadiationMode end
-struct GrayRadiation <: AbstractRadiationMode end
-struct ClearSkyRadiation <: AbstractRadiationMode end
-struct AllSkyRadiation <: AbstractRadiationMode end
-struct AllSkyRadiationWithClearSkyDiagnostics <: AbstractRadiationMode end
+abstract type AbstractRRTMGPMode end
+struct GrayRadiation <: AbstractRRTMGPMode end
+struct ClearSkyRadiation <: AbstractRRTMGPMode end
+struct AllSkyRadiation <: AbstractRRTMGPMode end
+struct AllSkyRadiationWithClearSkyDiagnostics <: AbstractRRTMGPMode end
 
 """
     abstract type AbstractInterpolation
@@ -475,7 +475,7 @@ function RRTMGPModel(
     ncol::Int,
     domain_nlay::Int,
     extension_nlay::Int = 0,
-    radiation_mode::AbstractRadiationMode = ClearSkyRadiation(),
+    radiation_mode::AbstractRRTMGPMode = ClearSkyRadiation(),
     interpolation::AbstractInterpolation = NoInterpolation(),
     bottom_extrapolation::AbstractBottomExtrapolation = SameAsInterpolation(),
     disable_longwave::Bool = false,

--- a/src/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection/TurbulenceConvection.jl
@@ -5,6 +5,9 @@ import ..EquilMoistModel
 import ..NonEquilMoistModel
 import ..AnelasticFluid
 import ..CompressibleFluid
+import ..RadiationNone
+import ..RadiationDYCOMS_RF01
+import ..RadiationTRMM_LBA
 
 import ClimaCore as CC
 import ClimaCore.Geometry as CCG

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -36,7 +36,7 @@ function compressibility_model(parsed_args)
     end
 end
 
-function radiation_model(parsed_args)
+function radiation_mode(parsed_args, ::Type{FT}) where {FT}
     radiation_name = parsed_args["rad"]
     @assert radiation_name in
             (nothing, "clearsky", "gray", "allsky", "allskywithclear")

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,3 +28,7 @@ Base.broadcastable(x::AbstractMoistureModel) = Ref(x)
 Base.broadcastable(x::AbstractEnergyFormulation) = Ref(x)
 Base.broadcastable(x::AbstractMicrophysicsModel) = Ref(x)
 Base.broadcastable(x::AbstractForcing) = Ref(x)
+
+struct RadiationNone end
+struct RadiationDYCOMS_RF01 end
+struct RadiationTRMM_LBA end

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -4,6 +4,7 @@ import NCDatasets as NC
 import OrdinaryDiffEq as ODE
 import Thermodynamics as TD
 
+import ClimaAtmos as CA
 import ClimaCore as CC
 import ClimaCore.Operators as CCO
 import ClimaCore.Geometry as CCG
@@ -82,11 +83,6 @@ struct ForcingNone end
 struct ForcingStandard end
 struct ForcingDYCOMS_RF01 end
 struct ForcingLES end
-
-struct RadiationNone end
-struct RadiationDYCOMS_RF01 end
-struct RadiationLES end
-struct RadiationTRMM_LBA end
 
 """
     ForcingBase
@@ -173,10 +169,10 @@ get_forcing_type(::DYCOMS_RF01) = ForcingDYCOMS_RF01
 get_forcing_type(::DYCOMS_RF02) = ForcingDYCOMS_RF01
 get_forcing_type(::TRMM_LBA) = ForcingNone
 
-get_radiation_type(::AbstractCaseType) = RadiationNone # default
-get_radiation_type(::DYCOMS_RF01) = RadiationDYCOMS_RF01
-get_radiation_type(::DYCOMS_RF02) = RadiationDYCOMS_RF01
-get_radiation_type(::TRMM_LBA) = RadiationTRMM_LBA
+get_radiation_type(::AbstractCaseType) = CA.RadiationNone # default
+get_radiation_type(::DYCOMS_RF01) = CA.RadiationDYCOMS_RF01
+get_radiation_type(::DYCOMS_RF02) = CA.RadiationDYCOMS_RF01
+get_radiation_type(::TRMM_LBA) = CA.RadiationTRMM_LBA
 
 large_scale_divergence(::Union{DYCOMS_RF01, DYCOMS_RF02}) = 3.75e-6
 

--- a/tc_driver/Radiation.jl
+++ b/tc_driver/Radiation.jl
@@ -1,11 +1,11 @@
 update_radiation(self::RadiationBase, grid, state, t::Real, param_set) = nothing
-initialize(self::RadiationBase{RadiationNone}, grid, state) = nothing
+initialize(self::RadiationBase{CA.RadiationNone}, grid, state) = nothing
 
 """
 see eq. 3 in Stevens et. al. 2005 DYCOMS paper
 """
 function update_radiation(
-    self::RadiationBase{RadiationDYCOMS_RF01},
+    self::RadiationBase{CA.RadiationDYCOMS_RF01},
     grid,
     state,
     t::Real,
@@ -81,31 +81,7 @@ function update_radiation(
     return
 end
 
-function initialize(
-    self::RadiationBase{RadiationLES},
-    grid,
-    state,
-    LESDat::LESData,
-)
-    # load from LES
-    aux_gm = TC.center_aux_grid_mean(state)
-    dTdt = NC.Dataset(LESDat.les_filename, "r") do data
-        imin = LESDat.imin
-        imax = LESDat.imax
-
-        # interpolate here
-        zc_les = Array(TC.get_nc_data(data, "zc"))
-        meandata = TC.mean_nc_data(data, "profiles", "dtdt_rad", imin, imax)
-        pyinterp(vec(grid.zc.z), zc_les, meandata)
-    end
-    @inbounds for k in TC.real_center_indices(grid)
-        aux_gm.dTdt_rad[k] = dTdt[k]
-    end
-    return
-end
-
-
-function initialize(self::RadiationBase{RadiationTRMM_LBA}, grid, state)
+function initialize(self::RadiationBase{CA.RadiationTRMM_LBA}, grid, state)
     aux_gm = TC.center_aux_grid_mean(state)
     rad = APL.TRMM_LBA_radiation(eltype(grid))
     @inbounds for k in real_center_indices(grid)
@@ -115,7 +91,7 @@ function initialize(self::RadiationBase{RadiationTRMM_LBA}, grid, state)
 end
 
 function update_radiation(
-    self::RadiationBase{RadiationTRMM_LBA},
+    self::RadiationBase{CA.RadiationTRMM_LBA},
     grid,
     state,
     t::Real,

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -322,11 +322,8 @@ function compute_gm_tendencies!(
         @. tendencies_gm.q_ice -= ∇q_ice_gm * aux_gm.subsidence
     end
     # Radiation
-    if Cases.rad_type(radiation) <: Union{
-        Cases.RadiationDYCOMS_RF01,
-        Cases.RadiationLES,
-        Cases.RadiationTRMM_LBA,
-    }
+    if Cases.rad_type(radiation) <:
+       Union{CA.RadiationDYCOMS_RF01, CA.RadiationTRMM_LBA}
         @. tendencies_gm.ρe_tot +=
             ρ_c * TD.cv_m(thermo_params, ts_gm) * aux_gm.dTdt_rad
     end


### PR DESCRIPTION
This is a peel off from #960. This PR:
 - Adds `AtmosphericProfilesLibrary` to the deps, which will be used for TRMM radiation when we add these types into src/
 - Changes the `model_spec` to contain `radiation_mode` instead of `radiation_model`. The difference is that `radiation_mode` dispatches on which type of `radiation_model` to use. This distinction is really only needed by RRTMGP, which has many options.
 - Renames `AbstractRadiationMode` to `AbstractRRTMGPMode`, since these do not apply to non-rrtmgp radiations
 - Fixes several places where we had `isnothing(radiation_mode)`/`isnothing(radiation_model)` to use `radiation_mode isa RRTMGPI.AbstractRRTMGPMode`
 - Renames `rrtmgp_model_tendency!` to `radiation_model_tendency!` and adds the radiation model as an argument (to be dispatched on)
 - Renames `rrtmgp_model_cache` to `radiation_model_cache` since this can dispatch on the radiation model
 - Moves some types into src