### PR TITLE
Fix crashing case, add warning

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -304,7 +304,8 @@ function perform_solve!(integrator, simulation, comms_ctx)
             return SimulationResults(sol, nothing, nothing)
         end
     catch sol_err
-        return SimulationResults(nothing, sol_err, walltime)
+        @warn "The simulation has crashed, rethrowing the error later."
+        return SimulationResults(nothing, sol_err, nothing)
     end
 end
 


### PR DESCRIPTION
This PR fixes the case where the simulation crashes and adds a warning to the log.