### PR TITLE
Skip inference on `fill_with_nans!` unless testing consistency

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -72,6 +72,11 @@ function default_cache(
 
     net_energy_flux_toa = [Geometry.WVector(FT(0))]
     net_energy_flux_sfc = [Geometry.WVector(FT(0))]
+    test = if parsed_args["test_dycore_consistency"]
+        TestDycoreConsistency()
+    else
+        nothing
+    end
 
     default_cache = (;
         simulation,
@@ -79,7 +84,7 @@ function default_cache(
         atmos,
         comms_ctx = ClimaComms.context(axes(Y.c)),
         sfc_setup = surface_setup(params),
-        test_dycore_consistency = parsed_args["test_dycore_consistency"],
+        test,
         moisture_model = atmos.moisture_model,
         model_config = atmos.model_config,
         Yₜ = similar(Y), # only needed when using increment formulation

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -5,7 +5,7 @@
 import ClimaCore: Fields, Geometry
 
 function implicit_tendency!(Yₜ, Y, p, t)
-    p.test_dycore_consistency && fill_with_nans!(p)
+    p.test isa TestDycoreConsistency && fill_with_nans!(p)
     @nvtx "implicit tendency" color = colorant"yellow" begin
         Yₜ .= zero(eltype(Yₜ))
         @nvtx "precomputed quantities" color = colorant"orange" begin

--- a/src/prognostic_equations/implicit/wfact.jl
+++ b/src/prognostic_equations/implicit/wfact.jl
@@ -60,7 +60,7 @@ end
 
 function Wfact!(W, Y, p, dtγ, t)
     NVTX.@range "Wfact!" color = colorant"green" begin
-        p.test_dycore_consistency && fill_with_nans!(p)
+        p.test isa TestDycoreConsistency && fill_with_nans!(p)
         set_precomputed_quantities!(Y, p, t)
         Fields.bycolumn(axes(Y.c)) do colidx
             Wfact!(W, Y, p, dtγ, t, colidx)

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -1,6 +1,6 @@
 
 function remaining_tendency!(Yₜ, Y, p, t)
-    p.test_dycore_consistency && fill_with_nans!(p)
+    p.test isa TestDycoreConsistency && fill_with_nans!(p)
     @nvtx "remaining tendency" color = colorant"yellow" begin
         Yₜ .= zero(eltype(Yₜ))
         @nvtx "precomputed quantities" color = colorant"orange" begin

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -149,6 +149,8 @@ end
 abstract type AbstractPerformanceMode end
 struct PerfExperimental <: AbstractPerformanceMode end
 struct PerfStandard <: AbstractPerformanceMode end
+struct TestDycoreConsistency end
+
 Base.broadcastable(x::AbstractPerformanceMode) = tuple(x)
 
 Base.@kwdef struct AtmosModel{


### PR DESCRIPTION
This PR adds a type, `TestDycoreConsistency`, so that we can skip inference on `fill_with_nans!` when we're not running consistency tests. This should be a fine work-around to close #1728.