### PR TITLE
Fix cli script

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,8 +1,9 @@
 import ClimaAtmos as CA
 
+include("cli_options.jl")
+(s, parsed_args_defaults) = parse_commandline()
 if !(@isdefined parsed_args)
-    include("cli_options.jl")
-    (s, parsed_args) = parse_commandline()
+    parsed_args = parsed_args_defaults
 end
 
 include("nvtx.jl")

--- a/src/utils/model_getters.jl
+++ b/src/utils/model_getters.jl
@@ -43,7 +43,7 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
         ClimaHyperdiffusion{enable_qt, FT}(; κ₄, divergence_damping_factor)
     elseif hyperdiff_name == "TempestHyperdiffusion"
         TempestHyperdiffusion{enable_qt, FT}(; κ₄, divergence_damping_factor)
-    elseif hyperdiff_name == "none" || hyperdiff_name == "false"
+    elseif hyperdiff_name in ("none", "false", false)
         nothing
     else
         error("Uncaught diffusion model type.")


### PR DESCRIPTION
This PR fixes the generic CLI script (which I tend to use for my workflow):

```julia
using Revise; include("examples/hybrid/cli_options.jl");
dict = parsed_args_per_job_id();
parsed_args = dict["edmf_soares"]; # (edmf_soares is the job_id)
parsed_args["enable_threading"] = false; # can re-set specific parsed args
include("examples/hybrid/driver.jl")
```

 - `s` is not defined when `!(@isdefined parsed_args)` is false
 - `hyperdiff_name` is `false` (`Bool`) for this particular example, and results in the `Uncaught diffusion model type.` error

The second bullet is a bit odd to me, since this is run in CI. Two thoughts on why this may fail:
 - `cli_defaults(s)` is used differently, and results in different results than when `!(@isdefined parsed_args)` is false
 - Maybe only parsing (types-strings) need to be fixed when `!(@isdefined parsed_args)` is false.

I am a bit concerned about `parsed_args` being returned in

```julia
params, parsed_args = create_parameter_set(FT, parsed_args, cli_defaults(s))
```
Users may be surprised that parsed args they've defined may be overwritten. We should probably be very clear about the precedence that these parameters are used, define them once and ensure that they are never re-defined. I like the way we do this in the flame graph script ([here](https://github.com/CliMA/ClimaAtmos.jl/blob/fd7450d293556eb0f2d2c82b76e8ebe9f8ac0809/perf/config_parsed_args.jl#L1-L47)). cc @nefrathenrici 