### PR TITLE
Try to fix consistency test

### DIFF
--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -122,7 +122,7 @@ end
 
 function sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
     (; edmf_cache, Δt, compressibility_model) = p
-    (; edmf, param_set, case, surf_params) = edmf_cache
+    (; edmf, param_set, case, surf_params, surf_ref_state) = edmf_cache
     (; precip_model, test_consistency, logpressure_fun) = edmf_cache
     thermo_params = CAP.thermodynamics_params(param_set)
     tc_params = CAP.turbconv_params(param_set)
@@ -140,6 +140,12 @@ function sgs_flux_tendency!(Yₜ, Y, p, t, colidx)
         CA.compute_ref_pressure!(
             p.edmf_cache.aux.face.p[colidx],
             logpressure_fun,
+        )
+        CA.compute_ref_density!(
+            p.edmf_cache.aux.face.ρ[colidx],
+            p.edmf_cache.aux.face.p[colidx],
+            thermo_params,
+            surf_ref_state,
         )
     end
     assign_thermo_aux!(state, grid, edmf.moisture_model, tc_params)


### PR DESCRIPTION
This PR attempts to fix the inconsistent edmf cache computations, by computing density on the cell faces in the anelastic case.