### PR TITLE
Fix tracer inference

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -63,7 +63,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 
 allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 3872
-allocs_limit["flame_perf_target_tracers"] = 1060841072
+allocs_limit["flame_perf_target_tracers"] = 427812464
 allocs_limit["flame_perf_target_edmfx"] = 346736
 allocs_limit["flame_perf_target_edmf"] = 9038246032
 allocs_limit["flame_perf_target_threaded"] = 3850064


### PR DESCRIPTION
This PR applies some type assertions and uses `map` / `Base.@_inline_meta` to unroll some loops and fix type inference for when tracers are added. May require https://github.com/CliMA/ClimaCore.jl/pull/1207. Nice, https://github.com/CliMA/ClimaCore.jl/pull/1207 is not even needed! 🎉 