### PR TITLE
Move fill with nans dispatch

### DIFF
--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -5,7 +5,7 @@
 import ClimaCore: Fields, Geometry
 
 function implicit_tendency!(Yₜ, Y, p, t)
-    p.test isa TestDycoreConsistency && fill_with_nans!(p)
+    fill_with_nans!(p)
     @nvtx "implicit tendency" color = colorant"yellow" begin
         Yₜ .= zero(eltype(Yₜ))
         @nvtx "precomputed quantities" color = colorant"orange" begin

--- a/src/prognostic_equations/implicit/wfact.jl
+++ b/src/prognostic_equations/implicit/wfact.jl
@@ -60,7 +60,7 @@ end
 
 function Wfact!(W, Y, p, dtγ, t)
     NVTX.@range "Wfact!" color = colorant"green" begin
-        p.test isa TestDycoreConsistency && fill_with_nans!(p)
+        fill_with_nans!(p)
         set_precomputed_quantities!(Y, p, t)
         Fields.bycolumn(axes(Y.c)) do colidx
             Wfact!(W, Y, p, dtγ, t, colidx)

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -1,6 +1,6 @@
 
 function remaining_tendency!(Yₜ, Y, p, t)
-    p.test isa TestDycoreConsistency && fill_with_nans!(p)
+    fill_with_nans!(p)
     @nvtx "remaining tendency" color = colorant"yellow" begin
         Yₜ .= zero(eltype(Yₜ))
         @nvtx "precomputed quantities" color = colorant"orange" begin

--- a/src/utils/debug_utils.jl
+++ b/src/utils/debug_utils.jl
@@ -195,4 +195,6 @@ end
 
 Fill a data structure's `Field`s / `FieldVector`s with NaNs.
 """
-fill_with_nans!(p) = fill_with_nans_generic!(p)
+fill_with_nans!(p) = fill_with_nans!(p, p.test)
+fill_with_nans!(p, ::Nothing) = nothing
+fill_with_nans!(p, ::TestDycoreConsistency) = fill_with_nans_generic!(p)


### PR DESCRIPTION
This PR makes `fill_with_nans!` itself do dispatch, so that it doesn't show up in the inference dict.