### PR TITLE
Add remap command to sphere simulations

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -44,7 +44,9 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe_tot) high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres --out_dir longrun_bw_rhoe_highres
         artifact_paths: "longrun_bw_rhoe_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -52,7 +54,9 @@ steps:
           slurm_ntasks: 32
       
       - label: ":computer: baroclinic wave (ρe_tot) high resolution topography (dcmip)"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
         artifact_paths: "longrun_bw_rhoe_highres_topography/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -80,7 +84,9 @@ steps:
           slurm_ntasks: 32
 
       - label: ":computer: held suarez (ρe_tot) high resolution hightop"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_max 45e3 --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 800days --job_id longrun_hs_rhoe_highres_hightop --dt_save_to_disk 10days"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --z_max 45e3 --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 400secs --t_end 800days --job_id longrun_hs_rhoe_highres_hightop --dt_save_to_disk 10days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_highres_hightop --out_dir longrun_hs_rhoe_highres_hightop
         artifact_paths: "longrun_hs_rhoe_highres_hightop/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -88,7 +94,9 @@ steps:
           slurm_ntasks: 32
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres --out_dir longrun_hs_rhoe_equil_highres
         artifact_paths: "longrun_hs_rhoe_equil_highres/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -96,7 +104,9 @@ steps:
           slurm_ntasks: 64
       
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (dcmip)"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography DCMIP200 --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography DCMIP200 --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
         artifact_paths: "longrun_hs_rhoe_equil_highres_topography/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -104,7 +114,9 @@ steps:
           slurm_ntasks: 64
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist high resolution clearsky radiation Float64"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 150secs --t_end 400days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 150secs --t_end 400days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64 --out_dir longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64
         artifact_paths: "longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -112,7 +124,9 @@ steps:
           slurm_ntasks: 64
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution hightop rayleigh sponge(30e5, 10)"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_max 45e3 --z_elem 50 --dz_bottom 30 --dz_top 3000 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --zd_rayleigh 30e3 --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt 150secs --t_end 400days --job_id longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3 --dt_save_to_disk 10days"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_max 45e3 --z_elem 50 --dz_bottom 30 --dz_top 3000 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --zd_rayleigh 30e3 --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt 150secs --t_end 400days --job_id longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3 --dt_save_to_disk 10days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3 --out_dir longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3
         artifact_paths: "longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -120,7 +134,9 @@ steps:
           slurm_ntasks: 64
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist clearsky high resolution hightop rayleigh sponge(35e5, 10) Float64"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --rad clearsky --moist equil --vert_diff true --surface_scheme monin_obukhov --precip_model 0M --z_max 45e3 --z_elem 50 --dz_bottom 30 --dz_top 3e3 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --zd_rayleigh 35e3 --alpha_rayleigh_w 10 --alpha_rayleigh_uh 0 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64 --FLOAT_TYPE Float64"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --rad clearsky --moist equil --vert_diff true --surface_scheme monin_obukhov --precip_model 0M --z_max 45e3 --z_elem 50 --dz_bottom 30 --dz_top 3e3 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --zd_rayleigh 35e3 --alpha_rayleigh_w 10 --alpha_rayleigh_uh 0 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64 --FLOAT_TYPE Float64
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64 --out_dir longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64
         artifact_paths: "longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -132,13 +148,17 @@ steps:
     steps:
 
       - label: ":computer: hydrostatic balance (ρe_tot)"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --perturb_initstate false --discrete_hydrostatic_balance true --t_end 2000days --dt_save_to_sol 10days --dt_save_to_disk 10days --fps 30 --job_id longrun_sphere_hydrostatic_balance_rhoe"
+        command: 
+          - julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --perturb_initstate false --discrete_hydrostatic_balance true --t_end 2000days --dt_save_to_sol 10days --dt_save_to_disk 10days --fps 30 --job_id longrun_sphere_hydrostatic_balance_rhoe
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_sphere_hydrostatic_balance_rhoe --out_dir longrun_sphere_hydrostatic_balance_rhoe
         artifact_paths: "longrun_sphere_hydrostatic_balance_rhoe/*"
         agents:
           slurm_cpus_per_task: 8
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist gray radiation"
-        command: "julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad gray --precip_model 0M --dt 450secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_gray --dt_save_to_sol 1days --dt_save_to_disk 10days"
+        command: 
+          - julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --rad gray --precip_model 0M --dt 450secs --t_end 600days --fps 30 --job_id longrun_aquaplanet_rhoe_equil_gray --dt_save_to_sol 1days --dt_save_to_disk 10days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_aquaplanet_rhoe_equil_gray --out_dir longrun_aquaplanet_rhoe_equil_gray
         artifact_paths: "longrun_aquaplanet_rhoe_equil_gray/*"
         agents:
           slurm_cpus_per_task: 8
@@ -148,7 +168,9 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution zalesak"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --tracer_upwinding zalesak --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_zalesak"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --tracer_upwinding zalesak --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --t_end 100days --dt_save_to_disk 1days --job_id longrun_bw_rhoe_equil_highres_zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_zalesak --out_dir longrun_bw_rhoe_equil_highres_zalesak
         artifact_paths: "longrun_bw_rhoe_equil_highres_zalesak/*"
         agents:
           slurm_mem: 20GB
@@ -158,7 +180,9 @@ steps:
           slurm_ntasks: 2
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution monin obukhov"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme monin_obukhov --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_monin_obukhov
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_monin_obukhov --out_dir longrun_hs_rhoe_equil_highres_monin_obukhov
         artifact_paths: "longrun_hs_rhoe_equil_highres_monin_obukhov/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
@@ -166,7 +190,9 @@ steps:
           slurm_ntasks: 32
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist high resolution allsky radiation float64"
-        command: "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad allskywithclear --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 150secs --dt_rad 1hours --idealized_insolation false --t_end 365days --job_id longrun_aquaplanet_rhoe_equil_highres_allsky_ft64 --dt_save_to_disk 10days --FLOAT_TYPE Float64"
+        command: 
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad allskywithclear --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --bubble true --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 150secs --dt_rad 1hours --idealized_insolation false --t_end 365days --job_id longrun_aquaplanet_rhoe_equil_highres_allsky_ft64 --dt_save_to_disk 10days --FLOAT_TYPE Float64
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_aquaplanet_rhoe_equil_highres_allsky_ft64 --out_dir longrun_aquaplanet_rhoe_equil_highres_allsky_ft64
         artifact_paths: "longrun_aquaplanet_rhoe_equil_highres_allsky_ft64/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,21 +120,29 @@ steps:
     steps:
 
       - label: ":computer: hydrostatic balance (ρe) float64"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --perturb_initstate false --discrete_hydrostatic_balance true --use_reference_state false --hyperdiff false --dt_save_to_sol 600secs --dt_save_to_disk 5days --job_id sphere_hydrostatic_balance_rhoe_ft64 --FLOAT_TYPE Float64 --bubble true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --perturb_initstate false --discrete_hydrostatic_balance true --use_reference_state false --hyperdiff false --dt_save_to_sol 600secs --dt_save_to_disk 5days --job_id sphere_hydrostatic_balance_rhoe_ft64 --FLOAT_TYPE Float64 --bubble true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_hydrostatic_balance_rhoe_ft64 --out_dir sphere_hydrostatic_balance_rhoe_ft64
         artifact_paths: "sphere_hydrostatic_balance_rhoe_ft64/*"
         agents:
           slurm_mem: 20GB
 
       - label: ":computer: baroclinic wave (ρe)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --dt 580secs --dt_save_to_disk 5days --regression_test true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --dt 580secs --dt_save_to_disk 5days --regression_test true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe --out_dir sphere_baroclinic_wave_rhoe
         artifact_paths: "sphere_baroclinic_wave_rhoe/*"
 
       - label: ":computer: baroclinic wave (ρe) h_elem8"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --h_elem 8 --kappa_4 5e16 --job_id sphere_baroclinic_wave_rhoe_he8 --dt 500secs --dt_save_to_disk 5days"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --h_elem 8 --kappa_4 5e16 --job_id sphere_baroclinic_wave_rhoe_he8 --dt 500secs --dt_save_to_disk 5days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe_he8 --out_dir sphere_baroclinic_wave_rhoe_he8
         artifact_paths: "sphere_baroclinic_wave_rhoe_he8/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs --dt_save_to_disk 5days"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --job_id sphere_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs --dt_save_to_disk 5days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe_equilmoist --out_dir sphere_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: baroclinic wave (ρe) equilmoist check conservation float64"
@@ -142,26 +150,36 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64/*"
 
       - label: ":computer: held suarez (ρθ)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --energy_name rhotheta --forcing held_suarez --job_id sphere_held_suarez_rhotheta --regression_test true --dt 500secs --t_end 30days --dt_save_to_disk 10days"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --energy_name rhotheta --forcing held_suarez --job_id sphere_held_suarez_rhotheta --regression_test true --dt 500secs --t_end 30days --dt_save_to_disk 10days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhotheta --out_dir sphere_held_suarez_rhotheta
         artifact_paths: "sphere_held_suarez_rhotheta/*"
 
       - label: ":computer: held suarez (ρe) hightop"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --forcing held_suarez --job_id sphere_held_suarez_rhoe_hightop --regression_test true --dt 500secs --dt_save_to_disk 5days"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --forcing held_suarez --job_id sphere_held_suarez_rhoe_hightop --regression_test true --dt 500secs --dt_save_to_disk 5days
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhoe_hightop --out_dir sphere_held_suarez_rhoe_hightop
         artifact_paths: "sphere_held_suarez_rhoe_hightop/*"
 
       - label: ":computer: held suarez (ρe) equilmoist hightop sponge"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_held_suarez_rhoe_equilmoist_hightop_sponge --dt 450secs --t_end 5days --dt_save_to_disk 5days --regression_test true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_held_suarez_rhoe_equilmoist_hightop_sponge --dt 450secs --t_end 5days --dt_save_to_disk 5days --regression_test true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_held_suarez_rhoe_equilmoist_hightop_sponge
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge/*"
 
   - group: "Sphere Examples (Aquaplanet)"
     steps:
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist allsky radiation monin_obukhov varying insolation gravity wave high top"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --idealized_insolation false --vert_diff true --surface_scheme monin_obukhov --moist equil --rad allskywithclear --non_orographic_gravity_wave true --orographic_gravity_wave true --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --zd_rayleigh 30e3 --job_id sphere_aquaplanet_rhoe_equilmoist_allsky_gw --dt 400secs --t_end 1days --dt_save_to_disk 1days --regression_test true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --idealized_insolation false --vert_diff true --surface_scheme monin_obukhov --moist equil --rad allskywithclear --non_orographic_gravity_wave true --orographic_gravity_wave true --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --zd_rayleigh 30e3 --job_id sphere_aquaplanet_rhoe_equilmoist_allsky_gw --dt 400secs --t_end 1days --dt_save_to_disk 1days --regression_test true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw --out_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw/*"
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist with EDMF"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist dry --anelastic_dycore false --job_id sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf --vert_diff true --surface_scheme bulk --dt 1secs --t_end 20secs --FLOAT_TYPE Float64 --turbconv edmf --turbconv_case Soares --config sphere --precip_model 0M --z_stretch false --post_process  false --apply_limiter false --dt_save_to_sol 10secs --dt_save_to_disk 10secs"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --moist dry --anelastic_dycore false --job_id sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf --vert_diff true --surface_scheme bulk --dt 1secs --t_end 20secs --FLOAT_TYPE Float64 --turbconv edmf --turbconv_case Soares --config sphere --precip_model 0M --z_stretch false --post_process  false --apply_limiter false --dt_save_to_sol 10secs --dt_save_to_disk 10secs
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf --out_dir sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_mo_edmf/*"
         agents:
           slurm_mem: 20GB
@@ -170,15 +188,21 @@ steps:
     steps:
 
       - label: ":computer: baroclinic wave (ρe) topography (dcmip): no viscous sponge"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe_topography_dcmip_rs --topography DCMIP200 --dt 200secs --dt_save_to_disk 5days --rayleigh_sponge true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe_topography_dcmip_rs --topography DCMIP200 --dt 200secs --dt_save_to_disk 5days --rayleigh_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe_topography_dcmip_rs --out_dir sphere_baroclinic_wave_rhoe_topography_dcmip_rs
         artifact_paths: "sphere_baroclinic_wave_rhoe_topography_dcmip_rs/*"
 
       - label: ":computer: held suarez (ρe) topography (dcmip)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --forcing held_suarez --job_id sphere_held_suarez_rhoe_topography_dcmip --t_end 6days --topography DCMIP200 --dt 200secs --dt_save_to_disk 6days --rayleigh_sponge true --viscous_sponge true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --forcing held_suarez --job_id sphere_held_suarez_rhoe_topography_dcmip --t_end 6days --topography DCMIP200 --dt 200secs --dt_save_to_disk 6days --rayleigh_sponge true --viscous_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhoe_topography_dcmip --out_dir sphere_held_suarez_rhoe_topography_dcmip
         artifact_paths: "sphere_held_suarez_rhoe_dcmip_topography_dcmip/*"
 
       - label: ":computer: held suarez (ρe) equilmoist topography (dcmip)"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --job_id sphere_held_suarez_rhoe_equilmoist_topography_dcmip --dt 200secs --t_end 3days --dt_save_to_disk 3days --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true"
+        command: 
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --job_id sphere_held_suarez_rhoe_equilmoist_topography_dcmip --dt 200secs --t_end 3days --dt_save_to_disk 3days --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhoe_equilmoist_topography_dcmip --out_dir sphere_held_suarez_rhoe_equilmoist_topography_dcmip
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_topography_dcmip/*"
 
   - group: "MPI Examples"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #1382.

- Adds remap command only to sphere simulations because the current remap pipeline only works for the sphere.
- Remapping is not added for jobid `sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64` because it doesn't work for moist simulations with no microphysics schemes (the remap script assumes `precipitation_removal` exists, we can fix it later, but it is not that important as this job is mostly to check conservation).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
