### PR TITLE
Remove some bycolumn calls

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -57,7 +57,7 @@ allocs_limit["flame_perf_target"] = 4320
 allocs_limit["flame_perf_target_tracers"] = 185904
 allocs_limit["flame_perf_target_edmfx"] = 33117648
 allocs_limit["flame_perf_target_edmf"] = 8636906992
-allocs_limit["flame_perf_target_threaded"] = 3850064
+allocs_limit["flame_perf_target_threaded"] = 6175664
 allocs_limit["flame_perf_target_callbacks"] = 11159912
 
 if allocs < allocs_limit[job_id] * buffer


### PR DESCRIPTION
This PR removes some bycolumn calls for explicit tendencies. A step towards #1761. I think the big remaining one will be in `additional_tendency!`.