### PR TITLE
Remove zeroing out of momentum fluxes

### DIFF
--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -254,7 +254,6 @@ Base.@kwdef struct FixedSurfaceFlux{
     cq::FT = FT(0)
     Ri_bulk_crit::FT = FT(0)
     ustar::FT = FT(0)
-    zero_uv_fluxes::Bool = false
 end
 
 function FixedSurfaceFlux(

--- a/src/tendencies/vertical_diffusion_boundary_layer.jl
+++ b/src/tendencies/vertical_diffusion_boundary_layer.jl
@@ -40,7 +40,6 @@ function vertical_diffusion_boundary_layer_cache(
         Ref(Geometry.WVector(FT(0)))
     end
 
-    cond_type = NamedTuple{(:shf, :lhf, :E, :ρτxz, :ρτyz), NTuple{5, FT}}
     surface_normal = Geometry.WVector.(ones(axes(Fields.level(Y.c, 1))))
 
     sfc_conditions =

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -626,15 +626,7 @@ function surface_params(
                 0,
                 cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)),
             )^FT(1.5)
-    kwargs = (;
-        Tsurface,
-        qsurface,
-        shf,
-        lhf,
-        ustar,
-        Ri_bulk_crit,
-        zero_uv_fluxes = true,
-    )
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
 end
 
@@ -720,15 +712,7 @@ function surface_params(
     shf = Dierckx.Spline1D(t_Sur_in, SH; k = 1)
     lhf = Dierckx.Spline1D(t_Sur_in, LH; k = 1)
 
-    kwargs = (;
-        Tsurface,
-        qsurface,
-        shf,
-        lhf,
-        ustar,
-        Ri_bulk_crit,
-        zero_uv_fluxes = true,
-    )
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
 end
 

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -71,8 +71,8 @@ function get_surface(
         obukhov_length = result.L_MO,
         cm = result.Cd,
         ch = result.Ch,
-        ρu_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτxz,
-        ρv_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτyz,
+        ρu_flux = result.ρτxz,
+        ρv_flux = result.ρτyz,
         ρe_tot_flux = shf + lhf,
         ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
     )


### PR DESCRIPTION
This PR attempts to remove the zero-ing out of momentum fluxes, as this is inconsistent with how momentum fluxes are determined in SurfaceFluxes.

The only reason why I think this could have been done intentionally is because these fluxes are used as BCs in the momentum SGS fluxes, and maybe this is done to somehow avoid double counting?

Either way it'll be interesting to see what happens if we don't zero them out