### PR TITLE
Use addition assignment in vertical transport

### DIFF
--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -15,7 +15,6 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
     ᶜJ = Fields.local_geometry_field(Y.c).J
 
     thermo_params = CAP.thermodynamics_params(params)
-    ρe_tot_tendency = ρq_tot_tendency = p.ᶜtemp_scalar[colidx]
     if p.atmos.edmfx_sgs_flux
         ᶠu³_diff_colidx = p.ᶠtemp_CT3[colidx]
         ᶜh_tot_diff_colidx = ᶜq_tot_diff_colidx = p.ᶜtemp_scalar[colidx]
@@ -23,7 +22,7 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
             @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
             @. ᶜh_tot_diff_colidx = ᶜh_totʲs.:($$j)[colidx] - ᶜh_tot[colidx]
             vertical_transport!(
-                ρe_tot_tendency,
+                Yₜ.c.ρe_tot[colidx],
                 ᶜJ[colidx],
                 Y.c.sgsʲs.:($j).ρa[colidx],
                 ᶠu³_diff_colidx,
@@ -31,7 +30,6 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
                 dt,
                 edmfx_upwinding,
             )
-            @. Yₜ.c.ρe_tot[colidx] += ρe_tot_tendency
         end
         @. ᶠu³_diff_colidx = ᶠu³⁰[colidx] - ᶠu³[colidx]
         @. ᶜh_tot_diff_colidx =
@@ -41,7 +39,7 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
                 ᶜspecific⁰.e_tot[colidx],
             ) - ᶜh_tot[colidx]
         vertical_transport!(
-            ρe_tot_tendency,
+            Yₜ.c.ρe_tot[colidx],
             ᶜJ[colidx],
             ᶜρa⁰[colidx],
             ᶠu³_diff_colidx,
@@ -49,7 +47,6 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
             dt,
             edmfx_upwinding,
         )
-        @. Yₜ.c.ρe_tot[colidx] += ρe_tot_tendency
 
         if !(p.atmos.moisture_model isa DryModel)
             for j in 1:n
@@ -57,7 +54,7 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
                 @. ᶜq_tot_diff_colidx =
                     ᶜspecificʲs.:($$j).q_tot[colidx] - ᶜspecific.q_tot[colidx]
                 vertical_transport!(
-                    ρq_tot_tendency,
+                    Yₜ.c.ρq_tot[colidx],
                     ᶜJ[colidx],
                     Y.c.sgsʲs.:($j).ρa[colidx],
                     ᶠu³_diff_colidx,
@@ -65,13 +62,12 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
                     dt,
                     edmfx_upwinding,
                 )
-                @. Yₜ.c.ρq_tot[colidx] += ρq_tot_tendency
             end
             @. ᶠu³_diff_colidx = ᶠu³⁰[colidx] - ᶠu³[colidx]
             @. ᶜq_tot_diff_colidx =
                 ᶜspecific⁰.q_tot[colidx] - ᶜspecific.q_tot[colidx]
             vertical_transport!(
-                ρq_tot_tendency,
+                Yₜ.c.ρq_tot[colidx],
                 ᶜJ[colidx],
                 ᶜρa⁰[colidx],
                 ᶠu³_diff_colidx,
@@ -79,7 +75,6 @@ function edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
                 dt,
                 edmfx_upwinding,
             )
-            @. Yₜ.c.ρq_tot[colidx] += ρq_tot_tendency
         end
     end
 

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -38,13 +38,13 @@ end
 # TODO: Can we rewrite ᶠfct_boris_book and ᶠfct_zalesak so that their broadcast
 # expressions are less convoluted?
 vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:none}) =
-    @. ᶜρχₜ = -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠu³ * ᶠinterp(ᶜχ)))
+    @. ᶜρχₜ += -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠu³ * ᶠinterp(ᶜχ)))
 vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:first_order}) =
-    @. ᶜρχₜ = -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠupwind1(ᶠu³, ᶜχ)))
+    @. ᶜρχₜ += -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠupwind1(ᶠu³, ᶜχ)))
 vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:third_order}) =
-    @. ᶜρχₜ = -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠupwind3(ᶠu³, ᶜχ)))
+    @. ᶜρχₜ += -(ᶜadvdivᵥ(ᶠwinterp(ᶜJ, ᶜρ) * ᶠupwind3(ᶠu³, ᶜχ)))
 vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:boris_book}) =
-    @. ᶜρχₜ = -(ᶜadvdivᵥ(
+    @. ᶜρχₜ += -(ᶜadvdivᵥ(
         ᶠwinterp(ᶜJ, ᶜρ) * (
             ᶠupwind1(ᶠu³, ᶜχ) + ᶠfct_boris_book(
                 ᶠupwind3(ᶠu³, ᶜχ) - ᶠupwind1(ᶠu³, ᶜχ),
@@ -53,7 +53,7 @@ vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:boris_boo
         ),
     ))
 vertical_transport!(ᶜρχₜ, ᶜJ, ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:zalesak}) =
-    @. ᶜρχₜ = -(ᶜadvdivᵥ(
+    @. ᶜρχₜ += -(ᶜadvdivᵥ(
         ᶠwinterp(ᶜJ, ᶜρ) * (
             ᶠupwind1(ᶠu³, ᶜχ) + ᶠfct_zalesak(
                 ᶠupwind3(ᶠu³, ᶜχ) - ᶠupwind1(ᶠu³, ᶜχ),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Uses addition assignment (+=) in vertical transport. We sometimes move around the vertical advection functions so I think this would be safer. We already zero out the tendencies at the beginning of the implicit and remaining tendencies, so this shouldn't cause any change.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation. 

-->

----
- [ ] I have read and checked the items on the review checklist.
