### PR TITLE
Delete entrainment_massflux_div_factor

### DIFF
--- a/src/TurbulenceConvection/closures/entr_detr.jl
+++ b/src/TurbulenceConvection/closures/entr_detr.jl
@@ -41,12 +41,6 @@ function get_Δw(εδ_model, w_up::FT, w_en::FT) where {FT}
     return Δw
 end
 
-function get_MdMdz(M::FT, dMdz::FT) where {FT}
-    MdMdz_ε = max(dMdz / max(M, eps(FT)), 0)
-    MdMdz_δ = max(-dMdz / max(M, eps(FT)), 0)
-    return MdMdz_ε, MdMdz_δ
-end
-
 function entrainment_inv_length_scale(
     εδ_model,
     b_up::FT,
@@ -83,12 +77,9 @@ function εδ_dyn(εδ_model, εδ_vars, ε_nondim, δ_nondim)
 
     area_limiter = max_area_limiter(εδ_model, εδ_vars.max_area, εδ_vars.a_up)
 
-    c_div = εδ_params(εδ_model).c_div
-    MdMdz_ε, MdMdz_δ = get_MdMdz(εδ_vars.M, εδ_vars.dMdz) .* c_div
-
     # fractional dynamical entrainment / detrainment [1 / m]
-    ε_dyn = εδ_dim_scale * ε_nondim + MdMdz_ε
-    δ_dyn = εδ_dim_scale * (δ_nondim + area_limiter) + MdMdz_δ
+    ε_dyn = εδ_dim_scale * ε_nondim
+    δ_dyn = εδ_dim_scale * (δ_nondim + area_limiter)
 
     return ε_dyn, δ_dyn
 end

--- a/src/TurbulenceConvection/types.jl
+++ b/src/TurbulenceConvection/types.jl
@@ -42,7 +42,6 @@ Base.@kwdef struct EntrDetr{FT}
 end
 
 Base.@kwdef struct εδModelParams{FT}
-    c_div::FT
     w_min::FT # minimum updraft velocity to avoid zero division in b/w²
     c_ε::FT # factor multiplier for dry term in entrainment/detrainment
     μ_0::FT # dimensional scale logistic function in the dry term in entrainment/detrainment
@@ -435,13 +434,6 @@ function EDMFModel(
 
     entr_closure_name = parsed_args["edmf_entr_closure"]
     if entr_closure_name == "MoistureDeficit"
-        c_div = parse_namelist(
-            namelist,
-            "turbulence",
-            "EDMF_PrognosticTKE",
-            "entrainment_massflux_div_factor";
-            default = 0.0,
-        )
         w_min = parse_namelist(
             namelist,
             "turbulence",
@@ -504,7 +496,6 @@ function EDMFModel(
         )
 
         εδ_params = εδModelParams{FT}(;
-            c_div,
             w_min,
             c_ε,
             μ_0,

--- a/tc_driver/generate_namelist.jl
+++ b/tc_driver/generate_namelist.jl
@@ -77,8 +77,6 @@ function default_namelist(
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["detrainment_factor"] =
         0.51
 
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_massflux_div_factor"] =
-        0.0
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["turbulent_entrainment_factor"] =
         0.075
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_smin_tke_coeff"] =


### PR DESCRIPTION
This parameter was added for the dry bubble case, which we don't have anymore. 