### PR TITLE
Remove more real_center_indices loops

### DIFF
--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -391,18 +391,18 @@ function q_surface_bc(
     return aux_gm.q_tot[kc_surf] + surface_scalar_coeff * sqrt(qt_var)
 end
 
-function compute_updraft_top(grid::Grid, state::State, i::Int)
+function compute_updraft_top(state::State, i::Int)
     aux_up = center_aux_updrafts(state)
-    return z_findlast_center(k -> aux_up[i].area[k] > 1e-3, grid)
+    (; value, z) = column_findlastvalue(a -> a[] > 1e-3, aux_up[i].area)
+    return z[]
 end
 
 function compute_plume_scale_height(
-    grid::Grid,
     state::State,
     H_up_min::FT,
     i::Int,
 )::FT where {FT}
-    updraft_top::FT = compute_updraft_top(grid, state, i)
+    updraft_top::FT = compute_updraft_top(state, i)
     return max(updraft_top, H_up_min)
 end
 

--- a/src/TurbulenceConvection/Fields.jl
+++ b/src/TurbulenceConvection/Fields.jl
@@ -129,9 +129,6 @@ function Base.cumsum!(
     )
 end
 
-get_Δz(field::CC.Fields.FiniteDifferenceField) =
-    parent(CC.Fields.weighted_jacobian(field))
-
 # TODO: move these things into ClimaCore
 
 isa_center_space(space) = false
@@ -158,4 +155,48 @@ function set_z!(field::CC.Fields.Field, u::Real, v::Real)
     uconst(coord) = u
     vconst(coord) = v
     @. field = CCG.Covariant12Vector(CCG.UVVector(uconst(lg), vconst(lg)))
+end
+
+# TODO: move to ClimaCore.
+
+"""
+    column_findfirstvalue(fn, field::Fields.ColumnField)
+
+A (;value, z)::NamedTuple containing the value and first z-location
+at which the condition, returned by `fn`, is met. If no value
+is found, the _last_ value is returned.
+"""
+function column_findfirstvalue(fn, field::Fields.ColumnField)
+    space = axes(field)
+    zfield = Fields.coordinate_field(space).z
+    li = Operators.left_idx(space)
+    ri = Operators.right_idx(space)
+    @inbounds for j in li:ri
+        level_field = Spaces.level(field, j)
+        if fn(level_field)
+            return (; value = level_field, z = Spaces.level(zfield, j))
+        end
+    end
+    return (; value = Spaces.level(field, ri), z = Spaces.level(zfield, ri))
+end
+
+"""
+    column_findlastvalue(fn, field::Fields.ColumnField)
+
+A (;value, z)::NamedTuple containing the value and last z-location
+at which the condition, returned by `fn`, is met. If no value
+is found, the _first_ value is returned.
+"""
+function column_findlastvalue(fn, field::Fields.ColumnField)
+    space = axes(field)
+    zfield = Fields.coordinate_field(space).z
+    li = Operators.left_idx(space)
+    ri = Operators.right_idx(space)
+    @inbounds for j in ri:-1:li
+        level_field = Spaces.level(field, j)
+        if fn(level_field)
+            return (; value = level_field, z = Spaces.level(zfield, j))
+        end
+    end
+    return (; value = Spaces.level(field, li), z = Spaces.level(zfield, li))
 end

--- a/src/TurbulenceConvection/Grid.jl
+++ b/src/TurbulenceConvection/Grid.jl
@@ -73,18 +73,3 @@ Base.iterate(
     state = Nstop,
 ) where {Nstart, Nstop, T <: CenterIndices{Nstart, Nstop}} =
     state < Nstart ? nothing : (Cent(state), state - 1)
-
-#=
-    findlast_center
-
-Grid-aware find-first / find-last indices with
-surface/toa (respectively) as the default index
-=#
-
-function findlast_center(f::Function, grid::Grid)
-    RI = real_center_indices(grid)
-    k = findlast(f, RI)
-    return RI[isnothing(k) ? kc_top_of_atmos(grid).i : k]
-end
-z_findlast_center(f::F, grid::Grid) where {F} =
-    grid.zc[findlast_center(f, grid)].z

--- a/src/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection/TurbulenceConvection.jl
@@ -14,6 +14,7 @@ import ..compute_kinetic!
 
 import ClimaCore as CC
 import ClimaCore.Geometry as CCG
+import ClimaCore.Operators as Operators
 import ClimaCore.Fields as Fields
 import ClimaCore.Spaces as Spaces
 import ClimaCore.Geometry: ⊗

--- a/src/TurbulenceConvection/closures/perturbation_pressure.jl
+++ b/src/TurbulenceConvection/closures/perturbation_pressure.jl
@@ -1,7 +1,6 @@
 """
     compute_nh_pressure!(
         state::State,
-        grid::Grid,
         edmf::EDMFModel,
         surf,
     )
@@ -14,16 +13,13 @@ Computes the
 for all updrafts, following [He2020](@cite), given:
 
  - `state`: state
- - `grid`: grid
  - `edmf`: EDMF model
  - `surf`: `SurfaceFluxes.SurfaceFluxConditions`
 """
-function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
+function compute_nh_pressure!(state::State, edmf::EDMFModel, surf)
 
     FT = float_type(state)
     N_up = n_updrafts(edmf)
-    kc_surf = kc_surface(grid)
-    kc_toa = kc_top_of_atmos(grid)
 
     Ifc = CCO.InterpolateF2C()
     wvec = CC.Geometry.WVector
@@ -37,7 +33,7 @@ function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
     aux_en_f = face_aux_environment(state)
     ρ_f = aux_gm_f.ρ
     plume_scale_height = ntuple(N_up) do i
-        compute_plume_scale_height(grid, state, edmf.H_up_min, i)
+        compute_plume_scale_height(state, edmf.H_up_min, i)
     end
 
     # Note: Independence of aspect ratio hardcoded in implementation.

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -290,7 +290,7 @@ function update_aux!(
     end
     # updraft pressure
     # TODO @. aux_up_f[i].nh_pressure = compute_nh_pressure(...)
-    compute_nh_pressure!(state, grid, edmf, surf)
+    compute_nh_pressure!(state, edmf, surf)
 
     #####
     ##### compute_eddy_diffusivities_tke


### PR DESCRIPTION
This PR
 - Removes some real_center_indices loops. A step towards https://github.com/CliMA/ClimaAtmos.jl/issues/887.
 - Removed `grid` from some functions that no longer use it.
 - Defines `column_findfirstvalue` and `column_findlastvalue`, similar to `findfirst`/`findlast` except that the last and first (respectively) elements in the field are returned if nothing is found.
 - Adds a TODO to move `column_findfirstvalue` and `column_findlastvalue` to ClimaCore. I think we need at least this behavior, possibly more (needed in the gravity wave parameterization).