### PR TITLE
kinetic energy conservation changes

### DIFF
--- a/examples/hybrid/callbacks.jl
+++ b/examples/hybrid/callbacks.jl
@@ -203,10 +203,13 @@ function rrtmgp_model_callback!(integrator)
 
     radiation_model.surface_temperature .= RRTMGPI.field2array(T_sfc)
 
-    C123 = Geometry.Covariant123Vector
     ᶜp = RRTMGPI.array2field(radiation_model.center_pressure, axes(Y.c))
     ᶜT = RRTMGPI.array2field(radiation_model.center_temperature, axes(Y.c))
-    @. ᶜK = LinearAlgebra.norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+    @. ᶜK =
+        (
+            LinearAlgebra.norm_sqr(Y.c.uₕ) +
+            ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w))
+        ) / 2
     CA.thermo_state!(Y, p, ᶜinterp; time = t)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     @. ᶜT = TD.air_temperature(thermo_params, ᶜts)
@@ -349,7 +352,11 @@ function save_to_disk_func(integrator)
     ᶜuₕ = Y.c.uₕ
     ᶠw = Y.f.w
     # kinetic
-    @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
+    @. ᶜK =
+        (
+            LinearAlgebra.norm_sqr(Y.c.uₕ) +
+            ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w))
+        ) / 2
 
     # thermo state
     CA.thermo_state!(Y, p, ᶜinterp; time = t)

--- a/examples/hybrid/staggered_nonhydrostatic_model.jl
+++ b/examples/hybrid/staggered_nonhydrostatic_model.jl
@@ -41,6 +41,10 @@ const ᶠinterp = Operators.InterpolateC2F(
     bottom = Operators.Extrapolate(),
     top = Operators.Extrapolate(),
 )
+const ᶠwinterp = Operators.WeightedInterpolateC2F(
+    bottom = Operators.Extrapolate(),
+    top = Operators.Extrapolate(),
+)
 const ᶜdivᵥ = Operators.DivergenceF2C(
     top = Operators.SetValue(Geometry.Contravariant3Vector(FT(0))),
     bottom = Operators.SetValue(Geometry.Contravariant3Vector(FT(0))),
@@ -172,6 +176,7 @@ function default_cache(
             ᶜinterp_stencil = Operators.Operator2Stencil(ᶜinterp),
             ᶠinterp_stencil = Operators.Operator2Stencil(ᶠinterp),
             ᶠinterp,
+            ᶠwinterp,
             ᶠcurlᵥ,
             ᶜinterp,
             ᶠgradᵥ,

--- a/post_processing/post_processing_funcs.jl
+++ b/post_processing/post_processing_funcs.jl
@@ -343,7 +343,11 @@ function paperplots_moist_baro_wave_ρe(sol, output_dir, p, nlat, nlon)
         ᶜuₕ_phy = @. Geometry.project(Geometry.UVAxis(), ᶜuvw_phy)
         ᶜw_phy = @. Geometry.project(Geometry.WAxis(), ᶜuvw_phy)
         ᶠw_phy = ᶠinterp.(ᶜw_phy)
-        @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
+        @. ᶜK =
+            (
+                LinearAlgebra.norm_sqr(Y.c.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w))
+            ) / 2
         CA.thermo_state!(Y, p, ᶜinterp)
         @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
 
@@ -701,7 +705,11 @@ function paperplots_held_suarez(sol, output_dir, p, nlat, nlon)
 
             # temperature
             ᶠw = Y.f.w
-            @. ᶜK = norm_sqr(C123(ᶜuₕ) + C123(ᶜinterp(ᶠw))) / 2
+            @. ᶜK =
+                (
+                    LinearAlgebra.norm_sqr(Y.c.uₕ) +
+                    ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w))
+                ) / 2
             CA.thermo_state!(Y, p, ᶜinterp)
             ᶜT = @. TD.air_temperature(thermo_params, ᶜts)
             ᶜθ = @. TD.dry_pottemp(thermo_params, ᶜts)

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -1,3 +1,5 @@
+import LinearAlgebra
+
 function update_aux!(
     edmf::EDMFModel,
     grid::Grid,
@@ -61,9 +63,8 @@ function update_aux!(
 
     @inbounds for i in 1:N_up
         @. aux_up[i].e_kin =
-            LA.norm_sqr(
-                C123(prog_gm_uₕ) + C123(Ic(CCG.WVector(prog_up_f[i].w))),
-            ) / 2
+            LinearAlgebra.norm_sqr(prog_gm_uₕ) +
+            Ic(LinearAlgebra.norm_sqr(prog_up_f[i].w)) / 2
     end
 
     @inbounds for k in real_center_indices(grid)
@@ -141,7 +142,8 @@ function update_aux!(
     end
 
     @. aux_en.e_kin =
-        LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(wvec(aux_en_f.w)))) / 2
+        LinearAlgebra.norm_sqr(prog_gm_uₕ) +
+        Ic(LinearAlgebra.norm_sqr(aux_en_f.w)) / 2
 
     @inbounds for k in real_center_indices(grid)
         e_pot = geopotential(thermo_params, grid.zc.z[k])

--- a/src/discrete_hydrostatic_balance.jl
+++ b/src/discrete_hydrostatic_balance.jl
@@ -26,7 +26,11 @@ function set_discrete_hydrostatic_balanced_state!(Y, p)
     end
     thermo_params = CAP.thermodynamics_params(p.params)
     C123 = Geometry.Covariant123Vector
-    @. p.ᶜK = norm_sqr(C123(Y.c.uₕ) + C123(ᶜinterp(Y.f.w))) / 2
+    @. p.ᶜK =
+        (
+            LinearAlgebra.norm_sqr(Y.c.uₕ) +
+            ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w))
+        ) / 2
     if p.atmos.moisture_model isa DryModel
         @. p.ᶜts = TD.PhaseDry_ρp(thermo_params, Y.c.ρ, p.ᶜp)
     elseif p.atmos.moisture_model isa EquilMoistModel

--- a/src/precomputed_quantities.jl
+++ b/src/precomputed_quantities.jl
@@ -20,7 +20,11 @@ function precomputed_quantities!(Y, p, t, colidx)
     (; ᶜinterp) = p.operators
     C123 = Geometry.Covariant123Vector
     @. ᶜuvw[colidx] = C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))
-    @. ᶜK[colidx] = norm_sqr(ᶜuvw[colidx]) / 2
+    @. ᶜK[colidx] =
+        (
+            LinearAlgebra.norm_sqr(Y.c.uₕ[colidx]) +
+            ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w[colidx]))
+        ) / 2
     thermo_params = CAP.thermodynamics_params(params)
     thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -98,7 +98,7 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         C123(ᶠinterp(ᶜuₕ[colidx])) + C123(ᶠw[colidx]),
     )
     @. Yₜ.c.uₕ[colidx] -=
-        ᶜinterp(ᶠω¹²[colidx] × ᶠu³[colidx]) +
+        ᶜinterp(ᶠinterp(ᶜρ[colidx] * J[colidx]) * ᶠω¹²[colidx] × ᶠu³[colidx]) / (ᶜρ[colidx] * J[colidx]) +
         (ᶜf[colidx] + ᶜω³[colidx]) ×
         (Geometry.project(Geometry.Contravariant12Axis(), ᶜuvw[colidx]))
     @. Yₜ.f.w[colidx] -= ᶠω¹²[colidx] × ᶠu¹²[colidx] + ᶠgradᵥ(ᶜK[colidx])

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -98,7 +98,8 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         C123(ᶠinterp(ᶜuₕ[colidx])) + C123(ᶠw[colidx]),
     )
     @. Yₜ.c.uₕ[colidx] -=
-        ᶜinterp(ᶠinterp(ᶜρ[colidx] * J[colidx]) * ᶠω¹²[colidx] × ᶠu³[colidx]) / (ᶜρ[colidx] * J[colidx]) +
+        ᶜinterp(ᶠinterp(ᶜρ[colidx] * J[colidx]) * ᶠω¹²[colidx] × ᶠu³[colidx]) /
+        (ᶜρ[colidx] * J[colidx]) +
         (ᶜf[colidx] + ᶜω³[colidx]) ×
         (Geometry.project(Geometry.Contravariant12Axis(), ᶜuvw[colidx]))
     @. Yₜ.f.w[colidx] -= ᶠω¹²[colidx] × ᶠu¹²[colidx] + ᶠgradᵥ(ᶜK[colidx])

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -73,9 +73,10 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     ᶠw = Y.f.w
     C123 = Geometry.Covariant123Vector
     (; ᶜuvw, ᶜK, ᶜp, ᶜω³, ᶠω¹², ᶠu¹², ᶠu³, ᶜf) = p
-    (; ᶜdivᵥ, ᶠinterp, ᶠcurlᵥ, ᶜinterp, ᶠgradᵥ) = p.operators
+    (; ᶜdivᵥ, ᶠinterp, ᶠwinterp, ᶠcurlᵥ, ᶜinterp, ᶠgradᵥ) = p.operators
     # Mass conservation
-    @. Yₜ.c.ρ[colidx] -= ᶜdivᵥ(ᶠinterp(ᶜρ[colidx] * ᶜuₕ[colidx]))
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
+    @. Yₜ.c.ρ[colidx] -= ᶜdivᵥ(ᶠwinterp(J[colidx], ᶜρ[colidx] * ᶜuₕ[colidx]))
 
     # Energy conservation
     if :ρθ in propertynames(Y.c)

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -16,39 +16,46 @@ import ClimaCore.Spaces as Spaces
 # the implicit tendency function. Since dt >= dtγ, we can safely use dt for now.
 function vertical_transport!(ᶜρcₜ, ᶠw, ᶜρ, ᶜρc, p, ::Val{:none})
     (; dt) = p.simulation
-    (; ᶜdivᵥ, ᶠinterp) = p.operators
-    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠinterp(ᶜρc) * ᶠw))
+    (; ᶜdivᵥ, ᶠwinterp) = p.operators
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
+    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠwinterp(J, ᶜρc) * ᶠw))
 end
 function vertical_transport!(ᶜρcₜ, ᶠw, ᶜρ, ᶜρc, p, ::Val{:first_order})
     (; dt) = p.simulation
-    (; ᶜdivᵥ, ᶠinterp, ᶠupwind1) = p.operators
-    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ)))
+    (; ᶜdivᵥ, ᶠwinterp, ᶠupwind1) = p.operators
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
+    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ)))
 end
 function vertical_transport!(ᶜρcₜ, ᶠw, ᶜρ, ᶜρc, p, ::Val{:third_order})
     (; dt) = p.simulation
-    (; ᶜdivᵥ, ᶠinterp, ᶠupwind3) = p.operators
-    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind3(ᶠw, ᶜρc / ᶜρ)))
+    (; ᶜdivᵥ, ᶠwinterp, ᶠupwind3) = p.operators
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
+    @. ᶜρcₜ = -(ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind3(ᶠw, ᶜρc / ᶜρ)))
 end
 function vertical_transport!(ᶜρcₜ, ᶠw, ᶜρ, ᶜρc, p, ::Val{:boris_book})
     (; dt) = p.simulation
-    (; ᶜdivᵥ, ᶠinterp, ᶠupwind1, ᶠupwind3, ᶠfct_boris_book) = p.operators
+    (; ᶜdivᵥ, ᶠwinterp, ᶠupwind1, ᶠupwind3, ᶠfct_boris_book) = p.operators
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
     @. ᶜρcₜ =
-        -(ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) - ᶜdivᵥ(
-            ᶠinterp(ᶜρ) * ᶠfct_boris_book(
+        -(ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) - ᶜdivᵥ(
+            ᶠwinterp(J, ᶜρ) * ᶠfct_boris_book(
                 ᶠupwind3(ᶠw, ᶜρc / ᶜρ) - ᶠupwind1(ᶠw, ᶜρc / ᶜρ),
-                (ᶜρc / dt - ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) / ᶜρ,
+                (ᶜρc / dt - ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) /
+                ᶜρ,
             ),
         )
 end
 function vertical_transport!(ᶜρcₜ, ᶠw, ᶜρ, ᶜρc, p, ::Val{:zalesak})
     (; dt) = p.simulation
-    (; ᶜdivᵥ, ᶠinterp, ᶠupwind1, ᶠupwind3, ᶠfct_zalesak) = p.operators
+    (; ᶜdivᵥ, ᶠwinterp, ᶠupwind1, ᶠupwind3, ᶠfct_zalesak) = p.operators
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
     @. ᶜρcₜ =
-        -(ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) - ᶜdivᵥ(
-            ᶠinterp(ᶜρ) * ᶠfct_zalesak(
+        -(ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) - ᶜdivᵥ(
+            ᶠwinterp(J, ᶜρ) * ᶠfct_zalesak(
                 ᶠupwind3(ᶠw, ᶜρc / ᶜρ) - ᶠupwind1(ᶠw, ᶜρc / ᶜρ),
                 ᶜρc / ᶜρ / dt,
-                (ᶜρc / dt - ᶜdivᵥ(ᶠinterp(ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) / ᶜρ,
+                (ᶜρc / dt - ᶜdivᵥ(ᶠwinterp(J, ᶜρ) * ᶠupwind1(ᶠw, ᶜρc / ᶜρ))) /
+                ᶜρ,
             ),
         )
 end

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -99,7 +99,10 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
 
     thermo_params = CAP.thermodynamics_params(params)
     dt = simulation.dt
-    @. ᶜK[colidx] = norm_sqr(C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))) / 2
+    @. ᶜK[colidx] = (
+        LinearAlgebra.norm_sqr(Y.c.uₕ[colidx]) +
+        ᶜinterp(LinearAlgebra.norm_sqr(Y.f.w[colidx])) / 2
+    )
     thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
 

--- a/src/tendencies/implicit/wfact.jl
+++ b/src/tendencies/implicit/wfact.jl
@@ -132,7 +132,10 @@ function Wfact!(W, Y, p, dtγ, t, colidx)
     # The εw is only necessary in case w = 0.
     # Since Operator2Stencil has not yet been extended to upwinding
     # operators, ᶠupwind_stencil is not available.
-    @. ᶜK[colidx] = norm_sqr(C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))) / 2
+    @. ᶜK[colidx] = (
+        LinearAlgebra.norm_sqr(ᶜuₕ[colidx]) +
+        ᶜinterp(LinearAlgebra.norm_sqr(ᶠw[colidx])) / 2
+    )
     thermo_params = CAP.thermodynamics_params(params)
     thermo_state!(Y, p, ᶜinterp, colidx; time = t)
     @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])

--- a/src/thermo_state.jl
+++ b/src/thermo_state.jl
@@ -176,13 +176,19 @@ function thermo_state_ρe_tot_anelastic!(
         @. ᶜts = TD.PhaseDry_pe(
             thermo_params,
             ᶜp,
-            Yc.ρe_tot / Yc.ρ - (norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(ᶠw))) / 2) - grav * z,
+            Yc.ρe_tot / Yc.ρ - (
+                LinearAlgebra.norm_sqr(Yc.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(ᶠw)) / 2
+            ) - grav * z,
         )
     elseif moisture_model isa EquilMoistModel
         @. ᶜts = TD.PhaseEquil_peq(
             thermo_params,
             ᶜp,
-            Yc.ρe_tot / Yc.ρ - (norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(ᶠw))) / 2) - grav * z,
+            Yc.ρe_tot / Yc.ρ - (
+                LinearAlgebra.norm_sqr(Yc.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(ᶠw)) / 2
+            ) - grav * z,
             Yc.ρq_tot / Yc.ρ,
         )
     else
@@ -251,7 +257,10 @@ function thermo_state_ρe_tot!(
         thermo_params,
         internal_energy(
             Yc,
-            (norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(ᶠw))) / 2),
+            (
+                LinearAlgebra.norm_sqr(Yc.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(ᶠw)) / 2
+            ),
             g,
             z,
         ) / Yc.ρ,
@@ -275,7 +284,10 @@ function thermo_state_ρe_tot!(
         Yc.ρ,
         internal_energy(
             Yc,
-            (norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(ᶠw))) / 2),
+            (
+                LinearAlgebra.norm_sqr(Yc.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(ᶠw)) / 2
+            ),
             g,
             z,
         ) / Yc.ρ,
@@ -299,7 +311,10 @@ function thermo_state_ρe_tot!(
         thermo_params,
         internal_energy(
             Yc,
-            (norm_sqr(C123(Yc.uₕ) + C123(ᶜinterp(ᶠw))) / 2),
+            (
+                LinearAlgebra.norm_sqr(Yc.uₕ) +
+                ᶜinterp(LinearAlgebra.norm_sqr(ᶠw)) / 2
+            ),
             g,
             z,
         ) / Yc.ρ,

--- a/tc_driver/dycore.jl
+++ b/tc_driver/dycore.jl
@@ -56,12 +56,12 @@ function set_grid_mean_from_thermo_state!(thermo_params, state, grid)
     ρ_c = prog_gm.ρ
     ρ_f = aux_gm_f.ρ
 
-    C123 = CCG.Covariant123Vector
     @. prog_gm.ρe_tot =
         ρ_c * TD.total_energy(
             thermo_params,
             ts_gm,
-            LA.norm_sqr(C123(prog_gm_uₕ) + C123(Ic(prog_gm_f.w))) / 2,
+            LinearAlgebra.norm_sqr(prog_gm_uₕ) +
+            Ic(LinearAlgebra.norm_sqr(prog_gm_f.w)) / 2,
             TC.geopotential(thermo_params, grid.zc.z),
         )
 


### PR DESCRIPTION
Following discussion with @tapios and @Zhengyu-Huang, there are some changes that are necessary to ensure kinetic energy conservation.


## Purpose 
Changes the reconstruction in the divergence term to be weighted by the Jacobian, this is necessary for kinetic energy conservation.


## To-do
There are 3 changes we have identified
- [x] use Jacobian-weighted reconstructions of the mass in the advection operator
- [x] in the kinetic energy term, compute $I(w^2)$ instead of $I(w)^2$.
- [x] use a mass-weighted reconstruction of the vertical curl term in the horizontal tendency

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
