### PR TITLE
Try to fixed error throwing on crashed simulations

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -376,7 +376,10 @@ if parsed_args["debugging_tc"]
 end
 
 # Throw crashing error
-isnothing(sol_res.sol_err) || rethrow(sol_res.sol_err.error)
+(; sol_err) = sol_res
+if !isnothing(sol_err)
+    hasproperty(sol_err, :error) ? rethrow(sol_err.error) : rethrow(sol_err)
+end
 # Simulation did not crash
 (; sol, walltime) = sol_res
 


### PR DESCRIPTION
This PR attempts to fix error throwing when simulations crashed. Sometimes the caught error does not have an `:error` property, observed [here](https://buildkite.com/clima/climaatmos-ci/builds/5971#0184cf14-8297-444b-880e-9ec5440bd346)