### PR TITLE
Mass weighting in cross product

### DIFF
--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -127,6 +127,11 @@ The ``(\nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \tim
 ```math
 (C^f_v[\boldsymbol{u}_h] + C_h[\boldsymbol{u}_v]) \times I^f(\boldsymbol{u}^h) ,
 ```
+```math
+\omega_f^{h} \times \boldsymbol{u}^{h} = \nabla_v \times \boldsymbol{u}^{h} \times \boldsymbol{u}^{h},
+\omega^{h} × I\^{f}(J \rho u_c^{h}) / I^{f}(\rho J),
+```
+with $\boldsymbol{u}_c^{h}$ evaluated at cell centers,  
 and the ``\frac{1}{\rho} \nabla_v p + \nabla_v(\Phi + K)`` term as
 ```math
 \frac{1}{I^f(\rho)} G^f_v[p] + G^f[K + \Phi] ,

--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -129,7 +129,7 @@ The ``(\nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \tim
 ```
 ```math
 \omega_f^{h} \times \boldsymbol{u}^{h} = \nabla_v \times \boldsymbol{u}^{h} \times \boldsymbol{u}^{h},
-\omega^{h} × I\^{f}(J \rho u_c^{h}) / I^{f}(\rho J),
+\omega^{h} × I^{f}(J \rho u_c^{h}) / I^{f}(\rho J),
 ```
 with $\boldsymbol{u}_c^{h}$ evaluated at cell centers,  
 and the ``\frac{1}{\rho} \nabla_v p + \nabla_v(\Phi + K)`` term as

--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -127,11 +127,11 @@ The ``(\nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \tim
 ```math
 (C^f_v[\boldsymbol{u}_h] + C_h[\boldsymbol{u}_v]) \times I^f(\boldsymbol{u}^h) ,
 ```
+with the term involving ``C_{h}[\boldsymbol{u}_{v}] = \omega^{h}`` expressed as 
 ```math
-\omega_f^{h} \times \boldsymbol{u}^{h} = \nabla_v \times \boldsymbol{u}^{h} \times \boldsymbol{u}^{h},
-\omega^{h} × I^{f}(J \rho u_c^{h}) / I^{f}(\rho J),
+\omega^{h} \times I^{f}(\rho J \boldsymbol{u}_c^{h}) / I^{f}(\rho J),
 ```
-with $\boldsymbol{u}_c^{h}$ evaluated at cell centers,  
+with ``\boldsymbol{u}_{c}^{h}`` evaluated at cell centers,  
 and the ``\frac{1}{\rho} \nabla_v p + \nabla_v(\Phi + K)`` term as
 ```math
 \frac{1}{I^f(\rho)} G^f_v[p] + G^f[K + \Phi] ,

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -90,8 +90,10 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
 
     # Momentum conservation
     @. ᶠω¹²[colidx] += ᶠcurlᵥ(ᶜuₕ[colidx])
-    @. ᶠu¹²[colidx] =
-        Geometry.project(Geometry.Contravariant12Axis(), ᶠinterp(ᶜuvw[colidx]))
+    @. ᶠu¹²[colidx] = Geometry.project(
+        Geometry.Contravariant12Axis(),
+        ᶠwinterp(ᶜρ * J, ᶜuvw[colidx]),
+    )
     @. ᶠu³[colidx] = Geometry.project(
         Geometry.Contravariant3Axis(),
         C123(ᶠinterp(ᶜuₕ[colidx])) + C123(ᶠw[colidx]),

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -76,6 +76,7 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     (; ᶜdivᵥ, ᶠinterp, ᶠwinterp, ᶠcurlᵥ, ᶜinterp, ᶠgradᵥ) = p.operators
     # Mass conservation
     @. Yₜ.c.ρ[colidx] -= ᶜdivᵥ(ᶠinterp(ᶜρ[colidx] * ᶜuₕ[colidx]))
+    J = Fields.local_geometry_field(axes(ᶜρ)).J
 
     # Energy conservation
     if :ρθ in propertynames(Y.c)
@@ -92,7 +93,7 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     @. ᶠω¹²[colidx] += ᶠcurlᵥ(ᶜuₕ[colidx])
     @. ᶠu¹²[colidx] = Geometry.project(
         Geometry.Contravariant12Axis(),
-        ᶠwinterp(ᶜρ * J, ᶜuvw[colidx]),
+        ᶠwinterp(ᶜρ[colidx] * J[colidx], ᶜuvw[colidx]),
     )
     @. ᶠu³[colidx] = Geometry.project(
         Geometry.Contravariant3Axis(),


### PR DESCRIPTION
### Purpose
Split the second change from PR#1234 to apply mass weighting in cross product term. 

Closes #1274