### PR TITLE
Refactor ode config

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -254,15 +254,14 @@ end
 # @info "Model composition" p.atmos...
 @info "Tendencies" p.tendency_knobs...
 
-@time "ode_configuration" ode_config = ode_configuration(Y, parsed_args, atmos)
-
+@time "get_ode_algorithm" ode_algo = get_ode_algorithm(Y, parsed_args, atmos)
 include("callbacks.jl")
 
 @time "get_callbacks" callback =
     get_callbacks(parsed_args, simulation, atmos, params)
 tspan = (t_start, simulation.t_end)
 @time "args_integrator" integrator_args, integrator_kwargs =
-    args_integrator(parsed_args, Y, p, tspan, ode_config, callback)
+    args_integrator(parsed_args, Y, p, tspan, ode_algo, callback)
 
 if haskey(ENV, "CI_PERF_SKIP_INIT") # for performance analysis
     throw(:exit_profile_init)


### PR DESCRIPTION
This PR refactors the ode config by:
 - Breaking `ode_configuration` down into several functions, which allows us to only return the ode algorithm (so `ode_configuration` is now renamed to `get_ode_algorithm`)
 - Several helper functions were added so that users can more easily test, using the `ode_algo_type`, intermediate parts of `get_ode_algorithm`

I think this should be slightly easier to extend for the new CTS changes, and it may have better inference due to all the function barriers