### PR TITLE
Refactor vert diff BL tend

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -471,7 +471,7 @@ function save_to_disk_func(integrator)
         turbulence_convection_diagnostic = NamedTuple()
     end
 
-    if vert_diff
+    if !isnothing(p.atmos.vert_diff)
         (; dif_flux_uₕ, dif_flux_energy, dif_flux_ρq_tot) = p
         vert_diff_diagnostic = (;
             sfc_flux_momentum = dif_flux_uₕ,

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -54,9 +54,9 @@ function parse_commandline()
         help = "EDMF coriolis [`nothing` (default), `Bomex`,`LifeCycleTan2018`,`Rico`,`ARM_SGP`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
         arg_type = String
         "--vert_diff"
-        help = "Vertical diffusion [`false` (default), `true`]"
-        arg_type = Bool
-        default = false
+        help = "Vertical diffusion [`false` (default), `VerticalDiffusion`, `true` (defaults to `VerticalDiffusion`)]"
+        arg_type = String
+        default = "false"
         "--surface_scheme"
         help = "Surface flux scheme [`nothing` (default), `bulk`, `monin_obukhov`]"
         arg_type = String

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -48,6 +48,22 @@ function hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
     end
 end
 
+function vertical_diffusion_model(
+    diffuse_momentum,
+    parsed_args,
+    ::Type{FT},
+) where {FT}
+    vert_diff_name = parsed_args["vert_diff"]
+    return if vert_diff_name in ("false", false, "none")
+        nothing
+    elseif vert_diff_name in ("true", true, "VerticalDiffusion")
+        C_E = FT(parsed_args["C_E"])
+        VerticalDiffusion{diffuse_momentum, FT}(; C_E)
+    else
+        error("Uncaught diffusion model `$vert_diff_name`.")
+    end
+end
+
 function perf_mode(parsed_args)
     return if parsed_args["perf_mode"] == "PerfExperimental"
         PerfExperimental()
@@ -56,11 +72,10 @@ function perf_mode(parsed_args)
     end
 end
 
-function energy_form(parsed_args)
+function energy_form(parsed_args, vert_diff)
     energy_name = parsed_args["energy_name"]
     @assert energy_name in ("rhoe", "rhoe_int", "rhotheta")
-    vert_diff = parsed_args["vert_diff"]
-    if vert_diff
+    if !isnothing(vert_diff)
         @assert energy_name == "rhoe"
     end
     return if energy_name == "rhoe"

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,6 +39,13 @@ end
 q_tot_hyperdiffusion_enabled(::ClimaHyperdiffusion{B}) where {B} = B
 q_tot_hyperdiffusion_enabled(::TempestHyperdiffusion{B}) where {B} = B
 
+abstract type AbstractVerticalDiffusion end
+Base.@kwdef struct VerticalDiffusion{DM, FT} <: AbstractVerticalDiffusion
+    C_E::FT
+end
+diffuse_momentum(::VerticalDiffusion{DM}) where {DM} = DM
+diffuse_momentum(::Nothing) = false
+
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
 struct Subsidence{T} <: AbstractForcing
@@ -133,6 +140,7 @@ Base.@kwdef struct AtmosModel{
     SS,
     GW,
     HD,
+    VD,
 }
     model_config::MC = nothing
     coupling::C = nothing
@@ -150,6 +158,7 @@ Base.@kwdef struct AtmosModel{
     surface_scheme::SS = nothing
     non_orographic_gravity_wave::GW = nothing
     hyperdiff::HD = nothing
+    vert_diff::VD = nothing
 end
 
 Base.broadcastable(x::AtmosModel) = Ref(x)


### PR DESCRIPTION
This PR:
 - Adds a `VerticalDiffusion` type, which incorporates `diffuse_momentum` and `C_E`
 - Fixes a reference to a non-constant global in the callbacks (`vert_diff`)
 - Changes the `vert_diff` CL option to be a string, which can still be `true`/`false`, but also `VerticalDiffusion` (which is default when `true`)

I've also changed `get_surface_fluxes!` so that it dispatches on `ClimaAtmos`'s `vert_diff` (either `VerticalDiffusion` or `Nothing`) and removed the dispatching on `Coupled`/`Decoupled`, so that it can be more easily called in other contexts. cc @szy21, @LenkaNovak.

To keep things working the same here, I've added a compile-time if-else around the calls, similar to what we had before:

```julia
        if p.atmos.coupling isa CA.Decoupled
            CA.get_surface_fluxes!(Y, p, t, colidx, vert_diff)
        end
```