### PR TITLE
Update examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ module load julia/1.8.5 openmpi/4.1.1 hdf5/1.12.1-ompi411
 
 export JULIA_MPI_BINARY=system
 export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
-export CLIMACORE_DISTRIBUTED="MPI"
+export CLIMACOMMS_CONTEXT="MPI"
 export JULIA_HDF5_PATH=""
 
 #export RESTART_FILE=$YOUR_HDF5_RESTART_FILE


### PR DESCRIPTION
We need to update the `examples/README.md` to reflect recent ClimaComms changes to run on the Cluster. 

We don't use the env variable `CLIMACORE_DISTRIBUTED` anymore, but we need to specify `CLIMACOMMS_CONTEXT` instead. Even though ClimaComms should detect automatically if we're running on a distributed MPI env, I tried this via `sbatch` and if we don't specify this env variable, we run multiple single-process runs, rather than a distributed run.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
