### PR TITLE
Do not cache log_pressure_fun

### DIFF
--- a/src/ref_state.jl
+++ b/src/ref_state.jl
@@ -9,20 +9,6 @@ import ClimaCore.Spaces as Spaces
 import ClimaCore.Topologies as Topologies
 
 """
-    compute_ref_pressure!(p::Fields.ColumnField, logpressure_fun)
-
-Computes the hydrostatically balanced reference pressure, given
- - `logpressure_fun` a callable object by `logpressure_fun(z)`,
-    which returns the log of the pressure
- - `p` the air pressure field (output)
-"""
-function compute_ref_pressure!(p::Fields.ColumnField, logpressure_fun)
-    z = Fields.coordinate_field(axes(p)).z
-    @. p .= exp(logpressure_fun(z))
-    return nothing
-end
-
-"""
     compute_ref_density!(
         ρ::Fields.ColumnField,
         p::Fields.ColumnField,


### PR DESCRIPTION
This PR removes `log_pressure_fun` from the cache, and replaces it with two `ColumnField`s. This has two advantages:
 - It seems to reduce compile time for `OrdinaryDiffEq.init()` by ~30%, which is dominating the cost of some of the compressible examples (observed in a previous build, will keep an eye on this one.)
 - It alleviates the need for pressure BCs, since we can just evaluate the pressure solution at the surface
 - Storing the column field is cheaper than storing the entire field, and it's very possibly cheaper than saving the ODE solution.

cc @dennisYatunin 