### PR TITLE
Add multiple high-resolution experiments with orography in long-run buildkite pipeline.

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -207,7 +207,17 @@ steps:
         command:
           - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
-        artifact_paths: "longrun_bw_rhoe_highres_topography/*"
+        artifact_paths: "longrun_bw_rhoe_highres_topography_dcmip/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+      
+      - label: ":computer: baroclinic wave (ρe_tot) high resolution topography div-damping (dcmip)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
+        artifact_paths: "longrun_bw_rhoe_highres_topography_dd10_dcmip/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
@@ -217,11 +227,22 @@ steps:
         command:
           - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography Earth --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
-        artifact_paths: "longrun_bw_rhoe_highres_topography/*"
+        artifact_paths: "longrun_bw_rhoe_highres_topography_earth/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 32
+      
+      - label: ":computer: baroclinic wave (ρe_tot) high resolution topography div-damping (earth)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography Earth --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
+        artifact_paths: "longrun_bw_rhoe_highres_topography_dd10_earth/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (dcmip)"
         command:
@@ -235,27 +256,37 @@ steps:
       
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (earth)"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography Earth --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor true
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography Earth --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
         artifact_paths: "longrun_bw_rhoe_equil_highres_topography_earth/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 32
-
-      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (dcmip)"
+      
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography div-damping (earth)"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography Earth --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 50secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography Earth --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
+        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_earth_dd10/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+
+      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography div-damping (earth)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography Earth --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 50secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
-        artifact_paths: "longrun_hs_rhoe_equil_highres_topography/*"
+        artifact_paths: "longrun_hs_rhoe_equil_highres_topography_dd10/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 64
       
-      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (earth)"
+      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (Earth)"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography DCMIP200 --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography Earth --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
         artifact_paths: "longrun_hs_rhoe_equil_highres_topography_earth/*"
         env:

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -223,6 +223,26 @@ steps:
         agents:
           slurm_ntasks: 32
       
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (dcmip)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography DCMIP200 --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
+        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_dcmip/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+      
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography div-damping(dcmip)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography DCMIP200 --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
+        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_dcmip_dd10/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+      
       - label: ":computer: baroclinic wave (ρe_tot) high resolution topography (earth)"
         command:
           - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography Earth --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
@@ -243,17 +263,6 @@ steps:
         agents:
           slurm_ntasks: 32
 
-
-      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (dcmip)"
-        command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography DCMIP200 --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
-        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_dcmip/*"
-        env:
-          CLIMACORE_DISTRIBUTED: "MPI"
-        agents:
-          slurm_ntasks: 32
-      
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (earth)"
         command:
           - mpiexec julia --project=examples examples/hybrid/driver.jl --topography Earth --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
@@ -278,7 +287,7 @@ steps:
         command:
           - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography Earth --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 50secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 10.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
-        artifact_paths: "longrun_hs_rhoe_equil_highres_topography_dd10/*"
+        artifact_paths: "longrun_hs_rhoe_equil_highres_topography_earth_dd10/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -65,9 +65,9 @@ steps:
         agents:
           slurm_ntasks: 32
 
-      - label: ":computer: no lim SSP baroclinic wave (ρe_tot) equilmoist high resolution"
+      - label: ":computer: SSP baroclinic wave (ρe_tot) equilmoist high resolution"
         command:
-          - "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --max_newton_iters 2 --initial_condition MoistBaroclinicWave --t_end 100days --dt_save_to_disk 10days --job_id longrun_ssp_bw_rhoe_equil_highres --ode_algo SSP333 --apply_limiter false"
+          - "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 100secs --max_newton_iters 2 --initial_condition MoistBaroclinicWave --t_end 100days --dt_save_to_disk 10days --job_id longrun_ssp_bw_rhoe_equil_highres --ode_algo SSP333"
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_bw_rhoe_equil_highres --out_dir longrun_ssp_bw_rhoe_equil_highres
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir longrun_ssp_bw_rhoe_equil_highres --fig_dir longrun_ssp_bw_rhoe_equil_highres --case_name moist_baroclinic_wave
         artifact_paths: "longrun_ssp_bw_rhoe_equil_highres/*"
@@ -96,9 +96,9 @@ steps:
         agents:
           slurm_ntasks: 64
 
-      - label: ":computer: no lim SSP held suarez (ρe_tot) equilmoist high resolution"
+      - label: ":computer: SSP held suarez (ρe_tot) equilmoist high resolution"
         command:
-          - "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 100secs --max_newton_iters 2 --t_end 400days --dt_save_to_disk 10days --job_id longrun_ssp_hs_rhoe_equil_highres --ode_algo SSP333 --apply_limiter false"
+          - "mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 75secs --max_newton_iters 2 --t_end 400days --dt_save_to_disk 10days --job_id longrun_ssp_hs_rhoe_equil_highres --ode_algo SSP333"
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_hs_rhoe_equil_highres --out_dir longrun_ssp_hs_rhoe_equil_highres
         artifact_paths: "longrun_ssp_hs_rhoe_equil_highres/*"
         env:
@@ -116,9 +116,9 @@ steps:
         agents:
           slurm_ntasks: 64
 
-      - label: ":computer: no lim SSP aquaplanet (ρe_tot) equilmoist high resolution clearsky radiation Float64"
+      - label: ":computer: SSP aquaplanet (ρe_tot) equilmoist high resolution clearsky radiation Float64"
         command:
-          - "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 100secs --max_newton_iters 2 --t_end 400days --fps 30 --job_id longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64 --ode_algo SSP333 --apply_limiter false"
+          - "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 75secs --max_newton_iters 2 --t_end 400days --fps 30 --job_id longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64 --ode_algo SSP333"
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --out_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64
         artifact_paths: "longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64/*"
         env:
@@ -212,12 +212,32 @@ steps:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 32
+      
+      - label: ":computer: baroclinic wave (ρe_tot) high resolution topography (earth)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition DryBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_highres_topography --topography Earth --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_highres_topography --out_dir longrun_bw_rhoe_highres_topography
+        artifact_paths: "longrun_bw_rhoe_highres_topography/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
 
       - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (dcmip)"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography DCMIP200 --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography DCMIP200 --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 400secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
-        artifact_paths: "longrun_bw_rhoe_equil_highres_topography (dcmip)/*"
+        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_dcmip/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 32
+      
+      - label: ":computer: baroclinic wave (ρe_tot) equilmoist high resolution topography (earth)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --topography Earth --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --initial_condition MoistBaroclinicWave --dt 100secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_bw_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_bw_rhoe_equil_highres_topography --out_dir longrun_bw_rhoe_equil_highres_topography
+        artifact_paths: "longrun_bw_rhoe_equil_highres_topography_earth/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
@@ -225,9 +245,19 @@ steps:
 
       - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (dcmip)"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography DCMIP200 --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 400days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography Earth --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 50secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true --divergence_damping_factor 1.0
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
         artifact_paths: "longrun_hs_rhoe_equil_highres_topography/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+        agents:
+          slurm_ntasks: 64
+      
+      - label: ":computer: held suarez (ρe_tot) equilmoist high resolution topography (earth)"
+        command:
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --topography DCMIP200 --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 150secs --t_end 100days --dt_save_to_disk 10days --job_id longrun_hs_rhoe_equil_highres_topography --rayleigh_sponge true --viscous_sponge true
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_hs_rhoe_equil_highres_topography --out_dir longrun_hs_rhoe_equil_highres_topography
+        artifact_paths: "longrun_hs_rhoe_equil_highres_topography_earth/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Climate Modeling Alliance"]
 version = "0.9.0"
 
 [deps]
+ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 AtmosphericProfilesLibrary = "86bc3604-9858-485a-bdbe-831ec50de11d"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -213,7 +213,7 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.6"
 
 [[deps.ClimaAtmos]]
-deps = ["AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "NCDatasets", "NVTX", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "StaticArrays", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics"]
+deps = ["ArtifactWrappers", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "NCDatasets", "NVTX", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "StaticArrays", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 version = "0.9.0"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -29,7 +29,6 @@ idealized_clouds = parsed_args["idealized_clouds"]
 import ClimaAtmos.RRTMGPInterface as RRTMGPI
 import ClimaAtmos.InitialConditions as ICs
 
-include(joinpath(pkgdir(CA), "artifacts", "artifact_funcs.jl"))
 
 import ClimaAtmos.TurbulenceConvection as TC
 include("TurbulenceConvectionUtils.jl")

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -224,7 +224,7 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.6"
 
 [[deps.ClimaAtmos]]
-deps = ["AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "NCDatasets", "NVTX", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "StaticArrays", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics"]
+deps = ["ArtifactWrappers", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "JLD2", "LambertW", "LinearAlgebra", "NCDatasets", "NVTX", "OrdinaryDiffEq", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "StaticArrays", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 version = "0.9.0"

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -4,6 +4,7 @@ using Dierckx
 using DiffEqBase
 using ImageFiltering
 using Interpolations
+using ArtifactWrappers
 import ClimaCore: InputOutput, Meshes, Spaces
 import ClimaAtmos.RRTMGPInterface as RRTMGPI
 
@@ -60,6 +61,7 @@ function get_atmos(::Type{FT}, parsed_args, turbconv_params) where {FT}
     return atmos
 end
 
+include(joinpath(pkgdir(ClimaAtmos), "artifacts", "artifact_funcs.jl"))
 function get_numerics(parsed_args)
     # wrap each upwinding mode in a Val for dispatch
     numerics = (;


### PR DESCRIPTION
Current Build#870 will track results for high-resolution test cases with both DCMIP and Earth-like topography, with adjusted timesteps, and with increased divergence damping. 
