### PR TITLE
delete retrying for MPI restart test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,9 +138,9 @@ steps:
         agents:
           slurm_ntasks: 2
         timeout_in_minutes: 20
-        retry:
-          automatic: true
         soft_fail: true
+        #retry:
+        #  automatic: true
 
       - label: ":computer: MPI aquaplanet (ρe_tot) equilmoist clearsky radiation"
         command: "mpiexec julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad clearsky --precip_model 0M --job_id mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky --dt 400secs --t_end 4days"


### PR DESCRIPTION
Can we stop retying this test for now? It's marked as a soft fail anyway and retrying it usually adds ~40min to the CI time