### PR TITLE
add mass and energy conservation check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -250,6 +250,10 @@ steps:
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs"
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
+      
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist check conservation float64"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64 --check_conservation true --FLOAT_TYPE Float64 --dt 450secs"
+        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64/*"
 
       - label: ":computer: held suarez (ρe_tot)"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --forcing held_suarez --job_id sphere_held_suarez_rhoe --regression_test true --t_end 30days --dt 500secs"

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -294,6 +294,10 @@ function parse_commandline()
         help = "Test dycore consistency [`false` (default), `true`]"
         arg_type = Bool
         default = false
+        "--check_conservation"
+        help = "Check conservation of mass and energy [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--non_orographic_gravity_wave"
         help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow"
         arg_type = Bool

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -398,3 +398,10 @@ if parsed_args["regression_test"]
         simulation.output_dir,
     )
 end
+
+if parsed_args["check_conservation"]
+    @test sum(sol.u[1].c.ρ) ≈ sum(sol.u[end].c.ρ) rtol = 10 * eps(FT)
+    @test sum(sol.u[1].c.ρe_tot) +
+          (p.net_energy_flux_sfc[][] - p.net_energy_flux_toa[][]) ≈
+          sum(sol.u[end].c.ρe_tot) rtol = 10 * eps(FT)
+end

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -123,6 +123,11 @@ function default_cache(
     ᶜρh_kwargs =
         :ρe_tot in pnc || :ρe_int in pnc ? (; ᶜρh = similar(Y.c, FT)) : ()
 
+    net_energy_flux_toa = [sum(similar(Y.f, Geometry.WVector{FT})) * 0]
+    net_energy_flux_toa[] = Geometry.WVector(FT(0))
+    net_energy_flux_sfc = [sum(similar(Y.f, Geometry.WVector{FT})) * 0]
+    net_energy_flux_sfc[] = Geometry.WVector(FT(0))
+
     return (;
         simulation,
         operators = (;
@@ -172,6 +177,8 @@ function default_cache(
         energy_upwinding,
         tracer_upwinding,
         ghost_buffer = ghost_buffer,
+        net_energy_flux_toa,
+        net_energy_flux_sfc,
     )
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Partially addresses #1079. Right now it only works when radiation is the only external tendency, as all other external tendencies change within one timestep. @simonbyrne suggests that a better way is to add some state variables to accumulate fluxes. I still would like to merge this in as a temporary solution though, as I think it would be good to make sure we are conserving mass and energy in ci.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
