### PR TITLE
Fix 0M/1M microphysics inconsistency

### DIFF
--- a/src/TurbulenceConvection/EDMF_Precipitation.jl
+++ b/src/TurbulenceConvection/EDMF_Precipitation.jl
@@ -74,14 +74,21 @@ end
 Computes the tendencies to θ_liq_ice, q_tot, q_rain and q_snow
 due to rain evaporation, snow deposition and sublimation and snow melt
 """
-compute_precipitation_sink_tendencies(
+function compute_precipitation_sink_tendencies(
     ::AbstractPrecipitationModel,
     ::AbstractPrecipFractionModel,
     grid::Grid,
     state::State,
     param_set::APS,
     Δt::Real,
-) = nothing
+)
+    FT = float_type(state)
+    aux_tc = center_aux_turbconv(state)
+    @. aux_tc.qt_tendency_precip_sinks = FT(0)
+    @. aux_tc.e_tot_tendency_precip_sinks = FT(0)
+
+    nothing
+end
 
 function compute_precipitation_sink_tendencies(
     ::Clima1M,


### PR DESCRIPTION
Finally fixes NaN-inconsistencies that has plagued us for a while.

Since we don't run 1-moment microphysics, the "abstract" version of `compute_precipitation_sink_tendencies` is used to compute precipitation sink tendencies. The 1M version computed tendencies for precipitation sinks of `qt` and `e_tot`, which is used in `compute_gm_tendencies!` to compute grid-mean tendencies for `ρq_tot` and `ρe_tot`. 

In the non-1M-case, these precipitation sink tendencies are not set at all.

This PR sets these tendencies to zero.

Ref: #1039, #1037.

Closes: #1017