### PR TITLE
Refactor compute_nh_pressure

### DIFF
--- a/src/TurbulenceConvection/EDMF_functions.jl
+++ b/src/TurbulenceConvection/EDMF_functions.jl
@@ -391,21 +391,6 @@ function q_surface_bc(
     return aux_gm.q_tot[kc_surf] + surface_scalar_coeff * sqrt(qt_var)
 end
 
-function compute_updraft_top(state::State, i::Int)
-    aux_up = center_aux_updrafts(state)
-    (; value, z) = column_findlastvalue(a -> a[] > 1e-3, aux_up[i].area)
-    return z[]
-end
-
-function compute_plume_scale_height(
-    state::State,
-    H_up_min::FT,
-    i::Int,
-)::FT where {FT}
-    updraft_top::FT = compute_updraft_top(state, i)
-    return max(updraft_top, H_up_min)
-end
-
 function compute_implicit_up_tendencies!(
     edmf::EDMFModel,
     grid::Grid,

--- a/src/TurbulenceConvection/Parameters.jl
+++ b/src/TurbulenceConvection/Parameters.jl
@@ -71,6 +71,11 @@ microph_scaling_melt(ps::ATCP) = ps.microph_scaling_melt
 ##### Forwarding parameters
 #####
 
+const TCPS = TurbulenceConvectionParameters
+for fn in fieldnames(TCPS)
+    @eval $(fn)(ps::ATCP) = ps.$(fn)
+end
+
 ##### Forwarding Thermodynamics.jl
 
 const TDPS = TD.Parameters.ThermodynamicsParameters

--- a/src/TurbulenceConvection/closures/perturbation_pressure.jl
+++ b/src/TurbulenceConvection/closures/perturbation_pressure.jl
@@ -1,63 +1,48 @@
+function compute_updraft_top(updraft_area)
+    (; value, z) = column_findlastvalue(a -> a[] > 1e-3, updraft_area)
+    return z[]
+end
+
 """
     compute_nh_pressure!(
-        state::State,
-        edmf::EDMFModel,
-        surf,
+        param_set,
+        buoy_up,
+        w_up,
+        div_w_up,
+        w_up_en_diff,
+        updraft_top,
     )
+where
+ - `param_set`: contains model parameters
+ - `buoy_up`: updraft buoyancy
+ - `w_up`: updraft vertical velocity
+ - `div_w_up`: updraft vertical velocity divergence
+ - `w_up_en_diff`: difference between updraft and environment vertical velocity
+ - `updraft_top`: height at which updraft terminates
 
-Computes the
-    - perturbation pressure gradient
-    - (perturbation?) pressure advection
-    - (perturbation?) pressure drag
-
-for all updrafts, following [He2020](@cite), given:
-
- - `state`: state
- - `edmf`: EDMF model
- - `surf`: `SurfaceFluxes.SurfaceFluxConditions`
+Returns the updraft perturbation pressure gradient advection and drag
+following [He2020](@cite)
 """
-function compute_nh_pressure!(state::State, edmf::EDMFModel, surf)
+function compute_nh_pressure!(
+    param_set,
+    buoy_up,
+    w_up,
+    div_w_up,
+    w_up_en_diff,
+    updraft_top,
+)
+    # factor multiplier for pressure buoyancy terms (effective buoyancy is (1-α_b))
+    α_b = TCP.pressure_normalmode_buoy_coeff1(param_set)
+    # factor multiplier for pressure advection
+    α_a = TCP.pressure_normalmode_adv_coeff(param_set)
+    # factor multiplier for pressure drag
+    α_d = TCP.pressure_normalmode_drag_coeff(param_set)
 
-    FT = float_type(state)
-    N_up = n_updrafts(edmf)
+    # Independence of aspect ratio hardcoded: α₂_asp_ratio² = FT(0)
 
-    Ifc = CCO.InterpolateF2C()
-    wvec = CC.Geometry.WVector
-    w_bcs =
-        (; bottom = CCO.SetValue(wvec(FT(0))), top = CCO.SetValue(wvec(FT(0))))
-    ∇ = CCO.DivergenceC2F(; w_bcs...)
-    aux_up = center_aux_updrafts(state)
-    aux_up_f = face_aux_updrafts(state)
-    prog_up_f = face_prog_updrafts(state)
-    aux_gm_f = face_aux_grid_mean(state)
-    aux_en_f = face_aux_environment(state)
-    ρ_f = aux_gm_f.ρ
-    plume_scale_height = ntuple(N_up) do i
-        compute_plume_scale_height(state, edmf.H_up_min, i)
-    end
+    H_up_min = TCP.min_updraft_top(param_set)
+    plume_scale_height = max(updraft_top, H_up_min)
 
-    # Note: Independence of aspect ratio hardcoded in implementation.
-    α₂_asp_ratio² = FT(0)
-    press_model_params = pressure_model_params(edmf)
-    α_b = press_model_params.α_b
-    α_a = press_model_params.α_a
-    α_d = press_model_params.α_d
-
-    @inbounds for i in 1:N_up
-        # pressure
-        b_up = aux_up_f[i].buoy
-        w_up = prog_up_f[i].w
-        H_up = plume_scale_height[i]
-        w_en = aux_en_f.w
-
-        nh_pressure = aux_up_f[i].nh_pressure
-
-        @. nh_pressure =
-            -α_b * b_up +
-            α_a * wcomponent(CCG.WVector(w_up)) * ∇(Ifc(CCG.WVector(w_up))) -
-            α_d *
-            (wcomponent(CCG.WVector(w_up - w_en))) *
-            abs(wcomponent(CCG.WVector(w_up - w_en))) / H_up
-    end
-    return nothing
+    return -α_b * buoy_up + α_a * w_up * div_w_up -
+           α_d * w_up_en_diff * abs(w_up_en_diff) / plume_scale_height
 end

--- a/src/TurbulenceConvection/update_aux.jl
+++ b/src/TurbulenceConvection/update_aux.jl
@@ -355,8 +355,21 @@ function update_aux!(
         )
     end
     # updraft pressure
-    # TODO @. aux_up_f[i].nh_pressure = compute_nh_pressure(...)
-    compute_nh_pressure!(state, edmf, surf)
+    wvec = CC.Geometry.WVector
+    w_bcs =
+        (; bottom = CCO.SetValue(wvec(FT(0))), top = CCO.SetValue(wvec(FT(0))))
+    ∇ = CCO.DivergenceC2F(; w_bcs...)
+    @inbounds for i in 1:N_up
+        updraft_top = compute_updraft_top(aux_up[i].area)
+        @. aux_up_f[i].nh_pressure = compute_nh_pressure!(
+            param_set,
+            aux_up_f[i].buoy,
+            wcomponent(CCG.WVector(prog_up_f[i].w)),
+            ∇(Ic(CCG.WVector(prog_up_f[i].w))),
+            wcomponent(CCG.WVector(prog_up_f[i].w - aux_en_f.w)),
+            updraft_top,
+        )
+    end
 
     #####
     ##### compute_eddy_diffusivities_tke


### PR DESCRIPTION
This PR:
  - makes `compute_nh_pressure` a pointwise function in preparation for porting it to EDMFX
  - removes some unnecessary structs from EDMF model
  - makes `TCP.your_fav_tc_parameter(param_set)` possible