### PR TITLE
Remove module loading from global scope

### DIFF
--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -1,4 +1,4 @@
-module TurbulenceConvectionUtils
+# module TurbulenceConvectionUtils
 
 using LinearAlgebra, StaticArrays
 import ClimaAtmos
@@ -18,7 +18,6 @@ import TerminalLoggers
 const ca_dir = pkgdir(ClimaAtmos)
 
 include(joinpath(ca_dir, "tc_driver", "Cases.jl"))
-import .Cases
 
 include(joinpath(ca_dir, "tc_driver", "dycore.jl"))
 include(joinpath(ca_dir, "tc_driver", "Surface.jl"))
@@ -47,10 +46,9 @@ function get_edmf_cache(
     Ri_bulk_crit = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     FT = CC.Spaces.undertype(axes(Y.c))
     test_consistency = parsed_args["test_edmf_consistency"]
-    case = Cases.get_case(namelist)
-    surf_ref_state = Cases.surface_ref_state(case, tc_params, namelist)
-    surf_params =
-        Cases.surface_params(case, surf_ref_state, tc_params; Ri_bulk_crit)
+    case = get_case(namelist)
+    surf_ref_state = surface_ref_state(case, tc_params, namelist)
+    surf_params = surface_params(case, surf_ref_state, tc_params; Ri_bulk_crit)
     edmf = turbconv_model
     @info "EDMFModel: \n$(summary(edmf))"
     return (;
@@ -82,7 +80,7 @@ function init_tc!(Y, p, param_set, namelist)
         compute_ref_state!(state, grid, tc_params; ts_g = surf_ref_state)
 
         # TODO: convert initialize_profiles to set prognostic state, not aux state
-        Cases.initialize_profiles(case, grid, tc_params, state)
+        initialize_profiles(case, grid, tc_params, state)
 
         # Temporarily, we'll re-populate ρq_tot based on initial aux q_tot
         q_tot = edmf_cache.aux.cent.q_tot[colidx]
@@ -140,4 +138,4 @@ function sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
     return nothing
 end
 
-end # module
+# end # module

--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -153,7 +153,7 @@ function turb_conv_affect_filter!(integrator)
     Fields.bycolumn(axes(Y.c)) do colidx
         state = TC.tc_column_state(Y, p, nothing, colidx)
         grid = TC.Grid(state)
-        surf = TCU.get_surface(surf_params, grid, state, t, tc_params)
+        surf = get_surface(surf_params, grid, state, t, tc_params)
         TC.affect_filter!(edmf, grid, state, tc_params, surf, t)
     end
 

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -48,9 +48,8 @@ include("types.jl")
 import ClimaAtmos as CA
 import ClimaAtmos.TurbulenceConvection as TC
 include("TurbulenceConvectionUtils.jl")
-import .TurbulenceConvectionUtils as TCU
 namelist = if turbconv == "edmf"
-    nl = TCU.NameList.default_namelist(case_name)
+    nl = NameList.default_namelist(case_name)
     nl
 else
     nothing
@@ -180,7 +179,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
         (; compressibility_model),
         !isnothing(turbconv_model) ?
         (;
-            edmf_cache = TCU.get_edmf_cache(
+            edmf_cache = get_edmf_cache(
                 Y,
                 turbconv_model,
                 precip_model,
@@ -218,7 +217,7 @@ function additional_tendency!(Yₜ, Y, p, t)
         microphy_0M &&
             CA.zero_moment_microphysics_tendency!(Yₜ, Y, p, t, colidx)
         rad_flux && radiation_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)
-        has_turbconv && TCU.sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
+        has_turbconv && sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
     end
     # TODO: make bycolumn-able
     (; non_orographic_gravity_wave) = p.tendency_knobs
@@ -272,7 +271,7 @@ end
 
 p = get_cache(Y, params, spaces, model_spec, numerics, simulation)
 if parsed_args["turbconv"] == "edmf"
-    TCU.init_tc!(Y, p, params, namelist)
+    init_tc!(Y, p, params, namelist)
 end
 
 # Print tendencies:

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -1,4 +1,4 @@
-module Cases
+# module Cases
 
 import NCDatasets as NC
 import OrdinaryDiffEq as ODE
@@ -1013,4 +1013,4 @@ function surface_params(case::GABLS, surf_ref_state, param_set; kwargs...)
     return TC.MoninObukhovSurface(FT; kwargs...)
 end
 
-end # module Cases
+# end # module Cases


### PR DESCRIPTION
Via slack:

> [re-running an example is] pretty slow going on account of the >10 minute compilation time every time I want to run a new integrator

So, we can try to alleviate this by, for now, removing the module loading from global scope so that fewer functions get recompiled on re-including.

cc @dennisYatunin 