### PR TITLE
Make comms_ctx optional again

### DIFF
--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -325,6 +325,7 @@ end
 function AtmosConfig(
     s = argparse_settings();
     parsed_args = parse_commandline(s),
+    comms_ctx = nothing,
 )
     FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
     toml_dict = CP.create_toml_dict(
@@ -334,7 +335,10 @@ function AtmosConfig(
     )
     toml_dict, parsed_args =
         merge_parsed_args_with_toml(toml_dict, parsed_args, CA.cli_defaults(s))
-    comms_ctx = CA.get_comms_context(parsed_args)
+
+    if isnothing(comms_ctx)
+        comms_ctx = CA.get_comms_context(parsed_args)
+    end
 
     # TODO: is there a better way? We need a better
     #       mechanism on the ClimaCore side.


### PR DESCRIPTION
## Purpose 
During the Coupler update in ClimaCoupler #[306](https://github.com/CliMA/ClimaCoupler.jl/pull/306), we noticed that the `comms_ctx` is not optional anymore. This clashes with the Coupler, which needs to define it at the very beginning of the simulation. 

Closes #1788 

## Content
- Made `comms_ctx` optional

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.



----
- [x] I have read and checked the items on the review checklist.
