### PR TITLE
Add grid-mean quicklook plots and IMEX GABLS example

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -387,14 +387,20 @@ steps:
           slurm_mem: 20GB
 
       - label: ":balloon: Single column EDMF GABLS"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist dry --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id edmf_gabls --dt 4secs --t_end 9hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist dry --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --split_ode false --ode_algo ODE.Euler --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id edmf_gabls --dt 400secs --t_end 9hours --regression_test true --anelastic_dycore true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "edmf_gabls/*"
         agents:
           slurm_mem: 20GB
 
-      - label: ":balloon: Compressible single column EDMF GABLS"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist dry --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id compressible_edmf_gabls --dt 4secs --t_end 9hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
+      - label: ":balloon: Compressible single column EDMF GABLS (Newton's Method)"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist dry --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --job_id compressible_edmf_gabls --dt 500secs --t_end 9hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "compressible_edmf_gabls/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":balloon: Compressible single column EDMF GABLS (JFNK with IMEX EDMF)"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist dry --edmf_coriolis GABLS --turbconv edmf --turbconv_case GABLS --dt_save_to_sol 5mins --z_elem 8 --z_stretch false --z_max 400 --imex_edmf_turbconv true --imex_edmf_gm true --use_krylov_method true --job_id compressible_edmf_gabls_jfnk_imex --quicklook_reference_job_id compressible_edmf_gabls --dt 600secs --t_end 9hours --regression_test true --apply_limiter false --debugging_tc true --dt_save_to_disk 5mins"
+        artifact_paths: "compressible_edmf_gabls_jfnk_imex/*"
         agents:
           slurm_mem: 20GB
 

--- a/post_processing/define_tc_quicklook_profiles.jl
+++ b/post_processing/define_tc_quicklook_profiles.jl
@@ -25,6 +25,9 @@ function plot_tc_profiles(folder; hdf5_filename, main_branch_data_path)
     p14 = Plots.plot(; title = "en Hvar", args...)
     p15 = Plots.plot(; title = "en QTvar", args...)
     p16 = Plots.plot(; title = "en HQTcov", args...)
+    p17 = Plots.plot(; title = "gm theta", args...)
+    p18 = Plots.plot(; title = "gm u", args...)
+    p19 = Plots.plot(; title = "gm v", args...)
 
     function add_to_plots!(input_filename; data_source)
         if !isfile(input_filename)
@@ -85,6 +88,24 @@ function plot_tc_profiles(folder; hdf5_filename, main_branch_data_path)
         plot!(p14, parent(D.env_Hvar)[:], zc; label = "$data_source")
         plot!(p15, parent(D.env_QTvar)[:], zc; label = "$data_source")
         plot!(p16, parent(D.env_HQTcov)[:], zc; label = "$data_source")
+        plot!(
+            p17,
+            parent(D.potential_temperature)[:],
+            zc;
+            label = "$data_source",
+        )
+        plot!(
+            p18,
+            parent(Geometry.UVector.(Y.c.uₕ))[:],
+            zc;
+            label = "$data_source",
+        )
+        plot!(
+            p19,
+            parent(Geometry.VVector.(Y.c.uₕ))[:],
+            zc;
+            label = "$data_source",
+        )
     end
 
     PR_filename = joinpath(folder, hdf5_filename)
@@ -117,7 +138,10 @@ function plot_tc_profiles(folder; hdf5_filename, main_branch_data_path)
         p13,
         p14,
         p15,
-        p16;
+        p16,
+        p17,
+        p18,
+        p19;
         more_args...,
     )
 
@@ -163,7 +187,7 @@ function get_contours(vars, input_filenames; data_source, have_main)
     K = collect(keys(contours))
     n = length(K)
     fig_width = 4500
-    fig_height = 3000
+    fig_height = 5000
     left_side = data_source == "main"
     if have_main
         l_margin = left_side ? 100 : 0
@@ -176,9 +200,9 @@ function get_contours(vars, input_filenames; data_source, have_main)
 
     for (i, name) in enumerate(K)
         fn = contours[name].fn
-        space = axes(fn(first(Ds)))
+        space = axes(fn(first(Ys), first(Ds)))
         z = parent(Fields.coordinate_field(space).z)[:]
-        Ds_parent = parent_data.(fn.(Ds))
+        Ds_parent = parent_data.(fn.(Ys, Ds))
         cdata = hcat(Ds_parent...)
         clims[name] = (minimum(cdata), maximum(cdata))
         Plots.contourf!(
@@ -311,13 +335,16 @@ end
 function _plot_tc_contours(folder; PR_filenames, main_filenames)
 
     vars = [
-        ("area fraction", D -> D.bulk_up_area),
-        ("up qt", D -> D.bulk_up_q_tot),
-        ("up ql", D -> D.bulk_up_q_liq),
-        ("up qi", D -> D.bulk_up_q_ice),
-        ("up w", D -> Geometry.WVector.(D.face_bulk_w)),
-        ("en qt", D -> D.env_q_tot),
-        ("en TKE", D -> D.env_TKE),
+        ("area fraction", (Y, D) -> D.bulk_up_area),
+        ("up qt", (Y, D) -> D.bulk_up_q_tot),
+        ("up ql", (Y, D) -> D.bulk_up_q_liq),
+        ("up qi", (Y, D) -> D.bulk_up_q_ice),
+        ("up w", (Y, D) -> Geometry.WVector.(D.face_bulk_w)),
+        ("en qt", (Y, D) -> D.env_q_tot),
+        ("en TKE", (Y, D) -> D.env_TKE),
+        ("gm theta", (Y, D) -> D.potential_temperature),
+        ("gm u", (Y, D) -> Geometry.UVector.(Y.c.uₕ)),
+        ("gm v", (Y, D) -> Geometry.VVector.(Y.c.uₕ)),
         # ("up qr", D-> parent(D.)[:])
     ]
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds 3 grid-mean plots to the quicklook profiles (`theta`, `u`, and `v`) per Tapio's request. It also adds a new job for compressible GABLS that uses JFNK with IMEX EDMF and a timestep of 2000 seconds (although larger timesteps are possible, they result in non-negligible changes to the solution profiles). It also increases the timesteps for the original two GABLS jobs from 4 seconds to 500 seconds, which is roughly the maximum timestep for both jobs.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
