### PR TITLE
Try removing getsetindex on arrays

### DIFF
--- a/src/TurbulenceConvection/Fields.jl
+++ b/src/TurbulenceConvection/Fields.jl
@@ -64,38 +64,6 @@ Base.@propagate_inbounds Base.setindex!(
     "Attempting to setindex with a face index (PlusHalf) into a Center field",
 )
 
-# TODO: deprecate, we should not overload getindex/setindex for ordinary arrays.
-Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Cent) =
-    Base.getindex(arr, i.i)
-Base.@propagate_inbounds Base.setindex!(arr::AbstractArray, v, i::Cent) =
-    Base.setindex!(arr, v, i.i)
-Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::CCO.PlusHalf) =
-    Base.getindex(arr, i.i)
-Base.@propagate_inbounds Base.setindex!(
-    arr::AbstractArray,
-    v,
-    i::CCO.PlusHalf,
-) = Base.setindex!(arr, v, i.i)
-Base.@propagate_inbounds Base.getindex(arr::AbstractArray, i::Int, j::Cent) =
-    Base.getindex(arr, i, j.i)
-Base.@propagate_inbounds Base.setindex!(
-    arr::AbstractArray,
-    v,
-    i::Int,
-    j::Cent,
-) = Base.setindex!(arr, v, i, j.i)
-Base.@propagate_inbounds Base.getindex(
-    arr::AbstractArray,
-    i::Int,
-    j::CCO.PlusHalf,
-) = Base.getindex(arr, i, j.i)
-Base.@propagate_inbounds Base.setindex!(
-    arr::AbstractArray,
-    v,
-    i::Int,
-    j::CCO.PlusHalf,
-) = Base.setindex!(arr, v, i, j.i)
-
 # Constant field
 function FieldFromNamedTuple(space, nt::NamedTuple)
     cmv(z) = nt


### PR DESCRIPTION
This PR removes some now unused getindex / setindex defined on AbstractArrays 🎉 