### PR TITLE
Add process filename for allocs table in lr dir

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -63,6 +63,7 @@ for clio in cli_options
         process_filename = function process_fn(fn)
             fn = "ClimaAtmos.jl/" * last(split(fn, "climaatmos-ci/"))
             fn = last(split(fn, "depot/cpu/packages/"))
+            fn = "ClimaAtmos.jl/" * last(split(fn, "longruns/"))
             return fn
         end,
     )


### PR DESCRIPTION
This PR adds filename processing for the allocs table in the long runs pipeline.