### PR TITLE
Remove duplicated code

### DIFF
--- a/examples/hybrid/get_cache_and_tendency.jl
+++ b/examples/hybrid/get_cache_and_tendency.jl
@@ -29,6 +29,9 @@ get_cache(
 
 function implicit_tendency!(Yₜ, Y, p, t)
     p.test_dycore_consistency && CA.fill_with_nans!(p)
+    @nvtx "precomputed quantities" color = colorant"orange" begin
+        CA.precomputed_quantities!(Y, p, t)
+    end
     @nvtx "implicit tendency" color = colorant"yellow" begin
         Fields.bycolumn(axes(Y.c)) do colidx
             CA.implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -65,7 +65,7 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 9360
 allocs_limit["flame_perf_target_tracers"] = 6245350392
 allocs_limit["flame_perf_target_edmf"] = 16003862184
-allocs_limit["flame_perf_target_threaded"] = 4465584
+allocs_limit["flame_perf_target_threaded"] = 5810000
 allocs_limit["flame_perf_target_callbacks"] = 11439104
 
 if allocs < allocs_limit[job_id] * buffer

--- a/src/precomputed_quantities.jl
+++ b/src/precomputed_quantities.jl
@@ -40,7 +40,7 @@ function precomputed_quantities!(Y, p, t, colidx)
         ᶠwinterp(
             Y.c.ρ[colidx] * ᶜJ[colidx],
             Geometry.Contravariant123Vector(ᶜuₕ[colidx]),
-        ) + Geometry.Contravariant123Vector(Y.f.w[colidx])
+        ) + Geometry.Contravariant123Vector(ᶠw[colidx])
     @. ᶠu³[colidx] =
         Geometry.project(Geometry.Contravariant3Axis(), ᶠu_tilde[colidx])
     compute_kinetic!(ᶜK[colidx], Y.c.uₕ[colidx], Y.f.w[colidx])

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -95,19 +95,9 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     (; ᶜρ_ref, ᶜp_ref) = p
     (; energy_upwinding, tracer_upwinding, simulation) = p
     (; ᶠgradᵥ, ᶜinterp, ᶠinterp, ᶠwinterp) = p.operators
-    C123 = Geometry.Covariant123Vector
-
     thermo_params = CAP.thermodynamics_params(params)
     dt = simulation.dt
     # TODO: can we move this to implicit tendencies?
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    @. ᶠu³[colidx] = Geometry.project(
-        Geometry.Contravariant3Axis(),
-        C123(ᶠwinterp(ᶜJ[colidx] * ᶜρ[colidx], ᶜuₕ[colidx])) + C123(ᶠw[colidx]),
-    )
-    compute_kinetic!(ᶜK[colidx], Y.c.uₕ[colidx], Y.f.w[colidx])
-    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
-    @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
 
     vertical_transport!(
         Yₜ.c.ρ[colidx],

--- a/src/tendencies/implicit/wfact.jl
+++ b/src/tendencies/implicit/wfact.jl
@@ -81,6 +81,7 @@ end
 function Wfact!(W, Y, p, dtγ, t)
     NVTX.@range "Wfact!" color = colorant"green" begin
         p.test_dycore_consistency && fill_with_nans!(p)
+        precomputed_quantities!(Y, p, t)
         Fields.bycolumn(axes(Y.c)) do colidx
             Wfact!(W, Y, p, dtγ, t, colidx)
         end
@@ -105,7 +106,6 @@ function Wfact!(W, Y, p, dtγ, t, colidx)
     FT = Spaces.undertype(axes(Y.c))
     C123 = Geometry.Covariant123Vector
     compose = Operators.ComposeStencils()
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
 
     R_d = FT(CAP.R_d(params))
     κ_d = FT(CAP.kappa_d(params))
@@ -137,11 +137,6 @@ function Wfact!(W, Y, p, dtγ, t, colidx)
     # The εw is only necessary in case w = 0.
     # Since Operator2Stencil has not yet been extended to upwinding
     # operators, ᶠupwind_stencil is not available.
-    compute_kinetic!(ᶜK[colidx], ᶜuₕ[colidx], ᶠw[colidx])
-
-    thermo_params = CAP.thermodynamics_params(params)
-    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
-    @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
 
     # ᶜinterp(ᶠw) =
     #     ᶜinterp(ᶠw)_data * ᶜinterp(ᶠw)_unit =


### PR DESCRIPTION
Removes duplicated kinetic energy, contravariant velocity, and thermo_state assignments in implicit tendencies: 

These are computed in `src/precomputed_quantities.jl`. 
The required code block in `precomputed_quantities` is: 

```
    @. ᶜu_bar[colidx] = C123(ᶜuₕ[colidx]) + C123(ᶜinterp(ᶠw[colidx]))
    @. ᶠu_tilde[colidx] =
        ᶠwinterp(
            Y.c.ρ[colidx] * ᶜJ[colidx],
            Geometry.Contravariant123Vector(ᶜuₕ[colidx]),
        ) + Geometry.Contravariant123Vector(Y.f.w[colidx])
    @. ᶠu³[colidx] =
        Geometry.project(Geometry.Contravariant3Axis(), ᶠu_tilde[colidx])
    compute_kinetic!(ᶜK[colidx], Y.c.uₕ[colidx], Y.f.w[colidx])
    thermo_params = CAP.thermodynamics_params(params)
    thermo_state!(Y, p, ᶜinterp, colidx; time = t)
    @. ᶜp[colidx] = TD.air_pressure(thermo_params, ᶜts[colidx])
```

This increases the threaded allocation count. 