### PR TITLE
Move hyperdiffusion into src

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -123,7 +123,7 @@ function additional_cache(Y, params, model_spec, dt; use_tempest_mode = false)
     end
 
     return merge(
-        hyperdiffusion_cache(
+        CA.hyperdiffusion_cache(
             Y,
             FT;
             κ₄ = FT(κ₄),
@@ -194,7 +194,7 @@ end
 
 function additional_tendency!(Yₜ, Y, p, t)
     (; viscous_sponge, hyperdiff) = p.tendency_knobs
-    hyperdiff && hyperdiffusion_tendency!(Yₜ, Y, p, t)
+    hyperdiff && CA.hyperdiffusion_tendency!(Yₜ, Y, p, t)
     viscous_sponge && CA.viscous_sponge_tendency!(Yₜ, Y, p, t)
 
     # Vertical tendencies

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -10,7 +10,6 @@ import Thermodynamics as TD
 using ClimaCore.Utilities: half
 
 include("schur_complement_W.jl")
-include("hyperdiffusion.jl")
 
 # Note: FT must be defined before `include("staggered_nonhydrostatic_model.jl")`
 

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -18,6 +18,7 @@ catch err
     end
 end
 
+import ClimaAtmos as CA
 import OrdinaryDiffEq as ODE
 import ClimaTimeSteppers as CTS
 ODE.step!(integrator) # compile first
@@ -46,7 +47,7 @@ trials["linsolve"] = get_trial(linsolve, (X, W, u), "linsolve");
 trials["implicit_tendency!"] = get_trial(f.f1, f1_args, "implicit_tendency!");
 trials["remaining_tendency!"] = get_trial(f.f2, f2_args, "remaining_tendency!");
 trials["additional_tendency!"] = get_trial(additional_tendency!, (X, u, p, t), "additional_tendency!");
-trials["hyperdiffusion_tendency!"] = get_trial(hyperdiffusion_tendency!, (X, u, p, t), "hyperdiffusion_tendency!");
+trials["hyperdiffusion_tendency!"] = get_trial(CA.hyperdiffusion_tendency!, (X, u, p, t), "hyperdiffusion_tendency!");
 trials["step!"] = get_trial(ODE.step!, (integrator, ), "step!");
 #! format: on
 

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -19,6 +19,7 @@ include(joinpath("tendencies", "forcing", "large_scale_advection.jl")) # TODO: s
 include(joinpath("tendencies", "forcing", "subsidence.jl"))
 include(joinpath("tendencies", "forcing", "held_suarez.jl"))
 
+include(joinpath("tendencies", "hyperdiffusion.jl"))
 include(joinpath("tendencies", "edmf_coriolis.jl"))
 include(joinpath("tendencies", "precipitation.jl"))
 include(joinpath("tendencies", "vertical_diffusion_boundary_layer.jl"))


### PR DESCRIPTION
This PR
 - moves the hyperdiffusion cache and tendencies into `src/tendencies/`
 - Comments out the `@nvtx` calls, as they cannot be easily moved into src yet
 - Removes closures over global constants