### PR TITLE
Add AtmosModel type and print summary

### DIFF
--- a/examples/hybrid/initial_conditions.jl
+++ b/examples/hybrid/initial_conditions.jl
@@ -8,10 +8,10 @@ function init_state(
     center_space,
     face_space,
     params,
-    model_spec,
+    atmos,
+    perturb_initstate,
 )
-    (; energy_form, perturb_initstate, moisture_model, turbconv_model) =
-        model_spec
+    (; energy_form, moisture_model, turbconv_model) = atmos
     ᶜlocal_geometry = Fields.local_geometry_field(center_space)
     ᶠlocal_geometry = Fields.local_geometry_field(face_space)
     c =
@@ -19,9 +19,9 @@ function init_state(
             ᶜlocal_geometry,
             params,
             energy_form,
-            perturb_initstate,
             moisture_model,
             turbconv_model,
+            perturb_initstate,
         )
     f = face_initial_condition.(ᶠlocal_geometry, params, turbconv_model)
     Y = Fields.FieldVector(; c, f)

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -68,12 +68,20 @@ const ᶠfct_zalesak = Operators.FCTZalesak(
 
 const C123 = Geometry.Covariant123Vector
 
-get_cache(Y, params, spaces, model_spec, numerics, simulation) = merge(
-    default_cache(Y, params, model_spec, spaces, numerics, simulation),
-    additional_cache(Y, params, model_spec, simulation.dt),
+get_cache(Y, parsed_args, params, spaces, atmos, numerics, simulation) = merge(
+    default_cache(Y, parsed_args, params, atmos, spaces, numerics, simulation),
+    additional_cache(Y, parsed_args, params, atmos, simulation.dt),
 )
 
-function default_cache(Y, params, model_spec, spaces, numerics, simulation)
+function default_cache(
+    Y,
+    parsed_args,
+    params,
+    atmos,
+    spaces,
+    numerics,
+    simulation,
+)
     (; energy_upwinding, tracer_upwinding, apply_limiter) = numerics
     ᶜcoord = Fields.local_geometry_field(Y.c).coordinates
     ᶠcoord = Fields.local_geometry_field(Y.f).coordinates
@@ -134,8 +142,8 @@ function default_cache(Y, params, model_spec, spaces, numerics, simulation)
             ᶠfct_zalesak,
         ),
         spaces,
-        moisture_model = model_spec.moisture_model,
-        model_config = model_spec.model_config,
+        moisture_model = atmos.moisture_model,
+        model_config = atmos.model_config,
         Yₜ = similar(Y), # only needed when using increment formulation
         limiters,
         ᶜρh_kwargs...,

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -49,18 +49,18 @@ trials["hyperdiffusion_tendency!"] = get_trial(CA.hyperdiffusion_tendency!, (X, 
 trials["step!"] = get_trial(ODE.step!, (integrator, ), "step!");
 #! format: on
 
-summary = OrderedCollections.OrderedDict()
+table_summary = OrderedCollections.OrderedDict()
 for k in keys(trials)
-    summary[k] = get_summary(trials[k])
+    table_summary[k] = get_summary(trials[k])
 end
-tabulate_summary(summary)
+tabulate_summary(table_summary)
 
 if get(ENV, "BUILDKITE", "") == "true"
-    # Export summary
+    # Export table_summary
     import JSON
     job_id = parsed_args["job_id"]
     path = ca_dir
     open(joinpath(path, "perf_benchmark_$job_id.json"), "w") do io
-        JSON.print(io, summary)
+        JSON.print(io, table_summary)
     end
 end

--- a/post_processing/post_processing_funcs.jl
+++ b/post_processing/post_processing_funcs.jl
@@ -184,11 +184,8 @@ end
 
 # Dispatcher:
 # baroclinic wave
-paperplots_baro_wave(model_spec, args...) = paperplots_baro_wave(
-    model_spec.energy_form,
-    model_spec.moisture_model,
-    args...,
-)
+paperplots_baro_wave(atmos, args...) =
+    paperplots_baro_wave(atmos.energy_form, atmos.moisture_model, args...)
 
 paperplots_baro_wave(::PotentialTemperature, ::DryModel, args...) =
     paperplots_dry_baro_wave(args...)
@@ -198,11 +195,8 @@ paperplots_baro_wave(::TotalEnergy, ::EquilMoistModel, args...) =
     paperplots_moist_baro_wave_ρe(args...)
 
 # held-suarez
-paperplots_held_suarez(model_spec, args...) = paperplots_held_suarez(
-    model_spec.energy_form,
-    model_spec.moisture_model,
-    args...,
-)
+paperplots_held_suarez(atmos, args...) =
+    paperplots_held_suarez(atmos.energy_form, atmos.moisture_model, args...)
 
 paperplots_held_suarez(::PotentialTemperature, ::DryModel, args...) =
     paperplots_dry_held_suarez(args...)

--- a/src/InitialConditions/baro_wave.jl
+++ b/src/InitialConditions/baro_wave.jl
@@ -6,9 +6,9 @@ function center_initial_condition_baroclinic_wave(
     local_geometry,
     params,
     energy_form,
-    perturb_initstate,
     moisture_model,
-    turbconv_model;
+    turbconv_model,
+    perturb_initstate,
 )
 
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/InitialConditions/box.jl
+++ b/src/InitialConditions/box.jl
@@ -6,9 +6,9 @@ function center_initial_condition_box(
     local_geometry,
     params,
     energy_form,
-    perturb_initstate,
     moisture_model,
-    turbconv_model;
+    turbconv_model,
+    perturb_initstate,
 )
 
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/InitialConditions/single_column.jl
+++ b/src/InitialConditions/single_column.jl
@@ -6,9 +6,9 @@ function center_initial_condition_column(
     local_geometry,
     params,
     energy_form,
-    perturb_initstate,
     moisture_model,
     turbconv_model,
+    perturb_initstate,
 )
     thermo_params = CAP.thermodynamics_params(params)
     z = local_geometry.coordinates.z

--- a/src/InitialConditions/sphere.jl
+++ b/src/InitialConditions/sphere.jl
@@ -6,9 +6,9 @@ function center_initial_condition_3d(
     local_geometry,
     params,
     energy_form,
-    perturb_initstate,
     moisture_model,
-    turbconv_model;
+    turbconv_model,
+    perturb_initstate,
 )
 
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/RRTMGPInterface.jl
+++ b/src/RRTMGPInterface.jl
@@ -93,10 +93,18 @@ parent_array_type(::Type{<:Base.ReshapedArray{T, N, P}}) where {T, N, P} =
     parent_array_type(P)
 
 abstract type AbstractRRTMGPMode end
-struct GrayRadiation <: AbstractRRTMGPMode end
-struct ClearSkyRadiation <: AbstractRRTMGPMode end
-struct AllSkyRadiation <: AbstractRRTMGPMode end
-struct AllSkyRadiationWithClearSkyDiagnostics <: AbstractRRTMGPMode end
+struct GrayRadiation <: AbstractRRTMGPMode
+    idealized_h2o::Bool
+end
+struct ClearSkyRadiation <: AbstractRRTMGPMode
+    idealized_h2o::Bool
+end
+struct AllSkyRadiation <: AbstractRRTMGPMode
+    idealized_h2o::Bool
+end
+struct AllSkyRadiationWithClearSkyDiagnostics <: AbstractRRTMGPMode
+    idealized_h2o::Bool
+end
 
 """
     abstract type AbstractInterpolation

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -48,6 +48,8 @@ function compressibility_model(parsed_args)
 end
 
 function radiation_mode(parsed_args, ::Type{FT}) where {FT}
+    idealized_h2o = parsed_args["idealized_h2o"]
+    @assert idealized_h2o in (true, false)
     radiation_name = parsed_args["rad"]
     @assert radiation_name in (
         nothing,
@@ -59,13 +61,13 @@ function radiation_mode(parsed_args, ::Type{FT}) where {FT}
         "TRMM_LBA",
     )
     return if radiation_name == "clearsky"
-        RRTMGPI.ClearSkyRadiation()
+        RRTMGPI.ClearSkyRadiation(idealized_h2o)
     elseif radiation_name == "gray"
-        RRTMGPI.GrayRadiation()
+        RRTMGPI.GrayRadiation(idealized_h2o)
     elseif radiation_name == "allsky"
-        RRTMGPI.AllSkyRadiation()
+        RRTMGPI.AllSkyRadiation(idealized_h2o)
     elseif radiation_name == "allskywithclear"
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics()
+        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics(idealized_h2o)
     elseif radiation_name == "DYCOMS_RF01"
         RadiationDYCOMS_RF01{FT}()
     elseif radiation_name == "TRMM_LBA"
@@ -210,13 +212,13 @@ function surface_scheme(FT, parsed_args)
 end
 
 """
-    ThermoDispatcher(model_spec)
+    ThermoDispatcher(atmos)
 
 A helper method for creating a thermodynamics dispatcher
 from the model specification struct.
 """
-function ThermoDispatcher(model_spec)
-    (; energy_form, moisture_model, compressibility_model) = model_spec
+function ThermoDispatcher(atmos)
+    (; energy_form, moisture_model, compressibility_model) = atmos
     return ThermoDispatcher(;
         energy_form,
         moisture_model,

--- a/src/tendencies/radiation.jl
+++ b/src/tendencies/radiation.jl
@@ -36,12 +36,12 @@ function radiation_model_cache(
     interpolation = RRTMGPI.BestFit(),
     bottom_extrapolation = RRTMGPI.SameAsInterpolation(),
     idealized_insolation = true,
-    idealized_h2o = false,
     idealized_clouds = false,
     thermo_dispatcher,
     data_loader,
     ᶜinterp,
 )
+    (; idealized_h2o) = radiation_mode
     FT = Spaces.undertype(axes(Y.c))
     rrtmgp_params = CAP.rrtmgp_params(params)
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/types.jl
+++ b/src/types.jl
@@ -81,3 +81,51 @@ Base.@kwdef struct ThermoDispatcher{EF, MM, CM}
     compressibility_model::CM
 end
 Base.broadcastable(x::ThermoDispatcher) = Ref(x)
+
+
+Base.@kwdef struct AtmosModel{MC, MM, EF, PM, F, S, RM, LA, EC, TCM, CM, SS, GW}
+    model_config::MC = nothing
+    moisture_model::MM = nothing
+    energy_form::EF = nothing
+    precip_model::PM = nothing
+    forcing_type::F = nothing
+    subsidence::S = nothing
+    radiation_mode::RM = nothing
+    ls_adv::LA = nothing
+    edmf_coriolis::EC = nothing
+    turbconv_model::TCM = nothing
+    compressibility_model::CM = nothing
+    surface_scheme::SS = nothing
+    non_orographic_gravity_wave::GW = nothing
+end
+
+function Base.summary(io::IO, atmos::AtmosModel)
+    pns = string.(propertynames(atmos))
+    buf = maximum(length.(pns))
+    keys = propertynames(atmos)
+    vals = repeat.(" ", map(s -> buf - length(s) + 2, pns))
+    bufs = (; zip(keys, vals)...)
+    print(io, '\n')
+    for pn in propertynames(atmos)
+        prop = getproperty(atmos, pn)
+        # Skip some data:
+        prop isa Bool && continue
+        prop isa NTuple && continue
+        prop isa Int && continue
+        prop isa Float64 && continue
+        prop isa Float32 && continue
+        s = string(
+            "  ", # needed for some reason
+            getproperty(bufs, pn),
+            '`',
+            string(pn),
+            '`',
+            "::",
+            '`',
+            typeof(prop),
+            '`',
+            '\n',
+        )
+        print(io, s)
+    end
+end


### PR DESCRIPTION
This PR:
 - Adds an `AtmosModel` type, to replace the `model_spec` `NamedTuple`
 - Defines `Base.summary` for `AtmosModel`, so that we have a better picture of the model at start up, now that some of the tendency knobs have been removed in favor of using dispatch.

We still need to add more properties to `AtmosModel`, in particular:

 - `viscous_sponge`
 - `hyperdiff`
 - `rayleigh_sponge`
 - `vert_diff`
 - `coupled_type` (type to add)
 - `non_orographic_gravity_wave`
