### PR TITLE
Port DC problem to ClimaAtmos

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -155,6 +155,10 @@ steps:
           --dt 0.5secs --t_end 600secs
           --job_id bomex_box_hydrostatic_balance_rhoe
         artifact_paths: "bomex_box_hydrostatic_balance_rhoe/*"
+      
+      - label: ":computer: 3D density current"
+        command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config box --x_max 51200.0 --y_max 6400.0 --z_max 6400.0 --x_elem 45 --y_elem 15 --z_elem 45 --dt 0.1secs --t_end 10.0secs --z_stretch false --vert_diff false --kappa_4 1e7 --dt_save_to_disk 10secs --initial_condition DryDensityCurrentProfile --discrete_hydrostatic_balance true --job_id box_density_current_test --ode_algo SSP33ShuOsher"
+        artifact_paths: box_density_current_test/*"
 
   - group: "Plane Examples"
     steps:
@@ -177,6 +181,7 @@ steps:
       - label: ":computer: Density current experiment"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config plane --x_max 51200.0 --z_max 6400.0 --x_elem 80 --z_elem 90 --dt 0.3secs --t_end 900.0secs --z_stretch false --vert_diff false --kappa_4 1e7 --dt_save_to_disk 3600secs --initial_condition DryDensityCurrentProfile --discrete_hydrostatic_balance true --job_id plane_density_current_test"
         artifact_paths: "plane_density_current_test/*"
+      
 
   - group: "Sphere Examples (Dycore)"
     steps:

--- a/src/solver/cli_options.jl
+++ b/src/solver/cli_options.jl
@@ -36,7 +36,7 @@ function argparse_settings()
         arg_type = String
         default = "sphere"
         "--initial_condition"
-        help = "Initial condition [`DryBaroclinicWave`, `MoistBaroclinicWave`, `DecayingProfile`, `IsothermalProfile`, `Bomex`, `DryDensityCurrentProfile`, `AgnesiHProfile`, `ScharProfile`]"
+        help = "Initial condition [`DryBaroclinicWave`, `MoistBaroclinicWave`, `DecayingProfile`, `IsothermalProfile`, `Bomex`, `DryDensityCurrentProfile`, `AgnesiHProfile`, `ScharProfile`, `RisingThermalBubbleProfile`]"
         arg_type = String
         default = "DecayingProfile"
         "--moist"

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -289,6 +289,7 @@ function get_initial_condition(parsed_args)
             "Bomex",
             "AgnesiHProfile",
             "DryDensityCurrentProfile",
+            "RisingThermalBubbleProfile",
             "ScharProfile",
         ]
             return getproperty(ICs, Symbol(parsed_args["initial_condition"]))()


### PR DESCRIPTION
cc @simonbyrne @sriharshakandala 
A simple example consisting of a negatively buoyant thermal bubble in a 3D box that may be used for GPU integration tests. Timestepper (explicit) used is SSP33ShuOsher. Default buildkite outputs include mid-plane slices along the y-coordinate. 

Closes #1784. 