### PR TITLE
Move zero momentum fluxes flag to edmf model

### DIFF
--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -183,9 +183,11 @@ function compute_sgs_flux!(
         CCG.Covariant3Vector(CCG.WVector(surf.ρe_tot_flux), lg_surf)
     sgs_flux_q_tot[kf_surf] =
         CCG.Covariant3Vector(CCG.WVector(surf.ρq_tot_flux), lg_surf)
+    ρu_flux = edmf.zero_uv_fluxes ? FT(0) : surf.ρu_flux
+    ρv_flux = edmf.zero_uv_fluxes ? FT(0) : surf.ρv_flux
     sgs_flux_uₕ[kf_surf] =
         CCG.Covariant3Vector(wvec(FT(1)), lg_surf) ⊗
-        CCG.Covariant12Vector(CCG.UVVector(surf.ρu_flux, surf.ρv_flux), lg_surf)
+        CCG.Covariant12Vector(CCG.UVVector(ρu_flux, ρv_flux), lg_surf)
 
     return nothing
 end
@@ -233,8 +235,10 @@ function compute_diffusive_fluxes(
 
     aeKHq_tot_bc = -surf.ρq_tot_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KH[kf_surf]
     aeKHh_tot_bc = -surf.ρe_tot_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KH[kf_surf]
-    aeKMu_bc = -surf.ρu_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
-    aeKMv_bc = -surf.ρv_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
+    ρu_flux = edmf.zero_uv_fluxes ? FT(0) : surf.ρu_flux
+    ρv_flux = edmf.zero_uv_fluxes ? FT(0) : surf.ρv_flux
+    aeKMu_bc = -ρu_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
+    aeKMv_bc = -ρv_flux / a_en[kc_surf] / aux_tc_f.ρ_ae_KM[kf_surf]
 
     aeKMuₕ_bc = CCG.UVVector(aeKMu_bc, aeKMv_bc)
 

--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -254,7 +254,6 @@ Base.@kwdef struct FixedSurfaceFlux{
     cq::FT = FT(0)
     Ri_bulk_crit::FT = FT(0)
     ustar::FT = FT(0)
-    zero_uv_fluxes::Bool = false
 end
 
 function FixedSurfaceFlux(
@@ -373,6 +372,7 @@ struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC}
     pressure_model_params::PMP
     entr_closure::EC
     H_up_min::FT # minimum updraft top to avoid zero division in pressure drag and turb-entr
+    zero_uv_fluxes::Bool
 end
 function EDMFModel(
     ::Type{FT},
@@ -382,6 +382,8 @@ function EDMFModel(
     parsed_args,
 ) where {FT}
 
+    tc_case = parsed_args["turbconv_case"]
+    zero_uv_fluxes = any(tcc -> tcc == tc_case, ["TRMM_LBA", "ARM_SGP"])
     # Set the number of updrafts (1)
     n_updrafts = parse_namelist(
         namelist,
@@ -716,6 +718,7 @@ function EDMFModel(
         pressure_model_params,
         entr_closure,
         H_up_min,
+        zero_uv_fluxes,
     )
 end
 

--- a/tc_driver/Cases.jl
+++ b/tc_driver/Cases.jl
@@ -625,15 +625,7 @@ function surface_params(
                 0,
                 cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)),
             )^FT(1.5)
-    kwargs = (;
-        Tsurface,
-        qsurface,
-        shf,
-        lhf,
-        ustar,
-        Ri_bulk_crit,
-        zero_uv_fluxes = true,
-    )
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
 end
 
@@ -719,15 +711,7 @@ function surface_params(
     shf = Dierckx.Spline1D(t_Sur_in, SH; k = 1)
     lhf = Dierckx.Spline1D(t_Sur_in, LH; k = 1)
 
-    kwargs = (;
-        Tsurface,
-        qsurface,
-        shf,
-        lhf,
-        ustar,
-        Ri_bulk_crit,
-        zero_uv_fluxes = true,
-    )
+    kwargs = (; Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
 end
 

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -71,8 +71,8 @@ function get_surface(
         obukhov_length = result.L_MO,
         cm = result.Cd,
         ch = result.Ch,
-        ρu_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτxz,
-        ρv_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτyz,
+        ρu_flux = result.ρτxz,
+        ρv_flux = result.ρτyz,
         ρe_tot_flux = shf + lhf,
         ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
     )


### PR DESCRIPTION
This PR moves the flag for zeroing of momentum surface fluxes to the edmf model, until we can somehow incorporate this into SurfaceFluxes.jl. For now, we'll handle this locally in edmf