### PR TITLE
Add allocation monitoring to long runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -170,3 +170,11 @@ steps:
         artifact_paths: "longrun_compressible_edmf_trmm/*"
         agents:
           slurm_mem: 20GB
+
+  - group: "Performance"
+    steps:
+
+      - label: ":mag: Allocations: perf target"
+        command: "julia --color=yes --project=perf perf/allocs.jl"
+        agents:
+          slurm_mem: 20GB

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -368,12 +368,6 @@ steps:
       - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
         command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"
 
-      # TODO: commented temporarily as this is 2x longer than any other job
-      # - label: ":mag: Allocations: perf target"
-      #   command: "julia --color=yes --project=perf perf/allocs.jl"
-      #   agents:
-      #     slurm_mem: 20GB
-
   - wait: ~
     continue_on_failure: true
 


### PR DESCRIPTION
This PR adds the allocation monitoring to the long runs, so that we have persistent monitoring