### PR TITLE
Postprocessing: Add integrated 1d KE spectra plots

### DIFF
--- a/post_processing/post_processing_funcs.jl
+++ b/post_processing/post_processing_funcs.jl
@@ -618,6 +618,36 @@ function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
                 "bw-2dspectrum1500-day" * string(day) * ".png",
             ),
         )
+        plot_spectrum_n_integrated = Plots.plot(
+            collect(0:1:(mesh_info.num_fourier))[:], # plot against the zonal wavenumber, m
+            sum(spectrum_2d[:, :, 1], dims = 2), # sum along the total wavenumber, n
+            xlabel = "zonal wavenumber (m)",
+            ylabel = "KE spectrum",
+            color = :balance,
+            title = "zonal wavenumber KE spectrum (1500m) day " * string(day),
+        )
+        png(
+            plot_spectrum_n_integrated,
+            joinpath(
+                output_dir,
+                "bw-n_integrated_ke_spectrum1500-day" * string(day) * ".png",
+            ),
+        )
+        plot_spectrum_m_integrated = Plots.plot(
+            collect(0:1:(mesh_info.num_spherical))[:], # plot against the total wavenumber, n
+            (sum(spectrum_2d[:, :, 1], dims = 1))', # sum along the zonal wavenumber, m
+            xlabel = "total wavenumber (n)",
+            ylabel = "KE spectrum",
+            color = :balance,
+            title = "total wavenumber KE spectrum (1500m) day " * string(day),
+        )
+        png(
+            plot_spectrum_m_integrated,
+            joinpath(
+                output_dir,
+                "bw-m_integrated_ke_spectrum1500-day" * string(day) * ".png",
+            ),
+        )
 
         rm(datafile_latlon; force = true)
     end


### PR DESCRIPTION
## Purpose 
This PR adds another way of visualizing the KE spectra. It is a follow-up of PR #1014 

Closes #1121 

## To-do

- Proposed task
Add KE spectra plots, where KE is a function of only the total or the zonal wave number, e.g., KE=KE(n) and KE=KE(m), by integrating the dependency on other component.


## Content

- Solution implemented

The two plots were added to the same example where the KE spectra calculator was added before, i.e., in the `moist_baro_wave_ρe` example. 

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
