### PR TITLE
Remove broken artifacts download

### DIFF
--- a/artifacts/download_artifacts.jl
+++ b/artifacts/download_artifacts.jl
@@ -1,5 +1,4 @@
 include(joinpath(@__DIR__, "artifact_funcs.jl"))
-import Insolation
 
 # Trigger download if data doesn't exist locally
 function trigger_download(lazy_download = true)
@@ -9,7 +8,6 @@ function trigger_download(lazy_download = true)
     @info "MiMA convective gravity wave path:`$(mima_gwf_path())`"
     @info "ETOPO1 arc-minute relief model:`$(topo_elev_dataset_path())`"
     @info "GFDL OGWD test data:`$(gfdl_ogw_data_path())`"
-    @info "Insolation orbital parameters:`$(Insolation.orbital_parameters_dataset_path())`"
     return nothing
 end
 trigger_download()


### PR DESCRIPTION
This PR removes some broken artifact downloads (the errors are thrown in Logging, so it doesn't actually fail the job). See the [latest build](https://buildkite.com/clima/climaatmos-ci/builds/10016#01885b92-5227-4444-82ea-9b60789bcf58/1295-1302)

This also tests out a minor adjustment to the CI settings.