### PR TITLE
Add model_config to model_spec and cache

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -31,7 +31,7 @@ function parse_commandline()
         arg_type = String
         default = "6hours"
         "--config" # TODO: add box
-        help = "Spatial configuration [`sphere` (default), `column`]"
+        help = "Spatial configuration [`sphere` (default), `column`, `box`]"
         arg_type = String
         default = "sphere"
         "--moist"

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -137,6 +137,7 @@ function default_cache(Y, params, model_spec, spaces, numerics, simulation)
         ),
         spaces,
         moisture_model = model_spec.moisture_model,
+        model_config = model_spec.model_config,
         Yₜ = similar(Y), # only needed when using increment formulation
         limiters,
         ᶜρh_kwargs...,

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -14,7 +14,10 @@ import ClimaAtmos:
     Microphysics0Moment,
     HeldSuarezForcing,
     BulkSurfaceScheme,
-    MoninObukhovSurface
+    MoninObukhovSurface,
+    SingleColumnModel,
+    SphericalModel,
+    BoxModel
 
 import ClimaCore: InputOutput
 
@@ -31,6 +34,7 @@ function get_model_spec(::Type{FT}, parsed_args, namelist) where {FT}
 
     model_spec = (;
         moisture_model,
+        model_config = CA.model_config(parsed_args),
         energy_form = CA.energy_form(parsed_args),
         perturb_initstate = parsed_args["perturb_initstate"],
         idealized_h2o,

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -10,6 +10,17 @@ function moisture_model(parsed_args)
     end
 end
 
+function model_config(parsed_args)
+    config = parsed_args["config"]
+    return if config == "sphere"
+        SphericalModel()
+    elseif config == "column"
+        SingleColumnModel()
+    elseif config == "box"
+        BoxModel()
+    end
+end
+
 function energy_form(parsed_args)
     energy_name = parsed_args["energy_name"]
     @assert energy_name in ("rhoe", "rhoe_int", "rhotheta")

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,6 +15,11 @@ struct InternalEnergy <: AbstractEnergyFormulation end
 abstract type AbstractMicrophysicsModel end
 struct Microphysics0Moment <: AbstractMicrophysicsModel end
 
+abstract type AbstractModelConfig end
+struct SingleColumnModel <: AbstractModelConfig end
+struct SphericalModel <: AbstractModelConfig end
+struct BoxModel <: AbstractModelConfig end
+
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
 struct Subsidence{T} <: AbstractForcing


### PR DESCRIPTION
This PR defines types for different model configurations (column, sphere, box), and adds `model_config` into `model_spec` and cache. This makes it easier to setup configuration-dependent functionalities.