### PR TITLE
Prep removing fields when unused

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -103,13 +103,7 @@ function additional_cache(
     use_tempest_mode = false,
 )
     FT = typeof(dt)
-    (;
-        precip_model,
-        forcing_type,
-        radiation_mode,
-        turbconv_model,
-        precip_model,
-    ) = atmos
+    (; precip_model, forcing_type, radiation_mode, turbconv_model) = atmos
 
     thermo_dispatcher = CA.ThermoDispatcher(atmos)
     compressibility_model = atmos.compressibility_model
@@ -183,7 +177,7 @@ function additional_cache(
         TCU.turbconv_cache(
             Y,
             turbconv_model,
-            precip_model,
+            atmos,
             namelist,
             params,
             parsed_args,

--- a/src/types.jl
+++ b/src/types.jl
@@ -127,6 +127,12 @@ Base.@kwdef struct AtmosModel{
     non_orographic_gravity_wave::GW = nothing
 end
 
+Base.broadcastable(x::AtmosModel) = Ref(x)
+
+is_compressible(atmos::AtmosModel) =
+    atmos.compressibility_model isa CompressibleFluid
+is_anelastic(atmos::AtmosModel) = atmos.compressibility_model isa AnelasticFluid
+
 function Base.summary(io::IO, atmos::AtmosModel)
     pns = string.(propertynames(atmos))
     buf = maximum(length.(pns))

--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -27,13 +27,13 @@ cent_aux_vars_gm(FT, local_geometry, edmf) = (;
     q_tot = FT(0),
     h_tot = FT(0),
 )
-cent_aux_vars(FT, local_geometry, edmf) = (;
+cent_aux_vars(FT, local_geometry, atmos, edmf) = (;
     cent_aux_vars_gm(FT, local_geometry, edmf)...,
     TC.cent_aux_vars_edmf(FT, local_geometry, edmf)...,
 )
 
 # Face only
-face_aux_vars_gm(FT, local_geometry, edmf) = (;
+face_aux_vars_gm(FT, local_geometry, atmos, edmf) = (;
     sgs_flux_h_tot = CCG.Covariant3Vector(FT(0)),
     sgs_flux_q_tot = CCG.Covariant3Vector(FT(0)),
     sgs_flux_uₕ = CCG.Covariant3Vector(FT(0)) ⊗
@@ -41,7 +41,7 @@ face_aux_vars_gm(FT, local_geometry, edmf) = (;
     p = FT(0),
     ρ = FT(0),
 )
-face_aux_vars(FT, local_geometry, edmf) = (;
-    face_aux_vars_gm(FT, local_geometry, edmf)...,
+face_aux_vars(FT, local_geometry, atmos, edmf) = (;
+    face_aux_vars_gm(FT, local_geometry, atmos, edmf)...,
     TC.face_aux_vars_edmf(FT, local_geometry, edmf)...,
 )


### PR DESCRIPTION
This PR preps the removal of some fields when they are unused. This should help us debug the compressible case (where we shouldn't be using certain fields).