### PR TITLE
Ensure mse key entries are correct

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -216,6 +216,7 @@ if !CA.is_distributed(comms_ctx) &&
     end
 end
 
+include(joinpath(@__DIR__, "..", "..", "regression_tests", "mse_tables.jl"))
 if parsed_args["regression_test"]
     # Test results against main branch
     include(
@@ -227,6 +228,13 @@ if parsed_args["regression_test"]
             "regression_tests.jl",
         ),
     )
+    @testset "Test regression table entries" begin
+        mse_keys = sort(collect(keys(all_best_mse[simulation.job_id])))
+        pcs = collect(Fields.property_chains(sol.u[end]))
+        for prop_chain in mse_keys
+            @test prop_chain in pcs
+        end
+    end
     perform_regression_tests(
         simulation.job_id,
         sol.u[end],
@@ -234,6 +242,8 @@ if parsed_args["regression_test"]
         simulation.output_dir,
     )
 end
+
+
 
 if parsed_args["check_conservation"]
     @test sum(sol.u[1].c.ρ) ≈ sum(sol.u[end].c.ρ) rtol = 25 * eps(FT)

--- a/regression_tests/regression_tests.jl
+++ b/regression_tests/regression_tests.jl
@@ -1,7 +1,6 @@
 import NCRegressionTests
 import JSON
 import ClimaCore.Fields as Fields
-include(joinpath(@__DIR__, "mse_tables.jl"))
 include(joinpath(@__DIR__, "compute_mse.jl"))
 
 function perform_regression_tests(


### PR DESCRIPTION
This PR adds a test to ensure that the mse table entries are correct. Suggested by @szy21. This should help prevent CI from breaking after ref counters are incremented.