### PR TITLE
Use newer limiter interface

### DIFF
--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -114,7 +114,7 @@ function default_cache(Y, params, model_spec, spaces, numerics, simulation)
         tracers = filter(CA.is_tracer_var, propertynames(Y.c))
         make_limiter =
             ᶜρc_name ->
-                Limiters.QuasiMonotoneLimiter(getproperty(Y.c, ᶜρc_name), Y.c.ρ)
+                Limiters.QuasiMonotoneLimiter(getproperty(Y.c, ᶜρc_name))
         limiters = NamedTuple{tracers}(map(make_limiter, tracers))
     else
         limiters = nothing


### PR DESCRIPTION
The long-run TRMM [build](https://buildkite.com/clima/climaatmos-longruns/builds/567#0184108a-60be-4b22-8e62-0d5fe747e92c) is flooded with limiter warnings: `Warning: Limiter failed to converge with rtol`

@valeriabarra, does updating to the new interface (without prescribing `rtol`) change how the limiter works?