### PR TITLE
Lower JET failure limit

### DIFF
--- a/perf/jet_nfailures.jl
+++ b/perf/jet_nfailures.jl
@@ -35,7 +35,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 31
+    n_allowed_failures = 27
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures
         @info "Please update the n-failures to $n"


### PR DESCRIPTION
This PR lowers the JET failure limit, to ensure that we don't regress on inference.