### PR TITLE
Fix perf target check bounds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,8 +187,8 @@ steps:
           slurm_ntasks: 2
 
       - label: ":computer: performance target checkbounds"
-        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_unthreaded_cb --enable_threading false --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded_cb/*"
+        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --job_id perf_target_checkbounds --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_checkbounds/*"
         soft_fail: true
         agents:
           slurm_mem: 20GB


### PR DESCRIPTION
This PR fixes the check-bounds job so that it doesn't break due to a missing surface scheme, and by fixing the job ID so that it's unique.