### PR TITLE
Refactor thermo_state

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -353,10 +353,11 @@ steps:
       - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"
 
-      - label: ":mag: Allocations: perf target"
-        command: "julia --color=yes --project=perf perf/allocs.jl"
-        agents:
-          slurm_mem: 20GB
+      # TODO: commented temporarily as this is 2x longer than any other job
+      # - label: ":mag: Allocations: perf target"
+      #   command: "julia --color=yes --project=perf perf/allocs.jl"
+      #   agents:
+      #     slurm_mem: 20GB
 
   - wait: ~
     continue_on_failure: true

--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -195,7 +195,7 @@ function save_to_disk_func(integrator)
     @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
 
     # thermo state
-    thermo_state!(ᶜts, Y, params, ᶜinterp, ᶜK)
+    thermo_state!(ᶜts, Y, thermo_params, p.thermo_dispatcher, ᶜinterp, ᶜK)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
     ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)

--- a/examples/hybrid/define_post_processing.jl
+++ b/examples/hybrid/define_post_processing.jl
@@ -189,7 +189,7 @@ paperplots_held_suarez(::TotalEnergy, ::EquilMoistModel, args...) =
 
 # plots in the Ullrish et al 2014 paper: surface pressure, 850 temperature and vorticity at day 8 and day 10 (if the simulation lasts 10 days)
 function paperplots_dry_baro_wave(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, ᶜp, params) = p
+    (; ᶜts, ᶜp, params, thermo_dispatcher) = p
     last_day = floor(Int, sol.t[end] / (24 * 3600))
     days = [last_day - 2, last_day]
     thermo_params = CAP.thermodynamics_params(params)
@@ -201,7 +201,7 @@ function paperplots_dry_baro_wave(sol, output_dir, p, nlat, nlon)
         iu = safe_index(ius, sol.t)
         Y = sol.u[iu]
         # compute pressure, temperature, vorticity
-        thermo_state!(ᶜts, Y, params, ᶜinterp)
+        thermo_state!(ᶜts, Y, thermo_params, thermo_dispatcher, ᶜinterp)
         @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
         ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
         curl_uh = @. curlₕ(Y.c.uₕ)
@@ -321,7 +321,7 @@ end
 
 # plots for moist baroclinic wave: https://www.cesm.ucar.edu/events/wg-meetings/2018/presentations/amwg/jablonowski.pdf
 function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, ᶜp, params, ᶜK) = p
+    (; ᶜts, ᶜp, params, ᶜK, thermo_dispatcher) = p
     last_day = floor(Int, sol.t[end] / (24 * 3600))
     days = [last_day - 2, last_day]
     thermo_params = CAP.thermodynamics_params(params)
@@ -342,7 +342,7 @@ function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
         ᶜw_phy = @. Geometry.project(Geometry.WAxis(), ᶜuvw_phy)
         ᶠw_phy = ᶠinterp.(ᶜw_phy)
         @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
-        thermo_state!(ᶜts, Y, params, ᶜinterp, ᶜK)
+        thermo_state!(ᶜts, Y, thermo_params, thermo_dispatcher, ᶜinterp, ᶜK)
         @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
 
         ᶜq = @. TD.PhasePartition(thermo_params, ᶜts)
@@ -604,7 +604,7 @@ calc_zonalave_timeave(x) =
 calc_zonalave_variance(x) = calc_zonalave_timeave((x .- mean(x, dims = 4)) .^ 2)
 
 function paperplots_dry_held_suarez(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, params) = p
+    (; ᶜts, params, thermo_dispatcher) = p
     thermo_params = CAP.thermodynamics_params(params)
     last_day = floor(Int, sol.t[end] / (24 * 3600))
 
@@ -640,7 +640,7 @@ function paperplots_dry_held_suarez(sol, output_dir, p, nlat, nlon)
             Y = sol.u[i]
 
             # temperature
-            thermo_state!(ᶜts, Y, params, ᶜinterp)
+            thermo_state!(ᶜts, Y, thermo_params, thermo_dispatcher, ᶜinterp)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)
 
@@ -782,7 +782,7 @@ function postprocessing_edmf(sol, output_dir, fps)
 end
 
 function paperplots_moist_held_suarez_ρe(sol, output_dir, p, nlat, nlon)
-    (; ᶜts, params, ᶜK) = p
+    (; ᶜts, params, ᶜK, thermo_dispatcher) = p
     thermo_params = CAP.thermodynamics_params(params)
     last_day = floor(Int, sol.t[end] / (24 * 3600))
 
@@ -825,7 +825,7 @@ function paperplots_moist_held_suarez_ρe(sol, output_dir, p, nlat, nlon)
             # temperature
             ᶠw = Y.f.w
             @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
-            thermo_state!(ᶜts, Y, params, ᶜinterp, ᶜK)
+            thermo_state!(ᶜts, Y, thermo_params, thermo_dispatcher, ᶜinterp, ᶜK)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)
 
@@ -979,8 +979,9 @@ function paperplots_moist_held_suarez_ρe(sol, output_dir, p, nlat, nlon)
     )
 end
 
-function custom_postprocessing(sol, output_dir)
+function custom_postprocessing(sol, output_dir, p)
     # TODO: remove closure over params
+    thermo_dispatcher = p.thermo_dispatcher
     thermo_params = CAP.thermodynamics_params(params)
     get_var(i, var) = Fields.single_field(sol.u[i], var)
     n = length(sol.u)
@@ -1001,7 +1002,7 @@ function custom_postprocessing(sol, output_dir)
     )
 
     anim = @animate for Y in sol.u
-        ᶜts = thermo_state(Y, params, ᶜinterp)
+        ᶜts = thermo_state(Y, thermo_params, thermo_dispatcher, ᶜinterp)
         plot(
             vec(TD.air_temperature.(thermo_params, ᶜts)),
             vec(Fields.coordinate_field(Y.c).z ./ 1000);

--- a/src/TurbulenceConvection/variables.jl
+++ b/src/TurbulenceConvection/variables.jl
@@ -4,8 +4,8 @@
 import ClimaCore.Geometry: ⊗
 
 # Helpers for adding empty thermodynamic state fields:
-thermo_state(FT, ::EquilMoistModel) = TD.PhaseEquil{FT}(0, 0, 0, 0, 0)
-thermo_state(FT, ::NonEquilMoistModel) =
+thermo_state_zeros(FT, ::EquilMoistModel) = TD.PhaseEquil{FT}(0, 0, 0, 0, 0)
+thermo_state_zeros(FT, ::NonEquilMoistModel) =
     TD.PhaseNonEquil{FT}(0, 0, TD.PhasePartition(FT(0), FT(0), FT(0)))
 
 ##### Auxiliary fields
@@ -28,7 +28,7 @@ cent_aux_vars_up_moisture(FT, ::NonEquilMoistModel) = (;
 )
 cent_aux_vars_up_moisture(FT, ::EquilMoistModel) = NamedTuple()
 cent_aux_vars_up(FT, local_geometry, edmf) = (;
-    ts = thermo_state(FT, edmf.moisture_model),
+    ts = thermo_state_zeros(FT, edmf.moisture_model),
     q_liq = FT(0),
     q_ice = FT(0),
     T = FT(0),
@@ -91,7 +91,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
             Val(n_updrafts(edmf)),
         ),
         en = (;
-            ts = thermo_state(FT, edmf.moisture_model),
+            ts = thermo_state_zeros(FT, edmf.moisture_model),
             w = FT(0),
             area = FT(0),
             q_tot = FT(0),

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -130,3 +130,18 @@ function surface_scheme(FT, parsed_args)
         surface_scheme
     end
 end
+
+"""
+    ThermoDispatcher(model_spec)
+
+A helper method for creating a thermodynamics dispatcher
+from the model specification struct.
+"""
+function ThermoDispatcher(model_spec)
+    (; energy_form, moisture_model, compressibility_model) = model_spec
+    return ThermoDispatcher(;
+        energy_form,
+        moisture_model,
+        compressibility_model,
+    )
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -47,3 +47,17 @@ struct RadiationTRMM_LBA{R}
         return new{typeof(rad_profile)}(rad_profile)
     end
 end
+
+"""
+    ThermoDispatcher
+
+A dispatching type for selecting the
+precise thermodynamics method call to
+be used.
+"""
+Base.@kwdef struct ThermoDispatcher{EF, MM, CM}
+    energy_form::EF
+    moisture_model::MM
+    compressibility_model::CM
+end
+Base.broadcastable(x::ThermoDispatcher) = Ref(x)


### PR DESCRIPTION
This PR refactors `thermo_state!` so that we can more easily move `set_thermo_state_peq!` logic into `thermo_state!`.

This is a step towards #949.