### PR TITLE
Improve perf summary filtering, add rosenbrock perf job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,7 +187,7 @@ steps:
           slurm_ntasks: 2
 
       - label: ":computer: performance target checkbounds"
-        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_cb --enable_threading false --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_unthreaded_cb --enable_threading false --forcing held_suarez --vert_diff true --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_unthreaded_cb/*"
         soft_fail: true
         agents:
@@ -255,22 +255,20 @@ steps:
   - group: "Performance targets"
     steps:
 
-      # TODO: add/exercise edmf code
-      # Comment out the following job for now, until flame graph w/ changing ID is cleared
-      # - label: ":computer: Unthreaded performance target (Rosenbrock)"
-      #   command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-      #   artifact_paths: "perf_target_unthreaded_rosenbrock/*"
-      #   agents:
-      #     slurm_mem: 20GB
+      - label: ":computer: Unthreaded performance target (Rosenbrock)"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        artifact_paths: "perf_target_unthreaded_rosenbrock/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: Unthreaded performance target"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_unthreaded/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":computer: Threaded performance target"
-        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --job_id perf_target_threaded --enable_threading true --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
+        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_threaded --enable_threading true --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --microphy 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
         artifact_paths: "perf_target_threaded/*"
         agents:
           slurm_ntasks: 8

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -250,6 +250,10 @@ function parse_commandline()
         help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow"
         arg_type = Bool
         default = false
+        "--perf_summary"
+        help = "Flag for collecting performance summary information"
+        arg_type = Bool
+        default = false
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/perf/tabulate_perf_summary.jl
+++ b/perf/tabulate_perf_summary.jl
@@ -26,11 +26,9 @@ all metrics can be found in `get_summary`.
 
 ca_dir = joinpath(dirname(@__DIR__))
 
-function get_job_ids(buildkite_yaml; trigger = "benchmark.jl")
+function get_job_ids(buildkite_yaml; trigger = "--perf_summary true")
     buildkite_commands = readlines(buildkite_yaml)
     filter!(x -> occursin(trigger, x), buildkite_commands)
-    # TODO: can we filter this better?
-    filter!(x -> occursin("perf_target", x), buildkite_commands)
     @assert length(buildkite_commands) > 0 # sanity check
     job_ids = map(buildkite_commands) do bkcs
         strip(first(split(last(split(bkcs, "--job_id ")), " ")), '\"')
@@ -41,7 +39,7 @@ end
 function combine_PRs_performance_benchmarks(path)
     job_ids = get_job_ids(
         joinpath(ca_dir, ".buildkite", "pipeline.yml");
-        trigger = "benchmark.jl",
+        trigger = "--perf_summary true",
     )
     # Combine summaries into one dict
     summaries = OrderedCollections.OrderedDict()


### PR DESCRIPTION
This PR should decouple our performance summary from individual benchmark jobs by adding a flag for opting into the perf summary, and this is what we use for filtering out which jobs to collect information for. This should make it easier to merge #991, for example.