### PR TITLE
Move advection into src, make implicit tendency with colidx

### DIFF
--- a/examples/hybrid/linsolve_test.jl
+++ b/examples/hybrid/linsolve_test.jl
@@ -35,7 +35,7 @@ function verify_matrix(x, A, b, update_matrix = false; kwargs...)
             matrix_column(∂ᶠ𝕄ₜ∂ᶜ𝔼, axes(x.c), i, j, h)
         J_col[ᶠ𝕄_indices, ᶠ𝕄_indices] .=
             matrix_column(∂ᶠ𝕄ₜ∂ᶠ𝕄, axes(x.f), i, j, h)
-        for ᶜ𝕋_position in findall(is_tracer_var, propertynames(x.c))
+        for ᶜ𝕋_position in findall(CA.is_tracer_var, propertynames(x.c))
             ᶜ𝕋_offset =
                 DataLayouts.fieldtypeoffset(FT, eltype(x.c), ᶜ𝕋_position)
             ᶜ𝕋_indices = (Nv * ᶜ𝕋_offset + 1):(Nv * (ᶜ𝕋_offset + 1))

--- a/examples/hybrid/schur_complement_W.jl
+++ b/examples/hybrid/schur_complement_W.jl
@@ -6,18 +6,6 @@ using ClimaCore.Utilities: half
 const compose = Operators.ComposeStencils()
 const apply = Operators.ApplyStencil()
 
-# Note: We denote energy variables with 𝔼, momentum variables with 𝕄, and tracer
-# variables with 𝕋.
-is_energy_var(symbol) = symbol in (:ρθ, :ρe_tot, :ρe_int)
-is_momentum_var(symbol) = symbol in (:uₕ, :ρuₕ, :w, :ρw)
-is_edmf_var(symbol) = symbol in (:turbconv,)
-is_tracer_var(symbol) = !(
-    symbol == :ρ ||
-    is_energy_var(symbol) ||
-    is_momentum_var(symbol) ||
-    is_edmf_var(symbol)
-)
-
 function FieldFromNamedTuple(space, nt::NamedTuple)
     cmv(z) = nt
     return cmv.(Fields.coordinate_field(space))
@@ -62,9 +50,9 @@ end
 
 function SchurComplementW(Y, transform, flags, test = false)
     @assert length(filter(isequal(:ρ), propertynames(Y.c))) == 1
-    @assert length(filter(is_energy_var, propertynames(Y.c))) == 1
-    @assert length(filter(is_momentum_var, propertynames(Y.c))) == 1
-    @assert length(filter(is_momentum_var, propertynames(Y.f))) == 1
+    @assert length(filter(CA.is_energy_var, propertynames(Y.c))) == 1
+    @assert length(filter(CA.is_momentum_var, propertynames(Y.c))) == 1
+    @assert length(filter(CA.is_momentum_var, propertynames(Y.f))) == 1
 
     FT = eltype(Y)
     dtγ_ref = Ref(zero(FT))
@@ -81,7 +69,7 @@ function SchurComplementW(Y, transform, flags, test = false)
     ∂ᶠ𝕄ₜ∂ᶜ𝔼 = Fields.Field(bidiag_type, axes(Y.f))
     ∂ᶠ𝕄ₜ∂ᶜρ = Fields.Field(bidiag_type, axes(Y.f))
     ∂ᶠ𝕄ₜ∂ᶠ𝕄 = Fields.Field(tridiag_type, axes(Y.f))
-    ᶜ𝕋_names = filter(is_tracer_var, propertynames(Y.c))
+    ᶜ𝕋_names = filter(CA.is_tracer_var, propertynames(Y.c))
     ∂ᶜ𝕋ₜ∂ᶠ𝕄_field =
         FieldFromNamedTuple(axes(Y.c), tracer_variables(FT, ᶜ𝕋_names))
 
@@ -259,13 +247,13 @@ function _linsolve_serial!(
 
     xᶜρ = xc.ρ
     bᶜρ = bc.ρ
-    ᶜ𝔼_name = filter(is_energy_var, propertynames(xc))[1]
+    ᶜ𝔼_name = filter(CA.is_energy_var, propertynames(xc))[1]
     xᶜ𝔼 = getproperty(xc, ᶜ𝔼_name)
     bᶜ𝔼 = getproperty(bc, ᶜ𝔼_name)
-    ᶜ𝕄_name = filter(is_momentum_var, propertynames(xc))[1]
+    ᶜ𝕄_name = filter(CA.is_momentum_var, propertynames(xc))[1]
     xᶜ𝕄 = getproperty(xc, ᶜ𝕄_name)
     bᶜ𝕄 = getproperty(bc, ᶜ𝕄_name)
-    ᶠ𝕄_name = filter(is_momentum_var, propertynames(xf))[1]
+    ᶠ𝕄_name = filter(CA.is_momentum_var, propertynames(xf))[1]
     xᶠ𝕄 = getproperty(xf, ᶠ𝕄_name).components.data.:1
     bᶠ𝕄 = getproperty(bf, ᶠ𝕄_name).components.data.:1
 
@@ -282,18 +270,18 @@ function _linsolve_serial!(
     @. xᶜρ = -bᶜρ + dtγ * apply(∂ᶜρₜ∂ᶠ𝕄, xᶠ𝕄)
     @. xᶜ𝔼 = -bᶜ𝔼 + dtγ * apply(∂ᶜ𝔼ₜ∂ᶠ𝕄, xᶠ𝕄)
     @. xᶜ𝕄 = -bᶜ𝕄
-    for ᶜ𝕋_name in filter(is_tracer_var, propertynames(xc))
+    for ᶜ𝕋_name in filter(CA.is_tracer_var, propertynames(xc))
         xᶜ𝕋 = getproperty(xc, ᶜ𝕋_name)
         bᶜ𝕋 = getproperty(bc, ᶜ𝕋_name)
         ∂ᶜ𝕋ₜ∂ᶠ𝕄 = getproperty(∂ᶜ𝕋ₜ∂ᶠ𝕄_field, ᶜ𝕋_name)
         @. xᶜ𝕋 = -bᶜ𝕋 + dtγ * apply(∂ᶜ𝕋ₜ∂ᶠ𝕄, xᶠ𝕄)
     end
-    for var_name in filter(is_edmf_var, propertynames(xc))
+    for var_name in filter(CA.is_edmf_var, propertynames(xc))
         xᶜ𝕋 = getproperty(xc, var_name)
         bᶜ𝕋 = getproperty(bc, var_name)
         @. xᶜ𝕋 = -bᶜ𝕋
     end
-    for var_name in filter(is_edmf_var, propertynames(xf))
+    for var_name in filter(CA.is_edmf_var, propertynames(xf))
         xᶠ𝕋 = getproperty(xf, var_name)
         bᶠ𝕋 = getproperty(bf, var_name)
         @. xᶠ𝕋 = -bᶠ𝕋

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -4,6 +4,7 @@ include("Parameters.jl")
 import .Parameters
 
 include("types.jl")
+include("utilities.jl")
 
 include("RRTMGPInterface.jl")
 import .RRTMGPInterface as RRTMGPI
@@ -12,6 +13,7 @@ include("TurbulenceConvection/TurbulenceConvection.jl")
 import .TurbulenceConvection as TC
 
 include(joinpath("tendencies", "viscous_sponge.jl"))
+include(joinpath("tendencies", "advection.jl"))
 
 include("model_getters.jl") # high-level (using parsed_args) model getters
 

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -1,0 +1,112 @@
+#####
+##### Advection
+#####
+
+using LinearAlgebra: ×, dot
+import ClimaCore.Fields as Fields
+import ClimaCore.Geometry as Geometry
+import ClimaCore.Operators as Operators
+
+function horizontal_advection_tendency!(Yₜ, Y, p, t)
+    divₕ = Operators.Divergence()
+    gradₕ = Operators.Gradient()
+    curlₕ = Operators.Curl()
+
+    ᶜρ = Y.c.ρ
+    ᶜuₕ = Y.c.uₕ
+    ᶠw = Y.f.w
+    (; ᶜuvw, ᶜK, ᶜΦ, ᶜts, ᶜp, ᶜω³, ᶠω¹², params) = p
+    point_type = eltype(Fields.local_geometry_field(axes(Y.c)).coordinates)
+
+    # Mass conservation
+    @. Yₜ.c.ρ -= divₕ(ᶜρ * ᶜuvw)
+
+    # Energy conservation
+    if :ρθ in propertynames(Y.c)
+        @. Yₜ.c.ρθ -= divₕ(Y.c.ρθ * ᶜuvw)
+    elseif :ρe_tot in propertynames(Y.c)
+        @. Yₜ.c.ρe_tot -= divₕ((Y.c.ρe_tot + ᶜp) * ᶜuvw)
+    elseif :ρe_int in propertynames(Y.c)
+        if point_type <: Geometry.Abstract3DPoint
+            @. Yₜ.c.ρe_int -=
+                divₕ((Y.c.ρe_int + ᶜp) * ᶜuvw) -
+                dot(gradₕ(ᶜp), Geometry.Contravariant12Vector(ᶜuₕ))
+        else
+            @. Yₜ.c.ρe_int -=
+                divₕ((Y.c.ρe_int + ᶜp) * ᶜuvw) -
+                dot(gradₕ(ᶜp), Geometry.Contravariant1Vector(ᶜuₕ))
+        end
+    end
+
+    # Momentum conservation
+    if point_type <: Geometry.Abstract3DPoint
+        @. ᶜω³ = curlₕ(ᶜuₕ)
+        @. ᶠω¹² = curlₕ(ᶠw)
+        @. Yₜ.c.uₕ -= gradₕ(ᶜp) / ᶜρ + gradₕ(ᶜK + ᶜΦ)
+    elseif point_type <: Geometry.Abstract2DPoint
+        ᶜω³ .= Ref(zero(eltype(ᶜω³)))
+        @. ᶠω¹² = Geometry.Contravariant12Vector(curlₕ(ᶠw))
+        @. Yₜ.c.uₕ -=
+            Geometry.Covariant12Vector(gradₕ(ᶜp) / ᶜρ + gradₕ(ᶜK + ᶜΦ))
+    end
+
+    # Tracer conservation
+    for ᶜρc_name in filter(is_tracer_var, propertynames(Y.c))
+        ᶜρc = getproperty(Y.c, ᶜρc_name)
+        ᶜρcₜ = getproperty(Yₜ.c, ᶜρc_name)
+        @. ᶜρcₜ -= divₕ(ᶜρc * ᶜuvw)
+    end
+    return nothing
+end
+
+function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
+    Fields.bycolumn(axes(Y.c)) do colidx
+        explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
+    end
+    return nothing
+end
+
+function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
+    ᶜρ = Y.c.ρ
+    ᶜuₕ = Y.c.uₕ
+    ᶠw = Y.f.w
+    C123 = Geometry.Covariant123Vector
+    (; ᶜuvw, ᶜK, ᶜp, ᶜω³, ᶠω¹², ᶠu¹², ᶠu³, ᶜf) = p
+    (; ᶜdivᵥ, ᶠinterp, ᶠcurlᵥ, ᶜinterp, ᶠgradᵥ) = p.operators
+    # Mass conservation
+    @. Yₜ.c.ρ[colidx] -= ᶜdivᵥ(ᶠinterp(ᶜρ[colidx] * ᶜuₕ[colidx]))
+
+    # Energy conservation
+    if :ρθ in propertynames(Y.c)
+        @. Yₜ.c.ρθ[colidx] -= ᶜdivᵥ(ᶠinterp(Y.c.ρθ[colidx] * ᶜuₕ[colidx]))
+    elseif :ρe_tot in propertynames(Y.c)
+        @. Yₜ.c.ρe_tot[colidx] -=
+            ᶜdivᵥ(ᶠinterp((Y.c.ρe_tot[colidx] + ᶜp[colidx]) * ᶜuₕ[colidx]))
+    elseif :ρe_int in propertynames(Y.c)
+        @. Yₜ.c.ρe_int[colidx] -=
+            ᶜdivᵥ(ᶠinterp((Y.c.ρe_int[colidx] + ᶜp[colidx]) * ᶜuₕ[colidx]))
+    end
+
+    # Momentum conservation
+    @. ᶠω¹²[colidx] += ᶠcurlᵥ(ᶜuₕ[colidx])
+    @. ᶠu¹²[colidx] =
+        Geometry.project(Geometry.Contravariant12Axis(), ᶠinterp(ᶜuvw[colidx]))
+    @. ᶠu³[colidx] = Geometry.project(
+        Geometry.Contravariant3Axis(),
+        C123(ᶠinterp(ᶜuₕ[colidx])) + C123(ᶠw[colidx]),
+    )
+    @. Yₜ.c.uₕ[colidx] -=
+        ᶜinterp(ᶠω¹²[colidx] × ᶠu³[colidx]) +
+        (ᶜf[colidx] + ᶜω³[colidx]) ×
+        (Geometry.project(Geometry.Contravariant12Axis(), ᶜuvw[colidx]))
+    @. Yₜ.f.w[colidx] -= ᶠω¹²[colidx] × ᶠu¹²[colidx] + ᶠgradᵥ(ᶜK[colidx])
+
+    # Tracer conservation
+    for ᶜρc_name in filter(is_tracer_var, propertynames(Y.c))
+        ᶜρc = getproperty(Y.c, ᶜρc_name)
+        ᶜρcₜ = getproperty(Yₜ.c, ᶜρc_name)
+        @. ᶜρcₜ[colidx] -= ᶜdivᵥ(ᶠinterp(ᶜρc[colidx] * ᶜuₕ[colidx]))
+    end
+
+    return nothing
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,13 @@
+#####
+##### Utility functions
+#####
+
+is_energy_var(symbol) = symbol in (:ρθ, :ρe_tot, :ρe_int)
+is_momentum_var(symbol) = symbol in (:uₕ, :ρuₕ, :w, :ρw)
+is_edmf_var(symbol) = symbol in (:turbconv,)
+is_tracer_var(symbol) = !(
+    symbol == :ρ ||
+    is_energy_var(symbol) ||
+    is_momentum_var(symbol) ||
+    is_edmf_var(symbol)
+)


### PR DESCRIPTION
This PR:
 - moves advection into src/
 - adds an implicit tendency method with `colidx` to improve indentation
 - Removes closures over global constant operators and parameters