### PR TITLE
Reduce plane hydrostatic mountain experiment simulation time

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,7 +144,7 @@ steps:
   - group: "Plane Examples"
     steps:
       - label: ":computer: Agnesi linear hydrostatic mountain experiment"
-        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config plane --x_max 240000.0 --z_max 25000.0 --x_elem 80 --z_elem 90 --dt 1.5secs --t_end 36000.0secs --z_stretch false --vert_diff false --kappa_4 1e6 --dt_save_to_disk 3600secs --initial_condition AgnesiHProfile --discrete_hydrostatic_balance true --topography Agnesi --rayleigh_sponge true --alpha_rayleigh_uh 0.0 --alpha_rayleigh_w 0.1 --job_id plane_agnesi_mountain_test"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config plane --x_max 240000.0 --z_max 25000.0 --x_elem 80 --z_elem 90 --dt 1.5secs --t_end 14400.0secs --z_stretch false --vert_diff false --kappa_4 1e6 --dt_save_to_disk 3600secs --initial_condition AgnesiHProfile --discrete_hydrostatic_balance true --topography Agnesi --rayleigh_sponge true --alpha_rayleigh_uh 0.0 --alpha_rayleigh_w 0.1 --job_id plane_agnesi_mountain_test"
         artifact_paths: "plane_agnesi_mountain_test/*"
 
       - label: ":computer: Density current experiment"


### PR DESCRIPTION
Modify buildkite arg to decrease simulated time to 4 hours. This should decrease CI runtime significantly. 
cc @trontrytel 