### PR TITLE
Add getters around SurfaceBase properties

### DIFF
--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -351,12 +351,24 @@ Base.@kwdef struct SurfaceBase{FT}
     ch::FT = 0
     bflux::FT = 0
     ustar::FT = 0
-    ρq_tot_flux::FT = 0
-    ρe_tot_flux::FT = 0
     ρu_flux::FT = 0
     ρv_flux::FT = 0
     obukhov_length::FT = 0
 end
+
+shf(surf::SurfaceBase) = surf.shf
+lhf(surf::SurfaceBase) = surf.lhf
+cm(surf::SurfaceBase) = surf.cm
+ch(surf::SurfaceBase) = surf.ch
+bflux(surf::SurfaceBase) = surf.bflux
+get_ustar(surf::SurfaceBase) = surf.ustar
+get_ρe_tot_flux(surf::SurfaceBase, thermo_params, ts_in) = shf(surf) + lhf(surf)
+get_ρq_tot_flux(surf::SurfaceBase, thermo_params, ts_in) =
+    lhf(surf) / TD.latent_heat_vapor(thermo_params, ts_in)
+get_ρu_flux(surf::SurfaceBase) = surf.ρu_flux
+get_ρv_flux(surf::SurfaceBase) = surf.ρv_flux
+obukhov_length(surf::SurfaceBase) = surf.obukhov_length
+
 
 struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC}
     surface_area::FT

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -22,7 +22,7 @@ function update_aux!(
     c_m = mixing_length_params(edmf).c_m
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
-    obukhov_length = surf.obukhov_length
+    oblength = obukhov_length(surf)
     FT = float_type(state)
     prog_gm = center_prog_grid_mean(state)
     prog_gm_f = face_prog_grid_mean(state)
@@ -423,13 +423,13 @@ function update_aux!(
             FT(eps(FT)),
         )
         aux_tc.prandtl_nvec[k] =
-            turbulent_Prandtl_number(mix_len_params, obukhov_length, ∇_Ri)
+            turbulent_Prandtl_number(mix_len_params, oblength, ∇_Ri)
 
         ml_model = MinDisspLen{FT}(;
             z = FT(grid.zc[k].z),
-            obukhov_length = obukhov_length,
+            obukhov_length = oblength,
             tke_surf = aux_en.tke[kc_surf],
-            ustar = surf.ustar,
+            ustar = get_ustar(surf),
             Pr = aux_tc.prandtl_nvec[k],
             p = p_c[k],
             ∇b = bg,
@@ -524,11 +524,11 @@ function update_aux!(
 
     ### Diagnostic thermodynamiccovariances
     if edmf.thermo_covariance_model isa DiagnosticThermoCovariances
-        flux1 = surf.shf / TD.cp_m(thermo_params, ts_gm[kc_surf])
-        flux2 = surf.ρq_tot_flux
+        flux1 = shf(surf) / TD.cp_m(thermo_params, ts_gm[kc_surf])
+        flux2 = get_ρq_tot_flux(surf, thermo_params, ts_gm[kc_surf])
         zLL::FT = grid.zc[kc_surf].z
-        ustar = surf.ustar
-        oblength = surf.obukhov_length
+        ustar = get_ustar(surf)
+        oblength = obukhov_length(surf)
         prog_gm = center_prog_grid_mean(state)
         ρLL = prog_gm.ρ[kc_surf]
         update_diagnostic_covariances!(edmf, grid, state, param_set, Val(:Hvar))

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -73,8 +73,6 @@ function get_surface(
         ch = result.Ch,
         ρu_flux = result.ρτxz,
         ρv_flux = result.ρτyz,
-        ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
     )
 end
 
@@ -99,7 +97,6 @@ function get_surface(
     zc_surf = grid.zc[kc_surf].z
     cm = surf_params.cm(zc_surf)
     ch = surf_params.ch(zc_surf)
-    Ri_bulk_crit = surf_params.Ri_bulk_crit
     thermo_params = TCP.thermodynamics_params(param_set)
 
     scheme = SF.FVScheme()
@@ -122,20 +119,16 @@ function get_surface(
         z0b = zrough,
     )
     result = SF.surface_conditions(surf_flux_params, sc, scheme)
-    lhf = result.lhf
-    shf = result.shf
 
     return TC.SurfaceBase{FT}(;
         cm = result.Cd,
         ch = result.Ch,
         obukhov_length = result.L_MO,
-        lhf = lhf,
-        shf = shf,
+        lhf = result.lhf,
+        shf = result.shf,
         ustar = result.ustar,
         ρu_flux = result.ρτxz,
         ρv_flux = result.ρτyz,
-        ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
         bflux = result.buoy_flux,
     )
 end
@@ -161,7 +154,6 @@ function get_surface(
     Tsurface = TC.surface_temperature(surf_params, t)
     qsurface = TC.surface_q_tot(surf_params, t)
     zrough = surf_params.zrough
-    Ri_bulk_crit = surf_params.Ri_bulk_crit
     thermo_params = TCP.thermodynamics_params(param_set)
 
     scheme = SF.FVScheme()
@@ -181,20 +173,15 @@ function get_surface(
         z0b = zrough,
     )
     result = SF.surface_conditions(surf_flux_params, sc, scheme)
-    lhf = result.lhf
-    shf = result.shf
-    zi = TC.get_inversion(grid, state, thermo_params, Ri_bulk_crit)
     return TC.SurfaceBase{FT}(;
         cm = result.Cd,
         ch = result.Ch,
         obukhov_length = result.L_MO,
-        lhf = lhf,
-        shf = shf,
+        lhf = result.lhf,
+        shf = result.shf,
         ustar = result.ustar,
         ρu_flux = result.ρτxz,
         ρv_flux = result.ρτyz,
-        ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
         bflux = result.buoy_flux,
     )
 end


### PR DESCRIPTION
This PR refactors the surface by adding getters around SurfaceBase, so that we can phase it out in favor of SurfaceFluxConditions