### PR TITLE
CI pipeline: add Zalesak tracer jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,13 +206,133 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist/*"
 
-      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist"
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt150 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --tracer_upwinding zalesak
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist/*"
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --dt 150secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt175 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --dt 175secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt200 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --dt 200secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt225 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --dt 225secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt250 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --dt 250secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt275 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --dt 275secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt300 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --dt 300secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt325 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --dt 325secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt350 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --dt 350secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt375 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --dt 375secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt400 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --dt 400secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt425 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --dt 425secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt450 newton 3"
+        command:
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3/*"
         agents:
           slurm_mem: 20GB
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,7 +208,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt150 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --dt 150secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --dt 150secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt150_newton3
@@ -218,7 +218,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt175 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --dt 175secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --dt 175secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt175_newton3
@@ -228,7 +228,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt200 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --dt 200secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --dt 200secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt200_newton3
@@ -238,7 +238,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt225 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --dt 225secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --dt 225secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt225_newton3
@@ -248,7 +248,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt250 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --dt 250secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --dt 250secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt250_newton3
@@ -258,7 +258,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt275 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --dt 275secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --dt 275secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt275_newton3
@@ -268,7 +268,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt300 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --dt 300secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --dt 300secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt300_newton3
@@ -278,7 +278,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt325 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --dt 325secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --dt 325secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt325_newton3
@@ -288,7 +288,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt350 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --dt 350secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --dt 350secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt350_newton3
@@ -298,7 +298,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt375 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --dt 375secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --dt 375secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt375_newton3
@@ -308,7 +308,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt400 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --dt 400secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --dt 400secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt400_newton3
@@ -318,7 +318,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt425 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --dt 425secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --dt 425secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt425_newton3
@@ -328,7 +328,7 @@ steps:
 
       - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist dt450 newton 3"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --dt 450secs --dt_save_to_disk 1days --ode_algo SSP333 --max_newton_iters 3 --tracer_upwinding zalesak
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3 --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist_dt450_newton3

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -213,6 +213,8 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: no lim ARS baroclinic wave (ρe) equilmoist check conservation float64"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --initial_condition MoistBaroclinicWave --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64 --check_conservation true --FLOAT_TYPE Float64 --dt 450secs --t_end 8days --dt_save_to_disk 8days --apply_limiter false"
@@ -277,6 +279,8 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --fig_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --case_name moist_held_suarez
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
         artifact_paths: "sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge/*"
+        agents:
+          slurm_mem: 20GB
 
   - group: "Sphere Examples (Aquaplanet)"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,20 +206,13 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist/*"
 
-      - label: ":computer: SSP 3rd-order tracer upwind baroclinic wave (ρe_tot) equilmoist"
+      - label: ":computer: SSP zalesak tracer upwind baroclinic wave (ρe_tot) equilmoist"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --tracer_upwinding third_order
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist
-        artifact_paths: "sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist/*"
-
-      - label: ":computer: SSP 3rd-order tracer & energy upwind baroclinic wave (ρe_tot) equilmoist"
-        command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --tracer_upwinding third_order --energy_upwinding third_order --regression_test true
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist
-          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist
-        artifact_paths: "sphere_third_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist/*"
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --initial_condition MoistBaroclinicWave --moist equil --precip_model 0M --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --regression_test true --dt 450secs --dt_save_to_disk 5days --ode_algo SSP333 --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --fig_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist
+        artifact_paths: "sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist/*"
 
       - label: ":computer: no lim ARS baroclinic wave (ρe) equilmoist check conservation float64"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --initial_condition MoistBaroclinicWave --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64 --check_conservation true --FLOAT_TYPE Float64 --dt 450secs --t_end 8days --dt_save_to_disk 8days --apply_limiter false"
@@ -277,20 +270,13 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --fig_dir sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --case_name moist_held_suarez
         artifact_paths: "sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge/*"
 
-      - label: ":computer: SSP 3rd-order tracer upwind held suarez (ρe) equilmoist hightop sponge"
+      - label: ":computer: SSP zalesak tracer upwind held suarez (ρe) equilmoist hightop sponge"
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --dt 450secs --t_end 5days --dt_save_to_disk 5days --ode_algo SSP333 --regression_test true --tracer_upwinding third_order
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
-          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --fig_dir sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --case_name moist_held_suarez
-          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
-        artifact_paths: "sphere_ssp_third_upwind_held_suarez_rhoe_equilmoist_hightop_sponge/*"
-
-      - label: ":computer: SSP 3rd-order tracer & energy upwind held suarez (ρe) equilmoist hightop sponge"
-        command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --dt 450secs --t_end 5days --dt_save_to_disk 5days --ode_algo SSP333 --tracer_upwinding third_order --energy_upwinding third_order --regression_test true
-          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
-          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --fig_dir sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --case_name moist_held_suarez
-        artifact_paths: "sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge/*"
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --z_max 45e3 --z_elem 25 --dz_bottom 300 --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --viscous_sponge true --zd_rayleigh 30e3 --zd_viscous 30e3 --job_id sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --dt 400secs --t_end 5days --dt_save_to_disk 5days --ode_algo SSP333 --regression_test true --tracer_upwinding zalesak
+          - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
+          - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --fig_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --case_name moist_held_suarez
+          - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge --out_dir sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge
+        artifact_paths: "sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge/*"
 
   - group: "Sphere Examples (Aquaplanet)"
     steps:

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -176,8 +176,8 @@ import ClimaAtmos.Parameters as CAP
 include("get_cache_and_tendency.jl")
 
 import ClimaCore: enable_threading
-# const enable_clima_core_threading = parsed_args["enable_threading"]
-# enable_threading() = enable_clima_core_threading
+const enable_clima_core_threading = parsed_args["enable_threading"]
+enable_threading() = enable_clima_core_threading
 
 @time "Allocating Y" if simulation.restart
     (Y, t_start) = CA.get_state_restart(comms_ctx)

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -176,8 +176,8 @@ import ClimaAtmos.Parameters as CAP
 include("get_cache_and_tendency.jl")
 
 import ClimaCore: enable_threading
-const enable_clima_core_threading = parsed_args["enable_threading"]
-enable_threading() = enable_clima_core_threading
+# const enable_clima_core_threading = parsed_args["enable_threading"]
+# enable_threading() = enable_clima_core_threading
 
 @time "Allocating Y" if simulation.restart
     (Y, t_start) = CA.get_state_restart(comms_ctx)

--- a/regression_tests/mse_tables.jl
+++ b/regression_tests/mse_tables.jl
@@ -43,6 +43,14 @@ all_best_mse["sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmo
 all_best_mse["sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0
 all_best_mse["sphere_first_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0
 #
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 0.0
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0.0
+all_best_mse["sphere_zalesak_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:f, :w, :components, :data, 1)] = 0.0
+#
 all_best_mse["sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
 all_best_mse["sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0
 all_best_mse["sphere_third_upwind_ssp_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0
@@ -120,6 +128,14 @@ all_best_mse["sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_
 all_best_mse["sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρe_tot)] = 0
 all_best_mse["sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρq_tot)] = 0
 all_best_mse["sphere_ssp_third_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:f, :w, :components, :data, 1)] = 0
+#
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρ)] = 0.0
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :uₕ, :components, :data, 1)] = 0.0
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :uₕ, :components, :data, 2)] = 0.0
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρe_tot)] = 0.0
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρq_tot)] = 0.0
+all_best_mse["sphere_ssp_zalesak_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"][(:f, :w, :components, :data, 1)] = 0.0
 #
 all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw"] = OrderedCollections.OrderedDict()
 all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw"][(:c, :ρ)] = 0

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -387,7 +387,6 @@ function ode_configuration(Y, parsed_args, atmos)
         return alg_or_tableau(; linsolve = linsolve!, nlsolve)
     elseif is_imex_CTS_algo_type(alg_or_tableau)
         newtons_method = CTS.NewtonsMethod(;
-            verbose = CTS.Verbose(),
             max_iters = parsed_args["max_newton_iters"],
             krylov_method = if parsed_args["use_krylov_method"]
                 CTS.KrylovMethod(;

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -387,6 +387,7 @@ function ode_configuration(Y, parsed_args, atmos)
         return alg_or_tableau(; linsolve = linsolve!, nlsolve)
     elseif is_imex_CTS_algo_type(alg_or_tableau)
         newtons_method = CTS.NewtonsMethod(;
+            verbose = CTS.Verbose(),
             max_iters = parsed_args["max_newton_iters"],
             krylov_method = if parsed_args["use_krylov_method"]
                 CTS.KrylovMethod(;


### PR DESCRIPTION
## Purpose 
Opening this PR to test `zalesak` flux-corrected transport on tracers again now that we've fixed the vertical transport Jacobian. 

Closes #1579 


## Content
- Modified the 3rd-order tracer upwinding jobs in the regular CI pipeline to use `zalesak` instead
- Removed the 3rd-order tracers & energy upwind jobs for now. They will be added back when the  vertical transport Jacobian will be fixed for energy as well.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

- [x] I have read and checked the items on the review checklist.
