### PR TITLE
Always have sfc_conditions, dispatch surface

### DIFF
--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -189,7 +189,14 @@ function implicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, ::TC.EDMFModel)
     end
     assign_thermo_aux!(state, grid, edmf.moisture_model, thermo_params)
 
-    surf = get_surface(surf_params, grid, state, t, tc_params)
+    surf = get_surface(
+        p.atmos.model_config,
+        surf_params,
+        grid,
+        state,
+        t,
+        tc_params,
+    )
 
     TC.affect_filter!(edmf, grid, state, tc_params, surf, t)
 
@@ -244,7 +251,14 @@ function explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, ::TC.EDMFModel)
     end
     assign_thermo_aux!(state, grid, edmf.moisture_model, thermo_params)
 
-    surf = get_surface(surf_params, grid, state, t, tc_params)
+    surf = get_surface(
+        p.atmos.model_config,
+        surf_params,
+        grid,
+        state,
+        t,
+        tc_params,
+    )
 
     TC.affect_filter!(edmf, grid, state, tc_params, surf, t)
 

--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -151,7 +151,14 @@ function turb_conv_affect_filter!(integrator)
     Fields.bycolumn(axes(Y.c)) do colidx
         state = TC.tc_column_state(Y, p, nothing, colidx)
         grid = TC.Grid(state)
-        surf = TCU.get_surface(surf_params, grid, state, t, tc_params)
+        surf = TCU.get_surface(
+            p.atmos.model_config,
+            surf_params,
+            grid,
+            state,
+            t,
+            tc_params,
+        )
         TC.affect_filter!(edmf, grid, state, tc_params, surf, t)
     end
 

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -98,6 +98,10 @@ function default_cache(
     end
     ᶜf = @. Geometry.Contravariant3Vector(Geometry.WVector(ᶜf))
     T_sfc = @. 29 * exp(-lat_sfc^2 / (2 * 26^2)) + 271
+
+    sfc_conditions =
+        similar(Fields.level(Y.f, half), SF.SurfaceFluxConditions{FT})
+
     ts_type = CA.thermo_state_type(Y.c, FT)
     ghost_buffer = (
         c = Spaces.create_ghost_buffer(Y.c),
@@ -166,6 +170,7 @@ function default_cache(
         ᶠu¹² = similar(Y.f, Geometry.Contravariant12Vector{FT}),
         ᶠu³ = similar(Y.f, Geometry.Contravariant3Vector{FT}),
         ᶜf,
+        sfc_conditions,
         z_sfc,
         T_sfc,
         ts_sfc = similar(Spaces.level(Y.f, half), ts_type),

--- a/src/tendencies/vertical_diffusion_boundary_layer.jl
+++ b/src/tendencies/vertical_diffusion_boundary_layer.jl
@@ -43,8 +43,6 @@ function vertical_diffusion_boundary_layer_cache(
     cond_type = NamedTuple{(:shf, :lhf, :E, :ρτxz, :ρτyz), NTuple{5, FT}}
     surface_normal = Geometry.WVector.(ones(axes(Fields.level(Y.c, 1))))
 
-    sfc_conditions =
-        similar(Fields.level(Y.f, half), SF.SurfaceFluxConditions{FT})
     ts_type = thermo_state_type(Y.c, FT)
     ts_inst = thermo_state_instance(Y.c, FT)
 
@@ -102,7 +100,6 @@ function vertical_diffusion_boundary_layer_cache(
     return (;
         surface_scheme,
         sfc_input_kwargs...,
-        sfc_conditions,
         C_E,
         ᶠp = similar(Y.f, FT),
         ᶠK_E = similar(Y.f, FT),

--- a/tc_driver/Surface.jl
+++ b/tc_driver/Surface.jl
@@ -145,3 +145,19 @@ function get_surface(
     )
     return SF.surface_conditions(surf_flux_params, sc, scheme)
 end
+
+using ClimaCore.Utilities: half
+import ClimaAtmos: SingleColumnModel, SphericalModel
+get_surface(::SingleColumnModel, args...) = get_surface(args...)
+function get_surface(
+    ::SphericalModel,
+    surf_params::TC.FixedSurfaceFlux,
+    grid::TC.Grid,
+    state::TC.State,
+    args...,
+)
+    # TODO: remove this kludge
+    sfc_conditions = state.p.sfc_conditions[state.colidx]
+    sfc_conditions_inst = CC.Fields._first(sfc_conditions)
+    return sfc_conditions_inst
+end

--- a/tc_driver/initial_conditions.jl
+++ b/tc_driver/initial_conditions.jl
@@ -17,7 +17,14 @@ function initialize_edmf(
     aux_gm = TC.center_aux_grid_mean(state)
     ts_gm = TC.center_aux_grid_mean_ts(state)
     @. aux_gm.θ_virt = TD.virtual_pottemp(thermo_params, ts_gm)
-    surf = get_surface(surf_params, grid, state, t, param_set)
+    surf = get_surface(
+        state.p.atmos.model_config,
+        surf_params,
+        grid,
+        state,
+        t,
+        param_set,
+    )
     initialize_updrafts(edmf, grid, state, surf)
     TC.set_edmf_surface_bc(edmf, grid, state, surf, param_set)
     return


### PR DESCRIPTION
This PR:
 - Adds `sfc_conditions` by default
 - Dispatches more on `get_surface` via the `model_config`

This is a peel off from #916.