### PR TITLE
Move try-catch to thermo_state function

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -204,7 +204,7 @@ function rrtmgp_model_callback!(integrator)
     ᶜp = RRTMGPI.array2field(radiation_model.center_pressure, axes(Y.c))
     ᶜT = RRTMGPI.array2field(radiation_model.center_temperature, axes(Y.c))
     @. ᶜK = LinearAlgebra.norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
-    CA.thermo_state!(Y, p, ᶜinterp)
+    CA.thermo_state!(Y, p, ᶜinterp; time = t)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     @. ᶜT = TD.air_temperature(thermo_params, ᶜts)
 
@@ -349,7 +349,7 @@ function save_to_disk_func(integrator)
     @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
 
     # thermo state
-    CA.thermo_state!(Y, p, ᶜinterp)
+    CA.thermo_state!(Y, p, ᶜinterp; time = t)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
     ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)

--- a/post_processing/post_processing_funcs.jl
+++ b/post_processing/post_processing_funcs.jl
@@ -225,7 +225,7 @@ function paperplots_dry_baro_wave(sol, output_dir, p, nlat, nlon)
         iu = safe_index(ius, sol.t)
         Y = sol.u[iu]
         # compute pressure, temperature, vorticity
-        CA.thermo_state!(Y, p, ᶜinterp)
+        CA.thermo_state!(Y, p, ᶜinterp; time = sol.t)
         @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
         ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
         curl_uh = @. curlₕ(Y.c.uₕ)
@@ -344,7 +344,7 @@ function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
         ᶜw_phy = @. Geometry.project(Geometry.WAxis(), ᶜuvw_phy)
         ᶠw_phy = ᶠinterp.(ᶜw_phy)
         @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
-        CA.thermo_state!(Y, p, ᶜinterp)
+        CA.thermo_state!(Y, p, ᶜinterp; time = sol.t)
         @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
 
         ᶜq = @. TD.PhasePartition(thermo_params, ᶜts)
@@ -702,7 +702,7 @@ function paperplots_held_suarez(sol, output_dir, p, nlat, nlon)
             # temperature
             ᶠw = Y.f.w
             @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
-            CA.thermo_state!(Y, p, ᶜinterp)
+            CA.thermo_state!(Y, p, ᶜinterp; time = sol.t)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)
 

--- a/src/precomputed_quantities.jl
+++ b/src/precomputed_quantities.jl
@@ -8,19 +8,12 @@ import ClimaCore.Fields as Fields
 import ClimaCore.Geometry as Geometry
 
 function precomputed_quantities!(Y, p, t)
-    try
-        Fields.bycolumn(axes(Y.c)) do colidx
-            precomputed_quantities!(Y, p, t, colidx)
-        end
-    catch
-        @info "Simulation failed at time $t"
-        Fields.bycolumn(axes(Y.c)) do colidx
-            precomputed_quantities!(Y, p, t, colidx; debug = true)
-        end
+    Fields.bycolumn(axes(Y.c)) do colidx
+        precomputed_quantities!(Y, p, t, colidx)
     end
 end
 
-function precomputed_quantities!(Y, p, t, colidx; debug = false)
+function precomputed_quantities!(Y, p, t, colidx)
     ᶜuₕ = Y.c.uₕ
     ᶠw = Y.f.w
     (; ᶜuvw, ᶜK, ᶜts, ᶜp, params) = p
@@ -29,7 +22,7 @@ function precomputed_quantities!(Y, p, t, colidx; debug = false)
     @. ᶜuvw[colidx] = C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))
     @. ᶜK[colidx] = norm_sqr(ᶜuvw[colidx]) / 2
     thermo_params = CAP.thermodynamics_params(params)
-    thermo_state!(Y, p, ᶜinterp, colidx; debug)
+    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
     return nothing
 end

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -92,7 +92,7 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     thermo_params = CAP.thermodynamics_params(params)
     dt = simulation.dt
     @. ᶜK[colidx] = norm_sqr(C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))) / 2
-    thermo_state!(Y, p, ᶜinterp, colidx)
+    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
 
     vertical_transport!(

--- a/src/tendencies/implicit/wfact.jl
+++ b/src/tendencies/implicit/wfact.jl
@@ -133,7 +133,7 @@ function Wfact!(W, Y, p, dtγ, t, colidx)
     # operators, ᶠupwind_stencil is not available.
     @. ᶜK[colidx] = norm_sqr(C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))) / 2
     thermo_params = CAP.thermodynamics_params(params)
-    thermo_state!(Y, p, ᶜinterp, colidx)
+    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
 
     # ᶜinterp(ᶠw) =


### PR DESCRIPTION
This PR reverts #1197 and moves the try-catch into `thermo_state!`, since it's called in many places (e.g., `wfact!`, `precomputed_quantities!`, `implicit_vertical_advection_tendency!` (and in callbacks).

Using `time` instead of `debug`, could also be useful in determining when to use the cached air temperature (always unless it's the initial condition)