### PR TITLE
Use ntuple in TC kernel

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -63,7 +63,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 9360
 allocs_limit["flame_perf_target_tracers"] = 6245350392
-allocs_limit["flame_perf_target_edmf"] = 18530198696
+allocs_limit["flame_perf_target_edmf"] = 14757684392
 allocs_limit["flame_perf_target_threaded"] = 4299280
 allocs_limit["flame_perf_target_callbacks"] = 11439104
 

--- a/src/TurbulenceConvection/closures/entr_detr.jl
+++ b/src/TurbulenceConvection/closures/entr_detr.jl
@@ -22,7 +22,7 @@ function compute_entr_detr!(
     m_entr_detr = aux_tc.ϕ_temporary
     ∇m_entr_detr = aux_tc.ψ_temporary
 
-    plume_scale_height = map(1:N_up) do i
+    plume_scale_height = ntuple(N_up) do i
         compute_plume_scale_height(grid, state, edmf.H_up_min, i)
     end
 

--- a/src/TurbulenceConvection/closures/perturbation_pressure.jl
+++ b/src/TurbulenceConvection/closures/perturbation_pressure.jl
@@ -36,7 +36,7 @@ function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
     aux_gm_f = face_aux_grid_mean(state)
     aux_en_f = face_aux_environment(state)
     ρ_f = aux_gm_f.ρ
-    plume_scale_height = map(1:N_up) do i
+    plume_scale_height = ntuple(N_up) do i
         compute_plume_scale_height(grid, state, edmf.H_up_min, i)
     end
 


### PR DESCRIPTION
This PR swaps `map` for `ntuple` in the TC kernel. It improves inference and preps for GPU-readiness. It also happens to trim allocations by 20%.