### PR TITLE
Remove SurfaceBase

### DIFF
--- a/src/TurbulenceConvection/closures/perturbation_pressure.jl
+++ b/src/TurbulenceConvection/closures/perturbation_pressure.jl
@@ -3,7 +3,7 @@
         state::State,
         grid::Grid,
         edmf::EDMFModel,
-        surf::SurfaceBase,
+        surf,
     )
 
 Computes the
@@ -16,7 +16,7 @@ for all updrafts, following [He2020](@cite), given:
  - `state`: state
  - `grid`: grid
  - `edmf`: EDMF model
- - `surf`: surface model
+ - `surf`: `SurfaceFluxes.SurfaceFluxConditions`
 """
 function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
 

--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -344,30 +344,18 @@ latent_heat_flux(s::AbstractSurfaceParameters, t::Real = 0) =
 fixed_ustar(::FixedSurfaceFlux{FT, FixedFrictionVelocity}) where {FT} = true
 fixed_ustar(::FixedSurfaceFlux{FT, VariableFrictionVelocity}) where {FT} = false
 
-Base.@kwdef struct SurfaceBase{FT}
-    shf::FT = 0
-    lhf::FT = 0
-    cm::FT = 0
-    ch::FT = 0
-    bflux::FT = 0
-    ustar::FT = 0
-    ρu_flux::FT = 0
-    ρv_flux::FT = 0
-    obukhov_length::FT = 0
-end
-
-shf(surf::SurfaceBase) = surf.shf
-lhf(surf::SurfaceBase) = surf.lhf
-cm(surf::SurfaceBase) = surf.cm
-ch(surf::SurfaceBase) = surf.ch
-bflux(surf::SurfaceBase) = surf.bflux
-get_ustar(surf::SurfaceBase) = surf.ustar
-get_ρe_tot_flux(surf::SurfaceBase, thermo_params, ts_in) = shf(surf) + lhf(surf)
-get_ρq_tot_flux(surf::SurfaceBase, thermo_params, ts_in) =
+shf(surf) = surf.shf
+lhf(surf) = surf.lhf
+cm(surf) = surf.Cd
+ch(surf) = surf.Ch
+bflux(surf) = surf.buoy_flux
+get_ustar(surf) = surf.ustar
+get_ρe_tot_flux(surf, thermo_params, ts_in) = shf(surf) + lhf(surf)
+get_ρq_tot_flux(surf, thermo_params, ts_in) =
     lhf(surf) / TD.latent_heat_vapor(thermo_params, ts_in)
-get_ρu_flux(surf::SurfaceBase) = surf.ρu_flux
-get_ρv_flux(surf::SurfaceBase) = surf.ρv_flux
-obukhov_length(surf::SurfaceBase) = surf.obukhov_length
+get_ρu_flux(surf) = surf.ρτxz
+get_ρv_flux(surf) = surf.ρτyz
+obukhov_length(surf) = surf.L_MO
 
 
 struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC}

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -2,7 +2,7 @@ function update_aux!(
     edmf::EDMFModel,
     grid::Grid,
     state::State,
-    surf::SurfaceBase,
+    surf,
     param_set::APS,
     t::Real,
     Δt::Real,

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -15,8 +15,6 @@ function get_surface(
     kf_surf = TC.kf_surface(grid)
     z_sfc = FT(0)
     z_in = grid.zc[kc_surf].z
-    aux_gm = TC.center_aux_grid_mean(state)
-    prog_gm = TC.center_prog_grid_mean(state)
     aux_gm_f = TC.face_aux_grid_mean(state)
     p_f_surf = aux_gm_f.p[kf_surf]
     Tsurface = TC.surface_temperature(surf_params, t)
@@ -62,18 +60,7 @@ function get_surface(
     else
         SF.Fluxes{FT}(; kwargs...)
     end
-    result = SF.surface_conditions(surf_flux_params, sc, scheme)
-    return TC.SurfaceBase{FT}(;
-        shf = shf,
-        lhf = lhf,
-        ustar = result.ustar,
-        bflux = bflux,
-        obukhov_length = result.L_MO,
-        cm = result.Cd,
-        ch = result.Ch,
-        ρu_flux = result.ρτxz,
-        ρv_flux = result.ρτyz,
-    )
+    return SF.surface_conditions(surf_flux_params, sc, scheme)
 end
 
 function get_surface(
@@ -88,8 +75,6 @@ function get_surface(
     kc_surf = TC.kc_surface(grid)
     kf_surf = TC.kf_surface(grid)
     aux_gm_f = TC.face_aux_grid_mean(state)
-    aux_gm = TC.center_aux_grid_mean(state)
-    prog_gm = TC.center_prog_grid_mean(state)
     Tsurface = TC.surface_temperature(surf_params, t)
     qsurface = TC.surface_q_tot(surf_params, t)
     p_f_surf = aux_gm_f.p[kf_surf]
@@ -118,19 +103,7 @@ function get_surface(
         z0m = zrough,
         z0b = zrough,
     )
-    result = SF.surface_conditions(surf_flux_params, sc, scheme)
-
-    return TC.SurfaceBase{FT}(;
-        cm = result.Cd,
-        ch = result.Ch,
-        obukhov_length = result.L_MO,
-        lhf = result.lhf,
-        shf = result.shf,
-        ustar = result.ustar,
-        ρu_flux = result.ρτxz,
-        ρv_flux = result.ρτyz,
-        bflux = result.buoy_flux,
-    )
+    return SF.surface_conditions(surf_flux_params, sc, scheme)
 end
 
 function get_surface(
@@ -146,8 +119,6 @@ function get_surface(
     FT = TC.float_type(state)
     z_sfc = FT(0)
     z_in = grid.zc[kc_surf].z
-    prog_gm = TC.center_prog_grid_mean(state)
-    aux_gm = TC.center_aux_grid_mean(state)
     aux_gm_f = TC.face_aux_grid_mean(state)
     p_f_surf = aux_gm_f.p[kf_surf]
     ts_gm = TC.center_aux_grid_mean_ts(state)
@@ -172,16 +143,5 @@ function get_surface(
         z0m = zrough,
         z0b = zrough,
     )
-    result = SF.surface_conditions(surf_flux_params, sc, scheme)
-    return TC.SurfaceBase{FT}(;
-        cm = result.Cd,
-        ch = result.Ch,
-        obukhov_length = result.L_MO,
-        lhf = result.lhf,
-        shf = result.shf,
-        ustar = result.ustar,
-        ρu_flux = result.ρτxz,
-        ρv_flux = result.ρτyz,
-        bflux = result.buoy_flux,
-    )
+    return SF.surface_conditions(surf_flux_params, sc, scheme)
 end

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -95,7 +95,7 @@ function compute_implicit_gm_tendencies!(
     edmf::TC.EDMFModel,
     grid::TC.Grid,
     state::TC.State,
-    surf::TC.SurfaceBase,
+    surf,
     param_set::APS,
 )
     tendencies_gm = TC.center_tendencies_grid_mean(state)
@@ -118,7 +118,7 @@ function compute_explicit_gm_tendencies!(
     edmf::TC.EDMFModel,
     grid::TC.Grid,
     state::TC.State,
-    surf::TC.SurfaceBase,
+    surf,
     param_set::APS,
 )
     tendencies_gm = TC.center_tendencies_grid_mean(state)


### PR DESCRIPTION
This PR removes `SurfaceBase`, and instead works with the `SurfaceFluxes.SurfaceFluxConditions` type, which the dycore uses.