### PR TITLE
Fix bugs in surface velocity computation and explicit algo construction

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -62,12 +62,12 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 @info "`allocs ($job_id)`: $(allocs)"
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target"] = 3872
-allocs_limit["flame_perf_target_tracers"] = 4800871040
-allocs_limit["flame_perf_target_edmfx"] = 4240
-allocs_limit["flame_perf_target_edmf"] = 8745398416
-allocs_limit["flame_perf_target_threaded"] = 5830000
-allocs_limit["flame_perf_target_callbacks"] = 11159384
+allocs_limit["flame_perf_target"] = 764512
+allocs_limit["flame_perf_target_tracers"] = 5685484032
+allocs_limit["flame_perf_target_edmfx"] = 764688
+allocs_limit["flame_perf_target_edmf"] = 9799049744
+allocs_limit["flame_perf_target_threaded"] = 1680000 # round this up; it can fluctuate
+allocs_limit["flame_perf_target_callbacks"] = 11920024
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/precomputed_quantities.jl
+++ b/src/precomputed_quantities.jl
@@ -6,46 +6,6 @@ import Thermodynamics as TD
 import ClimaCore: Geometry, Spaces, Fields
 
 """
-    set_boundary_velocity!(Y, turbconv_model)
-
-Modifies `Y.f.w` so that `ᶠu³` is 0 at the surface. If `turbconv_model` is
-EDMFX, also modifies `Y.f.sgsʲs` so that all of the subdomain's values of `w`
-are the same as `Y.f.w` at the surface.
-"""
-function set_boundary_velocity!(Y, turbconv_model)
-    uₕ_surface_data = Fields.level(Fields.field_values(Y.c.uₕ), 1)
-    uₕ_surface_geom = Fields.level(Spaces.local_geometry_data(axes(Y.c.uₕ)), 1)
-    uᵥ_surface_data = Fields.level(Fields.field_values(Y.f.w), 1)
-    uᵥ_surface_geom = Fields.level(Spaces.local_geometry_data(axes(Y.f.w)), 1)
-    @. uᵥ_surface_data = Geometry.Covariant3Vector(
-        -Geometry.contravariant3(uₕ_surface_data, uₕ_surface_geom) /
-        Geometry.contravariant3(one(uᵥ_surface_data), uᵥ_surface_geom),
-    )
-    if turbconv_model isa EDMFX
-        for j in 1:n_mass_flux_subdomains(turbconv_model)
-            Fields.level(Y.f.sgsʲs.:($j).w, half) .= Fields.level(Y.f.w, half)
-        end
-    end
-end
-
-# TODO: Ask Tapio whether we should use this version instead. We need to account
-# for the fact that Fields.level(ᶠuₕ, half) != Fields.level(Y.c.uₕ, 1). If we do
-# use this version, we will probably want to make ᶠuₕ a precomputed quantity.
-function set_boundary_velocity!(Y, ᶠuₕ, turbconv_model)
-    w_sfc = Fields.level(Y.f.w, half)
-    uₕ_sfc = Fields.level(ᶠuₕ, half)
-    lg_sfc = Fields.local_geometry_field(w_sfc)
-    @. w_sfc = Geometry.Covariant3Vector(
-        -Geometry.contravariant3(uₕ_sfc, lg_sfc) /
-        Geometry.contravariant3(one(w_sfc), lg_sfc),
-    )
-    for j in 1:n_mass_flux_subdomains(turbconv_model)
-        wʲ_sfc = Fields.level(Y.f.sgsʲs.:($j).w, half)
-        @. wʲ_sfc = w_sfc
-    end
-end
-
-"""
     precomputed_quantities(atmos, center_space, face_space)
 
 Allocates and returns the precomputed quantities:
@@ -55,10 +15,11 @@ Allocates and returns the precomputed quantities:
     - `ᶜts`: the thermodynamic state on cell centers
     - `ᶜp`: the air pressure on cell centers
 
-If the `turbconv_model` is EDMFX, there also two SGS versions of each quantity:
+If the `turbconv_model` is EDMFX, there also two SGS versions of every quantity
+except for `ᶜp` (we assume that `ᶜp⁰ = ᶜpʲ = ᶜp`):
     - `_⁰`: the value for the environment
     - `_ʲs`: a tuple of the values for the mass-flux subdomains
-In addition, there are several other SGS quantities:
+In addition, there are several other SGS quantities for the EDMFX model:
     - `ᶜρ⁰`: the air density of the environment on cell centers
     - `ᶜρa⁰`: the area-weighted air density of the environment on cell centers
     - `ᶠw⁰`: the vertical component of the covariant velocity of the environment
@@ -69,36 +30,31 @@ In addition, there are several other SGS quantities:
 TODO: Rename `ᶜK` to `ᶜκ`, and rename `ᶠw` to `ᶠuᵥ`.
 """
 function precomputed_quantities(atmos, center_space, face_space)
+    C3 = Geometry.Covariant3Vector
     C123 = Geometry.Covariant123Vector
     CT3 = Geometry.Contravariant3Vector
     FT = Spaces.undertype(center_space)
     TST = thermo_state_type(atmos.moisture_model, FT)
-    precomputed_sgs_quantities = if atmos.turbconv_model isa EDMFX
-        n = n_mass_flux_subdomains(atmos.turbconv_model)
-        (;
-            ᶜρa⁰ = Fields.Field(FT, center_space),
-            ᶠw⁰ = Fields.Field(Geometry.Covariant3Vector{FT}, face_space),
-            ᶜu⁰ = Fields.Field(C123{FT}, center_space),
-            ᶠu³⁰ = Fields.Field(CT3{FT}, face_space),
-            ᶜK⁰ = Fields.Field(FT, center_space),
-            ᶜts⁰ = Fields.Field(TST, center_space),
-            ᶜρ⁰ = Fields.Field(FT, center_space),
-            ᶜuʲs = Fields.Field(NTuple{n, C123{FT}}, center_space),
-            ᶠu³ʲs = Fields.Field(NTuple{n, CT3{FT}}, face_space),
-            ᶜKʲs = Fields.Field(NTuple{n, FT}, center_space),
-            ᶜtsʲs = Fields.Field(NTuple{n, TST}, center_space),
-            ᶜρʲs = Fields.Field(NTuple{n, FT}, center_space),
-        )
-    else
-        (;)
-    end
+    n = n_mass_flux_subdomains(atmos.turbconv_model)
+    T_or_Nothing(::Type{T}) where {T} = n > 0 ? T : Nothing
     return (;
         ᶜu = Fields.Field(C123{FT}, center_space),
         ᶠu³ = Fields.Field(CT3{FT}, face_space),
         ᶜK = Fields.Field(FT, center_space),
         ᶜts = Fields.Field(TST, center_space),
         ᶜp = Fields.Field(FT, center_space),
-        precomputed_sgs_quantities...,
+        ᶜρa⁰ = Fields.Field(T_or_Nothing(FT), center_space),
+        ᶠw⁰ = Fields.Field(T_or_Nothing(C3{FT}), face_space),
+        ᶜu⁰ = Fields.Field(T_or_Nothing(C123{FT}), center_space),
+        ᶠu³⁰ = Fields.Field(T_or_Nothing(CT3{FT}), face_space),
+        ᶜK⁰ = Fields.Field(T_or_Nothing(FT), center_space),
+        ᶜts⁰ = Fields.Field(T_or_Nothing(TST), center_space),
+        ᶜρ⁰ = Fields.Field(T_or_Nothing(FT), center_space),
+        ᶜuʲs = Fields.Field(T_or_Nothing(NTuple{n, C123{FT}}), center_space),
+        ᶠu³ʲs = Fields.Field(T_or_Nothing(NTuple{n, CT3{FT}}), face_space),
+        ᶜKʲs = Fields.Field(T_or_Nothing(NTuple{n, FT}), center_space),
+        ᶜtsʲs = Fields.Field(T_or_Nothing(NTuple{n, TST}), center_space),
+        ᶜρʲs = Fields.Field(T_or_Nothing(NTuple{n, FT}), center_space),
     )
 end
 
@@ -112,33 +68,60 @@ exactly `ρχ / ρ` (a tiny value of `ε` is added to the denominator of `ρaχ 
 in order to avoid returning `NaN` when `a == 0`, since `0 * Inf` is `NaN`).
 """
 function divide_by_ρa(ρaχ, ρa, ρχ, ρ, a_min)
-    ε = eps(zero(ρa)) # the smallest number bigger than 0 of the same type as ρa
+    ε = eps(zero(ρa)) # This is the smallest positive number we can add to ρa.
     sgs_weight = 1 / (1 + a_min^2 * ρ^2 / ρa^2) # TODO: Make this exponential.
     return sgs_weight * ρaχ / (ρa + ε) + (1 - sgs_weight) * ρχ / ρ
 end
 
-# The arguments ᶜu, ᶠu³, ᶜK, and ᶠw can be replaced with their SGS versions when
-# calling this function.
-function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠw, ᶜYc)
-    ᶜinterp = Operators.InterpolateF2C()
+# Interpolates the third contravariant component of Y.c.uₕ to cell faces.
+function set_ᶠuₕ³!(ᶠuₕ³, Y)
     ᶠwinterp = Operators.WeightedInterpolateC2F(
         bottom = Operators.Extrapolate(),
         top = Operators.Extrapolate(),
     )
-    ᶜJ = Fields.local_geometry_field(axes(ᶜYc)).J
-    Fields.bycolumn(axes(ᶜYc)) do colidx
-        C123 = Geometry.Covariant123Vector
-        CT123 = Geometry.Contravariant123Vector
-        @. ᶜu[colidx] = C123(ᶜYc.uₕ[colidx]) + ᶜinterp(C123(ᶠw[colidx]))
-        @. ᶠu³[colidx] = Geometry.project(
-            Geometry.Contravariant3Axis(),
-            ᶠwinterp(ᶜYc.ρ[colidx] * ᶜJ[colidx], CT123(ᶜYc.uₕ[colidx])) +
-            CT123(ᶠw[colidx]),
-        )
-        compute_kinetic!(ᶜK[colidx], ᶜYc.uₕ[colidx], ᶠw[colidx])
+    Fields.bycolumn(axes(Y.c)) do colidx
+        CT3 = Geometry.Contravariant3Vector
+        ᶜJ = Fields.local_geometry_field(Y.c).J
+        @. ᶠuₕ³[colidx] =
+            ᶠwinterp(Y.c.ρ[colidx] * ᶜJ[colidx], CT3(Y.c.uₕ[colidx]))
     end
 end
 
+"""
+    set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
+
+Modifies `Y.f.w` so that `ᶠu³` is 0 at the surface. If `turbconv_model` is
+EDMFX, also modifies `Y.f.sgsʲs` so that each `wʲ` is equal to `w` at the
+surface.
+"""
+function set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
+    sfc_w₃ = Fields.level(Y.f.w.components.data.:1, half)
+    sfc_uₕ³ = Fields.level(ᶠuₕ³.components.data.:1, half)
+    sfc_g = Fields.local_geometry_field(sfc_w₃).gⁱʲ.components.data
+    end_index = fieldcount(eltype(sfc_g)) # This will be 4 in 2D and 9 in 3D.
+    sfc_g³³ = sfc_g.:($end_index) # For both 2D and 3D spaces, g³³ = g[end].
+    @. sfc_w₃ = -sfc_uₕ³ / sfc_g³³ # u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³
+    for j in 1:n_mass_flux_subdomains(turbconv_model)
+        sfc_w₃ʲ = Fields.level(Y.f.sgsʲs.:($j).w.components.data.:1, half)
+        @. sfc_w₃ʲ = sfc_w₃
+    end
+end
+
+# This is used to set the grid-scale velocity quantities ᶜu, ᶠu³, ᶜK based on
+# ᶠw, and it is also used to set the SGS quantities based on ᶠw⁰ and ᶠwʲ.
+function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠw, ᶜuₕ, ᶠuₕ³)
+    ᶜinterp = Operators.InterpolateF2C()
+    Fields.bycolumn(axes(ᶜu)) do colidx
+        C123 = Geometry.Covariant123Vector
+        CT3 = Geometry.Contravariant3Vector
+        @. ᶜu[colidx] = C123(ᶜuₕ[colidx]) + ᶜinterp(C123(ᶠw[colidx]))
+        @. ᶠu³[colidx] = ᶠuₕ³[colidx] + CT3(ᶠw[colidx])
+        compute_kinetic!(ᶜK[colidx], ᶜuₕ[colidx], ᶠw[colidx])
+    end
+end
+
+# Putting the anonymous function sgsʲ -> sgsʲ.<symbol> directly into broadcast
+# expressions causes allocations, so this function should be used instead.
 get_ʲs(sgsʲs, ::Val{symbol}) where {symbol} =
     map(sgsʲ -> sgsʲ.:($symbol), sgsʲs)
 
@@ -326,14 +309,18 @@ function set_precomputed_quantities!(Y, p, t)
     (; energy_form, moisture_model, turbconv_model) = p.atmos
     thermo_params = CAP.thermodynamics_params(p.params)
     thermo_args = (thermo_params, energy_form, moisture_model)
-
-    # TODO: This should probably be moved to dss! (i.e., enforce_constraints!).
-    set_boundary_velocity!(Y, turbconv_model)
-
     (; ᶜu, ᶠu³, ᶜK, ᶜts, ᶜp, ᶜΦ) = p
-    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.w, Y.c)
+    (; ᶜρa⁰, ᶠw⁰, ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜρ⁰, ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜtsʲs, ᶜρʲs) = p
+    ᶠuₕ³ = p.ᶠtemp_CT3
+
+    set_ᶠuₕ³!(ᶠuₕ³, Y)
+
+    # TODO: We might want to move this to dss! (and rename dss! to something
+    # like enforce_constraints!).
+    set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
+
+    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.w, Y.c.uₕ, ᶠuₕ³)
     if turbconv_model isa EDMFX
-        (; ᶜρa⁰, ᶠw⁰) = p
         (; a_min) = turbconv_model
         @. ᶜρa⁰ = Y.c.ρ - sum(get_ʲs(Y.c.sgsʲs, Val{:ρa}()))
         set_ᶠw⁰!(ᶠw⁰, Y, ᶜρa⁰, a_min)
@@ -355,21 +342,18 @@ function set_precomputed_quantities!(Y, p, t)
     @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
 
     if turbconv_model isa EDMFX
-        (; ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜρ⁰, ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜtsʲs, ᶜρʲs) = p
-        set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠw⁰, Y.c)
+        set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠw⁰, Y.c.uₕ, ᶠuₕ³)
         @. ᶜK⁰ += divide_by_ρa(Y.c.sgs⁰.ρatke, ᶜρa⁰, 0, Y.c.ρ, a_min)
         @. ᶜts⁰ = ts⁰(Y.c, ᶜρa⁰, ᶜK⁰, ᶜp, ᶜΦ, a_min, thermo_args...)
         @. ᶜρ⁰ = TD.air_density(thermo_params, ᶜts⁰)
         for j in 1:n_mass_flux_subdomains(turbconv_model)
-            set_velocity_quantities!(
-                ᶜuʲs.:($j),
-                ᶠu³ʲs.:($j),
-                ᶜKʲs.:($j),
-                Y.f.sgsʲs.:($j).w,
-                Y.c,
-            )
+            ᶜuʲ = ᶜuʲs.:($j)
+            ᶠu³ʲ = ᶠu³ʲs.:($j)
+            ᶜKʲ = ᶜKʲs.:($j)
+            ᶠwʲ = Y.f.sgsʲs.:($j).w
+            set_velocity_quantities!(ᶜuʲ, ᶠu³ʲ, ᶜKʲ, ᶠwʲ, Y.c.uₕ, ᶠuₕ³)
             @. ᶜtsʲs[j] =
-                tsʲ(Y.c.sgsʲs[j], Y.c, ᶜKʲs[j], ᶜp, ᶜΦ, a_min, thermo_args...)
+                tsʲ(Y.c.sgsʲs[j], Y.c, ᶜKʲ, ᶜp, ᶜΦ, a_min, thermo_args...)
             @. ᶜρʲs[j] = TD.air_density(thermo_params, ᶜtsʲs[j])
         end
     end
@@ -394,11 +378,13 @@ function diagnostic_edmfx_quantities(Y, p, t)
     thermo_params = CAP.thermodynamics_params(p.params)
     thermo_args = (thermo_params, energy_form, moisture_model)
     (; ᶜp, ᶜΦ) = p
+    ᶠuₕ³ = p.ᶠtemp_CT3
+    (ᶠw⁺, ᶜu⁺, ᶠu³⁺, ᶜK⁺) = similar.((p.ᶠw⁰, p.ᶜu⁰, p.ᶠu³⁰, p.ᶜK⁰))
 
     @assert turbconv_model isa EDMFX
     (; a_min) = turbconv_model
-    (ᶠw⁺, ᶜu⁺, ᶠu³⁺, ᶜK⁺) = similar.((p.ᶠw⁰, p.ᶜu⁰, p.ᶠu³⁰, p.ᶜK⁰))
 
+    set_ᶠuₕ³!(ᶠuₕ³, Y)
     w⁺(ρaʲs, wʲs, ρ, w) =
         divide_by_ρa(sum(ρaʲs .* wʲs), sum(ρaʲs), ρ * w, ρ, a_min)
     Fields.bycolumn(axes(Y.c)) do colidx
@@ -409,7 +395,7 @@ function diagnostic_edmfx_quantities(Y, p, t)
             Y.f.w[colidx],
         )
     end
-    set_velocity_quantities!(ᶜu⁺, ᶠu³⁺, ᶜK⁺, ᶠw⁺, Y.c)
+    set_velocity_quantities!(ᶜu⁺, ᶠu³⁺, ᶜK⁺, ᶠw⁺, Y.c.uₕ, ᶠuₕ³)
 
     sgs⁺(Yc) = map(+, Yc.sgsʲs...)
     ᶜsgs⁺ = @. sgs⁺(Y.c)

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -284,6 +284,9 @@ end
 import ClimaTimeSteppers as CTS
 import OrdinaryDiffEq as ODE
 
+is_explicit_CTS_algo_type(alg_or_tableau) =
+    alg_or_tableau <: CTS.ERKAlgorithmName
+
 is_imex_CTS_algo_type(alg_or_tableau) =
     alg_or_tableau <: CTS.IMEXARKAlgorithmName
 
@@ -366,7 +369,9 @@ function ode_configuration(Y, parsed_args, atmos)
     end
     @info "Using ODE config: `$alg_or_tableau`"
 
-    if !is_implicit_type(alg_or_tableau)
+    if is_explicit_CTS_algo_type(alg_or_tableau)
+        return CTS.ExplicitAlgorithm(alg_or_tableau())
+    elseif !is_implicit_type(alg_or_tableau)
         return alg_or_tableau()
     elseif is_ordinary_diffeq_newton(alg_or_tableau)
         if parsed_args["max_newton_iters"] == 1

--- a/src/utils/types.jl
+++ b/src/utils/types.jl
@@ -111,6 +111,7 @@ struct EDMFX{N, FT}
 end
 EDMFX{N}(a_min::FT) where {N, FT} = EDMFX{N, FT}(a_min)
 n_mass_flux_subdomains(::EDMFX{N}) where {N} = N
+n_mass_flux_subdomains(::Any) = 0
 
 abstract type AbstractSurfaceThermoState end
 struct GCMSurfaceThermoState <: AbstractSurfaceThermoState end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR is split off from #1512. It fixes an issue with the computation of `Y.f.w` at the surface, and it fixes a bug that was preventing us from using explicit algorithms from ClimaTimeSteppers.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add the beginning of the new "temporary quantities" interface (to be continued in #1512), which for now will just be used to store `ᶠuₕ³` in `set_precomputed_quantities!`.
- Pass `ᶠuₕ³` to `set_velocity_quantities!` instead of recomputing it there, and also pass it to `set_velocity_at_surface!` (renamed from `set_boundary_velocity!`).
- Modify `set_velocity_at_surface!` to use `ᶠuₕ³` instead of `ᶜuₕ`. The new code for setting `Y.f.w` at the surface is `@. sfc_w₃ = -sfc_uₕ³ / sfc_g³³`. This formula comes from the fact that `u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³`, which means that `w₃ = -uₕ³ / g³³`.
- Modify `precomputed_quantities` so that the SGS variables are always present in `p`, even if they are not allocated (their element type can be set to `Nothing` so that they do not use any memory). This allows the code in `set_precomputed_quantities!` to be slightly cleaned up, and it will further simplify the code in #1512.
- Add an additional method for `n_mass_flux_subdomains` that makes it return `nothing` for any `turbconv_model` that isn't `EDMFX` (e.g., for `Nothing` and for `TC.EDMFModel`).
- Add an additional case to `ode_configuration` that allows explicit algorithms from ClimaTimeSteppers to be initialized correctly.
- Unfortunately, these changes to `set_precomputed_quantities!` have resulted in increased allocations, particularly for the `perf target (default)` and `perf target (edmfx)` jobs, which previously had very few allocations. I've spent some time trying to bring down the allocations, but only succeeded in reducing them by a small amount. The allocations flame graphs are empty for these jobs, so I'm  not sure what else to try. However, the allocations for these jobs are still under a megabyte, and the durations of CI jobs do not appear to have increased significantly. Since this is blocking other EDMFX development, I'll merge this in for now, but I'll keep trying to reduce the allocations.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
