### PR TITLE
Remove unused properties in TC grid

### DIFF
--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -110,7 +110,7 @@ function init_tc!(Y, p, params, colidx)
     thermo_params = CAP.thermodynamics_params(params)
 
     grid = TC.Grid(state)
-    FT = eltype(grid)
+    FT = CC.Spaces.undertype(axes(Y.c))
     C123 = CCG.Covariant123Vector
     t = FT(0)
 

--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -535,11 +535,7 @@ function get_GMV_CoVar(
     return nothing
 end
 
-function compute_updraft_top(
-    grid::Grid{FT},
-    state::State,
-    i::Int,
-)::FT where {FT}
+function compute_updraft_top(grid::Grid, state::State, i::Int)
     aux_up = center_aux_updrafts(state)
     return z_findlast_center(k -> aux_up[i].area[k] > 1e-3, grid)
 end

--- a/src/TurbulenceConvection/Grid.jl
+++ b/src/TurbulenceConvection/Grid.jl
@@ -1,28 +1,19 @@
-struct Grid{FT, NZ, CS, FS, SC, SF}
-    zmin::FT
-    zmax::FT
-    Δz::FT
+struct Grid{NZ, CS, FS, SC, SF}
     cs::CS
     fs::FS
     zc::SC
     zf::SF
     function Grid(space::CC.Spaces.CenterFiniteDifferenceSpace)
-
         nz = length(space)
         cs = space
         fs = CC.Spaces.FaceFiniteDifferenceSpace(cs)
         zc = CC.Fields.coordinate_field(cs)
         zf = CC.Fields.coordinate_field(fs)
-        Δz = zf[CCO.PlusHalf(2)].z - zf[CCO.PlusHalf(1)].z
-        FT = eltype(parent(zf))
-
-        zmin = zf.z[CCO.PlusHalf(1)]
-        zmax = zf.z[CCO.PlusHalf(nz + 1)]
         CS = typeof(cs)
         FS = typeof(fs)
         SC = typeof(zc)
         SF = typeof(zf)
-        return new{FT, nz, CS, FS, SC, SF}(zmin, zmax, Δz, cs, fs, zc, zf)
+        return new{nz, CS, FS, SC, SF}(cs, fs, zc, zf)
     end
 end
 
@@ -42,7 +33,7 @@ function Grid(Δz::FT, nz::Int) where {FT <: AbstractFloat}
     return Grid(mesh)
 end
 
-n_cells(::Grid{FT, NZ}) where {FT, NZ} = NZ
+n_cells(::Grid{NZ}) where {NZ} = NZ
 
 # Index of the first interior cell above the surface
 kc_surface(grid::Grid) = Cent(1)
@@ -124,5 +115,3 @@ function findlast_center(f::Function, grid::Grid)
 end
 z_findlast_center(f::F, grid::Grid) where {F} =
     grid.zc[findlast_center(f, grid)].z
-
-Base.eltype(::Grid{FT}) where {FT} = FT

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -18,7 +18,6 @@ function update_aux!(
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
-    kc_toa = kc_top_of_atmos(grid)
     c_m = mixing_length_params(edmf).c_m
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH


### PR DESCRIPTION
This PR removes some unused properties in TC's grid, to help clarify/simplify what we depend on for `getindex` (#887)