### PR TITLE
Fix names, return nothing, add dt_save_to_disk to cb flame

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -857,7 +857,7 @@ steps:
           slurm_mem: 20GB
 
       - label: ":fire: Flame graph: perf target (Callbacks)"
-        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_callbacks --dt_save_to_sol 1secs --dt_save_restart 1secs --dt_rad 1secs"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_target_callbacks --dt_save_to_sol 1secs --dt_save_to_disk 1secs --dt_save_restart 1secs --dt_rad 1secs"
         artifact_paths: "flame_perf_target_callbacks/*"
         agents:
           slurm_mem: 20GB

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -58,7 +58,7 @@ allocs_limit["flame_perf_target_tracers"] = 185904
 allocs_limit["flame_perf_target_edmfx"] = 277568
 allocs_limit["flame_perf_target_edmf"] = 8504529520
 allocs_limit["flame_perf_target_threaded"] = 6175664
-allocs_limit["flame_perf_target_callbacks"] = 8489208
+allocs_limit["flame_perf_target_callbacks"] = 42862456
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -51,7 +51,7 @@ function call_every_dt(f!, dt; skip_first = false, call_at_end = false)
     )
 end
 
-function dss_callback(integrator)
+function dss_callback!(integrator)
     Y = integrator.u
     ghost_buffer = integrator.p.ghost_buffer
     if integrator.p.do_dss
@@ -64,7 +64,7 @@ function dss_callback(integrator)
             Spaces.weighted_dss_ghost2!(Y.f, ghost_buffer.f)
         end
     end
-    # ODE.u_modified!(integrator, false) # TODO: try this
+    return nothing
 end
 
 horizontal_integral_at_boundary(f, lev) = sum(
@@ -83,6 +83,7 @@ function flux_accumulation!(integrator)
         net_energy_flux_sfc[] +=
             horizontal_integral_at_boundary(ᶠradiation_flux, half) * Δt
     end
+    return nothing
 end
 
 function turb_conv_affect_filter!(integrator)
@@ -241,6 +242,7 @@ function rrtmgp_model_callback!(integrator)
 
     RRTMGPI.update_fluxes!(radiation_model)
     RRTMGPI.field2array(ᶠradiation_flux) .= radiation_model.face_flux
+    return nothing
 end
 
 function save_to_disk_func(integrator)
@@ -537,4 +539,5 @@ function gc_func(integrator)
         "# pause" = num_post.pause,
         "# full_sweep" = num_post.full_sweep,
     )
+    return nothing
 end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -493,7 +493,7 @@ function get_callbacks(parsed_args, simulation, atmos, params)
     dt_save_restart = time_to_seconds(parsed_args["dt_save_restart"])
 
     dss_cb = if startswith(parsed_args["ode_algo"], "ODE.")
-        call_every_n_steps(dss_callback)
+        call_every_n_steps(dss_callback!)
     else
         nothing
     end


### PR DESCRIPTION
This PR:
 - Fixes some names, based on naming conventions (append `!` for mutating functions)
 - Returns `nothing` for some functions, to ensure we don't accidentally allocate
 - Adds the `dt_save_to_disk` callback to the flame graph