### PR TITLE
Refactor surface functions

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -298,10 +298,10 @@ function save_to_disk_func(integrator)
             col_integrated_rain,
             col_integrated_snow,
             T_sfc,
-            q_sfc,
+            ts_sfc,
         ) = p
     else
-        (; ᶜts, ᶜp, params, ᶜK, T_sfc, q_sfc) = p
+        (; ᶜts, ᶜp, params, ᶜK, T_sfc, ts_sfc) = p
     end
 
     thermo_params = CAP.thermodynamics_params(params)
@@ -323,6 +323,7 @@ function save_to_disk_func(integrator)
     ᶜvort = Geometry.WVector.(curl_uh)
     Spaces.weighted_dss!(ᶜvort)
 
+    q_sfc = @. TD.total_specific_humidity(thermo_params, ts_sfc)
     dry_diagnostic = (;
         pressure = ᶜp,
         temperature = ᶜT,

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -163,8 +163,7 @@ function default_cache(
         ᶜf,
         z_sfc,
         T_sfc,
-        ρ_sfc = similar(T_sfc, FT),
-        q_sfc = similar(T_sfc, FT),
+        ts_sfc = similar(Spaces.level(Y.f, half), ts_type),
         ∂ᶜK∂ᶠw_data = similar(
             Y.c,
             Operators.StencilCoefs{-half, half, NTuple{2, FT}},


### PR DESCRIPTION
This PR:
 - Refactors the surface functions by changing `set_surface_density_and_humidity!` to `set_surface_thermo_state!`, which we can use to dispatch between the GCM case vs a prescribed surface thermo state case (of which there are many for the TC SCM examples)
 - Removes `q_sfc` and `ρ_sfc` from the cache, since we can just store the surface thermo state instead.

This does add allocations to the diagnostics callback, but I've been thinking that it may be nice to split out the cache into solver vs diagnostics cache so that we can somehow ensure that computing diagnostics doesn't impact the solve.

Maybe these changes will slightly impact how we interact with the coupler? cc-ing @LenkaNovak 