### PR TITLE
Longruns SSP: Use max_newton_iters 3

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -11,7 +11,7 @@ agents:
   config: cpu
   queue: central
   slurm_ntasks: 1
-  slurm_time: 24:00:00
+  slurm_time: 50:00:00
 
 timeout_in_minutes: 1440
 
@@ -65,9 +65,9 @@ steps:
         agents:
           slurm_ntasks: 32
 
-      - label: ":computer: no lim SSP baroclinic wave (ρe_tot) equilmoist high resolution"
+      - label: ":computer: SSP baroclinic wave (ρe_tot) equilmoist high resolution"
         command:
-          - "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 200secs --max_newton_iters 2 --initial_condition MoistBaroclinicWave --t_end 100days --dt_save_to_disk 10days --job_id longrun_ssp_bw_rhoe_equil_highres --ode_algo SSP333 --apply_limiter false"
+          - "mpiexec julia --project=examples examples/hybrid/driver.jl --moist equil --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 300secs --max_newton_iters 3 --initial_condition MoistBaroclinicWave --t_end 100days --dt_save_to_disk 10days --job_id longrun_ssp_bw_rhoe_equil_highres --ode_algo SSP333"
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_bw_rhoe_equil_highres --out_dir longrun_ssp_bw_rhoe_equil_highres
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir longrun_ssp_bw_rhoe_equil_highres --fig_dir longrun_ssp_bw_rhoe_equil_highres --case_name moist_baroclinic_wave
         artifact_paths: "longrun_ssp_bw_rhoe_equil_highres/*"
@@ -98,9 +98,9 @@ steps:
         agents:
           slurm_ntasks: 64
 
-      - label: ":computer: no lim SSP held suarez (ρe_tot) equilmoist high resolution"
+      - label: ":computer: SSP held suarez (ρe_tot) equilmoist high resolution"
         command:
-          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 100secs --max_newton_iters 2 --t_end 400days --dt_save_to_disk 10days --job_id longrun_ssp_hs_rhoe_equil_highres --ode_algo SSP333 --apply_limiter false
+          - mpiexec julia --project=examples examples/hybrid/driver.jl --forcing held_suarez --moist equil --vert_diff true --surface_scheme bulk --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --dt 100secs --max_newton_iters 3 --t_end 400days --dt_save_to_disk 10days --job_id longrun_ssp_hs_rhoe_equil_highres --ode_algo SSP333
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_hs_rhoe_equil_highres --out_dir longrun_ssp_hs_rhoe_equil_highres
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir longrun_ssp_hs_rhoe_equil_highres --fig_dir longrun_ssp_hs_rhoe_equil_highres --case_name moist_held_suarez
         artifact_paths: "longrun_ssp_hs_rhoe_equil_highres/*"
@@ -120,9 +120,9 @@ steps:
         agents:
           slurm_ntasks: 64
 
-      - label: ":computer: no lim SSP aquaplanet (ρe_tot) equilmoist high resolution clearsky radiation Float64"
+      - label: ":computer: SSP aquaplanet (ρe_tot) equilmoist high resolution clearsky radiation Float64"
         command:
-          - "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 100secs --max_newton_iters 2 --t_end 400days --fps 30 --job_id longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64 --ode_algo SSP333 --apply_limiter false"
+          - "mpiexec julia --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme monin_obukhov --moist equil --rad clearsky --precip_model 0M --z_elem 45 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 100secs --max_newton_iters 3 --t_end 400days --fps 30 --job_id longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --dt_save_to_sol 10days --dt_save_to_disk 10days --FLOAT_TYPE Float64 --ode_algo SSP333"
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --out_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --fig_dir longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64 --case_name aquaplanet
         artifact_paths: "longrun_ssp_aquaplanet_rhoe_equil_highres_clearsky_ft64/*"


### PR DESCRIPTION
This PR uses `--max_newton_iters 3` for the SSP longrun tests. This guarantees that we have stable results for moist BW for `dt=300secs` and for moist HS and moist aquaplanet with `dt=100secs`. 

It was tested and produced stable results and plots (see this [build](https://buildkite.com/clima/climaatmos-longruns/builds/863#_)), with a better SYPD rate than the current setup (which was unstable) (see Issues #1490 and #1441 ).

## Components
- It raises `--max_newton_iters` to 3 for the SSP tests with limiters 
- It removes the `--apply_limiter false` option. I don't think the tests without limiters are necessary to keep (they are not our target). They were there initially just to compare results with/without limiters.
- It raises the `slurm_time` because the moist SSP aquaplanet run may take longer than the current `slurm_time` (the other tests cases don't).

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
