### PR TITLE
Centralize the edmfx pressure work term

### DIFF
--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -29,6 +29,8 @@ include("precomputed_quantities.jl")
 include(joinpath("InitialConditions", "InitialConditions.jl"))
 include(joinpath("utils", "discrete_hydrostatic_balance.jl"))
 
+include(joinpath("tendencies", "pressure_work.jl"))
+
 include(joinpath("tendencies", "implicit", "wfact.jl"))
 include(joinpath("tendencies", "implicit", "schur_complement_W.jl"))
 include(joinpath("tendencies", "implicit", "implicit_tendency.jl"))

--- a/src/tendencies/advection.jl
+++ b/src/tendencies/advection.jl
@@ -27,13 +27,12 @@ function horizontal_advection_tendency!(Yₜ, Y, p, t)
         if :ρθ in propertynames(Y.c)
             @. Yₜ.c.sgsʲs.:($$j).ρaθ -= divₕ(Y.c.sgsʲs.:($$j).ρaθ * ᶜuʲs.:($$j))
         elseif :ρe_tot in propertynames(Y.c)
-            @. Yₜ.c.sgsʲs.:($$j).ρae_tot -=
-                divₕ(
-                    (
-                        Y.c.sgsʲs.:($$j).ρae_tot +
-                        Y.c.sgsʲs.:($$j).ρa * ᶜp / ᶜρʲs.:($$j)
-                    ) * ᶜuʲs.:($$j),
-                ) + (ᶜp / Y.c.ρ) * divₕ(Y.c.sgsʲs.:($$j).ρa * ᶜuʲs.:($$j))
+            @. Yₜ.c.sgsʲs.:($$j).ρae_tot -= divₕ(
+                (
+                    Y.c.sgsʲs.:($$j).ρae_tot +
+                    Y.c.sgsʲs.:($$j).ρa * ᶜp / ᶜρʲs.:($$j)
+                ) * ᶜuʲs.:($$j),
+            )
         end
     end
 

--- a/src/tendencies/hyperdiffusion.jl
+++ b/src/tendencies/hyperdiffusion.jl
@@ -187,8 +187,6 @@ function tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
             @. ᶜρaχʲₜ -= κ₄ * wdivₕ(Y.c.sgsʲs.:($$j).ρa * gradₕ(ᶜ∇²χʲ))
             @. Yₜ.c.sgsʲs.:($$j).ρa -=
                 κ₄ * wdivₕ(Y.c.sgsʲs.:($$j).ρa * gradₕ(ᶜ∇²χʲ))
-            @. Yₜ.c.sgsʲs.:($$j).ρae_tot +=
-                ᶜp / (Y.c.ρ) * κ₄ * wdivₕ(Y.c.sgsʲs.:($$j).ρa * gradₕ(ᶜ∇²χʲ))
         end
     end
 end

--- a/src/tendencies/implicit/implicit_tendency.jl
+++ b/src/tendencies/implicit/implicit_tendency.jl
@@ -21,6 +21,8 @@ function implicit_tendency!(Yₜ, Y, p, t)
                     p.turbconv_model,
                 )
             end
+            # NOTE: All ρa tendencies should be applied before calling this function
+            pressure_work_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
         end
     end
 end
@@ -145,9 +147,6 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
                 dt,
                 edmfx_upwinding,
             )
-            # This assumes Yₜ.c.sgsʲs.:($$j).ρa only contains the vertical advection
-            @. Yₜ.c.sgsʲs.:($$j).ρae_tot[colidx] -=
-                (ᶜp[colidx] / Y.c.ρ[colidx]) * Yₜ.c.sgsʲs.:($$j).ρa[colidx]
         end
         for (ᶜρaχʲₜ, ᶜχʲ, χ_name) in
             matching_subfields(Yₜ.c.sgsʲs.:($j), ᶜspecificʲs.:($j))

--- a/src/tendencies/pressure_work.jl
+++ b/src/tendencies/pressure_work.jl
@@ -1,0 +1,16 @@
+#####
+##### Pressure work
+#####
+
+function pressure_work_tendency!(Yₜ, Y, p, t, colidx, ::EDMFX)
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    (; ᶜp) = p
+    for j in 1:n
+        if :ρe_tot in propertynames(Y.c)
+            @. Yₜ.c.sgsʲs.:($$j).ρae_tot[colidx] -=
+                ᶜp[colidx] / Y.c.ρ[colidx] * Yₜ.c.sgsʲs.:($$j).ρa[colidx]
+        end
+    end
+end
+
+pressure_work_tendency!(Yₜ, Y, p, t, colidx, ::Any) = nothing

--- a/src/tendencies/remaining_tendency.jl
+++ b/src/tendencies/remaining_tendency.jl
@@ -52,6 +52,8 @@ function additional_tendency!(Yₜ, Y, p, t)
         radiation_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)
         explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
         precipitation_tendency!(Yₜ, Y, p, t, colidx, p.precip_model)
+        # NOTE: All ρa tendencies should be applied before calling this function
+        pressure_work_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
     end
     # TODO: make bycolumn-able
     non_orographic_gravity_wave_tendency!(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a function that calculates the pressure work term in edmfx. The function is called at the end of implicit tendency and remaining tendency.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
