### PR TITLE
Add and use NonOrographicGravityWave type

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -311,7 +311,7 @@ function parse_commandline()
         arg_type = Bool
         default = false
         "--non_orographic_gravity_wave"
-        help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow"
+        help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow [`false` (default), `true`]"
         arg_type = Bool
         default = false
         "--apply_remap"

--- a/examples/hybrid/types.jl
+++ b/examples/hybrid/types.jl
@@ -25,8 +25,6 @@ import ClimaCore: InputOutput
 
 function get_atmos(::Type{FT}, parsed_args, namelist) where {FT}
     # should this live in the radiation model?
-    non_orographic_gravity_wave = parsed_args["non_orographic_gravity_wave"]
-    @assert non_orographic_gravity_wave in (true, false)
 
     moisture_model = CA.moisture_model(parsed_args)
     precip_model = CA.precipitation_model(parsed_args)
@@ -37,10 +35,11 @@ function get_atmos(::Type{FT}, parsed_args, namelist) where {FT}
     diffuse_momentum =
         !(forcing_type isa HeldSuarezForcing) && !isnothing(surface_scheme)
 
+    model_config = CA.model_config(parsed_args)
     vert_diff = CA.vertical_diffusion_model(diffuse_momentum, parsed_args, FT)
     atmos = CA.AtmosModel(;
         moisture_model,
-        model_config = CA.model_config(parsed_args),
+        model_config,
         coupling = CA.coupling_type(parsed_args),
         perf_mode = CA.perf_mode(parsed_args),
         energy_form = CA.energy_form(parsed_args, vert_diff),
@@ -59,7 +58,11 @@ function get_atmos(::Type{FT}, parsed_args, namelist) where {FT}
         ),
         compressibility_model = CA.compressibility_model(parsed_args),
         surface_scheme,
-        non_orographic_gravity_wave,
+        non_orographic_gravity_wave = CA.non_orographic_gravity_wave_model(
+            parsed_args,
+            model_config,
+            FT,
+        ),
         hyperdiff = CA.hyperdiffusion_model(parsed_args, FT),
         vert_diff,
         viscous_sponge = CA.viscous_sponge_model(parsed_args, FT),

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -94,6 +94,27 @@ function rayleigh_sponge_model(parsed_args, ::Type{FT}) where {FT}
     end
 end
 
+function non_orographic_gravity_wave_model(
+    parsed_args,
+    model_config,
+    ::Type{FT},
+) where {FT}
+    nogw_name = parsed_args["non_orographic_gravity_wave"]
+    @assert nogw_name in (true, false)
+    return if nogw_name == true
+        if model_config isa SingleColumnModel
+            NonOrographyGravityWave{FT}(; Bm = 1.2)
+        elseif model_config isa SphericalModel
+            # as in GFDL code (sphere)
+            NonOrographyGravityWave{FT}(; Bm = 0.4)
+        else
+            error("Uncaught case")
+        end
+    else
+        nothing
+    end
+end
+
 function perf_mode(parsed_args)
     return if parsed_args["perf_mode"] == "PerfExperimental"
         PerfExperimental()

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,6 +58,26 @@ Base.@kwdef struct RayleighSponge{FT} <: AbstractSponge
     α_w::FT
 end
 
+abstract type AbstractGravityWave end
+Base.@kwdef struct NonOrographyGravityWave{FT} <: AbstractGravityWave
+    source_pressure::FT = 3e4
+    source_height::FT = 15000
+    Bm::FT
+    F_S0::FT = 4e-3
+    dc::FT = 0.6
+    cmax::FT = 99.6
+    c0::FT = 0
+    kwv::FT = 2π / 100e5
+    cw::FT = 40.0
+    Bt_0::FT = 0.0003
+    Bt_n::FT = 0.0003
+    Bt_s::FT = 0.0003
+    ϕ0_n::FT = 30
+    ϕ0_s::FT = -30
+    dϕ_n::FT = 5
+    dϕ_s::FT = -5
+end
+
 abstract type AbstractForcing end
 struct HeldSuarezForcing <: AbstractForcing end
 struct Subsidence{T} <: AbstractForcing
@@ -150,7 +170,7 @@ Base.@kwdef struct AtmosModel{
     TCM,
     CM,
     SS,
-    GW,
+    NOGW,
     HD,
     VD,
     VS,
@@ -170,7 +190,7 @@ Base.@kwdef struct AtmosModel{
     turbconv_model::TCM = nothing
     compressibility_model::CM = nothing
     surface_scheme::SS = nothing
-    non_orographic_gravity_wave::GW = nothing
+    non_orographic_gravity_wave::NOGW = nothing
     hyperdiff::HD = nothing
     vert_diff::VD = nothing
     viscous_sponge::VS = nothing


### PR DESCRIPTION
This PR adds and uses a `NonOrographicGravityWave` type, and deletes `tendency_knobs`, since it's no longer needed.