### PR TITLE
Fix thermo_state for pressure interpolation in radiation

### DIFF
--- a/src/tendencies/radiation.jl
+++ b/src/tendencies/radiation.jl
@@ -88,7 +88,7 @@ function radiation_model_cache(
                 input_center_pressure,
                 input_center_volume_mixing_ratio_o3,
             )
-            ᶜts = thermo_state(Y, thermo_params, thermo_dispatcher, ᶜinterp, 0)
+            ᶜts = thermo_state(Y, thermo_params, thermo_dispatcher, ᶜinterp)
             ᶜp = @. TD.air_pressure(thermo_params, ᶜts)
             center_volume_mixing_ratio_o3 =
                 RRTMGPI.field2array(@. FT(pressure2ozone(ᶜp)))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fix the bug of setting kinetic energy to zero when computing pressure for interpolation in radiation.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
