### PR TITLE
Use radians in radiation

### DIFF
--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -51,7 +51,7 @@ function radiation_model_cache(
 
     bottom_coords = Fields.coordinate_field(Spaces.level(Y.c, 1))
     if eltype(bottom_coords) <: Geometry.LatLongZPoint
-        latitude = RRTMGPI.field2array(bottom_coords.lat)
+        latitude = RRTMGPI.field2array(@. deg2rad(bottom_coords.lat))
     else
         latitude = RRTMGPI.field2array(zero(bottom_coords.z)) # flat space is on Equator
     end
@@ -63,7 +63,7 @@ function radiation_model_cache(
                 lapse_rate = 3.5,
                 optical_thickness_parameter = (@. 7.2 +
                                                   (1.8 - 7.2) *
-                                                  sind(latitude)^2),
+                                                  sin(latitude)^2),
                 latitude,
             )
         else
@@ -175,7 +175,7 @@ function radiation_model_cache(
         if idealized_insolation # perpetual equinox with no diurnal cycle
             solar_zenith_angle = FT(π) / 3
             weighted_irradiance =
-                @. 1360 * (1 + FT(1.2) / 4 * (1 - 3 * sind(latitude)^2)) /
+                @. 1360 * (1 + FT(1.2) / 4 * (1 - 3 * sin(latitude)^2)) /
                    (4 * cos(solar_zenith_angle))
         else
             solar_zenith_angle = weighted_irradiance = NaN # initialized in callback


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
RRTMGP uses radians for latitude and longitude. This PR fixes the bug that we pass in latitude in degrees.
Closes #1716.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
