### PR TITLE
Do post-processing on CPU devices only

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -242,7 +242,7 @@ steps:
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_zalesak_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist --out_dir sphere_zalesak_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist
         artifact_paths: "sphere_zalesak_upwind_tracer_energy_ssp_baroclinic_wave_rhoe_equilmoist/*"
         agents:
-          slurm_mem: 20GB
+          slurm_mem: 32GB
 
       - label: ":computer: no lim ARS baroclinic wave (ρe) equilmoist check conservation float64"
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --moist equil --initial_condition MoistBaroclinicWave --rad clearsky --job_id sphere_baroclinic_wave_rhoe_equilmoist_conservation_ft64 --check_conservation true --FLOAT_TYPE Float64 --dt 450secs --t_end 8days --dt_save_to_disk 8days --apply_limiter false"

--- a/post_processing/contours_and_profiles.jl
+++ b/post_processing/contours_and_profiles.jl
@@ -1,5 +1,6 @@
 import ClimaAtmos: time_from_filename
 import ClimaCore: Geometry, Spaces, Fields, InputOutput
+import ClimaComms
 import CairoMakie: Makie
 import Statistics: mean
 
@@ -193,7 +194,10 @@ function contours_and_profiles(output_dir, ref_job_id = nothing)
     end
 
     function read_hdf5_file(file_path)
-        reader = InputOutput.HDF5Reader(file_path)
+        reader = InputOutput.HDF5Reader(
+            file_path,
+            ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice()),
+        )
         diagnostics = InputOutput.read_field(reader, "diagnostics")
         close(reader)
         return time_from_filename(file_path), diagnostics

--- a/post_processing/define_tc_quicklook_profiles.jl
+++ b/post_processing/define_tc_quicklook_profiles.jl
@@ -2,6 +2,7 @@ import ClimaCore: Fields, InputOutput, Geometry
 ENV["GKSwstype"] = "nul";
 import Plots
 import ClimaAtmos as CA
+import ClimaComms
 
 function getfun(D, sym::Symbol)
     if !hasproperty(D, sym)
@@ -55,7 +56,10 @@ function plot_tc_profiles(folder; hdf5_filename, main_branch_data_path)
             return
         end
 
-        reader = InputOutput.HDF5Reader(input_filename)
+        reader = InputOutput.HDF5Reader(
+            input_filename,
+            ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice()),
+        )
         Y = InputOutput.read_field(reader, "Y")
         D = InputOutput.read_field(reader, "diagnostics")
 
@@ -135,7 +139,10 @@ function get_contours(vars, input_filenames; data_source, have_main)
     end
 
     data = map(input_filenames) do input_filename
-        reader = InputOutput.HDF5Reader(input_filename)
+        reader = InputOutput.HDF5Reader(
+            input_filename,
+            ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice()),
+        )
         Y = InputOutput.read_field(reader, "Y")
         D = InputOutput.read_field(reader, "diagnostics")
         (Y, D)

--- a/post_processing/remap/remap_helpers.jl
+++ b/post_processing/remap/remap_helpers.jl
@@ -1,5 +1,6 @@
 import ClimaCoreTempestRemap
 import ClimaCore: Spaces, Fields
+import ClimaComms
 import ClimaAtmos: SurfaceConditions, CT3
 import ClimaCore.Utilities: half
 """
@@ -61,7 +62,10 @@ end
 
 function create_weightfile(filein, remap_tmpdir, nlat, nlon)
     @assert endswith(filein, "hdf5")
-    reader = InputOutput.HDF5Reader(filein)
+    reader = InputOutput.HDF5Reader(
+        filein,
+        ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice()),
+    )
     Y = InputOutput.read_field(reader, "Y")
     weightfile = joinpath(remap_tmpdir, "remap_weights.nc")
     create_weightfile(weightfile, axes(Y.c), axes(Y.f), nlat, nlon)
@@ -70,7 +74,10 @@ end
 
 function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
     @assert endswith(filein, "hdf5")
-    reader = InputOutput.HDF5Reader(filein)
+    reader = InputOutput.HDF5Reader(
+        filein,
+        ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice()),
+    )
     Y = InputOutput.read_field(reader, "Y")
     diag = InputOutput.read_field(reader, "diagnostics")
     t_now = InputOutput.HDF5.read_attribute(reader.file, "time")


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to pass the context to the `InputOutput.HDF5Reader` so that we explicitly specify that postprocessing should happen on the CPU (otherwise, when an NVIDIA GPU device is available, it would try to use that and break).

- Fixes #1741 


## Content
- Solution implemented: passed `ClimaComms.SingletonCommsContext(ClimaComms.CPUDevice())` to `HDF5Reader`

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
