### PR TITLE
Refactor surface

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -60,6 +60,10 @@ function parse_commandline()
         "--surface_scheme"
         help = "Surface flux scheme [`nothing` (default), `bulk`, `monin_obukhov`]"
         arg_type = String
+        "--surface_thermo_state_type"
+        help = "Surface thermo state type [`GCMSurfaceThermoState` (default), `PrescribedThermoState`]"
+        arg_type = String
+        default = "GCMSurfaceThermoState"
         "--C_E"
         help = "Bulk transfer coefficient"
         arg_type = Float64

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -206,7 +206,7 @@ function additional_tendency!(Yₜ, Y, p, t)
         CA.edmf_coriolis_tendency!(Yₜ, Y, p, t, colidx, p.edmf_coriolis)
         CA.large_scale_advection_tendency!(Yₜ, Y, p, t, colidx, p.ls_adv)
         if vert_diff
-            CA.get_surface_fluxes!(Y, p, colidx, p.atmos.coupling)
+            CA.get_surface_fluxes!(Y, p, t, colidx, p.atmos.coupling)
             CA.vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, colidx)
         end
         CA.radiation_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -210,13 +210,21 @@ function turbconv_model(FT, moisture_model, precip_model, parsed_args, namelist)
     end
 end
 
+function surface_thermo_state_type(parsed_args)
+    dict = Dict()
+    dict["GCMSurfaceThermoState"] = GCMSurfaceThermoState()
+    return dict[parsed_args["surface_thermo_state_type"]]
+end
+
+
 function surface_scheme(FT, parsed_args)
     surface_scheme = parsed_args["surface_scheme"]
+    sfc_thermo_state_type = surface_thermo_state_type(parsed_args)
     @assert surface_scheme in (nothing, "bulk", "monin_obukhov")
     return if surface_scheme == "bulk"
-        BulkSurfaceScheme()
+        BulkSurfaceScheme(sfc_thermo_state_type)
     elseif surface_scheme == "monin_obukhov"
-        MoninObukhovSurface()
+        MoninObukhovSurface(sfc_thermo_state_type)
     elseif surface_scheme == nothing
         surface_scheme
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -43,11 +43,19 @@ struct EDMFCoriolis{U, V, FT}
     coriolis_param::FT
 end
 
+abstract type AbstractSurfaceThermoState end
+struct GCMSurfaceThermoState <: AbstractSurfaceThermoState end
+
 abstract type AbstractSurfaceScheme end
-struct BulkSurfaceScheme <: AbstractSurfaceScheme end
-struct MoninObukhovSurface <: AbstractSurfaceScheme end # TODO: unify with MoninObukhovSurface in TC
+struct BulkSurfaceScheme{T} <: AbstractSurfaceScheme
+    sfc_thermo_state_type::T
+end
+struct MoninObukhovSurface{T} <: AbstractSurfaceScheme
+    sfc_thermo_state_type::T
+end # TODO: unify with MoninObukhovSurface in TC
 
 # Define broadcasting for types
+Base.broadcastable(x::AbstractSurfaceThermoState) = Ref(x)
 Base.broadcastable(x::AbstractSurfaceScheme) = Ref(x)
 Base.broadcastable(x::AbstractMoistureModel) = Ref(x)
 Base.broadcastable(x::AbstractEnergyFormulation) = Ref(x)


### PR DESCRIPTION
This PR further refactors the surface by:
 - Adding a `surface_thermo_state_type`, which we can dispatch between the cases with EDMF, and those for the grid-mean.

The next step will be to split up `surface_params` into `surface_thermo_state` (which we'll dispatch on) and (for now) `surface_params`, which will need to somehow get inlined into `get_surface`, or converted into a generic single column struct, e.g., `PrescribedSurface`, which can be dispatched on against `set_surface_inputs!`, note that there's some entanglement here between `surface_params` and `get_surface`.