### PR TITLE
Assert`SurfaceState` type fix

### DIFF
--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -61,7 +61,7 @@ function update_surface_conditions!(Y, p, t)
             atmos,
         )
     elseif sfc_setup isa Fields.Field # This case is needed for the Coupler
-        @assert eltype(sfc_setup) isa SurfaceState
+        @assert eltype(sfc_setup) <: SurfaceState
         sfc_setup_values = Fields.field_values(sfc_setup)
         @. sfc_conditions_values = surface_state_to_conditions(
             sfc_setup_values,


### PR DESCRIPTION
Fix when asserting type of `SurfaceState` for coupled runs. 

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
closes #1802 

(see issue for details)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
