### PR TITLE
Revert "Remove some bycolumn calls"

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -101,8 +101,11 @@ end
 
 # Interpolates the third contravariant component of Y.c.uₕ to cell faces.
 function set_ᶠuₕ³!(ᶠuₕ³, Y)
-    ᶜJ = Fields.local_geometry_field(Y.c).J
-    @. ᶠuₕ³ = ᶠwinterp(Y.c.ρ * ᶜJ, CT3(Y.c.uₕ))
+    Fields.bycolumn(axes(Y.c)) do colidx
+        ᶜJ = Fields.local_geometry_field(Y.c).J
+        @. ᶠuₕ³[colidx] =
+            ᶠwinterp(Y.c.ρ[colidx] * ᶜJ[colidx], CT3(Y.c.uₕ[colidx]))
+    end
 end
 
 """
@@ -129,29 +132,45 @@ end
 # This is used to set the grid-scale velocity quantities ᶜu, ᶠu³, ᶜK based on
 # ᶠu₃, and it is also used to set the SGS quantities based on ᶠu₃⁰ and ᶠu₃ʲ.
 function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠu₃, ᶜuₕ, ᶠuₕ³)
-    @. ᶜu = C123(ᶜuₕ) + ᶜinterp(C123(ᶠu₃))
-    @. ᶠu³ = ᶠuₕ³ + CT3(ᶠu₃)
-    compute_kinetic!(ᶜK, ᶜuₕ, ᶠu₃)
+    Fields.bycolumn(axes(ᶜu)) do colidx
+        @. ᶜu[colidx] = C123(ᶜuₕ[colidx]) + ᶜinterp(C123(ᶠu₃[colidx]))
+        @. ᶠu³[colidx] = ᶠuₕ³[colidx] + CT3(ᶠu₃[colidx])
+        compute_kinetic!(ᶜK[colidx], ᶜuₕ[colidx], ᶠu₃[colidx])
+    end
 end
 
 function set_sgs_ᶠu₃!(w_function, ᶠu₃, Y, turbconv_model)
     ρaʲs(sgsʲs) = map(sgsʲ -> sgsʲ.ρa, sgsʲs)
     u₃ʲs(sgsʲs) = map(sgsʲ -> sgsʲ.u₃, sgsʲs)
-    @. ᶠu₃ = w_function(
-        ᶠinterp(ρaʲs(Y.c.sgsʲs)),
-        u₃ʲs(Y.f.sgsʲs),
-        ᶠinterp(Y.c.ρ),
-        Y.f.u₃,
-        turbconv_model,
-    )
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. ᶠu₃[colidx] = w_function(
+            ᶠinterp(ρaʲs(Y.c.sgsʲs[colidx])),
+            u₃ʲs(Y.f.sgsʲs[colidx]),
+            ᶠinterp(Y.c.ρ[colidx]),
+            Y.f.u₃[colidx],
+            turbconv_model,
+        )
+    end
 end
 
 function add_sgs_ᶜK!(ᶜK, Y, ᶜρa⁰, ᶠu₃⁰, turbconv_model)
-    @. ᶜK += ᶜρa⁰ * ᶜinterp(dot(ᶠu₃⁰ - Yf.u₃, CT3(ᶠu₃⁰ - Yf.u₃))) / 2 / Yc.ρ
-    for j in 1:n_mass_flux_subdomains(turbconv_model)
-        ᶜρaʲ = Y.c.sgsʲs.:($j).ρa
-        ᶠu₃ʲ = Y.f.sgsʲs.:($j).u₃
-        @. ᶜK += ᶜρaʲ * ᶜinterp(dot(ᶠu₃ʲ - Yf.u₃, CT3(ᶠu₃ʲ - Yf.u₃))) / 2 / Yc.ρ
+    function do_col!(ᶜK, Yc, Yf, ᶜρa⁰, ᶠu₃⁰)
+        @. ᶜK += ᶜρa⁰ * ᶜinterp(dot(ᶠu₃⁰ - Yf.u₃, CT3(ᶠu₃⁰ - Yf.u₃))) / 2 / Yc.ρ
+        for j in 1:n_mass_flux_subdomains(turbconv_model)
+            ᶜρaʲ = Yc.sgsʲs.:($j).ρa
+            ᶠu₃ʲ = Yf.sgsʲs.:($j).u₃
+            @. ᶜK +=
+                ᶜρaʲ * ᶜinterp(dot(ᶠu₃ʲ - Yf.u₃, CT3(ᶠu₃ʲ - Yf.u₃))) / 2 / Yc.ρ
+        end
+    end
+    Fields.bycolumn(axes(Y.c)) do colidx
+        do_col!(
+            ᶜK[colidx],
+            Y.c[colidx],
+            Y.f[colidx],
+            ᶜρa⁰[colidx],
+            ᶠu₃⁰[colidx],
+        )
     end
 end
 

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -86,7 +86,9 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         @. ᶜω³ = zero(ᶜω³)
     end
 
-    @. ᶠω¹² = ᶠcurlᵥ(Y.c.uₕ)
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. ᶠω¹²[colidx] = ᶠcurlᵥ(Y.c.uₕ[colidx])
+    end
     if p.atmos.turbconv_model isa EDMFX
         for j in 1:n
             @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
@@ -100,15 +102,26 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 
-    @. Yₜ.c.uₕ -=
-        ᶜinterp(ᶠω¹² × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
-        (ᶜf + ᶜω³) × CT12(ᶜu)
-    @. Yₜ.f.u₃ -= ᶠω¹² × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
-    if p.atmos.turbconv_model isa EDMFX
-        (; ᶜuʲs, ᶜKʲs) = p
-        for j in 1:n
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-                ᶠω¹²ʲs.:($$j) × ᶠinterp(CT12(ᶜuʲs.:($$j))) + ᶠgradᵥ(ᶜKʲs.:($$j))
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. Yₜ.c.uₕ[colidx] -=
+            ᶜinterp(
+                ᶠω¹²[colidx] ×
+                (ᶠinterp(Y.c.ρ[colidx] * ᶜJ[colidx]) * ᶠu³[colidx]),
+            ) / (Y.c.ρ[colidx] * ᶜJ[colidx]) +
+            (ᶜf[colidx] + ᶜω³[colidx]) × CT12(ᶜu[colidx])
+        @. Yₜ.f.u₃[colidx] -=
+            ᶠω¹²[colidx] × ᶠinterp(CT12(ᶜu[colidx])) + ᶠgradᵥ(ᶜK[colidx])
+        if p.atmos.turbconv_model isa EDMFX
+            for j in 1:n
+                # TODO: Figure out why putting these extractions outside of the
+                # bycolumn triggers a lot of allocations.
+                (; ᶜuʲs, ᶜKʲs) = p
+                local ᶠω¹²ʲs = p.ᶠtemp_CT12ʲs # Adding `local` reduces allocations.
+
+                @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] -=
+                    ᶠω¹²ʲs.:($$j)[colidx] × ᶠinterp(CT12(ᶜuʲs.:($$j)[colidx])) +
+                    ᶠgradᵥ(ᶜKʲs.:($$j)[colidx])
+            end
         end
     end
 


### PR DESCRIPTION
In light of https://github.com/CliMA/ClimaCore.jl/pull/1341, this PR reverts https://github.com/CliMA/ClimaAtmos.jl/pull/1765.

It's unclear to me that threading over these loops is effective. There's not as much compute in them compared to the one in `additional_tendency!`.