### PR TITLE
Use report_opt in nfailures

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -29,7 +29,9 @@ import OrderedCollections
 using ClimaCoreTempestRemap
 using ClimaCorePlots, Plots
 using ClimaCoreMakie, CairoMakie
-include(joinpath(pkgdir(CA), "perf", "jet_report_nfailures.jl"))
+if config.comms_ctx isa ClimaComms.SingletonCommsContext
+    include(joinpath(pkgdir(CA), "perf", "jet_report_nfailures.jl"))
+end
 include(joinpath(pkgdir(CA), "post_processing", "contours_and_profiles.jl"))
 include(joinpath(pkgdir(CA), "post_processing", "post_processing_funcs.jl"))
 include(

--- a/perf/jet_report_nfailures.jl
+++ b/perf/jet_report_nfailures.jl
@@ -4,7 +4,7 @@ import JET
 # Suggested in: https://github.com/aviatesk/JET.jl/issues/455
 macro n_failures(ex)
     return :(
-        let result = JET.@report_call $(ex)
+        let result = JET.@report_opt $(ex)
             length(JET.get_reports(result.analyzer, result.result))
         end
     )

--- a/perf/jet_test_nfailures.jl
+++ b/perf/jet_test_nfailures.jl
@@ -12,7 +12,7 @@ OrdinaryDiffEq.step!(integrator) # Make sure no errors
 # Suggested in: https://github.com/aviatesk/JET.jl/issues/455
 macro n_failures(ex)
     return :(
-        let result = JET.@report_call $(ex)
+        let result = JET.@report_opt $(ex)
             length(JET.get_reports(result.analyzer, result.result))
         end
     )
@@ -26,7 +26,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 84
+    n_allowed_failures = 844
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures
         @info "Please update the n-failures to $n"


### PR DESCRIPTION
This PR changes the n-failure macros to use `report_opt`, since this seems to catch more jet failures.