### PR TITLE
Adds command line option for divergence damping factor.

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -246,6 +246,10 @@ function parse_commandline()
         help = "Hyperdiffusion parameter"
         arg_type = Float64
         default = Float64(2e17)
+        "--divergence_damping_factor"
+        help = "Divergence damping factor"
+        arg_type = Float64
+        default = Float64(1)
         "--rayleigh_sponge"
         help = "Rayleigh sponge [`true`, `false` (default)]"
         arg_type = Bool

--- a/src/utils/model_getters.jl
+++ b/src/utils/model_getters.jl
@@ -36,7 +36,7 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
     enable_qt = parsed_args["enable_qt_hyperdiffusion"]
     hyperdiff_name = parsed_args["hyperdiff"]
     κ₄ = FT(parsed_args["kappa_4"])
-    divergence_damping_factor = FT(1)
+    divergence_damping_factor = FT(parsed_args["divergence_damping_factor"])
     return if hyperdiff_name == "ClimaHyperdiffusion"
         ClimaHyperdiffusion{enable_qt, FT}(; κ₄, divergence_damping_factor)
     elseif hyperdiff_name == "TempestHyperdiffusion"


### PR DESCRIPTION
This makes the divergence damping coefficient consistent with other diffusive parameters 
being used in the model. 
modified:   examples/hybrid/cli_options.jl
modified:   src/utils/model_getters.jl
