### PR TITLE
Refactor surface

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -20,7 +20,6 @@ fps = parsed_args["fps"]
 idealized_insolation = parsed_args["idealized_insolation"]
 idealized_clouds = parsed_args["idealized_clouds"]
 vert_diff = parsed_args["vert_diff"]
-coupled = parsed_args["coupled"]
 hyperdiff = parsed_args["hyperdiff"]
 disable_qt_hyperdiffusion = parsed_args["disable_qt_hyperdiffusion"]
 turbconv = parsed_args["turbconv"]
@@ -165,7 +164,7 @@ function additional_cache(
             atmos.surface_scheme,
             C_E = FT(parsed_args["C_E"]),
             diffuse_momentum,
-            coupled,
+            atmos.coupling,
         ) : NamedTuple(),
         atmos.non_orographic_gravity_wave ?
         CA.gravity_wave_cache(atmos.model_config, Y, FT) : NamedTuple(),
@@ -207,8 +206,7 @@ function additional_tendency!(Yₜ, Y, p, t)
         CA.edmf_coriolis_tendency!(Yₜ, Y, p, t, colidx, p.edmf_coriolis)
         CA.large_scale_advection_tendency!(Yₜ, Y, p, t, colidx, p.ls_adv)
         if vert_diff
-            (; coupled) = p
-            !coupled && CA.get_surface_fluxes!(Y, p, colidx)
+            CA.get_surface_fluxes!(Y, p, colidx, p.atmos.coupling)
             CA.vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, colidx)
         end
         CA.precipitation_tendency!(Yₜ, Y, p, t, colidx, p.precip_model)

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -142,6 +142,7 @@ function default_cache(
             ᶠfct_zalesak,
         ),
         spaces,
+        atmos,
         moisture_model = atmos.moisture_model,
         model_config = atmos.model_config,
         Yₜ = similar(Y), # only needed when using increment formulation

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -35,6 +35,7 @@ function get_atmos(::Type{FT}, parsed_args, namelist) where {FT}
     atmos = CA.AtmosModel(;
         moisture_model,
         model_config = CA.model_config(parsed_args),
+        coupling = CA.coupling_type(parsed_args),
         energy_form = CA.energy_form(parsed_args),
         radiation_mode,
         subsidence = CA.subsidence_model(parsed_args, radiation_mode, FT),

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -21,6 +21,17 @@ function model_config(parsed_args)
     end
 end
 
+function coupling_type(parsed_args)
+    coupled = parsed_args["coupled"]
+    return if coupled == true
+        Coupled()
+    elseif coupled == false
+        Decoupled()
+    else
+        error("Uncaught coupled type.")
+    end
+end
+
 function energy_form(parsed_args)
     energy_name = parsed_args["energy_name"]
     @assert energy_name in ("rhoe", "rhoe_int", "rhotheta")

--- a/src/thermo_state.jl
+++ b/src/thermo_state.jl
@@ -19,6 +19,18 @@ function thermo_state_type(Yc::Fields.Field, ::Type{FT}) where {FT}
     end
 end
 
+# TODO: replace with zero(thermo_state_type) when supported
+function thermo_state_instance(Yc::Fields.Field, ::Type{FT}) where {FT}
+    pns = propertynames(Yc)
+    return if (:ρq_liq in pns && :ρq_ice in pns && :ρq_tot in pns)
+        TD.PhaseNonEquil{FT}(0, 0, TD.PhasePartition(FT(0), FT(0), FT(0)))
+    elseif :ρq_tot in pns
+        TD.PhaseEquil{FT}(0, 0, 0, 0, 0)
+    else
+        TD.PhaseDry{FT}(0, 0)
+    end
+end
+
 #= High-level wrapper =#
 function thermo_state!(Y::Fields.FieldVector, p, ᶜinterp, colidx)
     ᶜts = p.ᶜts[colidx]

--- a/src/types.jl
+++ b/src/types.jl
@@ -22,6 +22,10 @@ struct SingleColumnModel <: AbstractModelConfig end
 struct SphericalModel <: AbstractModelConfig end
 struct BoxModel <: AbstractModelConfig end
 
+abstract type AbstractCoupling end
+struct Coupled <: AbstractCoupling end
+struct Decoupled <: AbstractCoupling end
+
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
 struct Subsidence{T} <: AbstractForcing
@@ -83,8 +87,24 @@ end
 Base.broadcastable(x::ThermoDispatcher) = Ref(x)
 
 
-Base.@kwdef struct AtmosModel{MC, MM, EF, PM, F, S, RM, LA, EC, TCM, CM, SS, GW}
+Base.@kwdef struct AtmosModel{
+    MC,
+    C,
+    MM,
+    EF,
+    PM,
+    F,
+    S,
+    RM,
+    LA,
+    EC,
+    TCM,
+    CM,
+    SS,
+    GW,
+}
     model_config::MC = nothing
+    coupling::C = nothing
     moisture_model::MM = nothing
     energy_form::EF = nothing
     precip_model::PM = nothing


### PR DESCRIPTION
This PR refactors the surface handling in several ways:
 - Caches the surface fluxes object, so it can later be used by the edmf model
 - Caches the surface fluxes inputs, so that we can more simply dispatch
 - Changes (maybe fixes) `get_surface_density_and_humidity` to be mutating (now `set_surface_density_and_humidity!`) cc @szy21, @LenkaNovak, maybe we can discuss this change?
 - I've kept `surface_conditions` for now, just to minimize the blast radius, but I'd like to remove that since it's basically directly dependent on `SurfaceFluxConditions` and the surface flux input types (depending on which one is used)

Ultimately, this should allow us to delete nearly all of edmf's `get_surface` function, and just accept the already created `SurfaceFluxConditions`.

EDIT:

 - I also replaced the `coupled` Bool with a `coupling` type because I was trying to hunt down allocations in one of the broadcast expressions. I think it turned out to be that the nested thermo state and surface fluxes input expression was a bit too complex for the compiler to infer, and things started working smoothly when that was broken up. I didn't revert the coupling type because I figure that it's not a bad idea to do that anyway, since it will yield more precise generated code than the runtime Bool.