### PR TITLE
Print full n-inference failures dict

### DIFF
--- a/perf/jet_report_nfailures.jl
+++ b/perf/jet_report_nfailures.jl
@@ -39,4 +39,6 @@ n["fill_with_nans!"]                             = @n_failures CA.fill_with_nans
 #! format: on
 
 n = filter(x -> x.second ≠ 0, n)
-@info "n-jet failures (excluding n=0)" nfailures = n
+@info "n-jet failures (excluding n=0):"
+show(IOContext(stdout, :limit => false), MIME"text/plain"(), n)
+println()


### PR DESCRIPTION
This PR changes the printing of the n-inference failures dict to not truncate printing the dict, which happens in the log at the moment:

```
┌ Info: n-jet failures (excluding n=0)
│   nfailures =
│    Dict{Any, Any} with 13 entries:
│      "implicit_tendency!"             => 674
│      "hyperdiffusion_tendency!"       => 642
│      "additional_tendency!"           => 15
│      "update_surface_conditions!"     => 598
│      "fill_with_nans!"                => 3
│      "limited_tendency!"              => 649
│      "horizontal_advection_tendency!" => 584
└      ⋮                                => ⋮
```
The dict is 16 entries long, so it shouldn't bloat the log too much.