### PR TITLE
Remove condition for computing ustar

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -258,6 +258,8 @@ steps:
       - label: ":computer: held suarez (ρe_tot) equilmoist"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --job_id sphere_held_suarez_rhoe_equilmoist --regression_test true --dt 450secs"
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky radiation monin_obukhov"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --job_id sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 400secs --t_end 5days"

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -66,7 +66,7 @@ function get_surface(
     return TC.SurfaceBase{FT}(;
         shf = shf,
         lhf = lhf,
-        ustar = TC.fixed_ustar(surf_params) ? surf_params.ustar : result.ustar,
+        ustar = result.ustar,
         bflux = bflux,
         obukhov_length = result.L_MO,
         cm = result.Cd,


### PR DESCRIPTION
This PR removes a conditional for deciding how `ustar` is populated in `SurfaceBase`. This should be a no-op because `ustar` is passed into SurfaceFluxes if `TC.fixed_ustar(surf_params)`, so we should be able to recover it by consistency.