### PR TITLE
rename gravity_wave_parameterization to non_orographic_gravity_wave

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,13 +91,13 @@ steps:
         artifact_paths: "single_column_nonorographic_gravity_wave/*"
 
       - label: ":computer: non-orographic gravity wave parameterization unit test 3d"
-        command: "julia --color=yes --project=examples test/gravity_wave_parameterization/gw_test_3d.jl"
+        command: "julia --color=yes --project=examples test/non_orographic_gravity_wave/nogw_test_3d.jl"
         artifact_paths: "nonorographic_gravity_wave_test_3d/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":computer: non-orographic gravity wave parameterization unit test single column"
-        command: "julia --color=yes --project=examples test/gravity_wave_parameterization/gw_test_single_column.jl"
+        command: "julia --color=yes --project=examples test/non_orographic_gravity_wave/nogw_test_single_column.jl"
         artifact_paths: "nonorographic_gravity_wave_test_single_column/*"
 
   - group: "MPI Examples"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -163,7 +163,13 @@ function additional_tendency!(Yₜ, Y, p, t)
         CA.precipitation_tendency!(Yₜ, Y, p, t, colidx, p.precip_model)
     end
     # TODO: make bycolumn-able
-    CA.gravity_wave_tendency!(Yₜ, Y, p, t, p.atmos.non_orographic_gravity_wave)
+    CA.non_orographic_gravity_wave_tendency!(
+        Yₜ,
+        Y,
+        p,
+        t,
+        p.atmos.non_orographic_gravity_wave,
+    )
 end
 
 ################################################################################

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -31,7 +31,7 @@ include(joinpath("tendencies", "forcing", "subsidence.jl"))
 include(joinpath("tendencies", "forcing", "held_suarez.jl"))
 
 include(joinpath("tendencies", "radiation.jl"))
-include(joinpath("tendencies", "gravity_wave_parameterization.jl"))
+include(joinpath("tendencies", "non_orographic_gravity_wave.jl"))
 include(joinpath("tendencies", "hyperdiffusion.jl"))
 include(joinpath("tendencies", "edmf_coriolis.jl"))
 include(joinpath("tendencies", "precipitation.jl"))

--- a/src/tendencies/non_orographic_gravity_wave.jl
+++ b/src/tendencies/non_orographic_gravity_wave.jl
@@ -1,5 +1,5 @@
 #####
-##### Gravity wave parameterization
+##### Non-orographic gravity wave parameterization
 #####
 
 import ClimaCore.Spaces as Spaces
@@ -15,7 +15,7 @@ non_orographic_gravity_wave_cache(atmos, Y) = non_orographic_gravity_wave_cache(
 non_orographic_gravity_wave_cache(::Nothing, ::AbstractModelConfig, Y) =
     NamedTuple()
 
-gravity_wave_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing
+non_orographic_gravity_wave_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing
 
 function non_orographic_gravity_wave_cache(
     gw::NonOrographyGravityWave,
@@ -81,7 +81,13 @@ function non_orographic_gravity_wave_cache(
     )
 end
 
-function gravity_wave_tendency!(Yₜ, Y, p, t, ::NonOrographyGravityWave)
+function non_orographic_gravity_wave_tendency!(
+    Yₜ,
+    Y,
+    p,
+    t,
+    ::NonOrographyGravityWave,
+)
     #unpack
     (; ᶜts, ᶜT, ᶜdTdz, ᶜbuoyancy_frequency, params, model_config) = p
     (; gw_Bm, gw_source_ampl, gw_c, gw_cw, gw_c0, gw_nk, gw_k, gw_k2) = p
@@ -148,7 +154,7 @@ function gravity_wave_tendency!(Yₜ, Y, p, t, ::NonOrographyGravityWave)
 
     # GW parameterization applied bycolume
     Fields.bycolumn(axes(ᶜρ)) do colidx
-        parent(uforcing[colidx]) .= gravity_wave_forcing(
+        parent(uforcing[colidx]) .= non_orographic_gravity_wave_forcing(
             model_config,
             parent(u_phy[colidx]),
             Int(parent(source_level[colidx])[1]),
@@ -164,7 +170,7 @@ function gravity_wave_tendency!(Yₜ, Y, p, t, ::NonOrographyGravityWave)
             parent(ᶜρ[colidx]),
             parent(ᶠz[colidx]),
         )
-        parent(vforcing[colidx]) .= gravity_wave_forcing(
+        parent(vforcing[colidx]) .= non_orographic_gravity_wave_forcing(
             model_config,
             parent(v_phy[colidx]),
             Int(parent(source_level[colidx])[1]),
@@ -189,7 +195,7 @@ function gravity_wave_tendency!(Yₜ, Y, p, t, ::NonOrographyGravityWave)
 
 end
 
-function gravity_wave_forcing(
+function non_orographic_gravity_wave_forcing(
     model_config,
     ᶜu,
     source_level,

--- a/test/non_orographic_gravity_wave/nogw_test_3d.jl
+++ b/test/non_orographic_gravity_wave/nogw_test_3d.jl
@@ -15,7 +15,7 @@ center_z = 0.5 .* (face_z[1:(end - 1)] .+ face_z[2:end])
 model_config = CA.SingleColumnModel()
 
 # compute the source parameters
-function gravity_wave_cache(
+function non_orographic_gravity_wave_cache(
     ::Type{FT};
     source_height = FT(15000),
     Bm = FT(1.2),
@@ -43,7 +43,12 @@ function gravity_wave_cache(
     )
 end
 
-params = gravity_wave_cache(FT; Bm = 0.4, cmax = 150, kwv = 2π / 100e3)
+params = non_orographic_gravity_wave_cache(
+    FT;
+    Bm = 0.4,
+    cmax = 150,
+    kwv = 2π / 100e3,
+)
 source_level = argmin(abs.(center_z .- params.gw_source_height))
 
 include(joinpath(pkgdir(ClimaAtmos), "artifacts", "artifact_funcs.jl"))
@@ -126,7 +131,7 @@ Jan_bf = mean(center_bf_zonalave[:, :, month .== 1], dims = 3)[:, :, 1]
 Jan_ρ = mean(center_ρ_zonalave[:, :, month .== 1], dims = 3)[:, :, 1]
 Jan_uforcing = zeros(length(lat), length(center_z))
 for j in 1:length(lat)
-    Jan_uforcing[j, :] = CA.gravity_wave_forcing(
+    Jan_uforcing[j, :] = CA.non_orographic_gravity_wave_forcing(
         model_config,
         Jan_u[j, :],
         source_level,

--- a/test/non_orographic_gravity_wave/nogw_test_single_column.jl
+++ b/test/non_orographic_gravity_wave/nogw_test_single_column.jl
@@ -16,7 +16,7 @@ center_z = FT(0.5) .* (face_z[1:(end - 1)] .+ face_z[2:end])
 model_config = CA.SingleColumnModel()
 
 # compute the source parameters
-function gravity_wave_cache(
+function non_orographic_gravity_wave_cache(
     ::Type{FT};
     source_height = FT(15000),
     Bm = FT(1.2),
@@ -44,7 +44,12 @@ function gravity_wave_cache(
     )
 end
 
-params = gravity_wave_cache(FT; Bm = 0.4, cmax = 150, kwv = 2π / 100e3)
+params = non_orographic_gravity_wave_cache(
+    FT;
+    Bm = 0.4,
+    cmax = 150,
+    kwv = 2π / 100e3,
+)
 source_level = argmin(abs.(center_z .- params.gw_source_height))
 
 include(joinpath(pkgdir(ClimaAtmos), "artifacts", "artifact_funcs.jl"))
@@ -129,7 +134,7 @@ mkpath(output_dir)
 Jan_u = mean(center_u_mean[:, month .== 1], dims = 2)[:, 1]
 Jan_bf = mean(center_bf_mean[:, month .== 1], dims = 2)[:, 1]
 Jan_ρ = mean(center_ρ_mean[:, month .== 1], dims = 2)[:, 1]
-Jan_uforcing = CA.gravity_wave_forcing(
+Jan_uforcing = CA.non_orographic_gravity_wave_forcing(
     model_config,
     Jan_u,
     source_level,
@@ -154,7 +159,7 @@ png(
 April_u = mean(center_u_mean[:, month .== 4], dims = 2)[:, 1]
 April_bf = mean(center_bf_mean[:, month .== 4], dims = 2)[:, 1]
 April_ρ = mean(center_ρ_mean[:, month .== 4], dims = 2)[:, 1]
-April_uforcing = CA.gravity_wave_forcing(
+April_uforcing = CA.non_orographic_gravity_wave_forcing(
     model_config,
     April_u,
     source_level,
@@ -179,7 +184,7 @@ png(
 July_u = mean(center_u_mean[:, month .== 7], dims = 2)[:, 1]
 July_bf = mean(center_bf_mean[:, month .== 7], dims = 2)[:, 1]
 July_ρ = mean(center_ρ_mean[:, month .== 7], dims = 2)[:, 1]
-July_uforcing = CA.gravity_wave_forcing(
+July_uforcing = CA.non_orographic_gravity_wave_forcing(
     model_config,
     July_u,
     source_level,
@@ -204,7 +209,7 @@ png(
 Oct_u = mean(center_u_mean[:, month .== 10], dims = 2)[:, 1]
 Oct_bf = mean(center_bf_mean[:, month .== 10], dims = 2)[:, 1]
 Oct_ρ = mean(center_ρ_mean[:, month .== 10], dims = 2)[:, 1]
-Oct_uforcing = CA.gravity_wave_forcing(
+Oct_uforcing = CA.non_orographic_gravity_wave_forcing(
     model_config,
     Oct_u,
     source_level,


### PR DESCRIPTION
This PR renames `gravity_wave_parameterization` to `non_orographic_gravity_wave` to distinguish from the `orographic_gravity_wave` 