### PR TITLE
Remove unused pressure at cell faces

### DIFF
--- a/tc_driver/dycore_variables.jl
+++ b/tc_driver/dycore_variables.jl
@@ -38,7 +38,6 @@ face_aux_vars_gm(FT, local_geometry, atmos, edmf) = (;
     sgs_flux_q_tot = CCG.Covariant3Vector(FT(0)),
     sgs_flux_uₕ = CCG.Covariant3Vector(FT(0)) ⊗
                   CCG.Covariant12Vector(FT(0), FT(0)),
-    p = FT(0),
     ρ = FT(0),
 )
 face_aux_vars(FT, local_geometry, atmos, edmf) = (;


### PR DESCRIPTION
This PR removes pressure at cell faces, since it's no longer used. In this PR, density at the surface is extrapolated from the prognostic density, instead of computed using `CA.compute_ref_density!`

This turns out to be non-behavior changing