### PR TITLE
Allocations fix for diagnostic edmf

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -850,6 +850,12 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":fire: Flame graph: perf target (diagnostic edmfx)"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_diagnostic_edmfx --target_job diagnostic_edmfx_aquaplanet"
+        artifact_paths: "flame_perf_target_diagnostic_edmfx/*"
+        agents:
+          slurm_mem: 20GB
+
       - label: ":fire: Flame graph: perf target (edmf)"
         command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_edmf --target_job sphere_baroclinic_wave_rhoe_equilmoist_edmf --moist dry --precip_model nothing --rad nothing"
         artifact_paths: "flame_perf_target_edmf/*"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -56,6 +56,7 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 4320
 allocs_limit["flame_perf_target_tracers"] = 185904
 allocs_limit["flame_perf_target_edmfx"] = 277568
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 10288
 allocs_limit["flame_perf_target_edmf"] = 8504529520
 allocs_limit["flame_perf_target_threaded"] = 6175664
 allocs_limit["flame_perf_target_callbacks"] = 42862456

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -298,16 +298,27 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
                     (entr_detrʲ_prev_level.entr - entr_detrʲ_prev_level.detr)
                 )
 
+            # Using constant exponents in broadcasts allocate, so we use
+            # local_geometry_halflevel.J * local_geometry_halflevel.J instead.
+            # See ClimaCore.jl issue #1126.
             @. u³ʲ_datau³ʲ_data =
-                (1 / local_geometry_halflevel.J^2) * (
-                    local_geometry_prev_halflevel.J^2 *
+                (
+                    1 /
+                    (local_geometry_halflevel.J * local_geometry_halflevel.J)
+                ) * (
+                    local_geometry_prev_halflevel.J *
+                    local_geometry_prev_halflevel.J *
                     u³ʲ_data_prev_halflevel *
                     u³ʲ_data_prev_halflevel
                 )
 
             @. u³ʲ_datau³ʲ_data -=
-                (1 / local_geometry_halflevel.J^2) * (
-                    local_geometry_prev_level.J^2 *
+                (
+                    1 /
+                    (local_geometry_halflevel.J * local_geometry_halflevel.J)
+                ) * (
+                    local_geometry_prev_level.J *
+                    local_geometry_prev_level.J *
                     FT(2) *
                     (
                         ∇Φ³_prev_level_data * (ρʲ_prev_level - ρ_prev_level) /
@@ -316,28 +327,33 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
                 )
 
             @. u³ʲ_datau³ʲ_data +=
-                (1 / local_geometry_halflevel.J^2) * (
-                    local_geometry_prev_level.J^2 *
+                (
+                    1 /
+                    (local_geometry_halflevel.J * local_geometry_halflevel.J)
+                ) * (
+                    local_geometry_prev_level.J *
+                    local_geometry_prev_level.J *
                     FT(2) *
                     (
                         entr_detrʲ_prev_level.entr * u³⁰_data_prev_halflevel -
                         entr_detrʲ_prev_level.entr * u³ʲ_data_prev_halflevel
                     )
                 )
-
+            scale_factor = FT(1e-6)
             @. u³ʲ_halflevel = ifelse(
                 (
-                    u³ʲ_datau³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level^2) ||
-                    ρaʲu³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level)
+                    u³ʲ_datau³ʲ_data <
+                    (scale_factor / (∂x³∂ξ³_level * ∂x³∂ξ³_level)) ||
+                    ρaʲu³ʲ_data < (scale_factor / ∂x³∂ξ³_level)
                 ),
                 CT3(FT(0)),
                 CT3(sqrt(max(FT(0), u³ʲ_datau³ʲ_data))),
             )
-
             @. ρaʲ_level = ifelse(
                 (
-                    u³ʲ_datau³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level^2) ||
-                    ρaʲu³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level)
+                    u³ʲ_datau³ʲ_data <
+                    (scale_factor / (∂x³∂ξ³_level * ∂x³∂ξ³_level)) ||
+                    ρaʲu³ʲ_data < (scale_factor / ∂x³∂ξ³_level)
                 ),
                 FT(0),
                 ρaʲu³ʲ_data / sqrt(max(FT(0), u³ʲ_datau³ʲ_data)),
@@ -361,8 +377,9 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
                 )
             @. h_totʲ_level = ifelse(
                 (
-                    u³ʲ_datau³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level^2) ||
-                    ρaʲu³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level)
+                    u³ʲ_datau³ʲ_data <
+                    (scale_factor / (∂x³∂ξ³_level * ∂x³∂ξ³_level)) ||
+                    ρaʲu³ʲ_data < (scale_factor / ∂x³∂ξ³_level)
                 ),
                 h_tot_level,
                 ρaʲu³ʲ_datah_tot / ρaʲu³ʲ_data,
@@ -386,8 +403,9 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, turbconv_model)
                 )
             @. q_totʲ_level = ifelse(
                 (
-                    u³ʲ_datau³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level^2) ||
-                    ρaʲu³ʲ_data < (FT(1e-6) / ∂x³∂ξ³_level)
+                    u³ʲ_datau³ʲ_data <
+                    (scale_factor / (∂x³∂ξ³_level * ∂x³∂ξ³_level)) ||
+                    ρaʲu³ʲ_data < (scale_factor / ∂x³∂ξ³_level)
                 ),
                 q_tot_level,
                 ρaʲu³ʲ_dataq_tot / ρaʲu³ʲ_data,


### PR DESCRIPTION
This PR:
- fixes allocations for `set_diagnostic_edmf_precomputed_quantities!`
- Adds a performance test for job diagnostic_edmfx_aquaplanet

