### PR TITLE
Fix perf bug in edmf update aux

### DIFF
--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -245,18 +245,19 @@ function update_aux!(
             0
         end
 
-        @. aux_gm.tke = aux_en.area * aux_en.tke
+    end
+    @. aux_gm.tke = aux_en.area * aux_en.tke
+    @. aux_gm.tke +=
+        0.5 *
+        aux_en.area *
+        LA.norm_sqr(C123(Ic(wvec(aux_en_f.w - prog_gm_f.w))))
+    @inbounds for i in 1:N_up
         @. aux_gm.tke +=
             0.5 *
-            aux_en.area *
-            LA.norm_sqr(C123(Ic(wvec(aux_en_f.w - prog_gm_f.w))))
-        @inbounds for i in 1:N_up
-            @. aux_gm.tke +=
-                0.5 *
-                aux_up[i].area *
-                LA.norm_sqr(C123(Ic(wvec(prog_up_f[i].w - prog_gm_f.w))))
-        end
+            aux_up[i].area *
+            LA.norm_sqr(C123(Ic(wvec(prog_up_f[i].w - prog_gm_f.w))))
     end
+
     #####
     ##### face variables: diagnose primitive, diagnose env and compute bulk
     #####


### PR DESCRIPTION
Broadcast computations for kinetic energy were accidentally added inside a `k`-loop (`@inbounds for k in real_center_indices(grid)`) [here](https://github.com/CliMA/ClimaAtmos.jl/pull/1439/files#diff-4609bee2e6e4c6cb0baf3fa9e708cc2cc2d7b8a4f5e13a27acfd795034d3a955R273-R284) in #1439.

This shouldn't be behavior changing, but it should definitely improve performance of edmf-related jobs.