### PR TITLE
Add job for testing n-inference failures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -631,6 +631,9 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":rocket: JET n-failures (inference)"
+        command: "julia --color=yes --project=perf perf/jet_nfailures.jl --job_id jet_n_failures"
+
       - label: ":rocket: flame graph: perf target (ρe_tot) with tracers"
         command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_tracers --perf_mode PerfExperimental"
         artifact_paths: "flame_perf_target_rhoe_tracers/*"

--- a/perf/jet_nfailures.jl
+++ b/perf/jet_nfailures.jl
@@ -1,0 +1,46 @@
+import Profile
+
+ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
+
+filename = joinpath(dirname(@__DIR__), "examples", "hybrid", "driver.jl")
+
+# Uncomment for customizing specific jobs / specs:
+# dict = parsed_args_per_job_id(; trigger = "benchmark.jl"); # if job_id uses benchmark.jl
+# dict = parsed_args_per_job_id();                           # if job_id uses driver.jl
+# parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
+
+try
+    include(filename)
+catch err
+    if err.error !== :exit_profile
+        rethrow(err.error)
+    end
+end
+
+import JET
+
+OrdinaryDiffEq.step!(integrator) # Make sure no errors
+
+# Suggested in: https://github.com/aviatesk/JET.jl/issues/455
+macro n_failures(ex)
+    return :(
+        let result = JET.@report_call $(ex)
+            length(JET.get_reports(result.analyzer, result.result))
+        end
+    )
+end
+
+using Test
+@testset "Test N-jet failures" begin
+    n = @n_failures OrdinaryDiffEq.step!(integrator)
+    # This test is intended to provide some friction when we
+    # add code to our tendency function that results in degraded
+    # inference. By increasing this counter, we acknowledge that
+    # we have introduced an inference failure. We hope to drive
+    # this number down to 0.
+    n_allowed_failures = 7
+    @test n ≤ n_allowed_failures
+    if n < n_allowed_failures
+        @info "Please update the n-failures to $n"
+    end
+end


### PR DESCRIPTION
This PR adds a JET test to ensure that we don't increase the number of JET failures in `step!`