### PR TITLE
Reorganize perf jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -307,9 +307,10 @@ steps:
         agents:
           slurm_ntasks: 2
 
-      - label: ":computer: performance target checkbounds"
-        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --job_id perf_target_checkbounds --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --precip_model 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_checkbounds/*"
+      # TODO: we should somehow decouple this unit test from the perf env / scripts
+      - label: ":computer: checkbounds"
+        command: "julia --color=yes --check-bounds=yes --project=perf perf/benchmark.jl --job_id checkbounds"
+        artifact_paths: "checkbounds/*"
         agents:
           slurm_mem: 20GB
 
@@ -325,28 +326,6 @@ steps:
         artifact_paths: "no_surface/*"
         agents:
           slurm_mem: 20GB
-
-  - group: "Performance targets"
-    steps:
-
-      - label: ":computer: Unthreaded performance target (Rosenbrock)"
-        command: "julia --color=yes --project=ode_compat_examples perf/benchmark.jl --job_id perf_target_unthreaded_rosenbrock --ode_algo ODE.Rosenbrock23 --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --precip_model 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded_rosenbrock/*"
-        agents:
-          slurm_mem: 20GB
-
-      - label: ":computer: Unthreaded performance target"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_unthreaded --enable_threading false --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --precip_model 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_unthreaded/*"
-        agents:
-          slurm_mem: 20GB
-
-      - label: ":computer: Threaded performance target"
-        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --perf_summary true --job_id perf_target_threaded --enable_threading true --forcing held_suarez --vert_diff true --surface_scheme bulk --moist equil --rad allskywithclear --precip_model 0M --dt 1secs --t_end 10secs --dt_save_to_sol Inf --z_elem 25 --h_elem 12"
-        artifact_paths: "perf_target_threaded/*"
-        agents:
-          slurm_ntasks: 8
-          slurm_ntasks_per_node: 8
 
   - group: "TurbulenceConvection"
     steps:
@@ -666,50 +645,69 @@ steps:
   - group: "Performance"
     steps:
 
-      - label: ":rocket: flame graph: perf target (ρe_tot)"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe"
-        artifact_paths: "flame_perf_target_rhoe/*"
+      # Benchmarks
+      - label: ":computer: Benchmark: perf target (default)"
+        command: "julia --color=yes --project=perf perf/benchmark.jl --perf_summary true --job_id bm_perf_target"
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: JET n-failures (inference)"
-        command: "julia --color=yes --project=perf perf/jet_nfailures.jl --job_id jet_n_failures"
-
-      - label: ":rocket: flame graph: perf target (ρe_tot) with tracers"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_tracers --perf_mode PerfExperimental"
-        artifact_paths: "flame_perf_target_rhoe_tracers/*"
+      - label: ":computer: Benchmark: perf target (Rosenbrock)"
+        command: "julia --color=yes --project=ode_compat_examples perf/benchmark.jl --job_id bm_perf_target_rosenbrock --ode_algo ODE.Rosenbrock23"
         agents:
           slurm_mem: 20GB
 
-      - label: ":mag::rocket: Invalidations"
-        command: "julia --color=yes --project=perf perf/invalidations.jl --job_id invalidations"
-        artifact_paths: "invalidations/*"
+      - label: ":computer: Benchmark: perf target (Threaded)"
+        command: "julia --color=yes --threads 8 --project=perf perf/benchmark.jl --perf_summary true --job_id bm_perf_target_threaded --enable_threading true"
+        agents:
+          slurm_mem: 20GB
+          slurm_ntasks: 8
+          slurm_ntasks_per_node: 8
+
+      # Flame graphs
+      - label: ":fire: Flame graph: perf target (default)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target"
+        artifact_paths: "flame_perf_target/*"
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: flame graph: threaded perf target (ρe_tot)"
-        command: "julia --threads 8 --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_threaded --enable_threading true"
-        artifact_paths: "flame_perf_target_rhoe_threaded/*"
+      - label: ":fire: Flame graph: perf target (with tracers)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_tracers --perf_mode PerfExperimental"
+        artifact_paths: "flame_perf_target_tracers/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":fire: Flame graph: perf target (edmf)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_edmf --target_job sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf --moist dry --rad nothing"
+        artifact_paths: "flame_perf_target_edmf/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":fire: Flame graph: perf target (Threaded)"
+        command: "julia --threads 8 --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_threaded --enable_threading true"
+        artifact_paths: "flame_perf_target_threaded/*"
         agents:
           slurm_ntasks: 8
           slurm_ntasks_per_node: 8
           slurm_mem: 20GB
 
-      - label: ":rocket: flame graph: perf target callbacks"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_callbacks --dt_save_to_sol 1secs --dt_save_restart 1secs --dt_rad 1secs"
-        artifact_paths: "flame_perf_target_rhoe_callbacks/*"
+      - label: ":fire: Flame graph: perf target (Callbacks)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_callbacks --dt_save_to_sol 1secs --dt_save_restart 1secs --dt_rad 1secs"
+        artifact_paths: "flame_perf_target_callbacks/*"
         agents:
           slurm_mem: 20GB
 
-      # Comment out the following job for now, until flame graph w/ changing ID is cleared
-      # - label: ":rocket: flame graph: perf target (ρe_tot) (Rosenbrock)"
-      #   command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_rhoe_rosenbrock --ode_algo ODE.Rosenbrock23"
-      #   artifact_paths: "flame_perf_target_rhoe_rosenbrock/*"
-      #   agents:
-      #     slurm_mem: 20GB
+      # Inference
+      - label: ":rocket: JET n-failures (inference)"
+        command: "julia --color=yes --project=perf perf/jet_nfailures.jl --job_id jet_n_failures --target_job sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf --moist dry --rad nothing"
+        agents:
+          slurm_mem: 20GB
 
-      - label: ":rocket: benchmark: baroclinic wave (ρe_tot)"
-        command: "julia --color=yes --project=perf perf/benchmark.jl --job_id bm_sphere_baroclinic_wave_rhoe"
+      # Latency
+      - label: ":mag::rocket: Invalidations"
+        command: "julia --color=yes --project=perf perf/invalidations.jl --job_id invalidations"
+        artifact_paths: "invalidations/*"
+        agents:
+          slurm_mem: 20GB
 
   - wait: ~
     continue_on_failure: true

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -338,6 +338,9 @@ function parse_commandline()
         help = "A flag for analyzing performance [`PerfStandard` (default), `PerfExperimental`]"
         arg_type = String
         default = "PerfStandard"
+        "--target_job"
+        help = "An (optional) job to target for analyzing performance"
+        arg_type = String
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -1,12 +1,8 @@
+# Customizing specific jobs / specs in config_parsed_args.jl:
 ca_dir = joinpath(dirname(@__DIR__));
-include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"));
+include(joinpath(ca_dir, "perf", "config_parsed_args.jl")) # defines parsed_args
 
 ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
-
-# Uncomment for customizing specific jobs / specs:
-# dict = parsed_args_per_job_id(; trigger = "benchmark.jl"); # if job_id uses benchmark.jl
-# dict = parsed_args_per_job_id();                           # if job_id uses driver.jl
-# parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
 
 filename = joinpath(ca_dir, "examples", "hybrid", "driver.jl")
 

--- a/perf/config_parsed_args.jl
+++ b/perf/config_parsed_args.jl
@@ -1,0 +1,36 @@
+#=
+This script defines `parsed_args` for performance runs, and allows
+options to be overriden in several ways. In short the precedence
+for defining `parsed_args` is
+    - Highest precedence: args defined in `ARGS`
+    - Mid     precedence: args defined in `parsed_args_perf_target` (below)
+    - Lowest  precedence: args defined in `cli_defaults(s)`
+julia --project=perf/ perf/config_parsed_args.jl --target_job sphere_baroclinic_wave_rhoe_equilmoist
+=#
+ca_dir = joinpath(dirname(@__DIR__));
+include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"))
+(s, _parsed_args) = parse_commandline()
+parsed_args_defaults = cli_defaults(s);
+dict = parsed_args_per_job_id();
+
+# Start with performance target, and override anything provided in ARGS
+parsed_args_prescribed = parsed_args_from_ARGS(ARGS)
+
+target_job = get(parsed_args_prescribed, "target_job", nothing)
+parsed_args_perf_target = isnothing(target_job) ? Dict() : dict[target_job]
+
+parsed_args_perf_target["forcing"] = "held_suarez";
+parsed_args_perf_target["vert_diff"] = true;
+parsed_args_perf_target["surface_scheme"] = "bulk";
+parsed_args_perf_target["moist"] = "equil";
+parsed_args_perf_target["enable_threading"] = false;
+parsed_args_perf_target["rad"] = "allskywithclear";
+parsed_args_perf_target["precip_model"] = "0M";
+parsed_args_perf_target["dt"] = "1secs";
+parsed_args_perf_target["t_end"] = "10secs";
+parsed_args_perf_target["dt_save_to_sol"] = Inf;
+parsed_args_perf_target["z_elem"] = 25;
+parsed_args_perf_target["h_elem"] = 12;
+
+parsed_args =
+    merge(parsed_args_defaults, parsed_args_perf_target, parsed_args_prescribed);

--- a/perf/inference_flame_init.jl
+++ b/perf/inference_flame_init.jl
@@ -1,19 +1,11 @@
+# Run with target_job compressible_edmf_bomex
+# Customizing specific jobs / specs in config_parsed_args.jl:
 ca_dir = joinpath(dirname(@__DIR__));
-include(joinpath(ca_dir, "examples", "hybrid", "cli_options.jl"));
+include(joinpath(ca_dir, "perf", "config_parsed_args.jl")) # defines parsed_args
 
 ENV["CI_PERF_SKIP_INIT"] = true # we only need haskey(ENV, "CI_PERF_SKIP_INIT") == true
 
 filename = joinpath(ca_dir, "examples", "hybrid", "driver.jl")
-dict = parsed_args_per_job_id(; trigger = "driver.jl")
-parsed_args_prescribed = parsed_args_from_ARGS(ARGS)
-
-# Start with performance target, but override anything provided in ARGS
-parsed_args_target = dict["compressible_edmf_bomex"];
-parsed_args = merge(parsed_args_target, parsed_args_prescribed);
-parsed_args["enable_threading"] = false;
-
-# The callbacks flame graph is very expensive, so only do 2 steps.
-const n_samples = occursin("callbacks", parsed_args["job_id"]) ? 2 : 20
 
 try # capture integrator
     include(filename)

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -1,15 +1,12 @@
-import Profile
+# Customizing specific jobs / specs in config_parsed_args.jl:
+ca_dir = joinpath(dirname(@__DIR__));
+include(joinpath(ca_dir, "perf", "config_parsed_args.jl")) # defines parsed_args
 
 ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
 
-filename = joinpath(dirname(@__DIR__), "examples", "hybrid", "driver.jl")
+filename = joinpath(ca_dir, "examples", "hybrid", "driver.jl")
 
-# Uncomment for customizing specific jobs / specs:
-# dict = parsed_args_per_job_id(; trigger = "benchmark.jl"); # if job_id uses benchmark.jl
-# dict = parsed_args_per_job_id();                           # if job_id uses driver.jl
-# parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
-
-try
+try # capture integrator
     include(filename)
 catch err
     if err.error !== :exit_profile

--- a/perf/jet_nfailures.jl
+++ b/perf/jet_nfailures.jl
@@ -1,15 +1,12 @@
-import Profile
+# Customizing specific jobs / specs in config_parsed_args.jl:
+ca_dir = joinpath(dirname(@__DIR__));
+include(joinpath(ca_dir, "perf", "config_parsed_args.jl")) # defines parsed_args
 
 ENV["CI_PERF_SKIP_RUN"] = true # we only need haskey(ENV, "CI_PERF_SKIP_RUN") == true
 
-filename = joinpath(dirname(@__DIR__), "examples", "hybrid", "driver.jl")
+filename = joinpath(ca_dir, "examples", "hybrid", "driver.jl")
 
-# Uncomment for customizing specific jobs / specs:
-# dict = parsed_args_per_job_id(; trigger = "benchmark.jl"); # if job_id uses benchmark.jl
-# dict = parsed_args_per_job_id();                           # if job_id uses driver.jl
-# parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
-
-try
+try # capture integrator
     include(filename)
 catch err
     if err.error !== :exit_profile
@@ -38,7 +35,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 7
+    n_allowed_failures = 31
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures
         @info "Please update the n-failures to $n"

--- a/perf/tabulate_perf_summary.jl
+++ b/perf/tabulate_perf_summary.jl
@@ -211,8 +211,12 @@ function compute_has_func(summaries, funcs)
     for job_id in collect(keys(summaries["This PR"]))
         for commit in collect(keys(summaries))
             for func in funcs
-                has_func[func * commit] =
+                has_func[func * commit] = if haskey(summaries[commit], job_id)
                     haskey(summaries[commit][job_id], func)
+                else
+                    @warn "Key $job_id not found for commit $commit and func $func."
+                    false
+                end
             end
         end
     end

--- a/src/model_getters.jl
+++ b/src/model_getters.jl
@@ -177,6 +177,7 @@ function radiation_mode(parsed_args, ::Type{FT}) where {FT}
     radiation_name = parsed_args["rad"]
     @assert radiation_name in (
         nothing,
+        "nothing",
         "clearsky",
         "gray",
         "allsky",


### PR DESCRIPTION
The performance monitoring is a bit messy because it's a bit too heavily dependent on `parsed_args_per_job_id`.

This PR reorganizes the performance jobs:
 - Collects them all under `Performance` in the pipeline
 - Defines the model config in `perf/config_parsed_args.jl`
 - Unifies perf config scrips to use `perf/config_parsed_args.jl`
 - Specifies parameters by precedence:
    - Highest precedence: args defined in `ARGS`
    - Mid     precedence: args defined in `parsed_args_perf_target` (below)
    - Lowest  precedence: args defined in `cli_defaults(s)`
  - Adds a flame graph for a job with edmf on a sphere

This makes the perf monitoring configuration a bit more flat-- all jobs will now depend on the config defined in `perf/config_parsed_args.jl` using the described precedence.

Supersedes #1166.