### PR TITLE
Reuse thermo state

### DIFF
--- a/src/TurbulenceConvection/EDMF_Updrafts.jl
+++ b/src/TurbulenceConvection/EDMF_Updrafts.jl
@@ -20,9 +20,7 @@ function compute_precipitation_formation_tendencies(
 
     @inbounds for i in 1:N_up
         @inbounds for k in real_center_indices(grid)
-            T_up = aux_up[i].T[k]
-            q_tot_up = aux_up[i].q_tot[k]
-            ts_up = TD.PhaseEquil_pTq(thermo_params, p_c[k], T_up, q_tot_up)
+            ts_up = aux_up[i].ts[k]
 
             # autoconversion and accretion
             mph = precipitation_formation(

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -81,7 +81,7 @@ function update_aux!(
                 aux_up[i].area[k] = 0
                 aux_up[i].e_kin[k] = e_kin[k]
             end
-            ts_up = if edmf.moisture_model isa DryModel
+            aux_up[i].ts[k] = if edmf.moisture_model isa DryModel
                 TD.PhaseDry_pθ(thermo_params, p_c[k], aux_up[i].θ_liq_ice[k])
             elseif edmf.moisture_model isa EquilMoistModel
                 TD.PhaseEquil_pθq(
@@ -93,7 +93,7 @@ function update_aux!(
             elseif edmf.moisture_model isa NonEquilMoistModel
                 error("Unsupported moisture model")
             end
-            aux_up[i].ts[k] = ts_up
+            ts_up = aux_up[i].ts[k]
             aux_up[i].e_tot[k] =
                 TD.total_energy(thermo_params, ts_up, aux_up[i].e_kin[k], e_pot)
             aux_up[i].h_tot[k] = TD.total_specific_enthalpy(


### PR DESCRIPTION
This PR adds the re-use of the precomputed thermo state in `compute_precipitation_formation_tendencies`. (now possible since the buoyancy hack is gone!)