### PR TITLE
Move viscous sponge into src

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -139,7 +139,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
             α_rayleigh_w = FT(α_rayleigh_w),
         ) : NamedTuple(),
         viscous_sponge ?
-        viscous_sponge_cache(
+        CA.viscous_sponge_cache(
             Y;
             zd_viscous = FT(zd_viscous),
             κ₂ = FT(κ₂_sponge),
@@ -192,7 +192,7 @@ end
 function additional_tendency!(Yₜ, Y, p, t)
     (; viscous_sponge, hyperdiff) = p.tendency_knobs
     hyperdiff && hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    viscous_sponge && viscous_sponge_tendency!(Yₜ, Y, p, t)
+    viscous_sponge && CA.viscous_sponge_tendency!(Yₜ, Y, p, t)
 
     # Vertical tendencies
     Fields.bycolumn(axes(Y.c)) do colidx

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -11,6 +11,8 @@ import .RRTMGPInterface as RRTMGPI
 include("TurbulenceConvection/TurbulenceConvection.jl")
 import .TurbulenceConvection as TC
 
+include(joinpath("tendencies", "viscous_sponge.jl"))
+
 include("model_getters.jl") # high-level (using parsed_args) model getters
 
 end # module

--- a/src/tendencies/viscous_sponge.jl
+++ b/src/tendencies/viscous_sponge.jl
@@ -1,0 +1,58 @@
+#####
+##### Viscous sponge
+#####
+
+import ClimaCore.Fields as Fields
+import ClimaCore.Geometry as Geometry
+import ClimaCore.Spaces as Spaces
+import ClimaCore.Operators as Operators
+
+viscous_sponge_cache(Y; kwargs...) =
+    viscous_sponge_cache(Y, Spaces.undertype(axes(Y.c)); kwargs...)
+
+function viscous_sponge_cache(
+    Y,
+    ::Type{FT};
+    zd_viscous = FT(15e3),
+    κ₂ = FT(1e5),
+) where {FT}
+    ᶜz = Fields.coordinate_field(Y.c).z
+    ᶠz = Fields.coordinate_field(Y.f).z
+    ᶜαₘ = @. ifelse(ᶜz > zd_viscous, κ₂, FT(0))
+    ᶠαₘ = @. ifelse(ᶠz > zd_viscous, κ₂, FT(0))
+    zmax = maximum(ᶠz)
+    ᶜβ_viscous =
+        @. ᶜαₘ * sin(FT(π) / 2 * (ᶜz - zd_viscous) / (zmax - zd_viscous))^2
+    ᶠβ_viscous =
+        @. ᶠαₘ * sin(FT(π) / 2 * (ᶠz - zd_viscous) / (zmax - zd_viscous))^2
+    return (; ᶜβ_viscous, ᶠβ_viscous)
+end
+
+function viscous_sponge_tendency!(Yₜ, Y, p, t)
+    (; ᶜβ_viscous, ᶠβ_viscous, ᶜp) = p
+    divₕ = Operators.Divergence()
+    wdivₕ = Operators.WeakDivergence()
+    gradₕ = Operators.Gradient()
+    wgradₕ = Operators.WeakGradient()
+    curlₕ = Operators.Curl()
+    wcurlₕ = Operators.WeakCurl()
+
+    ᶜρ = Y.c.ρ
+    ᶜuₕ = Y.c.uₕ
+    if :ρθ in propertynames(Y.c)
+        @. Yₜ.c.ρθ += ᶜβ_viscous * wdivₕ(ᶜρ * gradₕ(Y.c.ρθ / ᶜρ))
+    elseif :ρe_tot in propertynames(Y.c)
+        @. Yₜ.c.ρe_tot += ᶜβ_viscous * wdivₕ(ᶜρ * gradₕ((Y.c.ρe_tot + ᶜp) / ᶜρ))
+    elseif :ρe_int in propertynames(Y.c)
+        @. Yₜ.c.ρe_int += ᶜβ_viscous * wdivₕ(ᶜρ * gradₕ((Y.c.ρe_int + ᶜp) / ᶜρ))
+    end
+    @. Yₜ.c.uₕ +=
+        ᶜβ_viscous * (
+            wgradₕ(divₕ(ᶜuₕ)) - Geometry.project(
+                Geometry.Covariant12Axis(),
+                wcurlₕ(Geometry.project(Geometry.Covariant3Axis(), curlₕ(ᶜuₕ))),
+            )
+        )
+    @. Yₜ.f.w.components.data.:1 +=
+        ᶠβ_viscous * wdivₕ(gradₕ(Y.f.w.components.data.:1))
+end


### PR DESCRIPTION
This PR moves the viscous sponge into the source code.

This removes the closures by adding the operators as arguments into the cache (which are still, at the moment closures in `additional_cache`)