### PR TITLE
Make the JFNK job soft-fail

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -324,6 +324,7 @@ steps:
       - label: ":balloon: Compressible single column EDMF Bomex (JFNK)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --use_krylov_method true --job_id compressible_edmf_bomex_jfnk --quicklook_reference_job_id compressible_edmf_bomex --dt 40secs --t_end 6hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 6hours"
         artifact_paths: "compressible_edmf_bomex_jfnk/*"
+        soft_fail: true
         agents:
           slurm_mem: 20GB
 


### PR DESCRIPTION
This PR makes the JFNK job soft-fail, so that we can merge things as we try to investigate why it's not reproducible. Related issue: #1098.