### PR TITLE
Remove non existent directory from alloc monitoring

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -16,7 +16,6 @@ dirs_to_monitor = [
     pkgdir(ClimaAtmos),
     example_dir,
     joinpath(example_dir, "hybrid"),
-    joinpath(example_dir, "hybrid", "sphere"),
     pkgdir(ClimaCore),
     pkgdir(SciMLBase),
     pkgdir(DiffEqBase),


### PR DESCRIPTION
This PR fixes the allocation monitoring (in the long runs) by removing a folder that no longer exists