### PR TITLE
Merge subsidence into dycore tendencies

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -278,25 +278,25 @@ steps:
     steps:
 
       - label: ":balloon: Single column EDMF Bomex"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex --dt 6secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex --dt 6secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
         artifact_paths: "edmf_bomex/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF Bomex"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id compressible_edmf_bomex --dt 1secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id compressible_edmf_bomex --dt 1secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
         artifact_paths: "compressible_edmf_bomex/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
         artifact_paths: "edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compresible single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
         artifact_paths: "compressible_edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
@@ -326,7 +326,7 @@ steps:
           slurm_mem: 20GB
 
       - label: ":dart: EDMF Consistency test Bomex"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex_consistency --dt 6secs --t_end 6hours --anelastic_dycore true --apply_limiter false --test_edmf_consistency true --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex_consistency --dt 6secs --t_end 6hours --anelastic_dycore true --apply_limiter false --test_edmf_consistency true --debugging_tc true --dt_save_to_disk 6hours"
         artifact_paths: "edmf_bomex_consistency/*"
         agents:
           slurm_mem: 20GB

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -44,6 +44,9 @@ function parse_commandline()
         "--forcing"
         help = "Forcing [`nothing` (default), `held_suarez`]"
         arg_type = String
+        "--subsidence"
+        help = "Subsidence [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `DYCOMS`]"
+        arg_type = String
         "--vert_diff"
         help = "Vertical diffusion [`false` (default), `true`]"
         arg_type = Bool

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -145,6 +145,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
             κ₂ = FT(κ₂_sponge),
         ) : NamedTuple(),
         CA.microphysics_cache(Y, microphysics_model),
+        CA.subsidence_cache(Y, model_spec.subsidence),
         forcing_type isa CA.HeldSuarezForcing ? CA.held_suarez_cache(Y) :
         NamedTuple(),
         radiation_cache,
@@ -202,6 +203,9 @@ function additional_tendency!(Yₜ, Y, p, t)
         (; rayleigh_sponge) = p.tendency_knobs
         rayleigh_sponge && CA.rayleigh_sponge_tendency!(Yₜ, Y, p, t, colidx)
         hs_forcing && CA.held_suarez_tendency!(Yₜ, Y, p, t, colidx)
+        if p.subsidence isa CA.Subsidence
+            CA.subsidence_tendency!(Yₜ, Y, p, t, colidx)
+        end
         if vert_diff
             (; coupled) = p
             !coupled && CA.get_surface_fluxes!(Y, p, colidx)

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -136,6 +136,7 @@ function default_cache(Y, params, model_spec, spaces, numerics, simulation)
             ᶠfct_zalesak,
         ),
         spaces,
+        moisture_model = model_spec.moisture_model,
         Yₜ = similar(Y), # only needed when using increment formulation
         limiters,
         ᶜρh_kwargs...,

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -27,13 +27,15 @@ function get_model_spec(::Type{FT}, parsed_args, namelist) where {FT}
 
     moisture_model = CA.moisture_model(parsed_args)
     precip_model = CA.precipitation_model(parsed_args, namelist)
+    radiation_mode = CA.radiation_mode(parsed_args, FT)
 
     model_spec = (;
         moisture_model,
         energy_form = CA.energy_form(parsed_args),
         perturb_initstate = parsed_args["perturb_initstate"],
         idealized_h2o,
-        radiation_mode = CA.radiation_mode(parsed_args, FT),
+        radiation_mode,
+        subsidence = CA.subsidence_model(parsed_args, radiation_mode, FT),
         microphysics_model = CA.microphysics_model(parsed_args),
         precip_model,
         forcing_type = CA.forcing_type(parsed_args),

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -14,6 +14,7 @@ import .TurbulenceConvection as TC
 
 include("thermo_state.jl")
 
+include(joinpath("tendencies", "forcing", "subsidence.jl"))
 include(joinpath("tendencies", "forcing", "held_suarez.jl"))
 
 include(joinpath("tendencies", "microphysics.jl"))

--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -58,6 +58,7 @@ function compute_sgs_flux!(
     surf::SurfaceBase,
     param_set::APS,
 )
+    thermo_params = TCP.thermodynamics_params(param_set)
     N_up = n_updrafts(edmf)
     tendencies_gm = center_tendencies_grid_mean(state)
     FT = float_type(state)
@@ -101,7 +102,8 @@ function compute_sgs_flux!(
     # compute total enthalpies
     ts_en = center_aux_environment(state).ts
     ts_gm = center_aux_grid_mean_ts(state)
-    @. h_tot_gm = total_enthalpy(param_set, prog_gm.ρe_tot / ρ_c, ts_gm)
+    @. h_tot_gm =
+        TD.total_specific_enthalpy(thermo_params, ts_gm, prog_gm.ρe_tot / ρ_c)
     # Compute the mass flux and associated scalar fluxes
     @. massflux = ρ_f * Ifae(a_en) * (w_en - wcomponent(CCG.WVector(w_gm)))
     @. massflux_h =

--- a/src/TurbulenceConvection/thermodynamics.jl
+++ b/src/TurbulenceConvection/thermodynamics.jl
@@ -50,18 +50,6 @@ function geopotential(param_set, z::Real)
     return grav * z
 end
 
-# TODO: move to Thermodynamics.jl
-function total_enthalpy(param_set::APS, e_tot::FT, ts) where {FT}
-    thermo_params = TCP.thermodynamics_params(param_set)
-    Rm = TD.gas_constant_air(thermo_params, ts)
-    T = TD.air_temperature(thermo_params, ts)
-    return e_tot + Rm * T
-end
-
-function total_enthalpy(param_set::APS, e_tot::FT, p::FT, ρ::FT) where {FT}
-    return e_tot + p / ρ
-end
-
 function enthalpy(h_tot::FT, e_kin::FT, e_pot::FT) where {FT}
     return h_tot - e_kin - e_pot
 end

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -107,8 +107,11 @@ function update_aux!(
                 aux_up[i].e_kin[k],
                 e_pot,
             )
-            aux_up[i].h_tot[k] =
-                total_enthalpy(param_set, aux_up[i].e_tot[k], ts_up_i)
+            aux_up[i].h_tot[k] = TD.total_specific_enthalpy(
+                thermo_params,
+                ts_up_i,
+                aux_up[i].e_tot[k],
+            )
         end
 
         #####

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -84,6 +84,25 @@ function forcing_type(parsed_args)
     end
 end
 
+function subsidence_model(parsed_args, radiation_mode, FT)
+    subsidence = parsed_args["subsidence"]
+    subsidence == nothing && return nothing
+
+    prof = if subsidence == "Bomex"
+        APL.Bomex_subsidence(FT)
+    elseif subsidence == "LifeCycleTan2018"
+        APL.LifeCycleTan2018_subsidence(FT)
+    elseif subsidence == "Rico"
+        APL.Rico_subsidence(FT)
+    elseif subsidence == "DYCOMS"
+        @assert radiation_mode isa RadiationDYCOMS_RF01
+        z -> -z * radiation_mode.divergence
+    else
+        error("Uncaught case")
+    end
+    return Subsidence(prof)
+end
+
 function precipitation_model(parsed_args, namelist)
     namelist isa Nothing && return TC.NoPrecipitation()
 

--- a/src/tendencies/forcing/subsidence.jl
+++ b/src/tendencies/forcing/subsidence.jl
@@ -1,0 +1,90 @@
+#####
+##### Subsidence forcing
+#####
+
+import Thermodynamics as TD
+import ClimaCore.Spaces as Spaces
+import ClimaCore.Fields as Fields
+import ClimaCore.Operators as Operators
+
+subsidence_cache(Y, subsidence::Nothing) = (; subsidence)
+function subsidence_cache(Y, subsidence::Subsidence)
+    FT = Spaces.undertype(axes(Y.c))
+    toa(f) = Spaces.level(f, Spaces.nlevels(axes(f)))
+    return (;
+        subsidence,
+        ᶜsubsidence = similar(Y.c, FT), # TODO: fix types
+        ᶜ∇MSE_gm = similar(Y.c, FT), # TODO: fix types
+        ᶜ∇q_tot_gm = similar(Y.c, FT), # TODO: fix types
+        ᶜ∇q_liq_gm = similar(Y.c, FT), # TODO: fix types
+        ᶜ∇q_ice_gm = similar(Y.c, FT), # TODO: fix types
+        ᶜMSE_gm_toa = similar(toa(Y.c), FT),
+        ᶜq_tot_gm_toa = similar(toa(Y.c), FT),
+        ᶜh_tot = similar(Y.c, FT),
+    )
+end
+
+function subsidence_tendency!(Yₜ, Y, p, t, colidx)
+    (; moisture_model) = p
+    thermo_params = CAP.thermodynamics_params(p.params)
+    subsidence_profile = p.subsidence.prof
+    FT = Spaces.undertype(axes(Y.c))
+
+    ᶜ∇MSE_gm = p.ᶜ∇MSE_gm[colidx]
+    ᶜsubsidence = p.ᶜsubsidence[colidx]
+    ᶜ∇q_tot_gm = p.ᶜ∇q_tot_gm[colidx]
+    ᶜK = p.ᶜK[colidx]
+    ᶜh_tot = p.ᶜh_tot[colidx]
+    ᶜts = p.ᶜts[colidx]
+    ᶜMSE_gm_toa = p.ᶜMSE_gm_toa[colidx]
+    ᶜq_tot_gm_toa = p.ᶜq_tot_gm_toa[colidx]
+
+    toa(f) = Spaces.level(f, Spaces.nlevels(axes(f)))
+    wvec = Geometry.WVector
+    ∇c = Operators.DivergenceF2C()
+    @. ᶜh_tot = TD.total_specific_enthalpy(
+        thermo_params,
+        ᶜts,
+        Y.c.ρe_tot[colidx] / Y.c.ρ[colidx],
+    )
+
+    z = Fields.coordinate_field(axes(ᶜsubsidence))
+    @. ᶜsubsidence = subsidence_profile(z.z)
+
+    ᶜh_tot_toa = toa(ᶜh_tot)
+    ᶜK_toa = toa(ᶜK)
+    @. ᶜMSE_gm_toa = ᶜh_tot_toa - ᶜK_toa
+    ρq_tot_toa = toa(Y.c.ρq_tot[colidx])
+    ρ_toa = toa(Y.c.ρ[colidx])
+    @. ᶜq_tot_gm_toa = ρq_tot_toa / ρ_toa
+    RBe = Operators.RightBiasedC2F(; top = Operators.SetValue(ᶜMSE_gm_toa))
+    RBq = Operators.RightBiasedC2F(; top = Operators.SetValue(ᶜq_tot_gm_toa))
+    @. ᶜ∇MSE_gm = ∇c(wvec(RBe(ᶜh_tot - ᶜK)))
+    @. ᶜ∇q_tot_gm = ∇c(wvec(RBq(Y.c.ρq_tot[colidx] / Y.c.ρ[colidx])))
+
+    if moisture_model isa NonEquilMoistModel
+        # TODO: fix for non-equilibrium case:
+        #   Y.c.q_liq -> Y.c.ρq_liq
+        #   Y.c.q_ice -> Y.c.ρq_ice
+        ᶜ∇q_liq_gm = p.ᶜ∇q_liq_gm[colidx]
+        ᶜ∇q_ice_gm = p.ᶜ∇q_ice_gm[colidx]
+        q_liq_gm_toa = toa(Y.c.q_liq[colidx])
+        q_ice_gm_toa = toa(Y.c.q_ice[colidx])
+        RBq_liq =
+            Operators.RightBiasedC2F(; top = Operators.SetValue(q_liq_gm_toa))
+        RBq_ice =
+            Operators.RightBiasedC2F(; top = Operators.SetValue(q_ice_gm_toa))
+        @. ᶜ∇q_liq_gm = ∇c(wvec(RBq(Y.c.q_liq[colidx])))
+        @. ᶜ∇q_ice_gm = ∇c(wvec(RBq(Y.c.q_ice[colidx])))
+    end
+
+    # LS Subsidence
+    @. Yₜ.c.ρe_tot[colidx] -= Y.c.ρ[colidx] * ᶜsubsidence * ᶜ∇MSE_gm
+    @. Yₜ.c.ρq_tot[colidx] -= Y.c.ρ[colidx] * ᶜsubsidence * ᶜ∇q_tot_gm
+    if moisture_model isa NonEquilMoistModel
+        @. Yₜ.c.ρq_liq[colidx] -= ᶜ∇q_liq_gm * ᶜsubsidence
+        @. Yₜ.c.ρq_ice[colidx] -= ᶜ∇q_ice_gm * ᶜsubsidence
+    end
+
+    return nothing
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,6 +17,9 @@ struct Microphysics0Moment <: AbstractMicrophysicsModel end
 
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
+struct Subsidence{T} <: AbstractForcing
+    prof::T
+end
 
 abstract type AbstractSurfaceScheme end
 struct BulkSurfaceScheme <: AbstractSurfaceScheme end

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -410,7 +410,6 @@ function initialize_forcing(::Bomex, forcing, grid::Grid, state, param_set)
     prof_ug = APL.Bomex_geostrophic_u(FT)
     prof_dTdt = APL.Bomex_dTdt(FT)
     prof_dqtdt = APL.Bomex_dqtdt(FT)
-    prof_subsidence = APL.Bomex_subsidence(FT)
 
     z = CC.Fields.coordinate_field(axes(aux_gm.uₕ_g)).z
     @. aux_gm.uₕ_g = CCG.Covariant12Vector(CCG.UVVector(prof_ug(z), FT(0)))
@@ -419,8 +418,6 @@ function initialize_forcing(::Bomex, forcing, grid::Grid, state, param_set)
     @. aux_gm.dTdt_hadv = prof_dTdt(TD.exner(thermo_params, ts_gm), z)
     # Set large-scale drying
     @. aux_gm.dqtdt_hadv = prof_dqtdt(z)
-    #Set large scale subsidence
-    @. aux_gm.subsidence = prof_subsidence(z)
     return nothing
 end
 
@@ -523,7 +520,6 @@ function initialize_forcing(
     prof_ug = APL.LifeCycleTan2018_geostrophic_u(FT)
     prof_dTdt = APL.LifeCycleTan2018_dTdt(FT)
     prof_dqtdt = APL.LifeCycleTan2018_dqtdt(FT)
-    prof_subsidence = APL.LifeCycleTan2018_subsidence(FT)
 
     aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
     TC.set_z!(aux_gm_uₕ_g, prof_ug, x -> FT(0))
@@ -534,8 +530,6 @@ function initialize_forcing(
     @. aux_gm.dTdt_hadv = prof_dTdt(TD.exner(thermo_params, ts_gm), z)
     # Set large-scale drying
     @. aux_gm.dqtdt_hadv = prof_dqtdt(z)
-    #Set large scale subsidence
-    @. aux_gm.subsidence = prof_subsidence(z)
     return nothing
 end
 
@@ -645,7 +639,6 @@ function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
     prof_vg = APL.Rico_geostrophic_vg(FT)
     prof_dTdt = APL.Rico_dTdt(FT)
     prof_dqtdt = APL.Rico_dqtdt(FT)
-    prof_subsidence = APL.Rico_subsidence(FT)
 
     z = CC.Fields.coordinate_field(axes(aux_gm.uₕ_g)).z
     aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
@@ -653,7 +646,6 @@ function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
 
     @. aux_gm.dTdt_hadv = prof_dTdt(TD.exner(thermo_params, ts_gm), z) # Set large-scale cooling
     @. aux_gm.dqtdt_hadv = prof_dqtdt(z) # Set large-scale moistening
-    @. aux_gm.subsidence = prof_subsidence(z) #Set large scale subsidence
     return nothing
 end
 
@@ -1067,10 +1059,6 @@ function initialize_forcing(
     TC.set_z!(aux_gm_uₕ_g, FT(7), FT(-5.5))
     z = CC.Fields.coordinate_field(axes(aux_gm_uₕ_g)).z
 
-    # large scale subsidence
-    divergence = forcing.divergence
-    @. aux_gm.subsidence = -z * divergence
-
     # no large-scale drying
     @. aux_gm.dqtdt_hadv = 0 #kg/(kg * s)
 end
@@ -1166,10 +1154,6 @@ function initialize_forcing(
     aux_gm_uₕ_g = TC.grid_mean_uₕ_g(state)
     TC.set_z!(aux_gm_uₕ_g, FT(5), FT(-5.5))
     z = CC.Fields.coordinate_field(axes(aux_gm_uₕ_g)).z
-
-    # large scale subsidence
-    divergence = forcing.divergence
-    @. aux_gm.subsidence = -z * divergence
 
     # no large-scale drying
     @. aux_gm.dqtdt_hadv .= 0 #kg/(kg * s)

--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -43,7 +43,6 @@ cent_aux_vars_gm(FT, local_geometry, edmf) = (;
     dTdt_rad = FT(0), # horizontal advection temperature tendency
     dqtdt_rad = FT(0), # horizontal advection moisture tendency
     # From ForcingBase
-    subsidence = FT(0), #Large-scale subsidence
     dTdt_hadv = FT(0), #Horizontal advection of temperature
     dqtdt_hadv = FT(0), #Horizontal advection of moisture
     T_nudge = FT(0), #Reference T profile for relaxation tendency
@@ -53,8 +52,6 @@ cent_aux_vars_gm(FT, local_geometry, edmf) = (;
     u_nudge = FT(0), #Reference u profile for relaxation tendency
     v_nudge = FT(0), #Reference v profile for relaxation tendency
     uₕ_g = CCG.Covariant12Vector(CCG.UVVector(FT(0), FT(0)), local_geometry), #Geostrophic u velocity
-    ∇MSE_gm = FT(0),
-    ∇q_tot_gm = FT(0),
     cent_aux_vars_gm_moisture(FT, edmf.moisture_model)...,
     θ_virt = FT(0),
     Ri = FT(0),


### PR DESCRIPTION
This PR:
 - moves subsidence computations into the dycore tendencies
 - Removes TC-internals from subsidence calculations
 - Moves the subsidence cache into the dycore cache (which is now optional)
 - Removes `total_enthalpy` and uses the Thermodynamics `total_specific_enthalpy`

Subsidence is not always a function of time, however this PR changes things so that it's always computed. This is a bit simpler in that there's no need for an initialization _and_ the update. Also, the cache is now tied to the tendency (which is now optional) and in closer proximity to the tendency.

This PR is a step towards #949.
