### PR TITLE
Update parsed_args_per_job_id comment

### DIFF
--- a/src/utils/cli_options.jl
+++ b/src/utils/cli_options.jl
@@ -483,7 +483,9 @@ whose keys are the `job_id`s from buildkite yaml.
 To run the `sphere_aquaplanet_rhoe_equilmoist_allsky`
 buildkite job from the standard buildkite pipeline, use:
 ```
-using Revise; include("src/utils/cli_options.jl");
+using Revise;
+include("src/utils/cli_options.jl");
+include("src/utils/yaml_helper.jl");
 dict = parsed_args_per_job_id();
 parsed_args = dict["sphere_aquaplanet_rhoe_equilmoist_allsky"];
 include("examples/hybrid/driver.jl")


### PR DESCRIPTION
This PR updates the comment in `parsed_args_per_job_id`, which demonstrates how users can run any buildkite job interactively with a few commands.