### PR TITLE
Remove more bycolumn loops

### DIFF
--- a/src/prognostic_equations/pressure_work.jl
+++ b/src/prognostic_equations/pressure_work.jl
@@ -2,15 +2,14 @@
 ##### Pressure work
 #####
 
-function pressure_work_tendency!(Yₜ, Y, p, t, colidx, ::EDMFX)
+function pressure_work_tendency!(Yₜ, Y, p, t, ::EDMFX)
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
     (; ᶜp) = p
     for j in 1:n
         if :ρe_tot in propertynames(Y.c)
-            @. Yₜ.c.sgsʲs.:($$j).ρae_tot[colidx] -=
-                ᶜp[colidx] / Y.c.ρ[colidx] * Yₜ.c.sgsʲs.:($$j).ρa[colidx]
+            @. Yₜ.c.sgsʲs.:($$j).ρae_tot -= ᶜp / Y.c.ρ * Yₜ.c.sgsʲs.:($$j).ρa
         end
     end
 end
 
-pressure_work_tendency!(Yₜ, Y, p, t, colidx, ::Any) = nothing
+pressure_work_tendency!(Yₜ, Y, p, t, ::Any) = nothing

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -52,13 +52,14 @@ function additional_tendency!(Yₜ, Y, p, t)
         edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
         explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
         precipitation_tendency!(Yₜ, Y, p, t, colidx, p.precip_model)
-        # NOTE: All ρa tendencies should be applied before calling this function
-        pressure_work_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
-
-        # NOTE: This will zero out all monmentum tendencies in the edmfx advection test
-        # please DO NOT add additional velocity tendencies after this function
-        zero_velocity_tendency!(Yₜ, Y, p, t, colidx)
     end
+
+    # NOTE: All ρa tendencies should be applied before calling this function
+    pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+
+    # NOTE: This will zero out all monmentum tendencies in the edmfx advection test
+    # please DO NOT add additional velocity tendencies after this function
+    zero_velocity_tendency!(Yₜ, Y, p, t)
     # TODO: make bycolumn-able
     non_orographic_gravity_wave_tendency!(
         Yₜ,

--- a/src/prognostic_equations/zero_velocity.jl
+++ b/src/prognostic_equations/zero_velocity.jl
@@ -2,18 +2,17 @@
 ### edmfx advection test 
 ###
 
-function zero_velocity_tendency!(Yₜ, Y, p, t, colidx)
+function zero_velocity_tendency!(Yₜ, Y, p, t)
     # turn off all monmentum tendencies in the advection test
     if p.atmos.edmfx_adv_test
         FT = eltype(Y)
         n = n_mass_flux_subdomains(p.atmos.turbconv_model)
 
-        @. Yₜ.c.uₕ[colidx] = C12(FT(0), FT(0))
-        @. Yₜ.f.u₃[colidx] = Geometry.Covariant3Vector(FT(0))
+        @. Yₜ.c.uₕ = C12(FT(0), FT(0))
+        @. Yₜ.f.u₃ = Geometry.Covariant3Vector(FT(0))
         if p.atmos.turbconv_model isa EDMFX
             for j in 1:n
-                @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] =
-                    Geometry.Covariant3Vector(FT(0))
+                @. Yₜ.f.sgsʲs.:($$j).u₃ = Geometry.Covariant3Vector(FT(0))
             end
         end
     end


### PR DESCRIPTION
This PR removes more `bycolumn` loops. These calls are inside the implicit tendency, which are still called with explicit solvers (except that the tendencies are added explicitly). This was found in this [build](https://buildkite.com/clima/climaatmos-ci/builds/10597#0188d9a4-752f-4a25-8841-b4d7aebff0bc).

This should fix some rather large performance issues for the gpu example (cc @bloops)

The benchmark is looking more promising:

Main branch:
`[ Info: Ran step! 10 times in 17.764 s (45437150 allocations: 9.56 GiB), (1.780 s per step)`
This PR:
`[ Info: Ran step! 10 times in 127.031 ms (244420 allocations: 35.30 MiB), (15.710 ms per step)`

I will say, one thing is very odd: why is the benchmark, which runs 20 steps, so much faster than the target job, which runs 60 steps? (at `15.710 ms` per step, the difference should be < 1 second)