### PR TITLE
Time cache allocation

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -245,7 +245,9 @@ else
     (Y, t_start) = get_state_fresh_start(parsed_args, spaces, params, atmos)
 end
 
-p = get_cache(Y, parsed_args, params, spaces, atmos, numerics, simulation)
+@time "Allocating cache (p)" begin
+    p = get_cache(Y, parsed_args, params, spaces, atmos, numerics, simulation)
+end
 if parsed_args["turbconv"] == "edmf"
     @time "init_tc!" TCU.init_tc!(Y, p, params)
 end


### PR DESCRIPTION
#1220 is timing out for the mpi restart job, and it's not fully clear where. This PR adds a `@time` around allocating the cache.