### PR TITLE
Refactor surface and ICs

### DIFF
--- a/src/TurbulenceConvection/turbulence_functions.jl
+++ b/src/TurbulenceConvection/turbulence_functions.jl
@@ -1,15 +1,15 @@
 # convective velocity scale
 get_wstar(bflux, zi) = cbrt(max(bflux * zi, 0))
 
-function buoyancy_c(param_set::APS, ρ::FT, ρ_i::FT) where {FT}
-    g::FT = TCP.grav(param_set)
+function buoyancy_c(thermo_params, ρ::FT, ρ_i::FT) where {FT}
+    g::FT = TD.Parameters.grav(thermo_params)
     return g * (ρ - ρ_i) / ρ
 end
 
 # BL height
-function get_inversion(grid::Grid, state::State, param_set::APS, Ri_bulk_crit)
+function get_inversion(grid::Grid, state::State, thermo_params, Ri_bulk_crit)
     FT = float_type(state)
-    g::FT = TCP.grav(param_set)
+    g::FT = TD.Parameters.grav(thermo_params)
     kc_surf = kc_surface(grid)
     θ_virt = center_aux_grid_mean(state).θ_virt
     u = physical_grid_mean_u(state)

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -162,7 +162,7 @@ function update_aux!(
         aux_en.q_liq[k] = TD.liquid_specific_humidity(thermo_params, ts_en)
         aux_en.q_ice[k] = TD.ice_specific_humidity(thermo_params, ts_en)
         rho = TD.air_density(thermo_params, ts_en)
-        aux_en.buoy[k] = buoyancy_c(param_set, ρ_c[k], rho)
+        aux_en.buoy[k] = buoyancy_c(thermo_params, ρ_c[k], rho)
         aux_en.RH[k] = TD.relative_humidity(thermo_params, ts_en)
     end
 
@@ -198,7 +198,7 @@ function update_aux!(
             aux_up[i].q_ice[k] = TD.ice_specific_humidity(thermo_params, ts_up)
             aux_up[i].T[k] = TD.air_temperature(thermo_params, ts_up)
             ρ = TD.air_density(thermo_params, ts_up)
-            aux_up[i].buoy[k] = buoyancy_c(param_set, ρ_c[k], ρ)
+            aux_up[i].buoy[k] = buoyancy_c(thermo_params, ρ_c[k], ρ)
             aux_up[i].RH[k] = TD.relative_humidity(thermo_params, ts_up)
         end
         aux_gm.buoy[k] = (1.0 - aux_bulk.area[k]) * aux_en.buoy[k]

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -39,7 +39,7 @@ function get_surface(
         ts_sfc,
         scheme,
     )
-    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    zi = TC.get_inversion(grid, state, thermo_params, Ri_bulk_crit)
     convective_vel = TC.get_wstar(bflux, zi) # yair here zi in TRMM should be adjusted
 
     u_sfc = SA.SVector{2, FT}(0, 0)
@@ -128,7 +128,7 @@ function get_surface(
     lhf = result.lhf
     shf = result.shf
 
-    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    zi = TC.get_inversion(grid, state, thermo_params, Ri_bulk_crit)
     convective_vel = TC.get_wstar(result.buoy_flux, zi)
     return TC.SurfaceBase{FT}(;
         cm = result.Cd,
@@ -191,7 +191,7 @@ function get_surface(
     result = SF.surface_conditions(surf_flux_params, sc, scheme)
     lhf = result.lhf
     shf = result.shf
-    zi = TC.get_inversion(grid, state, param_set, Ri_bulk_crit)
+    zi = TC.get_inversion(grid, state, thermo_params, Ri_bulk_crit)
     convective_vel = TC.get_wstar(result.buoy_flux, zi)
     return TC.SurfaceBase{FT}(;
         cm = result.Cd,


### PR DESCRIPTION
This PR refactors the surface and IC functions by
 - Passing `ThermodynamicsParameters` instead of all of `ClimaAtmosParameters`
 - Improves names: `surface_ref_state` -> `surface_thermo_state`
 - Avoids passing `namelist` into the Cases module to better decouple the namelist from initialization