### PR TITLE
remove redundant function for edmfx boundary condition

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -144,7 +144,7 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
             Geometry.WVector(FT(0.01), local_geometry_int_halflevel),
             local_geometry_int_halflevel,
         )
-        @. h_totʲ_int_level = sgs_h_tot_first_interior_bc(
+        @. h_totʲ_int_level = sgs_scalar_first_interior_bc(
             z_int_level - z_sfc_halflevel,
             ρ_int_level,
             h_tot_int_level,
@@ -154,7 +154,7 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
             obukhov_length_sfc_halflevel,
             local_geometry_int_halflevel,
         )
-        @. q_totʲ_int_level = sgs_q_tot_first_interior_bc(
+        @. q_totʲ_int_level = sgs_scalar_first_interior_bc(
             z_int_level - z_sfc_halflevel,
             ρ_int_level,
             q_tot_int_level,

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -377,7 +377,7 @@ function set_precomputed_quantities!(Y, p, t)
             )
             ᶜh_tot_int_val = Fields.field_values(Fields.level(ᶜh_tot, 1))
             ᶜh_totʲ_int_val = Fields.field_values(Fields.level(ᶜh_totʲ, 1))
-            @. ᶜh_totʲ_int_val = sgs_h_tot_first_interior_bc(
+            @. ᶜh_totʲ_int_val = sgs_scalar_first_interior_bc(
                 ᶜz_int_val - z_sfc_val,
                 ᶜρ_int_val,
                 ᶜh_tot_int_val,
@@ -393,7 +393,7 @@ function set_precomputed_quantities!(Y, p, t)
                 Fields.field_values(Fields.level(ᶜspecific.q_tot, 1))
             ᶜq_totʲ_int_val =
                 Fields.field_values(Fields.level(ᶜspecificʲ.q_tot, 1))
-            @. ᶜq_totʲ_int_val = sgs_q_tot_first_interior_bc(
+            @. ᶜq_totʲ_int_val = sgs_scalar_first_interior_bc(
                 ᶜz_int_val - z_sfc_val,
                 ᶜρ_int_val,
                 ᶜq_tot_int_val,

--- a/src/prognostic_equations/edmfx_boundary_condition.jl
+++ b/src/prognostic_equations/edmfx_boundary_condition.jl
@@ -2,21 +2,21 @@
 ##### EDMFX SGS boundary condition
 #####
 
-function sgs_h_tot_first_interior_bc(
+function sgs_scalar_first_interior_bc(
     ᶜz_int::FT,
     ᶜρ_int::FT,
-    ᶜh_tot_int::FT,
+    ᶜscalar_int::FT,
     sfc_buoyancy_flux,
-    sfc_ρ_flux_h_tot,
+    sfc_ρ_flux_scalar,
     ustar,
     obukhov_length,
     sfc_local_geometry,
 ) where {FT}
-    sfc_buoyancy_flux > 0 || return ᶜh_tot_int
+    sfc_buoyancy_flux > 0 || return ᶜscalar_int
     # a_total = edmf.surface_area
     # a_ = area_surface_bc(surface_conditions, edmf)
-    h_tot_var = get_first_interior_variance(
-        sfc_ρ_flux_h_tot / ᶜρ_int,
+    scalar_var = get_first_interior_variance(
+        sfc_ρ_flux_scalar / ᶜρ_int,
         ustar,
         ᶜz_int,
         obukhov_length,
@@ -27,35 +27,7 @@ function sgs_h_tot_first_interior_bc(
     #     1 - a_total + i * a_,
     # )
     surface_scalar_coeff = FT(1.75)
-    return ᶜh_tot_int + surface_scalar_coeff * sqrt(h_tot_var)
-end
-
-function sgs_q_tot_first_interior_bc(
-    ᶜz_int::FT,
-    ᶜρ_int::FT,
-    ᶜq_tot_int::FT,
-    sfc_buoyancy_flux,
-    sfc_ρ_flux_q_tot,
-    ustar,
-    obukhov_length,
-    sfc_local_geometry,
-) where {FT}
-    sfc_buoyancy_flux > 0 || return ᶜq_tot_int
-    # a_total = edmf.surface_area
-    # a_ = area_surface_bc(surface_conditions, edmf)
-    q_tot_var = get_first_interior_variance(
-        sfc_ρ_flux_q_tot / ᶜρ_int,
-        ustar,
-        ᶜz_int,
-        obukhov_length,
-        sfc_local_geometry,
-    )
-    # surface_scalar_coeff = percentile_bounds_mean_norm(
-    #     1 - a_total + (i - 1) * a_,
-    #     1 - a_total + i * a_,
-    # )
-    surface_scalar_coeff = FT(1.75)
-    return ᶜq_tot_int + surface_scalar_coeff * sqrt(q_tot_var)
+    return ᶜscalar_int + surface_scalar_coeff * sqrt(scalar_var)
 end
 
 function get_first_interior_variance(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Combine `sgs_h_tot_first_interior_bc` and `sgs_q_tot_first_interior_bc` into one function as they are the same.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
