### PR TITLE
Add buffer to test

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -77,5 +77,5 @@ end
 
 # https://github.com/CliMA/ClimaAtmos.jl/issues/827
 @testset "Allocations limit" begin
-    @test allocs ≤ allocs_limit[job_id]
+    @test allocs ≤ allocs_limit[job_id] * buffer
 end


### PR DESCRIPTION
I thought we used this buffer in the test, but it's only currently used to determine if we print the info statement. Closes #1414. This should make copy-pasting the numbers simpler / more robust to these changes. (actually, 1.4 may be a bit larger than we need, but I'm fine with it)