### PR TITLE
Log device type being used

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -643,6 +643,7 @@ function get_comms_context(parsed_args)
     else
         ClimaComms.CPUDevice()
     end
+    @info "Running on $(nameof(typeof(device)))."
     comms_ctx = ClimaComms.context(device)
     ClimaComms.init(comms_ctx)
     if ClimaComms.iamroot(comms_ctx)


### PR DESCRIPTION
This PR adds an `@info` statement to print the device type being used to the log.