### PR TITLE
add edmfx advection on the sphere

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -431,13 +431,25 @@ steps:
       - label: ":genie: EDMFX advection test in a box"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_adv_test_box
-          --initial_condition DryAdiabaticProfileEDMFX --edmfx_adv_test true --turbconv edmfx --edmfx_entr_detr false
+          --initial_condition MoistAdiabaticProfileEDMFX --edmfx_adv_test true --turbconv edmfx --edmfx_entr_detr false
           --config box --hyperdiff true --kappa_4 1e8
-          --x_max 1e4 --y_max 1e4 --x_elem 2 --y_elem 2 --z_elem 45 --z_max 30e3 --dz_bottom 50
-          --moist equil --ode_algo SSP33ShuOsher --apply_limiter false --dt 0.1secs --t_end 1000secs
-          --dt_save_to_disk 10secs
+          --x_max 1e4 --y_max 1e4 --x_elem 2 --y_elem 2 --z_elem 45 --z_max 30e3 --dz_bottom 30
+          --moist equil --ode_algo SSP33ShuOsher --apply_limiter false --dt 10secs --t_end 1000secs
+          --dt_save_to_disk 100secs
 
         artifact_paths: "edmfx_adv_test_box/*"
+        agents:
+          slurm_mem: 20GB
+      
+      - label: ":genie: EDMFX advection test in a sphere"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_adv_test_sphere
+          --initial_condition MoistAdiabaticProfileEDMFX --edmfx_adv_test true --turbconv edmfx --edmfx_entr_detr false
+          --config sphere --z_elem 45 --z_max 30e3 --dz_bottom 30
+          --moist equil --ode_algo SSP33ShuOsher --apply_limiter false --dt 10secs --t_end 1000secs
+          --dt_save_to_disk 100secs
+
+        artifact_paths: "edmfx_adv_test_sphere/*"
         agents:
           slurm_mem: 20GB
 

--- a/src/utils/type_getters.jl
+++ b/src/utils/type_getters.jl
@@ -275,7 +275,7 @@ function get_initial_condition(parsed_args)
             "MoistBaroclinicWave",
             "DecayingProfile",
             "MoistBaroclinicWaveWithEDMF",
-            "DryAdiabaticProfileEDMFX",
+            "MoistAdiabaticProfileEDMFX",
         ]
             return getproperty(ICs, Symbol(parsed_args["initial_condition"]))(
                 parsed_args["perturb_initstate"],


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds an edmfx advection test on the sphere. Also adds moisture to the edmfx advection tests, and uses a smooth initial condition.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
