### PR TITLE
Rm THERMO_VAR env variable in remap pipeline

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -76,7 +76,6 @@ Commonly used command line arguements for experiment setups are [here](https://c
 `remap_pipeline.jl` remaps CG output onto lat/lon using the `TempestRemapping` subpackage. One needs to specify the following environment variables:
 * `JLD2_DIR`: the directory of saved `jld2` files from the simulation;
 * `HDF5_DIR`: the directory of saved `hdf5` files from the simulation;
-* `THERMO_VAR`: either `e_tot` or `theta` based on the thermodynamic variable of the simulation;
 * `NC_DIR`: the directory where remapped `nc` files will be saved in; if not specified, a subdirectory named `nc` will be created under `JLD2_DIR`;
 * `NLAT` and `NLON`: the number of evenly distributed grids in latitudes and longitudes; if not specified, they are default to `90` and `180` respectively.
 

--- a/examples/hybrid/sphere/remap_pipeline.jl
+++ b/examples/hybrid/sphere/remap_pipeline.jl
@@ -1,6 +1,5 @@
 import ClimaCore
 import ClimaAtmos
-const ca_dir = pkgdir(ClimaAtmos)
 using ClimaCore:
     Geometry, Meshes, Domains, Topologies, Spaces, Operators, InputOutput
 using NCDatasets
@@ -38,7 +37,7 @@ const ᶜinterp = Operators.InterpolateF2C()
 ext = ".hdf5"
 data_files = filter(x -> endswith(x, ext), readdir(data_dir, join = true))
 
-include(joinpath(ca_dir, "examples", "hybrid", "remap_helpers.jl"))
+include(joinpath(pkgdir(ClimaAtmos), "examples", "hybrid", "remap_helpers.jl"))
 
 function create_weightfile(filein, nc_dir, nlat, nlon)
     if split(filein, ".")[end] == "hdf5"
@@ -87,7 +86,7 @@ function remap2latlon(filein, nc_dir, weightfile, nlat, nlon)
     nc_rho = defVar(nc, "rho", FT, cspace, ("time",))
     thermo_var = if :ρe_tot in propertynames(Y.c)
         "e_tot"
-    elseif :ρθ
+    elseif :ρθ in propertynames(Y.c)
         "theta"
     else
         error("Unfound thermodynamic variable")


### PR DESCRIPTION
This PR:
 - Removes the `THERMO_VAR` environment variable from the remap pipeline
 - Inlines the use of `pkgdir` (to remove the constant) in the remap pipeline

This is a peel off from #1055.