### PR TITLE
Run long run trmm for shorter to see output

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -171,7 +171,7 @@ steps:
     steps:
 
       - label: ":balloon: Compressible single column EDMF TRMM_LBA"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --dt_save_to_sol 5mins --z_elem 90 --z_stretch false --z_max 17000 --rayleigh_sponge true --zd_rayleigh 15000 --job_id longrun_compressible_edmf_trmm --dt 0.2secs --t_end 4.5hours"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --rad TRMM_LBA --turbconv edmf --turbconv_case TRMM_LBA --precip_model 1M --dt_save_to_sol 5mins --z_elem 90 --z_stretch false --z_max 17000 --rayleigh_sponge true --zd_rayleigh 15000 --job_id longrun_compressible_edmf_trmm --dt 0.2secs --t_end 3.8hours"
         artifact_paths: "longrun_compressible_edmf_trmm/*"
         agents:
           slurm_mem: 20GB


### PR DESCRIPTION
This PR shortens the TRMM long run so that we can (hopefully) see the output