### PR TITLE
Fix conditional_assign! allocations

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -65,7 +65,7 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 4320
 allocs_limit["flame_perf_target_tracers"] = 185904
 allocs_limit["flame_perf_target_edmfx"] = 1040
-allocs_limit["flame_perf_target_edmf"] = 11739124336
+allocs_limit["flame_perf_target_edmf"] = 8278037104
 allocs_limit["flame_perf_target_threaded"] = 3850064
 allocs_limit["flame_perf_target_callbacks"] = 11159912
 

--- a/src/TurbulenceConvection/utility_functions.jl
+++ b/src/TurbulenceConvection/utility_functions.jl
@@ -72,7 +72,13 @@ function compare(a::F, b::F, pn0 = "") where {F <: CC.Fields.Field}
     end
 end
 
-function conditional_assign!(v, ts, f::Function, thermo_params, cond = x -> x)
+function conditional_assign!(
+    v,
+    ts,
+    f::F,
+    thermo_params,
+    cond::CF = identity,
+) where {F, CF}
     @. v = ifelse(
         cond(TD.has_condensate(thermo_params, ts)),
         f(thermo_params, ts),


### PR DESCRIPTION
Reduce allocations by specializing the `conditional_assign!` function, used in the old EDMF.
See [here](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing) - 
`g_func(g::Function, num) = ntuple(g, div(num, 2))` will not specialize, but 
`h_func(h::H, num) where {H} = ntuple(h, div(num, 2))` does.

Thanks @simonbyrne