### PR TITLE
EDMFX vertical transport as explicit, hardcode area at first level

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,7 +156,7 @@ steps:
           --dt 0.5secs --t_end 600secs
           --job_id bomex_box_rhoe
         artifact_paths: "bomex_box_rhoe/*"
-      
+
       - label: ":computer: 3D density current"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config box --x_max 51200.0 --y_max 6400.0 --z_max 6400.0 --x_elem 45 --y_elem 15 --z_elem 45 --dt 0.1secs --t_end 10.0secs --z_stretch false --vert_diff false --kappa_4 1e7 --dt_save_to_disk 10secs --initial_condition DryDensityCurrentProfile --discrete_hydrostatic_balance true --job_id box_density_current_test --ode_algo SSP33ShuOsher"
         artifact_paths: box_density_current_test/*"
@@ -182,7 +182,7 @@ steps:
       - label: ":computer: Density current experiment"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config plane --x_max 51200.0 --z_max 6400.0 --x_elem 80 --z_elem 90 --dt 0.3secs --t_end 900.0secs --z_stretch false --vert_diff false --kappa_4 1e7 --dt_save_to_disk 3600secs --initial_condition DryDensityCurrentProfile --discrete_hydrostatic_balance true --job_id plane_density_current_test"
         artifact_paths: "plane_density_current_test/*"
-      
+
 
   - group: "Sphere Examples (Dycore)"
     steps:
@@ -461,7 +461,7 @@ steps:
         artifact_paths: "diagnostic_edmfx_bomex_box/*"
         agents:
           slurm_mem: 20GB
-      
+
       - label: ":genie: Diagnostic EDMFX aquaplanet"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_aquaplanet
@@ -487,17 +487,36 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":genie: EDMFX Bomex in a box"
+      - label: ":genie: EDMFX Bomex in a box entr 1 detr 0.001 dt 1 t_end 3hrs"
         command: >
-          julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_bomex_box
+          julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_bomex_box_v1
           --initial_condition Bomex --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --surface_setup Bomex
-          --turbconv edmfx --edmfx_entr_detr true --edmfx_sgs_flux true --edmfx_nh_pressure true
-          --moist equil --vert_diff true --C_E 0.044
-          --config box --hyperdiff true --kappa_4 1e8
+          --turbconv edmfx --edmfx_entr_detr true --edmfx_sgs_flux false --edmfx_nh_pressure false
+          --moist equil
+          --config box --hyperdiff true --kappa_4 1e12 --perturb_initstate false
+          --vert_diff true --C_E 0.044
+          --apply_limiter false --edmfx_upwinding first_order
           --x_max 1e5 --y_max 1e5 --x_elem 2 --y_elem 2 --z_elem 60 --z_max 3e3 --z_stretch false
-          --ode_algo SSP33ShuOsher --apply_limiter false
-          --dt 0.1secs --t_end 20secs --dt_save_to_disk 0.1secs
-        artifact_paths: "edmfx_bomex_box/*"
+          --dt 1secs --t_end 10800secs --dt_save_to_disk 60secs
+          --entr_coeff 1.0 --detr_coeff 0.001
+        artifact_paths: "edmfx_bomex_box_v1/*"
+        soft_fail: true
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":genie: EDMFX Bomex in a box entr 1 detr 0.01 dt 1 t_end 3hrs"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl --job_id edmfx_bomex_box_v2
+          --initial_condition Bomex --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --surface_setup Bomex
+          --turbconv edmfx --edmfx_entr_detr true --edmfx_sgs_flux false --edmfx_nh_pressure false
+          --moist equil
+          --config box --hyperdiff true --kappa_4 1e12 --perturb_initstate false
+          --vert_diff true --C_E 0.044
+          --apply_limiter false --edmfx_upwinding first_order
+          --x_max 1e5 --y_max 1e5 --x_elem 2 --y_elem 2 --z_elem 60 --z_max 3e3 --z_stretch false
+          --dt 1secs --t_end 10800secs --dt_save_to_disk 60secs
+          --entr_coeff 1.0 --detr_coeff 0.01
+        artifact_paths: "edmfx_bomex_box_v2/*"
         soft_fail: true
         agents:
           slurm_mem: 20GB
@@ -522,6 +541,7 @@ steps:
           --turbconv edmfx --edmfx_entr_detr true --edmfx_sgs_flux true
           --moist equil --precip_model 0M
           --ode_algo SSP33ShuOsher --apply_limiter false --dt 1secs --t_end 6mins
+          --vert_diff true --C_E 0.044
           --dt_save_to_disk 30secs
           --reference_job_id sphere_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist_edmfx/*"

--- a/post_processing/contours_and_profiles.jl
+++ b/post_processing/contours_and_profiles.jl
@@ -69,15 +69,25 @@ function contour_plot!(
     end
     ts = getindex.(var_col_time_series, 1)
     zs = var_col_time_series[1][2]
+
+    #values_adjoint = hcat(getindex.(var_col_time_series, 3)...)
+    #values = permutedims(values_adjoint, (2, 1))
     values = hcat(getindex.(var_col_time_series, 3)...)'
+
     if isnothing(ref_var_col_time_series)
         limits = extrema(values)
     else
         ref_ts = getindex.(ref_var_col_time_series, 1)
         ref_zs = ref_var_col_time_series[1][2]
+
+        #ref_values_adjoint = hcat(getindex.(ref_var_col_time_series, 3)...)
+        #ref_values = permutedims(ref_values_adjoint, (2, 1))
         ref_values = hcat(getindex.(ref_var_col_time_series, 3)...)'
+
         limits = extrema((extrema(values)..., extrema(ref_values)...))
     end
+
+
     limits = limits .+ (-1, 1) .* (padding_fraction * (limits[2] - limits[1]))
     if negative_values_allowed
         extendlow = nothing
@@ -382,11 +392,13 @@ function contours_and_profiles(output_dir, ref_job_id = nothing)
         (:gm, :v_velocity),
         (:gm, :w_velocity),
         (draft_or_gm, :buoyancy),
+        (draft_or_gm, :specific_enthalpy),
     )
     if has_moisture
         contour_variables = (
             contour_variables...,
             (env_or_gm, :relative_humidity),
+            (draft_or_gm, :q_tot),
             (draft_or_gm, :q_vap),
             (draft_or_gm, :q_liq),
             (draft_or_gm, :q_ice),
@@ -412,11 +424,13 @@ function contours_and_profiles(output_dir, ref_job_id = nothing)
         ((:gm,), :v_velocity),
         (all_categories, :w_velocity),
         (all_categories, :buoyancy),
+        (all_categories, :specific_enthalpy),
     )
     if has_moisture
         profile_variables = (
             profile_variables...,
             (all_categories, :relative_humidity),
+            (all_categories, :q_tot),
             (all_categories, :q_vap),
             (all_categories, :q_liq),
             (all_categories, :q_ice),

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -409,9 +409,10 @@ function set_precomputed_quantities!(Y, p, t)
                 Fields.field_values(Fields.level(Y.c.sgsʲs.:($j).ρae_tot, 1))
             sgsʲs_ρaq_tot_int_val =
                 Fields.field_values(Fields.level(Y.c.sgsʲs.:($j).ρaq_tot, 1))
+
+            FT = Spaces.undertype(axes(Y.c))
             @. sgsʲs_ρa_int_val =
-                sgsʲs_ρa_int_val / sgsʲs_ρ_int_val *
-                TD.air_density(thermo_params, ᶜtsʲ_int_val)
+                FT(0.1) * TD.air_density(thermo_params, ᶜtsʲ_int_val)
             @. sgsʲs_ρae_tot_int_val =
                 sgsʲs_ρa_int_val * TD.total_energy(
                     thermo_params,

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -259,6 +259,7 @@ function save_to_disk_func(integrator)
             w_velocity = Geometry.WVector.(ᶜu),
             temperature = TD.air_temperature.(thermo_params, ᶜts),
             potential_temperature = TD.dry_pottemp.(thermo_params, ᶜts),
+            specific_enthalpy = TD.specific_enthalpy.(thermo_params, ᶜts),
             buoyancy = CAP.grav(params) .* (p.ᶜρ_ref .- ᶜρ) ./ ᶜρ,
         )
         if !(p.atmos.moisture_model isa DryModel)
@@ -267,6 +268,7 @@ function save_to_disk_func(integrator)
                 q_vap = TD.vapor_specific_humidity.(thermo_params, ᶜts),
                 q_liq = TD.liquid_specific_humidity.(thermo_params, ᶜts),
                 q_ice = TD.ice_specific_humidity.(thermo_params, ᶜts),
+                q_tot = TD.total_specific_humidity.(thermo_params, ᶜts),
                 relative_humidity = TD.relative_humidity.(thermo_params, ᶜts),
             )
         end

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -26,6 +26,8 @@ Base.@kwdef struct ClimaAtmosParameters{FT, TP, RP, IP, MPP, SFP, TCP} <: ACAP
     microphysics_params::MPP
     surfacefluxes_params::SFP
     turbconv_params::TCP
+    entr_coeff::FT = 1
+    detr_coeff::FT = 0.001
 end
 
 Base.eltype(::ClimaAtmosParameters{FT}) where {FT} = FT
@@ -58,6 +60,8 @@ astro_unit(ps::ACAP) = ps.astro_unit
 f(ps::ACAP) = ps.f
 Cd(ps::ACAP) = ps.Cd
 uh_g(ps::ACAP) = CC.Geometry.UVVector(ps.ug, ps.vg)
+entr_coeff(ps::ACAP) = ps.entr_coeff
+detr_coeff(ps::ACAP) = ps.detr_coeff
 
 # Forwarding CloudMicrophysics parameters
 ρ_cloud_liq(ps::ACAP) = CM.Parameters.ρ_cloud_liq(microphysics_params(ps))

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -119,6 +119,8 @@ function create_climaatmos_parameter_set(
         rrtmgp_params = rrtmgp_params,
         surfacefluxes_params = surf_flux_params,
         turbconv_params = tc_params,
+        entr_coeff = FTD(parsed_args["entr_coeff"]),
+        detr_coeff = FTD(parsed_args["detr_coeff"]),
     )
     # logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
     # CP.log_parameter_information(toml_dict, logfilepath)

--- a/src/prognostic_equations/edmfx_closures.jl
+++ b/src/prognostic_equations/edmfx_closures.jl
@@ -151,6 +151,9 @@ function pi_groups_entr_detr(
     else
         g = CAP.grav(params)
 
+        entr_coeff = CAP.entr_coeff(params)
+        detr_coeff = CAP.detr_coeff(params)
+
         turbconv_params = CAP.turbconv_params(params)
         ᶜaʲ_max = TCP.max_area(turbconv_params)
         max_area_limiter = 0.1 * exp(-10 * (ᶜaʲ_max - ᶜaʲ))
@@ -184,8 +187,8 @@ function pi_groups_entr_detr(
         # TODO - Temporary: Switch to Π groups after simple tests are done
         # (kinematic, bubble, Bomex)
         # and/or we can calibrate things in ClimaAtmos
-        entr = max(0, 1 * ᶜwʲ / ᶜz)
-        detr = max(0, 1e-3 * ᶜwʲ)
+        entr = max(0, entr_coeff * ᶜwʲ / ᶜz)
+        detr = max(0, detr_coeff * ᶜwʲ)
 
         return (; entr, detr)
     end

--- a/src/solver/cli_options.jl
+++ b/src/solver/cli_options.jl
@@ -66,6 +66,14 @@ function argparse_settings()
         help = "If set to true, it switches on EDMFX entrainment/detrainment closure.  [`true`, `false` (default)]"
         arg_type = Bool
         default = false
+        "--entr_coeff"
+        help = "Entrainment coefficient"
+        arg_type = Float64
+        default = Float64(1.0)
+        "--detr_coeff"
+        help = "Detrainment coefficient"
+        arg_type = Float64
+        default = Float64(0.001)
         "--edmfx_sgs_flux"
         help = "If set to true, it switches on EDMFX SGS flux.  [`true`, `false` (default)]"
         arg_type = Bool


### PR DESCRIPTION
This PR:
- adds enthalpy and q_tot to output and simulation plots
- hardcodes the area fraction at first interior to be 0.1
- moves EDMFX vertical transport from implicit to explicit tendency

Co-authored-by: @nefrathenrici  (thank you for the allocation fixes!)