### PR TITLE
Fix race condition in ogwd tests

### DIFF
--- a/test/orographic_gravity_wave/ogwd_3d.jl
+++ b/test/orographic_gravity_wave/ogwd_3d.jl
@@ -74,7 +74,6 @@ end
 p_center = 0.5 * (p_half[:, :, 1:(end - 1), :] .+ p_half[:, :, 2:end, :])
 
 # earth warp
-include(joinpath(pkgdir(ClimaAtmos), "artifacts", "artifact_funcs.jl"))
 data_path = joinpath(topo_elev_dataset_path(), "ETOPO1_coarse.nc")
 earth_spline = NCDataset(data_path) do data
     zlevels = data["elevation"][:]
@@ -351,9 +350,9 @@ output_dir = "orographic_gravity_wave_test_3d"
 mkpath(output_dir)
 
 # remap uforcing and vforcing to regular lat/lon grid
-REMAP_DIR = joinpath(@__DIR__, "remap_data/")
+REMAP_DIR = joinpath(@__DIR__, "ogwd_3d", "remap_data/")
 if !isdir(REMAP_DIR)
-    mkdir(REMAP_DIR)
+    mkpath(REMAP_DIR)
 end
 datafile_cg = joinpath(REMAP_DIR, "data_cg.nc")
 nc = NCDataset(datafile_cg, "c")

--- a/test/orographic_gravity_wave/ogwd_baseflux.jl
+++ b/test/orographic_gravity_wave/ogwd_baseflux.jl
@@ -87,10 +87,11 @@ end
 
 # Remap base flux to regular lat/lon grid for visualization
 TOPO_DIR = joinpath(@__DIR__, "remap_data/")
-if !isdir(TOPO_DIR)
-    mkdir(TOPO_DIR)
+REMAP_DIR = joinpath(TOPO_DIR, "ogwd_baseflux")
+if !isdir(REMAP_DIR)
+    mkpath(REMAP_DIR)
 end
-datafile_cg = joinpath(TOPO_DIR, "data_cg.nc")
+datafile_cg = joinpath(REMAP_DIR, "data_cg.nc")
 nc = NCDataset(datafile_cg, "c")
 def_space_coord(nc, center_space, type = "cgll")
 nc_time = def_time_coord(nc)
@@ -103,10 +104,10 @@ close(nc)
 
 nlat = 90
 nlon = 180
-weightfile = joinpath(TOPO_DIR, "remap_weights.nc")
+weightfile = joinpath(REMAP_DIR, "remap_weights.nc")
 create_weightfile(weightfile, axes(Y.c), axes(Y.f), nlat, nlon)
 
-datafile_rll = joinpath(TOPO_DIR, "data_rll.nc")
+datafile_rll = joinpath(REMAP_DIR, "data_rll.nc")
 apply_remap(datafile_rll, datafile_cg, weightfile, ["tau_x", "tau_y"])
 
 # Plot the zonal and meridional components of the base flux


### PR DESCRIPTION
This PR fixes a race condition, introduced in #1462, where the same filename is written to the same directory by different buildkite jobs. Here is an example failure [here](https://buildkite.com/clima/climaatmos-ci/builds/9401#0187de22-2d33-49df-913e-dafe25ef84e7).