### PR TITLE
Fix remap pipeline

### DIFF
--- a/post_processing/remap/remap_helpers.jl
+++ b/post_processing/remap/remap_helpers.jl
@@ -1,6 +1,6 @@
 import ClimaCoreTempestRemap
 import ClimaCore: Spaces, Fields
-import ClimaAtmos: SurfaceStates, CT3
+import ClimaAtmos: SurfaceStates, C3
 import ClimaCore.Utilities: half
 """
     create_weightfile(
@@ -218,11 +218,10 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
         nc_sfc_flux_energy[:, 1] = sfc_flux_energy_phy.components.data.:1
         sfc_flux_momentum = diag.sfc_flux_momentum
         sfc_local_geometry = Fields.local_geometry_field(sfc_flux_momentum)
-        w_unit = @. CT3(
-            SurfaceStates.unit_basis_vector_data(CT3, sfc_local_geometry),
-        )
+        sfc_normal =
+            @. C3(SurfaceStates.unit_basis_vector_data(C3, sfc_local_geometry))
         sfc_flux_momentum_phy =
-            Geometry.UVVector.(adjoint.(sfc_flux_momentum) .* w_unit)
+            Geometry.UVVector.(adjoint.(sfc_flux_momentum) .* sfc_normal)
         nc_sfc_flux_u[:, 1] = sfc_flux_momentum_phy.components.data.:1
         nc_sfc_flux_v[:, 1] = sfc_flux_momentum_phy.components.data.:2
         if :sfc_evaporation in propertynames(diag)


### PR DESCRIPTION
## Purpose 
This PR fixes a bug in the remap pipeline. 

It will close #1700 


## Content
Solution implemented:
- Used `C3` rather than `CT3` in the calculation of `w_unit`, which was renamed `sfc_normal` for consistency with recent changes

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
