### PR TITLE
Add support to upwind density

### DIFF
--- a/examples/hybrid/cli_options.jl
+++ b/examples/hybrid/cli_options.jl
@@ -124,7 +124,11 @@ function parse_commandline()
         "--tracer_upwinding"
         help = "Tracer upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
         arg_type = Symbol
-        default = :none  # TODO: change to :zalesak
+        default = :none
+        "--density_upwinding"
+        help = "Denisity upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
+        arg_type = Symbol
+        default = :none
         "--ode_algo"
         help = "ODE algorithm [`ARS343` (default), `SSP333`, `IMKG343a`, `ODE.Euler`, `ODE.IMEXEuler`, `ODE.Rosenbrock23`, etc.]"
         arg_type = String

--- a/src/staggered_nonhydrostatic_model.jl
+++ b/src/staggered_nonhydrostatic_model.jl
@@ -75,7 +75,8 @@ function default_cache(
         top = Operators.FirstOrderOneSided(),
     )
 
-    (; energy_upwinding, tracer_upwinding, apply_limiter) = numerics
+    (; energy_upwinding, tracer_upwinding, density_upwinding, apply_limiter) =
+        numerics
     ᶜcoord = Fields.local_geometry_field(Y.c).coordinates
     ᶠcoord = Fields.local_geometry_field(Y.f).coordinates
     R_d = FT(CAP.R_d(params))
@@ -203,6 +204,7 @@ function default_cache(
         params,
         energy_upwinding,
         tracer_upwinding,
+        density_upwinding,
         ghost_buffer = ghost_buffer,
         net_energy_flux_toa,
         net_energy_flux_sfc,

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -89,7 +89,7 @@ end
 function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     ᶜρ = Y.c.ρ
     (; ᶠgradᵥ_ᶜΦ, ᶜp, ᶠu³, ᶜρ_ref, ᶜp_ref) = p
-    (; energy_upwinding, tracer_upwinding) = p
+    (; energy_upwinding, tracer_upwinding, density_upwinding) = p
     (; ᶠgradᵥ, ᶠinterp) = p.operators
 
     vertical_transport!(
@@ -98,7 +98,7 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         ᶜρ[colidx],
         ᶜρ[colidx],
         p,
-        Val(:none),
+        density_upwinding,
     )
 
     if :ρθ in propertynames(Y.c)

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -65,6 +65,7 @@ function get_numerics(parsed_args)
     numerics = (;
         energy_upwinding = Val(Symbol(parsed_args["energy_upwinding"])),
         tracer_upwinding = Val(Symbol(parsed_args["tracer_upwinding"])),
+        density_upwinding = Val(Symbol(parsed_args["density_upwinding"])),
         apply_limiter = parsed_args["apply_limiter"],
         bubble = parsed_args["bubble"],
     )


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to add support for different density upwinding modes, similar to the modes we have for energy and tracers. 

This will close #1513  

## Content

- [x] Added CLI option: `--density_upwinding` with the different upwinding modes (similar to `--energy_upwinding` and `--tracer_upwinding`)
- [x] Modified `vertical_transport!` function call for density in `implicit_vertical_advection_tendency!`
- [x] added two regular CI pipeline jobs that use `first_order` upwinding for density (These should NOT give any different results from what we have now, i.e.,  `:none`. We can remove them once CI passes. We don't need to keep them in the pipeline).
- [x] modified MSE tables and ref counter for the new jobs



I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
