### PR TITLE
Add hyperdiffusion types

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -83,7 +83,11 @@ function parse_commandline()
         arg_type = Bool
         default = false
         "--hyperdiff"
-        help = "Hyperdiffusion [`true` (default), `false`]"
+        help = "Hyperdiffusion [`ClimaHyperdiffusion` (default), `TempestHyperdiffusion`, `none` (or `false`)]"
+        arg_type = String
+        default = "ClimaHyperdiffusion"
+        "--enable_qt_hyperdiffusion"
+        help = "Enable the hyperdiffusion of specific humidity [`true` (default), `false`] (TODO: reconcile this with `ρe_tot` or remove if instability fixed with limiters)"
         arg_type = Bool
         default = true
         "--idealized_insolation"
@@ -266,10 +270,6 @@ function parse_commandline()
         help = "Viscous sponge coefficient"
         arg_type = Float64
         default = Float64(1e6)
-        "--disable_qt_hyperdiffusion"
-        help = "Disable the hyperdiffusion of specific humidity [`true`, `false` (default)] (TODO: reconcile this with ρe_tot or remove if instability fixed with limiters)"
-        arg_type = Bool
-        default = false
         "--start_date"
         help = "Start date of the simulation"
         arg_type = String

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -54,6 +54,7 @@ function get_atmos(::Type{FT}, parsed_args, namelist) where {FT}
         compressibility_model = CA.compressibility_model(parsed_args),
         surface_scheme = CA.surface_scheme(FT, parsed_args),
         non_orographic_gravity_wave,
+        hyperdiff = CA.hyperdiffusion_model(parsed_args, FT),
     )
 
     return atmos

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -69,7 +69,7 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target_rhoe"] = 248592
 allocs_limit["flame_perf_target_rhoe_tracers"] = 6237627000
 allocs_limit["flame_perf_target_rhoe_threaded"] = 5253664
-allocs_limit["flame_perf_target_rhoe_callbacks"] = 11404184
+allocs_limit["flame_perf_target_rhoe_callbacks"] = 11439104
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -32,6 +32,22 @@ function coupling_type(parsed_args)
     end
 end
 
+function hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
+    enable_qt = parsed_args["enable_qt_hyperdiffusion"]
+    hyperdiff_name = parsed_args["hyperdiff"]
+    κ₄ = FT(parsed_args["kappa_4"])
+    divergence_damping_factor = FT(1)
+    return if hyperdiff_name == "ClimaHyperdiffusion"
+        ClimaHyperdiffusion{enable_qt, FT}(; κ₄, divergence_damping_factor)
+    elseif hyperdiff_name == "TempestHyperdiffusion"
+        TempestHyperdiffusion{enable_qt, FT}(; κ₄, divergence_damping_factor)
+    elseif hyperdiff_name == "none" || hyperdiff_name == "false"
+        nothing
+    else
+        error("Uncaught diffusion model type.")
+    end
+end
+
 function perf_mode(parsed_args)
     return if parsed_args["perf_mode"] == "PerfExperimental"
         PerfExperimental()

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,19 @@ abstract type AbstractCoupling end
 struct Coupled <: AbstractCoupling end
 struct Decoupled <: AbstractCoupling end
 
+abstract type AbstractHyperdiffusion end
+Base.@kwdef struct ClimaHyperdiffusion{B, FT} <: AbstractHyperdiffusion
+    κ₄::FT
+    divergence_damping_factor::FT
+end
+Base.@kwdef struct TempestHyperdiffusion{B, FT} <: AbstractHyperdiffusion
+    κ₄::FT
+    divergence_damping_factor::FT
+end
+
+q_tot_hyperdiffusion_enabled(::ClimaHyperdiffusion{B}) where {B} = B
+q_tot_hyperdiffusion_enabled(::TempestHyperdiffusion{B}) where {B} = B
+
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
 struct Subsidence{T} <: AbstractForcing
@@ -119,6 +132,7 @@ Base.@kwdef struct AtmosModel{
     CM,
     SS,
     GW,
+    HD,
 }
     model_config::MC = nothing
     coupling::C = nothing
@@ -135,6 +149,7 @@ Base.@kwdef struct AtmosModel{
     compressibility_model::CM = nothing
     surface_scheme::SS = nothing
     non_orographic_gravity_wave::GW = nothing
+    hyperdiff::HD = nothing
 end
 
 Base.broadcastable(x::AtmosModel) = Ref(x)


### PR DESCRIPTION
This PR adds a hyperdiffusion type into the atmos model, and removes some global variables (`hyperdiff` and `disable_qt_hyperdiffusion`) from scope