### PR TITLE
Add function barrier to get_integrator

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -280,8 +280,10 @@ include("callbacks.jl")
 @time "get_callbacks" callback =
     get_callbacks(parsed_args, simulation, model_spec, params)
 tspan = (t_start, simulation.t_end)
+@time "args_integrator" integrator_args, integrator_kwargs =
+    args_integrator(parsed_args, Y, p, tspan, ode_config, callback)
 @time "get_integrator" integrator =
-    get_integrator(parsed_args, Y, p, tspan, ode_config, callback)
+    get_integrator(integrator_args, integrator_kwargs)
 
 if haskey(ENV, "CI_PERF_SKIP_RUN") # for performance analysis
     throw(:exit_profile)

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -329,7 +329,7 @@ function ode_configuration(Y, parsed_args, model_spec)
     return (; jac_kwargs, alg_kwargs, ode_algorithm)
 end
 
-function get_integrator(parsed_args, Y, p, tspan, ode_config, callback)
+function args_integrator(parsed_args, Y, p, tspan, ode_config, callback)
     (; jac_kwargs, alg_kwargs, ode_algorithm) = ode_config
     (; dt) = p.simulation
     FT = eltype(tspan)
@@ -377,7 +377,12 @@ function get_integrator(parsed_args, Y, p, tspan, ode_config, callback)
     else
         [tspan[1]:dt_save_to_sol:tspan[2]..., tspan[2]]
     end # ensure that tspan[2] is always saved
-    @time "Define integrator" integrator =
-        ODE.init(problem, ode_algo; saveat, callback, dt, integrator_kwargs...)
+    args = (problem, ode_algo)
+    kwargs = (; saveat, callback, dt, integrator_kwargs...)
+    return (args, kwargs)
+end
+
+function get_integrator(args, kwargs)
+    @time "Define integrator" integrator = ODE.init(args...; kwargs...)
     return integrator
 end


### PR DESCRIPTION
This PR adds a function barrier to `get_integrator`, in order to force inference before `get_integrator` is called.