### PR TITLE
Add EDMFX model without tendencies and add new post-processing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -355,9 +355,26 @@ steps:
           slurm_mem: 20GB
 
       - label: ":dart: Dycore Consistency test"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --use_krylov_method true --job_id dycore_consistency --quicklook_reference_job_id edmf_bomex --dt 40secs --t_end 6hours --apply_limiter false --test_dycore_consistency true --debugging_tc true --dt_save_to_disk 5mins"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config column --FLOAT_TYPE Float64 --hyperdiff false --moist equil --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --turbconv edmf --turbconv_case Bomex --dt_save_to_sol 5mins --z_elem 60 --z_stretch false --z_max 3e3 --use_krylov_method true --job_id dycore_consistency --reference_job_id edmf_bomex --dt 40secs --t_end 6hours --apply_limiter false --test_dycore_consistency true --debugging_tc true --dt_save_to_disk 5mins"
         artifact_paths: "dycore_consistency/*"
         soft_fail: true
+        agents:
+          slurm_mem: 20GB
+
+  - group: "EDMFX"
+    steps:
+
+      - label: ":genie: no lim ARS baroclinic wave (ρe) equilmoist with EDMFX"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe_equilmoist_edmfx --initial_condition MoistBaroclinicWaveWithEDMF --moist equil --precip_model 0M --turbconv edmfx --apply_limiter false --dt 450secs --t_end 4days --dt_save_to_disk 2days --reference_job_id sphere_baroclinic_wave_rhoe_equilmoist
+        artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_edmfx/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":genie: EDMFX Bomex on a sphere"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_bomex_sphere --initial_condition Bomex --moist equil --turbconv edmfx --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --apply_limiter false --z_elem 60 --z_stretch false --z_max 3e3 --dt 60secs --t_end 1hours --dt_save_to_disk 5mins --reference_job_id edmf_bomex
+        artifact_paths: "edmfx_bomex_sphere/*"
         agents:
           slurm_mem: 20GB
 
@@ -409,7 +426,7 @@ steps:
           --imex_edmf_turbconv true
           --imex_edmf_gm true
           --use_krylov_method true
-          --quicklook_reference_job_id edmf_nieuwstadt
+          --reference_job_id edmf_nieuwstadt
           --job_id edmf_nieuwstadt_jfnk_imex
           --dt 50secs
         artifact_paths: "edmf_nieuwstadt_jfnk_imex/*"
@@ -444,7 +461,7 @@ steps:
           --imex_edmf_turbconv true
           --imex_edmf_gm true
           --use_krylov_method true
-          --quicklook_reference_job_id edmf_soares
+          --reference_job_id edmf_soares
           --job_id edmf_soares_jfnk_imex
           --dt 50secs
         artifact_paths: "edmf_soares_jfnk_imex/*"
@@ -477,7 +494,7 @@ steps:
           --t_end 6hours --dt_save_to_sol 5mins --dt_save_to_disk 5mins
           --moist equil
           --use_krylov_method true
-          --quicklook_reference_job_id edmf_bomex
+          --reference_job_id edmf_bomex
           --job_id edmf_bomex_jfnk
           --dt 15secs
         artifact_paths: "edmf_bomex_jfnk/*"
@@ -496,7 +513,7 @@ steps:
           --imex_edmf_turbconv true
           --imex_edmf_gm true
           --use_krylov_method true
-          --quicklook_reference_job_id edmf_bomex
+          --reference_job_id edmf_bomex
           --job_id edmf_bomex_jfnk_imex
           --dt 30secs
         artifact_paths: "edmf_bomex_jfnk_imex/*"
@@ -510,7 +527,7 @@ steps:
           --FLOAT_TYPE Float64
           --toml ./.buildkite/toml/bomex.toml
           --job_id toml_edmf_bomex
-          --quicklook_reference_job_id edmf_bomex
+          --reference_job_id edmf_bomex
           --dt 20secs
         artifact_paths: "toml_edmf_bomex/*"
         agents:
@@ -623,6 +640,12 @@ steps:
       - label: ":fire: Flame graph: perf target (with tracers)"
         command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_tracers --perf_mode PerfExperimental"
         artifact_paths: "flame_perf_target_tracers/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":fire: Flame graph: perf target (edmfx)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_edmfx --target_job sphere_baroclinic_wave_rhoe_equilmoist_edmfx"
+        artifact_paths: "flame_perf_target_edmfx/*"
         agents:
           slurm_mem: 20GB
 

--- a/examples/hybrid/TurbulenceConvectionUtils.jl
+++ b/examples/hybrid/TurbulenceConvectionUtils.jl
@@ -27,15 +27,15 @@ include(joinpath(ca_dir, "tc_driver", "Surface.jl"))
 
 turbconv_cache(
     Y,
-    turbconv_model::Nothing,
+    turbconv_model,
     atmos,
     param_set,
     parsed_args,
     initial_condition,
 ) = (; turbconv_model)
 
-implicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, ::Nothing) = nothing
-explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, ::Nothing) = nothing
+implicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, _) = nothing
+explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, _) = nothing
 
 #####
 ##### EDMF

--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -179,7 +179,7 @@ function parse_commandline()
         "--job_id"
         help = "Uniquely identifying string for a particular job"
         arg_type = String
-        "--quicklook_reference_job_id"
+        "--reference_job_id"
         help = "Identifier of job to use as the \"reference\" solution in the quicklook plot; the current job's results get compared to the results of the quicklook job on the main branch (only used if `debugging_tc` is `true`)"
         arg_type = String
         "--trunc_stack_traces"

--- a/examples/hybrid/get_callbacks.jl
+++ b/examples/hybrid/get_callbacks.jl
@@ -28,7 +28,7 @@ function get_callbacks(parsed_args, simulation, atmos, params)
             ()
         end
 
-    if !isnothing(atmos.turbconv_model)
+    if p.atmos.turbconv_model isa TC.EDMFModel
         additional_callbacks = (additional_callbacks..., tc_callbacks)
     end
 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -64,6 +64,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 3872
 allocs_limit["flame_perf_target_tracers"] = 4800871040
+allocs_limit["flame_perf_target_edmfx"] = 4240
 allocs_limit["flame_perf_target_edmf"] = 8745398416
 allocs_limit["flame_perf_target_threaded"] = 5830000
 allocs_limit["flame_perf_target_callbacks"] = 11159384

--- a/post_processing/contours_and_profiles.jl
+++ b/post_processing/contours_and_profiles.jl
@@ -1,0 +1,519 @@
+import ClimaAtmos: time_from_filename
+import ClimaCore: Geometry, Spaces, Fields, InputOutput
+import CairoMakie: Makie
+import Statistics: mean
+
+function best_time_unit(value_in_seconds)
+    unit_options = (
+        (60 * 60 * 24 * 365, "yr"),
+        (60 * 60 * 24, "d"),
+        (60 * 60, "h"),
+        (60, "min"),
+        (1, "s"),
+    )
+    minimum_value_in_units = 2
+    index = findfirst(unit_options) do (seconds_per_unit, _)
+        return value_in_seconds / seconds_per_unit >= minimum_value_in_units
+    end
+    return unit_options[isnothing(index) ? end : index]
+end
+
+function time_string_with_unit(value_in_seconds)
+    seconds_per_unit, abbreviation = best_time_unit(value_in_seconds)
+    value_in_units = round(value_in_seconds / seconds_per_unit; sigdigits = 6)
+    return "$value_in_units $abbreviation"
+end
+
+# This is an extended version of the time tick locator and formatter from the
+# Makie docs: https://docs.makie.org/stable/examples/blocks/axis/index.html.
+struct TimeTicks end
+function Makie.get_ticks(::TimeTicks, scale, formatter, vmin, vmax)
+    seconds_per_unit, abbreviation = best_time_unit(max(abs(vmin), abs(vmax)))
+    values_in_units = Makie.get_tickvalues(
+        Makie.automatic,
+        scale,
+        vmin / seconds_per_unit,
+        vmax / seconds_per_unit,
+    )
+    values_in_seconds = values_in_units .* seconds_per_unit
+    labels =
+        Makie.get_ticklabels(formatter, values_in_units) .* " $abbreviation"
+    return values_in_seconds, labels
+end
+
+function contour_plot!(
+    grid_position,
+    var_col_time_series,
+    ref_var_col_time_series,
+    category,
+    name,
+    draw_ref_plot,
+    label_ts,
+    label_zs,
+    negative_values_allowed,
+)
+    # There seems to be a bug in contourf! that occasionally causes the highest
+    # or lowest contour band to disappear. Adding a tiny amount of padding to
+    # the limits fixes this problem.
+    padding_fraction = 1e-6 # Increase this if any contour bands aren't plotted.
+
+    # There is a known issue in Makie that causes aliasing artifacts to appear
+    # between adjacent bands drawn by contourf! (and apparently also Colorbar):
+    # https://discourse.julialang.org/t/aliasing-with-makie-contourf/71783.
+    # Redrawing plots on top of themselves fixes this problem.
+    n_redraws = 2 # Increase this if any aliasing artifacts are observed.
+
+    ts = getindex.(var_col_time_series, 1)
+    zs = var_col_time_series[1][2]
+    values = hcat(getindex.(var_col_time_series, 3)...)'
+    if isnothing(ref_var_col_time_series)
+        limits = extrema(values)
+    else
+        ref_ts = getindex.(ref_var_col_time_series, 1)
+        ref_zs = ref_var_col_time_series[1][2]
+        ref_values = hcat(getindex.(ref_var_col_time_series, 3)...)'
+        limits = extrema((extrema(values)..., extrema(ref_values)...))
+    end
+    limits = limits .+ (-1, 1) .* (padding_fraction * (limits[2] - limits[1]))
+    if negative_values_allowed
+        extendlow = nothing
+    else
+        limits = max.(limits, 0)
+        extendlow = :red
+    end
+
+    if limits[1] == limits[2]
+        colorbar_ticks_kwarg = (; ticks = [limits[1]])
+
+        # Since contourf! requires nonempty contours, the limits need to be
+        # expanded. If negative values are allowed, expand the limits so that
+        # the contour plot is filled with the color located in the middle of the
+        # color bar; otherwise, expand them so that it is filled with the color
+        # at the bottom of the color bar.
+        limits = limits[1] .+ (negative_values_allowed ? (-1, 1) : (0, 1))
+    else
+        colorbar_ticks_kwarg = (;)
+    end
+    n_bands = 20
+    levels = range(limits..., n_bands + 1)
+    kwargs = (; levels, extendlow, colormap = :viridis)
+
+    grid_layout = Makie.GridLayout(; default_rowgap = 10, default_colgap = 10)
+    grid_position[:, :] = grid_layout
+
+    axis = Makie.Axis(
+        grid_layout[1, :];
+        title = "$category $name",
+        xticks = TimeTicks(),
+        xlabel = label_ts && !draw_ref_plot ? "Time" : "",
+        ylabel = label_zs ?
+                 (draw_ref_plot ? "PR\n" : "") * "Elevation (km)" : "",
+        xticksvisible = !draw_ref_plot,
+        xticklabelsvisible = label_ts && !draw_ref_plot,
+        yticklabelsvisible = label_zs,
+    )
+    first_plot = Makie.contourf!(axis, ts, zs, values; kwargs...)
+    for _ in 1:n_redraws
+        Makie.contourf!(axis, ts, zs, values; kwargs...)
+    end
+
+    if draw_ref_plot
+        ref_axis = Makie.Axis(
+            grid_layout[2, :];
+            xticks = TimeTicks(),
+            xlabel = label_ts ? "Time" : "",
+            ylabel = label_zs ? "main\nElevation (km)" : "",
+            xticklabelsvisible = label_ts,
+            yticklabelsvisible = label_zs,
+        )
+        if isnothing(ref_var_col_time_series)
+            Makie.contourf!(ref_axis, ts, zs, fill(NaN, size(values)))
+        else
+            for _ in 1:(n_redraws + 1)
+                Makie.contourf!(ref_axis, ref_ts, ref_zs, ref_values; kwargs...)
+            end
+        end
+    end
+
+    for _ in 1:(n_redraws + 1)
+        Makie.Colorbar(grid_layout[:, 2], first_plot; colorbar_ticks_kwarg...)
+    end
+end
+
+function profile_plot!(
+    grid_position,
+    final_var_cols,
+    ref_final_var_cols,
+    categories,
+    name,
+    label_zs,
+)
+    # Use maximally distinguishable colors that are neither too bright nor too
+    # dark (restrict their luminance range from [0, 100] to [30, 40]).
+    colors = Makie.ColorSchemes.distinguishable_colors(6; lchoices = 30:40)
+    color_indices = Dict(:gm => 1, :draft => 2, :env => 3)
+    ref_color_indices = Dict(:gm => 4, :draft => 5, :env => 6)
+    alpha = 0.6 # Use transparency to see when lines are on top of each other.
+
+    axis = Makie.Axis(
+        grid_position;
+        xlabel = "$name",
+        ylabel = label_zs ? "Elevation (km)" : "",
+        yticksvisible = label_zs,
+        yticklabelsvisible = label_zs,
+    )
+    any_refs_available = any(!isnothing, getindex.(ref_final_var_cols, 2))
+    for (category, (zs, values)) in zip(categories, final_var_cols)
+        color = (colors[color_indices[category]], alpha)
+        label = (any_refs_available ? "PR " : "") * "$category"
+        Makie.lines!(axis, values, zs; color, label)
+    end
+    for (category, (zs, values)) in zip(categories, ref_final_var_cols)
+        isnothing(values) && continue
+        color = (colors[ref_color_indices[category]], alpha)
+        label = "main $category"
+        Makie.lines!(axis, values, zs; color, label, linestyle = :dash)
+    end
+end
+
+function contours_and_profiles(output_dir, ref_job_id = nothing)
+    ##
+    ## Reading in time series data:
+    ##
+
+    function sorted_hdf5_files(dir)
+        file_paths = readdir(dir; join = true)
+        filter!(endswith(".hdf5"), file_paths)
+        sort!(file_paths; by = time_from_filename)
+        return file_paths
+    end
+
+    function read_hdf5_file(file_path)
+        reader = InputOutput.HDF5Reader(file_path)
+        diagnostics = InputOutput.read_field(reader, "diagnostics")
+        close(reader)
+        return time_from_filename(file_path), diagnostics
+    end
+
+    time_series = map(read_hdf5_file, sorted_hdf5_files(output_dir))
+    t_end = time_series[end][1]
+
+    ref_time_series = nothing
+    if !isnothing(ref_job_id) && haskey(ENV, "BUILDKITE_COMMIT")
+        main_dir = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
+        isdir(main_dir) ||
+            error("Unable to find $main_dir when running on Buildkite")
+        commit_dirs = readdir(main_dir; join = true)
+
+        # Only commits that increment the "ref_counter" currently generate hdf5
+        # files. The files are zipped for TC cases, but not for other CI jobs.
+        # TODO: Unify how reference data is stored and simplify this code.
+        has_hdf5_files(commit_dir) =
+            isdir(joinpath(commit_dir, ref_job_id)) &&
+            any(endswith(".hdf5"), readdir(joinpath(commit_dir, ref_job_id)))
+        zip_file(commit_dir) = joinpath(commit_dir, ref_job_id, "hdf5files.zip")
+        filter!(commit_dirs) do commit_dir
+            return has_hdf5_files(commit_dir) || isfile(zip_file(commit_dir))
+        end
+        if isempty(commit_dirs)
+            @warn "Unable to find reference data for $ref_job_id in $main_dir"
+        else
+            latest_commit_dir =
+                argmax(commit_dir -> stat(commit_dir).mtime, commit_dirs)
+            commit_id = basename(latest_commit_dir)
+            @info "Loading reference data from main branch (commit $commit_id)"
+            if has_hdf5_files(latest_commit_dir)
+                ref_files_dir = joinpath(latest_commit_dir, ref_job_id)
+            else
+                ref_files_dir = mktempdir(output_dir; prefix = "unzip_dir_")
+                run(`unzip $(zip_file(latest_commit_dir)) -d $ref_files_dir`)
+            end
+            ref_file_paths = sorted_hdf5_files(ref_files_dir)
+            _, last_index = findmin(ref_file_paths) do ref_file_path
+                return abs(t_end - time_from_filename(ref_file_path))
+            end # End the reference time series as close to t_end as possible.
+            ref_time_series = map(read_hdf5_file, ref_file_paths[1:last_index])
+            ref_t_end = ref_time_series[end][1]
+        end
+    end
+
+    ##
+    ## Extracting a column of data from each time series:
+    ##
+
+    # Assume that all variables are on the same horizontal space.
+    horizontal_space(time_series) =
+        Spaces.horizontal_space(axes(time_series[1][2].temperature))
+
+    is_on_sphere(time_series) =
+        eltype(Fields.coordinate_field(horizontal_space(time_series))) <:
+        Geometry.LatLongPoint
+
+    function column_view_time_series(time_series, column)
+        ((i, j), h) = column
+        is_extruded_field(object) =
+            axes(object) isa Spaces.ExtrudedFiniteDifferenceSpace
+        column_view(field) = Fields.column(field, i, j, h)
+        column_zs(object) =
+            is_extruded_field(object) ?
+            vec(parent(Fields.coordinate_field(column_view(object)).z)) / 1000 :
+            nothing
+        column_values(object) =
+            is_extruded_field(object) ? vec(parent(column_view(object))) :
+            nothing
+        col_time_series = map(time_series) do (t, diagnostics)
+            objects = Fields._values(diagnostics)
+            return t, map(column_zs, objects), map(column_values, objects)
+        end
+
+        # Assume that all variables have the same horizontal coordinates.
+        coords =
+            Fields.coordinate_field(column_view(time_series[1][2].temperature))
+
+        coord_strings = map(filter(!=(:z), propertynames(coords))) do symbol
+            # Add 0 to every horizontal coordinate value so that -0.0 gets
+            # printed without the unnecessary negative sign.
+            value = round(mean(getproperty(coords, symbol)); sigdigits = 6) + 0
+            return "$symbol = $value"
+        end
+        col_string = "column data from $(join(coord_strings, ", "))"
+
+        return col_time_series, col_string
+    end
+
+    get_column_1(time_series) =
+        isnothing(time_series) ? (nothing, nothing) :
+        column_view_time_series(time_series, ((1, 1), 1))
+
+    column_at_latitude_getter(latitude) =
+        time_series -> begin
+            isnothing(time_series) && return (nothing, nothing)
+            column = if is_on_sphere(time_series)
+                horz_space = horizontal_space(time_series)
+                horz_coords = Fields.coordinate_field(horz_space)
+                FT = eltype(eltype(horz_coords))
+                target_column_coord =
+                    Geometry.LatLongPoint(FT(latitude), FT(0))
+                distance_to_target(((i, j), h)) =
+                    Geometry.great_circle_distance(
+                        Spaces.column(horz_coords, i, j, h)[],
+                        target_column_coord,
+                        horz_space.global_geometry,
+                    )
+                argmin(distance_to_target, Spaces.all_nodes(horz_space))
+            else
+                ((1, 1), 1) # If the data is not on a sphere, extract column 1.
+            end
+            return column_view_time_series(time_series, column)
+        end
+
+    # TODO: Add averaging over multiple columns.
+    column_info = if is_on_sphere(time_series)
+        map((0, 30, 60, 90)) do latitude
+            return column_at_latitude_getter(latitude), "_from_$(latitude)N_0E"
+        end
+    else
+        ((get_column_1, ""),)
+    end
+
+    ##
+    ## Extracting data for a specific variable from each column time series:
+    ##
+
+    function variable_column_time_series(col_time_series, category, name)
+        isnothing(col_time_series) && return nothing
+        symbol = category === :gm ? name : Symbol(category, :_, name)
+
+        # TODO: Remove this workaround when the old EDMF model is deleted.
+        deprecated_symbols = Dict(
+            :env_temperature => :env_temperature,
+            :draft_temperature => :bulk_up_temperature,
+            :env_potential_temperature => :env_theta_liq_ice,
+            :env_w_velocity => :face_env_w,
+            :draft_w_velocity => :face_bulk_w,
+            :draft_buoyancy => :bulk_up_buoyancy,
+            :draft_q_liq => :bulk_up_q_liq,
+            :draft_q_ice => :bulk_up_q_ice,
+            :env_relative_humidity => :env_RH,
+            :draft_cloud_fraction => :bulk_up_cloud_fraction,
+            :draft_area => :bulk_up_area,
+            :env_tke => :env_TKE,
+        )
+        if !hasproperty(col_time_series[1][2], symbol) &&
+           symbol in keys(deprecated_symbols)
+            symbol = deprecated_symbols[symbol]
+        end
+
+        hasproperty(col_time_series[1][2], symbol) || return nothing
+        return map(col_time_series) do (t, zs, diagnostics)
+            return t, getproperty(zs, symbol), getproperty(diagnostics, symbol)
+        end
+    end
+
+    final_variable_columns(col_time_series, categories, name) =
+        map(categories) do category
+            var_col_time_series =
+                variable_column_time_series(col_time_series, category, name)
+            return isnothing(var_col_time_series) ? (nothing, nothing) :
+                   var_col_time_series[end][2:3]
+        end
+
+    has_moisture = hasproperty(time_series[1][2], :q_vap)
+    has_precipitation = hasproperty(time_series[1][2], :q_rai)
+    has_sgs = hasproperty(time_series[1][2], :draft_area)
+
+    negative_values_allowed_names =
+        (:u_velocity, :v_velocity, :w_velocity, :buoyancy)
+
+    env_or_gm = has_sgs ? :env : :gm
+    draft_or_gm = has_sgs ? :draft : :gm
+    contour_variables = (
+        (draft_or_gm, :temperature),
+        (:gm, :potential_temperature),
+        (:gm, :u_velocity),
+        (:gm, :v_velocity),
+        (:gm, :w_velocity),
+        (draft_or_gm, :buoyancy),
+    )
+    if has_moisture
+        contour_variables = (
+            contour_variables...,
+            (env_or_gm, :relative_humidity),
+            (draft_or_gm, :q_vap),
+            (draft_or_gm, :q_liq),
+            (draft_or_gm, :q_ice),
+        )
+    end
+    if has_precipitation
+        contour_variables =
+            (contour_variables..., (draft_or_gm, :q_rai), (draft_or_gm, :q_sno))
+    end
+    if has_sgs
+        if has_moisture
+            contour_variables = (contour_variables..., (:gm, :cloud_fraction))
+        end
+        contour_variables =
+            (contour_variables..., (:draft, :area), (:env, :tke))
+    end
+
+    all_categories = has_sgs ? (:gm, :env, :draft) : (:gm,)
+    profile_variables = (
+        (all_categories, :temperature),
+        (all_categories, :potential_temperature),
+        ((:gm,), :u_velocity),
+        ((:gm,), :v_velocity),
+        (all_categories, :w_velocity),
+        (all_categories, :buoyancy),
+    )
+    if has_moisture
+        profile_variables = (
+            profile_variables...,
+            (all_categories, :relative_humidity),
+            (all_categories, :q_vap),
+            (all_categories, :q_liq),
+            (all_categories, :q_ice),
+        )
+    end
+    if has_precipitation
+        profile_variables = (
+            profile_variables...,
+            (all_categories, :q_rai),
+            (all_categories, :q_sno),
+        )
+    end
+    if has_sgs
+        if has_moisture
+            profile_variables =
+                (profile_variables..., ((:gm,), :cloud_fraction))
+        end
+        profile_variables =
+            (profile_variables..., ((:draft,), :area), ((:env,), :tke))
+    end
+
+    ##
+    ## Generating the contour and profile plots:
+    ##
+
+    # Organize the variables into squares, or something close to squares.
+    # If they are not squares, the contour plots should have more rows than
+    # columns, whereas the profile plots should have more columns than rows.
+    sqrt_factors(n) = minmax(round(Int, sqrt(n)), cld(n, round(Int, sqrt(n))))
+    n_contour_cols, n_contour_rows = sqrt_factors(length(contour_variables))
+    n_profile_rows, n_profile_cols = sqrt_factors(length(profile_variables))
+
+    # Plot the variables by starting at the bottom of the first column and
+    # moving upward, then going to the bottom of the second column and moving
+    # upward, and so on. This ensures that the first column and the bottom row
+    # are always filled, which means that axis ticks do not need to be drawn in
+    # the remaining rows and columns.
+    function row_and_col(index, n_rows)
+        col, row = divrem(index - 1, n_rows, RoundDown) .+ 1
+        return n_rows + 1 - row, col
+    end
+
+    contour_resolution = (700 * n_contour_cols, 400 * n_contour_rows)
+    profile_resolution = (400 * n_profile_cols, 400 * n_profile_rows)
+
+    for (get_column, filename_suffix) in column_info
+        col_time_series, col_string = get_column(time_series)
+        ref_col_time_series, ref_col_string = get_column(ref_time_series)
+
+        contour_title =
+            isnothing(ref_col_time_series) || ref_col_string == col_string ?
+            col_string : "PR $col_string\nmain branch $ref_col_string"
+
+        profile_title =
+            isnothing(ref_col_time_series) ||
+            (ref_col_string == col_string && ref_t_end == t_end) ?
+            "$col_string after $(time_string_with_unit(t_end))" :
+            "PR $col_string after $(time_string_with_unit(t_end))\nmain branch \
+             $ref_col_string after $(time_string_with_unit(ref_t_end))"
+
+        # Assume that all variables have the same vertical coordinate limits.
+        z_limits = extrema(col_time_series[1][2].temperature)
+
+        figure = Makie.Figure()
+        for (index, (category, name)) in enumerate(contour_variables)
+            row, col = row_and_col(index, n_contour_rows)
+            contour_plot!(
+                figure[row, col],
+                variable_column_time_series(col_time_series, category, name),
+                variable_column_time_series(
+                    ref_col_time_series,
+                    category,
+                    name,
+                ),
+                category,
+                name,
+                !isnothing(ref_col_time_series),
+                row == n_contour_rows,
+                col == 1,
+                name in negative_values_allowed_names,
+            )
+        end
+        all_axes = filter(object -> object isa Makie.Axis, figure.content)
+        foreach(axis -> Makie.limits!(axis, (0, t_end), z_limits), all_axes)
+        Makie.Label(figure[0, :], contour_title; font = :bold, fontsize = 20)
+        file_path = joinpath(output_dir, "contours$(filename_suffix).png")
+        Makie.save(file_path, figure; resolution = contour_resolution)
+
+        figure = Makie.Figure()
+        for (index, (categories, name)) in enumerate(profile_variables)
+            row, col = row_and_col(index, n_profile_rows)
+            profile_plot!(
+                figure[row, col],
+                final_variable_columns(col_time_series, categories, name),
+                final_variable_columns(ref_col_time_series, categories, name),
+                categories,
+                name,
+                col == 1,
+            )
+        end
+        all_axes = filter(object -> object isa Makie.Axis, figure.content)
+        foreach(axis -> Makie.ylims!(axis, z_limits), all_axes)
+        Makie.Legend(figure[0, :], all_axes[1]; orientation = :horizontal)
+        Makie.Label(figure[-1, :], profile_title; font = :bold, fontsize = 20)
+        file_path = joinpath(output_dir, "final_profiles$(filename_suffix).png")
+        Makie.save(file_path, figure; resolution = profile_resolution)
+    end
+end

--- a/src/InitialConditions/InitialConditions.jl
+++ b/src/InitialConditions/InitialConditions.jl
@@ -11,6 +11,9 @@ import ..Microphysics0Moment
 import ..Microphysics1Moment
 import ..PerfStandard
 import ..PerfExperimental
+import ..EDMFX
+import ..n_mass_flux_subdomains
+import ..times_a
 
 import Thermodynamics.TemperatureProfiles: DecayingTemperatureProfile
 import ClimaCore: Fields, Geometry

--- a/src/InitialConditions/atmos_state.jl
+++ b/src/InitialConditions/atmos_state.jl
@@ -33,25 +33,32 @@ In order to extend this function to new sub-models, add more functions of the
 form `variables(ls, model, args...)`, where `args` can be used for dispatch or
 for avoiding duplicate computations.
 """
-atmos_center_variables(ls, atmos_model::AtmosModel) = (;
-    ρ = ls.ρ,
-    uₕ = Geometry.project(Geometry.Covariant12Axis(), ls.velocity, ls.geometry),
-    energy_variables(ls, atmos_model.energy_form)...,
-    moisture_variables(ls, atmos_model.moisture_model)...,
-    precip_variables(ls, atmos_model.precip_model, atmos_model.perf_mode)...,
-    turbconv_center_variables(ls, atmos_model.turbconv_model)...,
-)
+function atmos_center_variables(ls, atmos_model)
+    gs_vars = grid_scale_center_variables(ls, atmos_model)
+    sgs_vars =
+        turbconv_center_variables(ls, atmos_model.turbconv_model, gs_vars)
+    return (; gs_vars..., sgs_vars...)
+end
 
 """
     atmos_face_variables(ls, atmos_model)
 
 Like `atmos_center_variables`, but for cell faces.
 """
-atmos_face_variables(ls, atmos_model::AtmosModel) = (;
+atmos_face_variables(ls, atmos_model) = (;
     w = Geometry.project(Geometry.Covariant3Axis(), ls.velocity, ls.geometry),
     turbconv_face_variables(ls, atmos_model.turbconv_model)...,
 )
 
+grid_scale_center_variables(ls, atmos_model) = (;
+    ρ = ls.ρ,
+    uₕ = Geometry.project(Geometry.Covariant12Axis(), ls.velocity, ls.geometry),
+    energy_variables(ls, atmos_model.energy_form)...,
+    moisture_variables(ls, atmos_model.moisture_model)...,
+    precip_variables(ls, atmos_model.precip_model, atmos_model.perf_mode)...,
+)
+
+# TODO: Rename ρθ to ρθ_liq_ice.
 energy_variables(ls, ::PotentialTemperature) =
     (; ρθ = ls.ρ * TD.liquid_ice_pottemp(ls.thermo_params, ls.thermo_state))
 energy_variables(ls, ::TotalEnergy) = (;
@@ -90,20 +97,25 @@ precip_variables(ls, _, ::PerfExperimental) =
     (; ρq_rai = zero(eltype(ls)), ρq_sno = zero(eltype(ls)))
 
 # We can use paper-based cases for LES type configurations (no TKE)
-# or SGS type configurations (initial TKE needed)
-turbconv_center_variables(ls, ::Nothing) = (;)
-function turbconv_center_variables(ls, turbconv_model::TC.EDMFModel)
-    ρa = ls.ρ * turbconv_model.minimum_area
+# or SGS type configurations (initial TKE needed), so we do not need to assert
+# that there is no TKE when there is no turbconv_model.
+turbconv_center_variables(ls, ::Nothing, gs_vars) = (;)
+function turbconv_center_variables(ls, turbconv_model::TC.EDMFModel, gs_vars)
+    n = TC.n_updrafts(turbconv_model)
+    a_draft = max(ls.turbconv_state.draft_area, n * turbconv_model.minimum_area)
+    ρa = ls.ρ * a_draft / n
     ρaθ_liq_ice = ρa * TD.liquid_ice_pottemp(ls.thermo_params, ls.thermo_state)
     ρaq_tot = ρa * TD.total_specific_humidity(ls.thermo_params, ls.thermo_state)
-    n_up = TC.n_updrafts(turbconv_model)
-    ρa_en_tke = (ls.ρ - n_up * ρa) * ls.turbconv_state.tke
-    return (;
-        turbconv = (;
-            en = (; ρatke = ρa_en_tke),
-            up = ntuple(_ -> (; ρarea = ρa, ρaθ_liq_ice, ρaq_tot), Val(n_up)),
-        )
-    )
+    en = (; ρatke = (ls.ρ - n * ρa) * ls.turbconv_state.tke)
+    up = ntuple(_ -> (; ρarea = ρa, ρaθ_liq_ice, ρaq_tot), Val(n))
+    return (; turbconv = (; en, up))
+end
+function turbconv_center_variables(ls, turbconv_model::EDMFX, gs_vars)
+    n = n_mass_flux_subdomains(turbconv_model)
+    a_draft = ls.turbconv_state.draft_area
+    sgs⁰ = (; ρatke = ls.ρ * (1 - a_draft) * ls.turbconv_state.tke)
+    sgsʲs = ntuple(_ -> times_a(gs_vars, a_draft / n), Val(n))
+    return (; sgs⁰, sgsʲs)
 end
 
 turbconv_face_variables(ls, ::Nothing) = (;)
@@ -113,5 +125,11 @@ turbconv_face_variables(ls, turbconv_model::TC.EDMFModel) = (;
             _ -> (; w = Geometry.Covariant3Vector(zero(eltype(ls)))),
             Val(TC.n_updrafts(turbconv_model)),
         )
+    )
+)
+turbconv_face_variables(ls, turbconv_model::EDMFX) = (;
+    sgsʲs = ntuple(
+        _ -> (; w = Geometry.Covariant3Vector(zero(eltype(ls)))),
+        Val(n_mass_flux_subdomains(turbconv_model)),
     )
 )

--- a/src/InitialConditions/initial_conditions.jl
+++ b/src/InitialConditions/initial_conditions.jl
@@ -311,6 +311,37 @@ function (initial_condition::MoistBaroclinicWave)(params)
     return local_state
 end
 
+"""
+    MoistBaroclinicWaveWithEDMF(; perturb = true)
+
+The same `InitialCondition` as `MoistBaroclinicWave`, except with an initial TKE
+of 1 and an initial draft area fraction of 0.5. This is not a physically
+meaningful initial condition, and it should be removed once the new EDMF model
+is past its initial testing stage.
+"""
+Base.@kwdef struct MoistBaroclinicWaveWithEDMF <: InitialCondition
+    perturb::Bool = true
+end
+
+function (initial_condition::MoistBaroclinicWaveWithEDMF)(params)
+    (; perturb) = initial_condition
+    function local_state(local_geometry)
+        FT = eltype(params)
+        thermo_params = CAP.thermodynamics_params(params)
+        (; z, lat, long) = local_geometry.coordinates
+        (; p, T, q_tot, u, v) =
+            moist_baroclinic_wave_values(z, lat, long, params, perturb)
+        return LocalState(;
+            params,
+            geometry = local_geometry,
+            thermo_state = TD.PhaseEquil_pTq(thermo_params, p, T, q_tot),
+            velocity = Geometry.UVVector(u, v),
+            turbconv_state = EDMFState(; tke = FT(1), draft_area = FT(0.5)),
+        )
+    end
+    return local_state
+end
+
 ##
 ## EDMF Test Cases
 ##

--- a/src/InitialConditions/local_state.jl
+++ b/src/InitialConditions/local_state.jl
@@ -62,18 +62,16 @@ values required by the `turbconv_model` are set to 0.
 """
 struct NoTurbconvState{FT} <: TurbconvState{FT} end
 
-@inline Base.getproperty(ts::NoTurbconvState{FT}, s::Symbol) where {FT} =
-    s in (:tke, :Hvar, :QTVar, :HQTcov) ? FT(0) : getfield(ts, s)
+@inline Base.getproperty(::NoTurbconvState{FT}, ::Symbol) where {FT} = FT(0)
 
 """
-    EDMFState(; tke)
+    EDMFState(; tke, draft_area)
 
-Stores the value of `tke` for a `turbconv_model::EDMFModel`. Any other values
-required by the `turbconv_model` are set to 0.
+Stores the values of `tke` and `draft_area` for the `turbconv_model`. If
+`draft_area` is omitted, it is set to 0.
 """
-Base.@kwdef struct EDMFState{FT} <: TurbconvState{FT}
+struct EDMFState{FT} <: TurbconvState{FT}
     tke::FT
+    draft_area::FT
 end
-
-@inline Base.getproperty(ts::EDMFState{FT}, s::Symbol) where {FT} =
-    s in (:Hvar, :QTVar, :HQTcov) ? FT(0) : getfield(ts, s)
+EDMFState(; tke, draft_area = 0) = EDMFState{typeof(tke)}(tke, draft_area)

--- a/src/parameterizations/microphysics/precipitation.jl
+++ b/src/parameterizations/microphysics/precipitation.jl
@@ -33,13 +33,7 @@ function precipitation_cache(Y, precip_model::Microphysics0Moment)
     )
 end
 
-function compute_precipitation_cache!(
-    Y,
-    p,
-    colidx,
-    ::Microphysics0Moment,
-    ::Nothing,
-)
+function compute_precipitation_cache!(Y, p, colidx, ::Microphysics0Moment, _)
     (; ᶜts, ᶜS_ρq_tot, params) = p
     cm_params = CAP.microphysics_params(params)
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/precomputed_quantities.jl
+++ b/src/precomputed_quantities.jl
@@ -6,11 +6,13 @@ import Thermodynamics as TD
 import ClimaCore: Geometry, Spaces, Fields
 
 """
-    set_boundary_velocity!(Y)
+    set_boundary_velocity!(Y, turbconv_model)
 
-Modifies `Y.f.w` so that `ᶠu³` is 0 at the surface.
+Modifies `Y.f.w` so that `ᶠu³` is 0 at the surface. If `turbconv_model` is
+EDMFX, also modifies `Y.f.sgsʲs` so that all of the subdomain's values of `w`
+are the same as `Y.f.w` at the surface.
 """
-function set_boundary_velocity!(Y)
+function set_boundary_velocity!(Y, turbconv_model)
     uₕ_surface_data = Fields.level(Fields.field_values(Y.c.uₕ), 1)
     uₕ_surface_geom = Fields.level(Spaces.local_geometry_data(axes(Y.c.uₕ)), 1)
     uᵥ_surface_data = Fields.level(Fields.field_values(Y.f.w), 1)
@@ -19,15 +21,104 @@ function set_boundary_velocity!(Y)
         -Geometry.contravariant3(uₕ_surface_data, uₕ_surface_geom) /
         Geometry.contravariant3(one(uᵥ_surface_data), uᵥ_surface_geom),
     )
+    if turbconv_model isa EDMFX
+        for j in 1:n_mass_flux_subdomains(turbconv_model)
+            Fields.level(Y.f.sgsʲs.:($j).w, half) .= Fields.level(Y.f.w, half)
+        end
+    end
+end
+
+# TODO: Ask Tapio whether we should use this version instead. We need to account
+# for the fact that Fields.level(ᶠuₕ, half) != Fields.level(Y.c.uₕ, 1). If we do
+# use this version, we will probably want to make ᶠuₕ a precomputed quantity.
+function set_boundary_velocity!(Y, ᶠuₕ, turbconv_model)
+    w_sfc = Fields.level(Y.f.w, half)
+    uₕ_sfc = Fields.level(ᶠuₕ, half)
+    lg_sfc = Fields.local_geometry_field(w_sfc)
+    @. w_sfc = Geometry.Covariant3Vector(
+        -Geometry.contravariant3(uₕ_sfc, lg_sfc) /
+        Geometry.contravariant3(one(w_sfc), lg_sfc),
+    )
+    for j in 1:n_mass_flux_subdomains(turbconv_model)
+        wʲ_sfc = Fields.level(Y.f.sgsʲs.:($j).w, half)
+        @. wʲ_sfc = w_sfc
+    end
 end
 
 """
-    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠw, ᶜYc)
+    precomputed_quantities(atmos, center_space, face_space)
 
-Uses `ᶠw` and `ᶜYc` to set the values of `ᶜu`, `ᶠu³`, and `ᶜK`, assuming that
-the horizontal velocity is `ᶜYc.uₕ` and that it should be interpolated to cell
-faces using `ᶜYc.ρ * ᶜJ` in the weighted interpolation.
+Allocates and returns the precomputed quantities:
+    - `ᶜu`: the covariant velocity on cell centers
+    - `ᶠu³`: the third component of contravariant velocity on cell faces
+    - `ᶜK`: the kinetic energy on cell centers
+    - `ᶜts`: the thermodynamic state on cell centers
+    - `ᶜp`: the air pressure on cell centers
+
+If the `turbconv_model` is EDMFX, there also two SGS versions of each quantity:
+    - `_⁰`: the value for the environment
+    - `_ʲs`: a tuple of the values for the mass-flux subdomains
+In addition, there are several other SGS quantities:
+    - `ᶜρ⁰`: the air density of the environment on cell centers
+    - `ᶜρa⁰`: the area-weighted air density of the environment on cell centers
+    - `ᶠw⁰`: the vertical component of the covariant velocity of the environment
+        on cell faces
+    - `ᶜρʲs`: a tuple of the air densities of the mass-flux subdomains on cell
+        centers
+
+TODO: Rename `ᶜK` to `ᶜκ`, and rename `ᶠw` to `ᶠuᵥ`.
 """
+function precomputed_quantities(atmos, center_space, face_space)
+    C123 = Geometry.Covariant123Vector
+    CT3 = Geometry.Contravariant3Vector
+    FT = Spaces.undertype(center_space)
+    TST = thermo_state_type(atmos.moisture_model, FT)
+    precomputed_sgs_quantities = if atmos.turbconv_model isa EDMFX
+        n = n_mass_flux_subdomains(atmos.turbconv_model)
+        (;
+            ᶜρa⁰ = Fields.Field(FT, center_space),
+            ᶠw⁰ = Fields.Field(Geometry.Covariant3Vector{FT}, face_space),
+            ᶜu⁰ = Fields.Field(C123{FT}, center_space),
+            ᶠu³⁰ = Fields.Field(CT3{FT}, face_space),
+            ᶜK⁰ = Fields.Field(FT, center_space),
+            ᶜts⁰ = Fields.Field(TST, center_space),
+            ᶜρ⁰ = Fields.Field(FT, center_space),
+            ᶜuʲs = Fields.Field(NTuple{n, C123{FT}}, center_space),
+            ᶠu³ʲs = Fields.Field(NTuple{n, CT3{FT}}, face_space),
+            ᶜKʲs = Fields.Field(NTuple{n, FT}, center_space),
+            ᶜtsʲs = Fields.Field(NTuple{n, TST}, center_space),
+            ᶜρʲs = Fields.Field(NTuple{n, FT}, center_space),
+        )
+    else
+        (;)
+    end
+    return (;
+        ᶜu = Fields.Field(C123{FT}, center_space),
+        ᶠu³ = Fields.Field(CT3{FT}, face_space),
+        ᶜK = Fields.Field(FT, center_space),
+        ᶜts = Fields.Field(TST, center_space),
+        ᶜp = Fields.Field(FT, center_space),
+        precomputed_sgs_quantities...,
+    )
+end
+
+"""
+    divide_by_ρa(ρaχ, ρa, ρχ, ρ, a_min)
+
+Computes `ρaχ / ρa`, regularizing the result to avoid issues when `a` is small.
+This is done by performing a linear interpolation from `ρaχ / ρa` to `ρχ / ρ`,
+interpolating closer to `ρχ / ρ` when `a` is small. When `a == 0`, the result is
+exactly `ρχ / ρ` (a tiny value of `ε` is added to the denominator of `ρaχ / ρa`
+in order to avoid returning `NaN` when `a == 0`, since `0 * Inf` is `NaN`).
+"""
+function divide_by_ρa(ρaχ, ρa, ρχ, ρ, a_min)
+    ε = eps(zero(ρa)) # the smallest number bigger than 0 of the same type as ρa
+    sgs_weight = 1 / (1 + a_min^2 * ρ^2 / ρa^2) # TODO: Make this exponential.
+    return sgs_weight * ρaχ / (ρa + ε) + (1 - sgs_weight) * ρχ / ρ
+end
+
+# The arguments ᶜu, ᶠu³, ᶜK, and ᶠw can be replaced with their SGS versions when
+# calling this function.
 function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠw, ᶜYc)
     ᶜinterp = Operators.InterpolateF2C()
     ᶠwinterp = Operators.WeightedInterpolateC2F(
@@ -48,11 +139,45 @@ function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠw, ᶜYc)
     end
 end
 
-"""
-    thermo_state(thermo_params; ρ, p, θ, e_int, q_tot, q_pt)
+get_ʲs(sgsʲs, ::Val{symbol}) where {symbol} =
+    map(sgsʲ -> sgsʲ.:($symbol), sgsʲs)
 
-Constructs a thermodynamic state based on the supplied keyword arguments.
-"""
+function set_ᶠw⁰!(ᶠw⁰, Y, ᶜρa⁰, a_min)
+    ᶠinterp = Operators.InterpolateC2F(
+        bottom = Operators.Extrapolate(),
+        top = Operators.Extrapolate(),
+    )
+    w⁰(ρa⁰, ρaʲs, wʲs, ρ, w, a_min) =
+        divide_by_ρa(ρ * w - sum(ρaʲs .* wʲs), ρa⁰, ρ * w, ρ, a_min)
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. ᶠw⁰[colidx] = w⁰(
+            ᶠinterp(ᶜρa⁰[colidx]),
+            ᶠinterp(get_ʲs(Y.c.sgsʲs[colidx], Val{:ρa}())),
+            get_ʲs(Y.f.sgsʲs[colidx], Val{:w}()),
+            ᶠinterp(Y.c.ρ[colidx]),
+            Y.f.w[colidx],
+            a_min,
+        )
+    end
+end
+
+# TODO: Ask Tapio whether this function is correct.
+function add_sgs_ᶜK!(ᶜK, Y, ᶜρa⁰, ᶠw⁰, turbconv_model)
+    ᶜinterp = Operators.InterpolateF2C()
+    function do_col!(ᶜK, Yc, Yf, ᶜρa⁰, ᶠw⁰)
+        CT3 = Geometry.Contravariant3Vector
+        @. ᶜK += ᶜρa⁰ * ᶜinterp(dot(ᶠw⁰ - Yf.w, CT3(ᶠw⁰ - Yf.w))) / 2 / Yc.ρ
+        for j in 1:n_mass_flux_subdomains(turbconv_model)
+            ᶜρaʲ = Yc.sgsʲs[j].ρa
+            ᶠwʲ = Yf.sgsʲs[j].w
+            @. ᶜK += ᶜρaʲ * ᶜinterp(dot(ᶠwʲ - Yf.w, CT3(ᶠwʲ - Yf.w))) / 2 / Yc.ρ
+        end
+    end
+    Fields.bycolumn(axes(Y.c)) do colidx
+        do_col!(ᶜK[colidx], Y.c[colidx], Y.f[colidx], ᶜρa⁰[colidx], ᶠw⁰[colidx])
+    end
+end
+
 function thermo_state(
     thermo_params;
     ρ = nothing,
@@ -111,16 +236,186 @@ function ts(Yc, K, Φ, thermo_params, energy_form, moisture_model)
     return thermo_state(thermo_params; ρ = Yc.ρ, energy_var..., moisture_var...)
 end
 
+function tsʲ(
+    sgsʲ,
+    Yc,
+    Kʲ,
+    p,
+    Φ,
+    a_min,
+    thermo_params,
+    energy_form,
+    moisture_model,
+)
+    energy_var = if energy_form isa PotentialTemperature
+        (; θ = divide_by_ρa(sgsʲ.ρaθ, sgsʲ.ρa, Yc.ρθ, Yc.ρ, a_min))
+    elseif energy_form isa TotalEnergy
+        e_totʲ = divide_by_ρa(sgsʲ.ρae_tot, sgsʲ.ρa, Yc.ρe_tot, Yc.ρ, a_min)
+        (; e_int = e_totʲ - Kʲ - Φ)
+    end
+    moisture_var = if moisture_model isa DryModel
+        (;)
+    else
+        q_totʲ = divide_by_ρa(sgsʲ.ρaq_tot, sgsʲ.ρa, Yc.ρq_tot, Yc.ρ, a_min)
+        if moisture_model isa EquilMoistModel
+            (; q_tot = q_totʲ)
+        elseif moisture_model isa NonEquilMoistModel
+            q_liqʲ = divide_by_ρa(sgsʲ.ρaq_liq, sgsʲ.ρa, Yc.ρq_liq, Yc.ρ, a_min)
+            q_iceʲ =
+                divide_by_ρa(sgsʲ.ρaq_ice, sgsʲ.ρa, Yc.ρq_ice, Yc.ρ, a_min)
+            (; q_pt = TD.PhasePartition(q_totʲ, q_liqʲ, q_iceʲ))
+        end
+    end
+    return thermo_state(thermo_params; p, energy_var..., moisture_var...)
+end
+
+function ts⁰(
+    Yc,
+    ρa⁰,
+    K⁰,
+    p,
+    Φ,
+    a_min,
+    thermo_params,
+    energy_form,
+    moisture_model,
+)
+    energy_var = if energy_form isa PotentialTemperature
+        ρθ⁰ = Yc.ρθ - sum(get_ʲs(Yc.sgsʲs, Val{:ρaθ}()))
+        (; θ = divide_by_ρa(ρθ⁰, ρa⁰, Yc.ρθ, Yc.ρ, a_min))
+    elseif energy_form isa TotalEnergy
+        ρae_tot⁰ = Yc.ρe_tot - sum(get_ʲs(Yc.sgsʲs, Val{:ρae_tot}()))
+        e_tot⁰ = divide_by_ρa(ρae_tot⁰, ρa⁰, Yc.ρe_tot, Yc.ρ, a_min)
+        (; e_int = e_tot⁰ - K⁰ - Φ)
+    end
+    moisture_var = if moisture_model isa DryModel
+        (;)
+    else
+        ρaq_tot⁰ = Yc.ρq_tot - sum(get_ʲs(Yc.sgsʲs, Val{:ρaq_tot}()))
+        q_tot⁰ = divide_by_ρa(ρaq_tot⁰, ρa⁰, Yc.ρq_tot, Yc.ρ, a_min)
+        if moisture_model isa EquilMoistModel
+            (; q_tot = q_tot⁰)
+        elseif moisture_model isa NonEquilMoistModel
+            ρaq_liq⁰ = Yc.ρq_liq - sum(get_ʲs(Yc.sgsʲs, Val{:ρaq_liq}()))
+            ρaq_ice⁰ = Yc.ρq_ice - sum(get_ʲs(Yc.sgsʲs, Val{:ρaq_ice}()))
+            q_liq⁰ = divide_by_ρa(ρaq_liq⁰, ρa⁰, Yc.ρq_liq, Yc.ρ, a_min)
+            q_ice⁰ = divide_by_ρa(ρaq_ice⁰, ρa⁰, Yc.ρq_ice, Yc.ρ, a_min)
+            (; q_pt = TD.PhasePartition(q_tot⁰, q_liq⁰, q_ice⁰))
+        end
+    end
+    return thermo_state(thermo_params; p, energy_var..., moisture_var...)
+end
+
+"""
+    set_precomputed_quantities!(Y, p, t)
+
+Updates the precomputed quantities stored in `p` based on the current state `Y`.
+
+This function also applies a "filter" to `Y` in order to ensure that `ᶠu³` is 0
+at the surface (i.e., to enforce the impenetrable boundary condition). If the
+`turbconv_model` is EDMFX, the filter also ensures that `ᶠu³⁰` and `ᶠu³ʲs` are 0
+at the surface. In the future, we will probably want to move this filtering
+elsewhere, but doing it here ensures that it occurs whenever the precomputed
+quantities are updated.
+
+Note: If you need to use any of the precomputed quantities, please call this
+function instead of recomputing the value yourself. Otherwise, it will be
+difficult to ensure that the duplicated computations are consistent.
+"""
 function set_precomputed_quantities!(Y, p, t)
-    (; energy_form, moisture_model) = p.atmos
+    (; energy_form, moisture_model, turbconv_model) = p.atmos
     thermo_params = CAP.thermodynamics_params(p.params)
-    (; ᶜΦ) = p
+    thermo_args = (thermo_params, energy_form, moisture_model)
 
     # TODO: This should probably be moved to dss! (i.e., enforce_constraints!).
-    set_boundary_velocity!(Y)
+    set_boundary_velocity!(Y, turbconv_model)
 
-    (; ᶜu, ᶠu³, ᶜK, ᶜts, ᶜp) = p
+    (; ᶜu, ᶠu³, ᶜK, ᶜts, ᶜp, ᶜΦ) = p
     set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.w, Y.c)
-    @. ᶜts = ts(Y.c, ᶜK, ᶜΦ, thermo_params, energy_form, moisture_model)
+    if turbconv_model isa EDMFX
+        (; ᶜρa⁰, ᶠw⁰) = p
+        (; a_min) = turbconv_model
+        @. ᶜρa⁰ = Y.c.ρ - sum(get_ʲs(Y.c.sgsʲs, Val{:ρa}()))
+        set_ᶠw⁰!(ᶠw⁰, Y, ᶜρa⁰, a_min)
+
+        # TODO: In the following increments to ᶜK, we actually need to add
+        # quantities of the form ᶜρaχ⁰ / ᶜρ⁰ and ᶜρaχʲ / ᶜρʲ to ᶜK, rather than
+        # quantities of the form ᶜρaχ⁰ / ᶜρ and ᶜρaχʲ / ᶜρ. However, we cannot
+        # compute ᶜρ⁰ and ᶜρʲ without first computing ᶜts⁰ and ᶜtsʲ, both of
+        # which depend on the value of ᶜp, which in turn depends on ᶜts. Since
+        # ᶜts depends on ᶜK (at least when the energy_form is TotalEnergy), this
+        # means that the amount by which ᶜK needs to be incremented is a
+        # function of ᶜK itself. So, unless we run a nonlinear solver here, this
+        # circular dependency will prevent us from computing the exact value of
+        # ᶜK. For now, we will make the anelastic approximation ᶜρ⁰ ≈ ᶜρʲ ≈ ᶜρ.
+        add_sgs_ᶜK!(ᶜK, Y, ᶜρa⁰, ᶠw⁰, turbconv_model)
+        @. ᶜK += Y.c.sgs⁰.ρatke / Y.c.ρ
+    end
+    @. ᶜts = ts(Y.c, ᶜK, ᶜΦ, thermo_args...)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
+
+    if turbconv_model isa EDMFX
+        (; ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜρ⁰, ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜtsʲs, ᶜρʲs) = p
+        set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠw⁰, Y.c)
+        @. ᶜK⁰ += divide_by_ρa(Y.c.sgs⁰.ρatke, ᶜρa⁰, 0, Y.c.ρ, a_min)
+        @. ᶜts⁰ = ts⁰(Y.c, ᶜρa⁰, ᶜK⁰, ᶜp, ᶜΦ, a_min, thermo_args...)
+        @. ᶜρ⁰ = TD.air_density(thermo_params, ᶜts⁰)
+        for j in 1:n_mass_flux_subdomains(turbconv_model)
+            set_velocity_quantities!(
+                ᶜuʲs.:($j),
+                ᶠu³ʲs.:($j),
+                ᶜKʲs.:($j),
+                Y.f.sgsʲs.:($j).w,
+                Y.c,
+            )
+            @. ᶜtsʲs[j] =
+                tsʲ(Y.c.sgsʲs[j], Y.c, ᶜKʲs[j], ᶜp, ᶜΦ, a_min, thermo_args...)
+            @. ᶜρʲs[j] = TD.air_density(thermo_params, ᶜtsʲs[j])
+        end
+    end
+
+    return nothing
+end
+
+"""
+    diagnostic_edmfx_quantities(Y, p, t)
+
+Allocates, sets, and returns `ᶜsgs⁰`, `ᶜsgs⁺`, `ᶜu⁺`, and `ᶜts⁺` in a manner
+that is consistent with `set_precomputed_quantities!`. This function should only
+be used to generate diagnostics for EDMFX, and it should only be called after
+`set_precomputed_quantities!` has been called.
+"""
+function diagnostic_edmfx_quantities(Y, p, t)
+    ᶠinterp = Operators.InterpolateC2F(
+        bottom = Operators.Extrapolate(),
+        top = Operators.Extrapolate(),
+    )
+    (; energy_form, moisture_model, turbconv_model) = p.atmos
+    thermo_params = CAP.thermodynamics_params(p.params)
+    thermo_args = (thermo_params, energy_form, moisture_model)
+    (; ᶜp, ᶜΦ) = p
+
+    @assert turbconv_model isa EDMFX
+    (; a_min) = turbconv_model
+    (ᶠw⁺, ᶜu⁺, ᶠu³⁺, ᶜK⁺) = similar.((p.ᶠw⁰, p.ᶜu⁰, p.ᶠu³⁰, p.ᶜK⁰))
+
+    w⁺(ρaʲs, wʲs, ρ, w) =
+        divide_by_ρa(sum(ρaʲs .* wʲs), sum(ρaʲs), ρ * w, ρ, a_min)
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. ᶠw⁺[colidx] = w⁺(
+            ᶠinterp(get_ʲs(Y.c.sgsʲs[colidx], Val{:ρa}())),
+            get_ʲs(Y.f.sgsʲs[colidx], Val{:w}()),
+            ᶠinterp(Y.c.ρ[colidx]),
+            Y.f.w[colidx],
+        )
+    end
+    set_velocity_quantities!(ᶜu⁺, ᶠu³⁺, ᶜK⁺, ᶠw⁺, Y.c)
+
+    sgs⁺(Yc) = map(+, Yc.sgsʲs...)
+    ᶜsgs⁺ = @. sgs⁺(Y.c)
+    sgs⁰(Yc, sgs⁺) = merge(map(-, times_a(Yc, 1), sgs⁺), Yc.sgs⁰)
+    ᶜsgs⁰ = @. sgs⁰(Y.c, ᶜsgs⁺)
+    ᶜts⁺ = @. tsʲ(ᶜsgs⁺, Y.c, ᶜK⁺, ᶜp, ᶜΦ, a_min, thermo_args...)
+
+    return (; ᶜsgs⁰, ᶜsgs⁺, ᶜu⁺, ᶜts⁺)
 end

--- a/src/staggered_nonhydrostatic_model.jl
+++ b/src/staggered_nonhydrostatic_model.jl
@@ -24,19 +24,6 @@ import ClimaCore.Fields: ColumnField
 # The model also depends on f_plane_coriolis_frequency(params)
 # This is a constant Coriolis frequency that is only used if space is flat
 
-# TODO: Rename ᶜK to ᶜκ, and rename ᶠw to ᶠuᵥ.
-function precomputed_quantities(Y, atmos)
-    FT = eltype(Y)
-    TST = thermo_state_type(atmos.moisture_model, FT)
-    return (;
-        ᶜu = similar(Y.c, Geometry.Covariant123Vector{FT}),
-        ᶠu³ = similar(Y.f, Geometry.Contravariant3Vector{FT}),
-        ᶜK = similar(Y.c, FT),
-        ᶜts = similar(Y.c, TST),
-        ᶜp = similar(Y.c, FT),
-    )
-end
-
 function default_cache(
     Y,
     parsed_args,
@@ -219,7 +206,11 @@ function default_cache(
         ghost_buffer = ghost_buffer,
         net_energy_flux_toa,
         net_energy_flux_sfc,
-        precomputed_quantities(Y, atmos)...,
+        precomputed_quantities(
+            atmos,
+            spaces.center_space,
+            spaces.face_space,
+        )...,
     )
     set_precomputed_quantities!(Y, default_cache, FT(0))
     return default_cache

--- a/src/utils/model_getters.jl
+++ b/src/utils/model_getters.jl
@@ -312,7 +312,7 @@ function get_turbconv_model(
     turbconv_params,
 )
     turbconv = parsed_args["turbconv"]
-    @assert turbconv in (nothing, "edmf")
+    @assert turbconv in (nothing, "edmf", "edmfx")
 
     return if turbconv == "edmf"
         TC.EDMFModel(
@@ -322,6 +322,8 @@ function get_turbconv_model(
             parsed_args,
             turbconv_params,
         )
+    elseif turbconv == "edmfx"
+        EDMFX{turbconv_params.updraft_number}(turbconv_params.min_area)
     else
         nothing
     end

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -251,8 +251,12 @@ end
 
 function get_initial_condition(parsed_args)
     if isnothing(parsed_args["turbconv_case"])
-        if parsed_args["initial_condition"] in
-           ["DryBaroclinicWave", "MoistBaroclinicWave", "DecayingProfile"]
+        if parsed_args["initial_condition"] in [
+            "DryBaroclinicWave",
+            "MoistBaroclinicWave",
+            "DecayingProfile",
+            "MoistBaroclinicWaveWithEDMF",
+        ]
             return getproperty(ICs, Symbol(parsed_args["initial_condition"]))(
                 parsed_args["perturb_initstate"],
             )

--- a/src/utils/types.jl
+++ b/src/utils/types.jl
@@ -106,6 +106,12 @@ struct EDMFCoriolis{U, V, FT}
     coriolis_param::FT
 end
 
+struct EDMFX{N, FT}
+    a_min::FT # WARNING: this should never be used outside of divide_by_ρa
+end
+EDMFX{N}(a_min::FT) where {N, FT} = EDMFX{N, FT}(a_min)
+n_mass_flux_subdomains(::EDMFX{N}) where {N} = N
+
 abstract type AbstractSurfaceThermoState end
 struct GCMSurfaceThermoState <: AbstractSurfaceThermoState end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds the "EDMFX" model to ClimaAtmos, but without any tendencies. This includes adding prognostic variables, precomputed quantities, and diagnostics, as described in  ClimaAtmos's new [documentation for EDMF](https://clima.github.io/ClimaAtmos.jl/dev/edmf_equations/), along with adding the post-processing that we will need in order to debug this new model's tendencies.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add the total draft area to the initial condition's `EDMFState`, and set it to 0 by default. Clean up `getproperty` for `EDMFState` and `NoTurbconvState`, since it was not updated when the second moments were removed.
- Define the `EDMFX` struct and the `n_mass_flux_subdomains` function (which was called `n_updrafts` in the original EDMF model) in `types.jl`. Also define the `times_a` function in `utilities.jl`, which takes in a `NamedTuple` of variables and returns a new `NamedTuple` with every variable of the form `ρ` or `ρχ` transformed to `ρa` or `ρaχ`, respectively. Construct the EDMFX model in `model_getters.jl`.
- Separate the initial condition's `atmos_center_variables` into `grid_scale_center_variables` and `turbconv_center_variables`. Leave the original EDMF model's `turbconv_center_variables` unchanged, but have the EDMFX model's `turbconv_center_variables` return a copy of `grid_scale_center_variables` with every variable multiplied by `a` (the total draft area divided by the number of mass flux subdomains). Also add a new method for `turbconv_face_variables` for the EDMFX model that sets all of the draft vertical velocities to 0. Modify `is_turbconv_var` to recognize the new groups of EDMFX variables.
- Add `ᶜρa⁰`, `ᶠw⁰`, `ᶜu⁰`, `ᶠu³⁰`, `ᶜK⁰`, `ᶜts⁰`, `ᶜρa`, `ᶜuʲs`, `ᶠu³ʲs`, `ᶜKʲs`, `ᶜtsʲs`, and `ᶜρʲs` to `precomputed_quantities` for the EDMFX model, and set these values in `set_precomputed_quantities!`. Make `set_precomputed_quantities` add the SGS kinetic energy to the grid-scale `ᶜK`, and make `set_boundary_velocity!` set the draft vertical velocities equal to the grid-scale vertical velocity at the surface. Compute all specific SGS quantities from the prognostic state using the new `divide_by_ρa` function, which regularizes divisions by returning quantities closer to the grid-scale values when `a` is small.
- Define a `diagnostic_edmfx_quantities` function, which allocates and sets `ᶜsgs⁰`, `ᶜsgsᴰ`, `ᶜuᴰ`, and `ᶜtsᴰ` in a manner that is consistent with `set_precomputed_quantities!`. Call this function from `save_to_disk_func`, and use it to define the actual EDMFX diagnostics that are saved to hdf5 files.
- Make the implicit solver set the Jacobian blocks for the EDMFX model to 0 by modifying the `ldiv!` method for `SchurComplementW`. More generally, this modification causes the implicit solver to automatically zero out all Jacobian blocks that are not set in `_ldiv_serial!`.
- Ensure that none of the original EDMF code is run for the EDMFX model. This includes removing the `::Nothing` type restrictions from `turbconv_cache`, `implicit_sgs_flux_tendency!`, `explicit_sgs_flux_tendency!`, and `compute_precipitation_cache!`. It also includes replacing `!isnothing(atmos.turbconv_model)` with `p.atmos.turbconv_model isa TC.EDMFModel` in `get_callbacks`, replacing `any(is_turbconv_var, propertynames(Y.c))` with `:turbconv in propertynames(Y.c)` in `SchurComplementW`, and replacing `any(is_turbconv_var, propertynames(xc))` with `:turbconv in propertynames(xc)` in `_ldiv_serial!`.
- Rename the CLI option `quicklook_reference_job_id` to `reference_job_id`, since it will now be used by the new post-processing as well as the original "quicklook profiles".
- Define the new post processing in `contours_and_profiles.jl`, which is the bulk of this PR. This post-processing generates contour and profile plots using Makie, with the column data extracted from 0°N 0°E, 30°N 0°E, 60°N 0°E, and 90°N 0°E on a sphere or from the first column in a box (it does not currently support extracting data from a plane but that can be easily changed). In the future, we may also want to add averaging over multiple columns. When running on Buildkite, the reference data is read in from the latest commit on the main branch that contains hdf5 files (either zipped or unzipped) for the specified `reference_job_id` (which is just the `job_id` by default). The reference files do not need to have the same timestamps or contain data on the same spaces as the simulation's files. The reference files also do not need to contain all of the same diagnostic variables as the simulation; any reference diagnostics that are missing do not get plotted. Values that should never be negative (e.g., specific quantities or temperatures) but are still negative get highlighted in red on the contour plots.
- Call `contours_and_profiles` from the driver when the `post_process` CLI option is `true` and the EDMFX model is being used. Ensure that the other post-processing is not run for the EDMFX model by adding checks for `!is_edmfx` to the relevant `if`-blocks. After calling `contours_and_profiles`, also call `zip_and_cleanup_output` in order to make the various plot files easier to find among the Buildkite artifacts. Move the `include` call for `define_tc_quicklook_profiles.jl` to an earlier line so that `zip_and_cleanup_output` can be used without needing to be redefined.
- Add `env_q_vap` and `draft_q_vap` to the old EDMF model's diagnostics, so that they can be compared to the values obtained with the new model.
- Add a `MoistBaroclinicWaveWithEDMF` initial condition, which is exactly like the `MoistBaroclinicWave` initial condition, except that it also has an initial draft area of 0.5 and an initial TKE of 1.
- Add three new jobs to CI that test the EDMFX model. The first is a copy of `sphere_baroclinic_wave_rhoe_equilmoist` with the initial condition changed to `MoistBaroclinicWaveWithEDMF` and `t_end` reduced to 4 days. The second is a copy of `edmf_bomex` that uses the default `sphere` configuration, `Float32` type, and active hyperdiffusion, with `dt` increased to 60 seconds and `t_end` reduced to 1 hour. Both jobs use the original versions as references for plotting. The third job is a performance test for the first job, which checks that the amount of memory allocated per timestep is reasonable (it is currently around 4 kB, whereas the amount allocated per timestep for the old EDMF model is around 8 GB).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
