### PR TITLE
add mono option to post-processing remap

### DIFF
--- a/examples/hybrid/orographic_gravity_wave_helper.jl
+++ b/examples/hybrid/orographic_gravity_wave_helper.jl
@@ -114,13 +114,8 @@ function create_regrid_weight_files(
     write_exodus(meshfile_cgll, topology)
     overlap_mesh(meshfile_overlap, meshfile_rll, meshfile_cgll)
 
-    # 'in_np = 1' and 'mono = true' arguments ensure mapping is conservative and monotone
-    # Note: for a kwarg not followed by a value, set it to true here (i.e. pass 'mono = true' to produce '--mono')
-    # Note: out_np = degrees of freedom = polynomial degree + 1
-
     kwargs = (; out_type = out_type, out_np = Nq)
-    kwargs =
-        mono ? (; (kwargs)..., in_np = mono ? 1 : false, mono = mono) : kwargs
+    kwargs = mono ? (; (kwargs)..., mono = mono) : kwargs
     remap_weights(
         weightfile,
         meshfile_rll,

--- a/post_processing/remap/remap_helpers.jl
+++ b/post_processing/remap/remap_helpers.jl
@@ -22,7 +22,8 @@ function create_weightfile(
     cspace::Spaces.AbstractSpace,
     fspace::Spaces.AbstractSpace,
     nlat::Int,
-    nlon::Int,
+    nlon::Int;
+    mono = false,
 )
     # space info to generate nc raw data
     hspace = cspace.horizontal_space
@@ -44,13 +45,14 @@ function create_weightfile(
             meshfile_rll,
         )
         tmp_weightfile = joinpath(tmp, "remap_weights.nc")
+        kwargs = (; in_type = "cgll", in_np = Nq)
+        kwargs = mono ? (; (kwargs)..., mono = mono) : kwargs
         ClimaCoreTempestRemap.remap_weights(
             tmp_weightfile,
             meshfile_cc,
             meshfile_rll,
             meshfile_overlap;
-            in_type = "cgll",
-            in_np = Nq,
+            kwargs...,
         )
         mv(tmp_weightfile, weightfile; force = true)
     end


### PR DESCRIPTION
This PR adds mono (default to false) option to the remapping functionality. mono = true forces monotonicity in the remapping process.