### PR TITLE
Add contour diagnostic plots for single column config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -310,62 +310,62 @@ steps:
     steps:
 
       - label: ":balloon: Single column EDMF Bomex"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex --dt 6secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex --dt 6secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "edmf_bomex/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF Bomex (Newton's method)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id compressible_edmf_bomex --dt 40secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id compressible_edmf_bomex --dt 40secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "compressible_edmf_bomex/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF Bomex (JFNK)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --use_krylov_method true --job_id compressible_edmf_bomex_jfnk --quicklook_reference_job_id compressible_edmf_bomex --dt 40secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --use_krylov_method true --job_id compressible_edmf_bomex_jfnk --quicklook_reference_job_id compressible_edmf_bomex --dt 40secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "compressible_edmf_bomex_jfnk/*"
         soft_fail: true
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --edmf_coriolis DYCOMS_RF01 --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --edmf_coriolis DYCOMS_RF01 --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 2mins"
         artifact_paths: "edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compresible single column EDMF DYCOMS_RF01"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --edmf_coriolis DYCOMS_RF01 --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 4hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence DYCOMS --edmf_coriolis DYCOMS_RF01 --rad DYCOMS_RF01 --turbconv edmf --turbconv_case DYCOMS_RF01 --dt_save_to_sol 5mins --z_elem 30 --z_stretch false --z_max 1500 --job_id compressible_edmf_dycoms_rf01 --dt 6secs --t_end 4hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 2mins"
         artifact_paths: "compressible_edmf_dycoms_rf01/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --dt_save_to_disk 3hours --z_elem 82 --z_stretch false --z_max 16400 --job_id edmf_trmm --dt 1secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --dt_save_to_disk 3hours --z_elem 82 --z_stretch false --z_max 16400 --job_id edmf_trmm --dt 1secs --t_end 6hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "edmf_trmm/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --dt_save_to_sol 5mins --z_elem 82 --z_stretch false --z_max 16400 --rayleigh_sponge true --zd_rayleigh 15000 --job_id compressible_edmf_trmm --dt 0.1secs --t_end 1hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 1hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --dt_save_to_sol 5mins --z_elem 82 --z_stretch false --z_max 16400 --rayleigh_sponge true --zd_rayleigh 15000 --job_id compressible_edmf_trmm --dt 0.1secs --t_end 1hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 1mins"
         artifact_paths: "compressible_edmf_trmm/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF GABLS"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id edmf_gabls --dt 4secs --t_end 9hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 9hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id edmf_gabls --dt 4secs --t_end 9hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "edmf_gabls/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":balloon: Compressible single column EDMF GABLS"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id compressible_edmf_gabls --dt 4secs --t_end 9hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 9hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id compressible_edmf_gabls --dt 4secs --t_end 9hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "compressible_edmf_gabls/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":dart: EDMF Consistency test Bomex"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex_consistency --dt 6secs --t_end 6hours --anelastic_dycore true --apply_limiter false --test_edmf_consistency true --debugging_tc true --dt_save_to_disk 6hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --job_id edmf_bomex_consistency --dt 6secs --t_end 6hours --anelastic_dycore true --apply_limiter false --test_edmf_consistency true --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "edmf_bomex_consistency/*"
         agents:
           slurm_mem: 20GB

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -398,3 +398,27 @@ if parsed_args["regression_test"]
         simulation.output_dir,
     )
 end
+
+# Zip and clean up output
+if atmos.model_config isa CA.SingleColumnModel
+    try
+        files = filter(
+            x -> endswith(x, ".hdf5"),
+            readdir(simulation.output_dir, join = true),
+        )
+        files = basename.(files)
+        cd(simulation.output_dir) do
+            run(
+                pipeline(
+                    Cmd(["zip", "hdf5files", files...]),
+                    stdout = IOBuffer(),
+                ),
+            )
+            for f in files
+                rm(f)
+            end
+        end
+    catch
+        @warn "Failed to zip hdf5 files."
+    end
+end

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -332,15 +332,11 @@ if !simulation.is_distributed && parsed_args["post_process"]
     ENV["GKSwstype"] = "nul" # avoid displaying plots
     if is_baro_wave(parsed_args)
         paperplots_baro_wave(atmos, sol, simulation.output_dir, p, 90, 180)
-    elseif is_column_without_edmf(parsed_args)
-        custom_postprocessing(sol, simulation.output_dir, p)
-    elseif is_column_edmf(parsed_args)
-        postprocessing_edmf(sol, simulation.output_dir, fps)
     elseif is_solid_body(parsed_args)
         postprocessing(sol, simulation.output_dir, fps)
     elseif is_box(parsed_args)
         postprocessing_box(sol, simulation.output_dir)
-    else
+    elseif atmos.forcing_type isa CA.HeldSuarezForcing
         paperplots_held_suarez(atmos, sol, simulation.output_dir, p, 90, 180)
     end
 end
@@ -371,6 +367,12 @@ if parsed_args["debugging_tc"]
 
     day = floor(Int, simulation.t_end / (60 * 60 * 24))
     sec = floor(Int, simulation.t_end % (60 * 60 * 24))
+
+    plot_tc_contours(
+        simulation.output_dir;
+        main_branch_data_path,
+        name_match = simulation.job_id,
+    )
     plot_tc_profiles(
         simulation.output_dir;
         hdf5_filename = "day$day.$sec.hdf5",

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -16,6 +16,32 @@ is_tracer_var(symbol) = !(
 # https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
 fast_pow(x::FT, y::FT) where {FT <: AbstractFloat} = exp(y * log(x))
 
+"""
+    time_from_filename(file)
+
+Returns the time (Float64) from a given filename
+
+## Example
+```
+time_from_filename("day4.46906.hdf5")
+392506.0
+```
+"""
+function time_from_filename(file)
+    arr = split(basename(file), ".")
+    day = parse(Float64, replace(arr[1], "day" => ""))
+    sec = parse(Float64, arr[2])
+    return day * (60 * 60 * 24) + sec
+end
+
+"""
+    sort_files_by_time(files)
+
+Sorts an array of files by the time,
+determined by the filename.
+"""
+sort_files_by_time(files) =
+    permute!(files, sortperm(time_from_filename.(files)))
 
 #####
 ##### State debugging tools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using SafeTestsets
 using Test
 
 @safetestset "Aqua" begin
+    @time include("utilities.jl")
     @time include("aqua.jl")
 end
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,0 +1,14 @@
+using Test
+import ClimaAtmos as CA
+
+@testset "sort_hdf5_files" begin
+    day_sec(t) =
+        (floor(Int, t / (60 * 60 * 24)), floor(Int, t % (60 * 60 * 24)))
+    filenames(d, s) = "day$d.$s.hdf5"
+    filenames(t) = filenames(day_sec(t)...)
+    t = map(i -> rand(1:(10^6)), 1:100)
+    t_sorted = sort(t)
+    fns = filenames.(t)
+    sort!(fns)
+    @test CA.sort_files_by_time(fns) == filenames.(t_sorted)
+end


### PR DESCRIPTION
This PR
 - Adds contour diagnostic plots for single column configurations, when using `debugging_tc`.
 - Increases the frequency at which diagnostics are exported when `debugging_tc == true`
 - Zips the `.hdf5` files so that the artifacts path isn't too cluttered

Closes #654.