### PR TITLE
Pass comms_ctx through to Topology

### DIFF
--- a/src/utils/common_spaces.jl
+++ b/src/utils/common_spaces.jl
@@ -34,15 +34,18 @@ end
 function make_horizontal_space(
     mesh,
     quad,
-    ::ClimaComms.SingletonCommsContext,
+    comms_ctx::ClimaComms.SingletonCommsContext,
     bubble,
 )
     if mesh isa Meshes.AbstractMesh1D
-        topology = Topologies.IntervalTopology(mesh)
+        topology = Topologies.IntervalTopology(comms_ctx, mesh)
         space = Spaces.SpectralElementSpace1D(topology, quad)
     elseif mesh isa Meshes.AbstractMesh2D
-        topology =
-            Topologies.Topology2D(mesh, Topologies.spacefillingcurve(mesh))
+        topology = Topologies.Topology2D(
+            comms_ctx,
+            mesh,
+            Topologies.spacefillingcurve(mesh),
+        )
         space = Spaces.SpectralElementSpace2D(
             topology,
             quad;


### PR DESCRIPTION
Since I have a CUDA GPU, I got an error when running some cases locally. The comms context isn't properly passed through, so it gets reset to the default value in the topology constructor. This causes incompatible allocations on the GPU and CPU.
As @charleskawczynski has already suggested elsewhere, this could be fixed each time by adding the following snippet when running locally, so I don't know if this is necessary to add, but it would make life easier for local testing.
```
import RRTMGP
RRTMGP.Device.array_device(::Union{Array}) = RRTMGP.Device.CPU()
RRTMGP.Device.array_type() = Array
```
