### PR TITLE
Improve GPU test label, use baro wave init

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,13 +64,12 @@ steps:
 
   - group: "GPU"
     steps:
-      - label: "Simple GPU test"
-        key: "gpu_example"
+      - label: "GPU explicit baroclinic wave"
+        key: "gpu_explicit_barowave"
         command:
           - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
-          - "julia --color=yes --project=examples examples/hybrid/driver.jl --enable_threading false --ode_algo SSP33ShuOsher --t_end 1mins --dt 1secs --dt_save_to_sol Inf --dt_save_to_disk Inf --job_id gpu_example --device CUDADevice"
-        artifact_paths: "gpu_example/*"
-        soft_fail: true
+          - "julia --color=yes --project=examples examples/hybrid/driver.jl --enable_threading false --ode_algo SSP33ShuOsher --initial_condition DryBaroclinicWave --t_end 1mins --dt 1secs --dt_save_to_sol Inf --dt_save_to_disk Inf --job_id gpu_explicit_barowave --device CUDADevice"
+        artifact_paths: "gpu_explicit_barowave/*"
         agents:
           slurm_gpus: 1
 

--- a/perf/benchmark_step.jl
+++ b/perf/benchmark_step.jl
@@ -15,7 +15,7 @@ import Random
 Random.seed!(1234)
 import ClimaAtmos as CA
 
-parsed_args = CA.AtmosTargetConfig(; target_job = "gpu_example");
+parsed_args = CA.AtmosTargetConfig(; target_job = "gpu_explicit_barowave");
 # parsed_args["device"] = "CPUDevice"; # uncomment to run on cpu
 config = CA.AtmosConfig(; parsed_args)
 


### PR DESCRIPTION
This PR improves the GPU test label. As far as I can tell, the default config is basically the baroclinic wave (assuming we use the baro wave init profile). So, this PR updates the label and changes initialization since this is a well known configuration.