### PR TITLE
Refactor radiation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -278,25 +278,25 @@ steps:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
         artifact_paths: "edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compresible single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
         artifact_paths: "compressible_edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case TRMM_LBA --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --dt_save_to_disk 3hours --z_elem 82 --z_stretch false --z_max 16400 --job_id edmf_trmm --dt 1secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --dt_save_to_disk 3hours --z_elem 82 --z_stretch false --z_max 16400 --job_id edmf_trmm --dt 1secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
         artifact_paths: "edmf_trmm/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case TRMM_LBA --dt_save_to_sol 5mins --z_elem 82 --z_stretch false --z_max 16400 --rayleigh_sponge true --zd_rayleigh 15000 --job_id compressible_edmf_trmm --dt 0.1secs --t_end 1hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 1hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --dt_save_to_sol 5mins --z_elem 82 --z_stretch false --z_max 16400 --rayleigh_sponge true --zd_rayleigh 15000 --job_id compressible_edmf_trmm --dt 0.1secs --t_end 1hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 1hours"
         artifact_paths: "compressible_edmf_trmm/*"
         agents:
           slurm_mem: 20GB

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -219,7 +219,7 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.4"
 
 [[deps.ClimaAtmos]]
-deps = ["ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "CloudMicrophysics", "Dierckx", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "Insolation", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "OperatorFlux", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Test", "Thermodynamics", "UnPack"]
+deps = ["AtmosphericProfilesLibrary", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "CloudMicrophysics", "Dierckx", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "Insolation", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "OperatorFlux", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Test", "Thermodynamics", "UnPack"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 version = "0.5.0"

--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -39,6 +39,7 @@ function get_edmf_cache(
     Y,
     turbconv_model,
     precip_model,
+    radiation,
     namelist,
     param_set,
     parsed_args,
@@ -50,7 +51,6 @@ function get_edmf_cache(
     test_consistency = parsed_args["test_edmf_consistency"]
     forcing =
         Cases.ForcingBase(case, FT; Cases.forcing_kwargs(case, namelist)...)
-    radiation = Cases.RadiationBase(case, FT)
     surf_ref_state = Cases.surface_ref_state(case, tc_params, namelist)
     surf_params =
         Cases.surface_params(case, surf_ref_state, tc_params; Ri_bulk_crit)

--- a/examples/hybrid/classify_case.jl
+++ b/examples/hybrid/classify_case.jl
@@ -24,5 +24,7 @@ is_column_edmf(parsed_args) = all((
     parsed_args["energy_name"] == "rhoe",
     parsed_args["forcing"] == nothing,
     parsed_args["turbconv"] == "edmf",
+    parsed_args["rad"] == "DYCOMS_RF01" ||
+    parsed_args["rad"] == "TRMM_LBA" ||
     parsed_args["rad"] == nothing,
 ))

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -106,7 +106,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
     compressibility_model = model_spec.compressibility_model
 
     radiation_cache = if radiation_mode isa Nothing
-        NamedTuple()
+        (; radiation_model = radiation_mode)
     elseif radiation_mode isa RRTMGPI.AbstractRRTMGPMode
         radiation_model_cache(
             Y,
@@ -177,6 +177,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
                 Y,
                 turbconv_model,
                 precip_model,
+                radiation_cache.radiation_model,
                 namelist,
                 params,
                 parsed_args,
@@ -204,8 +205,7 @@ function additional_tendency!(Yₜ, Y, p, t)
             vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, colidx)
         end
         microphy_0M && zero_moment_microphysics_tendency!(Yₜ, Y, p, t, colidx)
-        rad_flux &&
-            radiation_model_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)
+        rad_flux && radiation_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)
         has_turbconv && TCU.sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
     end
     # TODO: make bycolumn-able

--- a/examples/hybrid/radiation_utilities.jl
+++ b/examples/hybrid/radiation_utilities.jl
@@ -216,11 +216,11 @@ function radiation_model_cache(
         radiation_model,
     )
 end
-function radiation_model_tendency!(Yₜ, Y, p, t, colidx, ::RRTMGPI.RRTMGPModel)
+function radiation_tendency!(Yₜ, Y, p, t, colidx, ::RRTMGPI.RRTMGPModel)
     (; ᶠradiation_flux) = p
     ᶜdivᵥ = Operators.DivergenceF2C()
     if :ρθ in propertynames(Y.c)
-        error("radiation_model_tendency! not implemented for ρθ")
+        error("radiation_tendency! not implemented for ρθ")
     elseif :ρe_tot in propertynames(Y.c)
         @. Yₜ.c.ρe_tot[colidx] -= ᶜdivᵥ(ᶠradiation_flux[colidx])
     elseif :ρe_int in propertynames(Y.c)
@@ -355,3 +355,19 @@ function rrtmgp_model_callback!(integrator)
     RRTMGPI.update_fluxes!(radiation_model)
     RRTMGPI.field2array(ᶠradiation_flux) .= radiation_model.face_flux
 end
+
+#####
+##### RadiationDYCOMS_RF01
+#####
+radiation_model_cache(Y, params, radiation_mode::CA.RadiationDYCOMS_RF01) =
+    (; radiation_model = radiation_mode)
+# Temporarily handled elsewhere
+radiation_tendency!(Yₜ, Y, p, t, colidx, ::CA.RadiationDYCOMS_RF01) = nothing
+
+#####
+##### RadiationTRMM_LBA
+#####
+radiation_model_cache(Y, params, radiation_mode::CA.RadiationTRMM_LBA) =
+    (; radiation_model = radiation_mode)
+# Temporarily handled elsewhere
+radiation_tendency!(Yₜ, Y, p, t, colidx, ::CA.RadiationTRMM_LBA) = nothing

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -230,7 +230,7 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.4"
 
 [[deps.ClimaAtmos]]
-deps = ["ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "CloudMicrophysics", "Dierckx", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "Insolation", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "OperatorFlux", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Test", "Thermodynamics", "UnPack"]
+deps = ["AtmosphericProfilesLibrary", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "CloudMicrophysics", "Dierckx", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "Insolation", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "OperatorFlux", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Test", "Thermodynamics", "UnPack"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 version = "0.5.0"

--- a/src/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection/TurbulenceConvection.jl
@@ -5,7 +5,6 @@ import ..EquilMoistModel
 import ..NonEquilMoistModel
 import ..AnelasticFluid
 import ..CompressibleFluid
-import ..RadiationNone
 import ..RadiationDYCOMS_RF01
 import ..RadiationTRMM_LBA
 

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -38,8 +38,15 @@ end
 
 function radiation_mode(parsed_args, ::Type{FT}) where {FT}
     radiation_name = parsed_args["rad"]
-    @assert radiation_name in
-            (nothing, "clearsky", "gray", "allsky", "allskywithclear")
+    @assert radiation_name in (
+        nothing,
+        "clearsky",
+        "gray",
+        "allsky",
+        "allskywithclear",
+        "DYCOMS_RF01",
+        "TRMM_LBA",
+    )
     return if radiation_name == "clearsky"
         RRTMGPI.ClearSkyRadiation()
     elseif radiation_name == "gray"
@@ -48,6 +55,10 @@ function radiation_mode(parsed_args, ::Type{FT}) where {FT}
         RRTMGPI.AllSkyRadiation()
     elseif radiation_name == "allskywithclear"
         RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics()
+    elseif radiation_name == "DYCOMS_RF01"
+        RadiationDYCOMS_RF01{FT}()
+    elseif radiation_name == "TRMM_LBA"
+        RadiationTRMM_LBA(FT)
     else
         nothing
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,6 +29,21 @@ Base.broadcastable(x::AbstractEnergyFormulation) = Ref(x)
 Base.broadcastable(x::AbstractMicrophysicsModel) = Ref(x)
 Base.broadcastable(x::AbstractForcing) = Ref(x)
 
-struct RadiationNone end
-struct RadiationDYCOMS_RF01 end
-struct RadiationTRMM_LBA end
+Base.@kwdef struct RadiationDYCOMS_RF01{FT}
+    "Large-scale divergence (same as in ForcingBase)"
+    # TODO: make sure in sync with large_scale_divergence
+    divergence::FT = 3.75e-6
+    alpha_z::FT = 1.0
+    kappa::FT = 85.0
+    F0::FT = 70.0
+    F1::FT = 22.0
+end
+import AtmosphericProfilesLibrary as APL
+
+struct RadiationTRMM_LBA{R}
+    rad_profile::R
+    function RadiationTRMM_LBA(::Type{FT}) where {FT}
+        rad_profile = APL.TRMM_LBA_radiation(FT)
+        return new{typeof(rad_profile)}(rad_profile)
+    end
+end

--- a/tc_driver/Radiation.jl
+++ b/tc_driver/Radiation.jl
@@ -1,11 +1,10 @@
-update_radiation(self::RadiationBase, grid, state, t::Real, param_set) = nothing
-initialize(self::RadiationBase{CA.RadiationNone}, grid, state) = nothing
+update_radiation(self, grid, state, t::Real, param_set) = nothing
 
 """
 see eq. 3 in Stevens et. al. 2005 DYCOMS paper
 """
 function update_radiation(
-    self::RadiationBase{CA.RadiationDYCOMS_RF01},
+    self::CA.RadiationDYCOMS_RF01,
     grid,
     state,
     t::Real,
@@ -81,7 +80,7 @@ function update_radiation(
     return
 end
 
-function initialize(self::RadiationBase{CA.RadiationTRMM_LBA}, grid, state)
+function initialize(self::CA.RadiationTRMM_LBA, grid, state)
     aux_gm = TC.center_aux_grid_mean(state)
     rad = APL.TRMM_LBA_radiation(eltype(grid))
     @inbounds for k in real_center_indices(grid)
@@ -91,7 +90,7 @@ function initialize(self::RadiationBase{CA.RadiationTRMM_LBA}, grid, state)
 end
 
 function update_radiation(
-    self::RadiationBase{CA.RadiationTRMM_LBA},
+    self::CA.RadiationTRMM_LBA,
     grid,
     state,
     t::Real,

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -239,7 +239,7 @@ function compute_gm_tendencies!(
     grid::TC.Grid,
     state::TC.State,
     surf::TC.SurfaceBase,
-    radiation::Cases.RadiationBase,
+    radiation,
     force::Cases.ForcingBase,
     param_set::APS,
 )
@@ -322,8 +322,8 @@ function compute_gm_tendencies!(
         @. tendencies_gm.q_ice -= ∇q_ice_gm * aux_gm.subsidence
     end
     # Radiation
-    if Cases.rad_type(radiation) <:
-       Union{CA.RadiationDYCOMS_RF01, CA.RadiationTRMM_LBA}
+    if radiation isa CA.RadiationDYCOMS_RF01 ||
+       radiation isa CA.RadiationTRMM_LBA
         @. tendencies_gm.ρe_tot +=
             ρ_c * TD.cv_m(thermo_params, ts_gm) * aux_gm.dTdt_rad
     end

--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -40,7 +40,6 @@ cent_aux_vars_gm(FT, local_geometry, edmf) = (;
     H_third_m = FT(0),
     W_third_m = FT(0),
     QT_third_m = FT(0),
-    # From RadiationBase
     dTdt_rad = FT(0), # horizontal advection temperature tendency
     dqtdt_rad = FT(0), # horizontal advection moisture tendency
     # From ForcingBase


### PR DESCRIPTION
This is another peel off from #960. This PR:
 - Adds `AtmosphericProfilesLibrary.jl` to the dep list for perf/examples env
 - replaces `RadiationBase` with `RadiationDYCOMS_RF01` and `RadiationTRMM_LBA`