### PR TITLE
Move more code into src

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -279,6 +279,8 @@ steps:
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw --fig_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw --case_name aquaplanet
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_aquaplanet_rhoe_equilmoist_allsky_gw --out_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":computer: aquaplanet (ρe_tot) equilmoist with EDMF"
         command:
@@ -309,6 +311,8 @@ steps:
           - julia --color=yes --project=examples examples/hybrid/driver.jl --vert_diff true --surface_scheme bulk --moist equil --forcing held_suarez --precip_model 0M --job_id sphere_held_suarez_rhoe_equilmoist_topography_dcmip --dt 200secs --t_end 2days --dt_save_to_disk 2days --topography DCMIP200 --rayleigh_sponge true --viscous_sponge true
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_held_suarez_rhoe_equilmoist_topography_dcmip --out_dir sphere_held_suarez_rhoe_equilmoist_topography_dcmip
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_topography_dcmip/*"
+        agents:
+          slurm_mem: 20GB
 
   - group: "MPI Examples"
     steps:

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -63,7 +63,7 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 
 allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 3872
-allocs_limit["flame_perf_target_tracers"] = 427812464
+allocs_limit["flame_perf_target_tracers"] = 428000000
 allocs_limit["flame_perf_target_edmfx"] = 346736
 allocs_limit["flame_perf_target_edmf"] = 9038246032
 allocs_limit["flame_perf_target_threaded"] = 3850064

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -80,5 +80,6 @@ include(joinpath("callbacks", "callbacks.jl"))
 include(joinpath("utils", "model_getters.jl")) # high-level (using parsed_args) model getters
 include(joinpath("utils", "type_getters.jl"))
 include(joinpath("utils", "yaml_helper.jl"))
+include(joinpath("solve.jl"))
 
 end # module

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,0 +1,52 @@
+import ClimaTimeSteppers as CTS
+import OrdinaryDiffEq as ODE
+
+struct AtmosSolveResults{S, RT, WT}
+    sol::S
+    ret_code::RT
+    walltime::WT
+end
+
+"""
+    solve_atmos!(integrator)
+
+Call the ClimaTimeSteppers solve on the integrator.
+Returns a `AtmosSolveResults`, containing the
+solution, walltime, and a return code `Symbol`
+indicating one of:
+
+ - `:success`
+ - `:success`
+ - `:simulation_crashed`
+
+`try-catch` is used to allow plotting
+results for simulations that have crashed.
+"""
+function solve_atmos!(integrator)
+    comms_ctx = Spaces_comm_context(axes(integrator.u.c))
+    try
+        if CA.is_distributed(comms_ctx)
+            ODE.step!(integrator)
+            # GC.enable(false) # disabling GC causes a memory leak
+            GC.gc()
+            ClimaComms.barrier(comms_ctx)
+            if ClimaComms.iamroot(comms_ctx)
+                @timev "solve!" begin
+                    walltime = @elapsed sol = ODE.solve!(integrator)
+                end
+            else
+                walltime = @elapsed sol = ODE.solve!(integrator)
+            end
+            ClimaComms.barrier(comms_ctx)
+            GC.enable(true)
+            return AtmosSolveResults(sol, :success, walltime)
+        else
+            sol = @timev "solve!" ODE.solve!(integrator)
+            return AtmosSolveResults(sol, :success, nothing)
+        end
+    catch ret_code
+        @error "ClimaAtmos simulation crashed. Stacktrace for failed simulation" exception =
+            (ret_code, catch_backtrace())
+        return AtmosSolveResults(nothing, :simulation_crashed, nothing)
+    end
+end

--- a/src/staggered_nonhydrostatic_model.jl
+++ b/src/staggered_nonhydrostatic_model.jl
@@ -48,7 +48,6 @@ function default_cache(
     spaces,
     numerics,
     simulation,
-    comms_ctx,
 )
     FT = eltype(params)
     (; energy_upwinding, tracer_upwinding, density_upwinding, edmfx_upwinding) =
@@ -102,7 +101,7 @@ function default_cache(
         simulation,
         spaces,
         atmos,
-        comms_ctx,
+        comms_ctx = Spaces_comm_context(axes(Y.c)),
         test_dycore_consistency = parsed_args["test_dycore_consistency"],
         moisture_model = atmos.moisture_model,
         model_config = atmos.model_config,

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -137,3 +137,23 @@ function verify_callbacks(t)
         )
     end
 end
+
+using ClimaComms
+is_distributed(::ClimaComms.SingletonCommsContext) = false
+is_distributed(::ClimaComms.AbstractCommsContext) = true # deprecate after upgrading
+# is_distributed(::ClimaComms.MPICommsContext) = true # use this after upgrading
+
+
+# TODO: remove after upgrading to latest ClimaCore:
+Spaces_comm_context(field::Fields.Field) = Spaces_comm_context(axes(field))
+
+Spaces_comm_context(space::Spaces.ExtrudedFiniteDifferenceSpace) =
+    Spaces_comm_context(space.horizontal_space)
+Spaces_comm_context(space::Spaces.SpectralElementSpace2D) =
+    Spaces_comm_context(space.topology)
+Spaces_comm_context(space::S) where {S <: Spaces.AbstractSpace} =
+    ClimaComms.SingletonCommsContext()
+import ClimaCore.Topologies as Topologies
+Spaces_comm_context(topology::Topologies.Topology2D) = topology.context
+Spaces_comm_context(topology::T) where {T <: Topologies.AbstractTopology} =
+    ClimaComms.SingletonCommsContext()


### PR DESCRIPTION
This PR moves more code into `src/`. A step towards #1383.

I've temporarily defined `Spaces_comm_context`, so that updating will be easier and isolated to replacing `Spaces_comm_context` with `Spaces.comm_context` and removing the added definitions in `src/utils/utilities.jl`.