### PR TITLE
Add flame graph for gravity wave kernels

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -862,6 +862,12 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":fire: Flame graph: gravity wave"
+        command: "julia --color=yes --project=perf perf/flame.jl --job_id flame_perf_gw --z_max 45e3 --z_elem 25 --dz_bottom 300 --idealized_insolation false --vert_diff true --surface_setup DefaultMoninObukhov --moist equil --rad allskywithclear --non_orographic_gravity_wave true --orographic_gravity_wave raw_topo --precip_model 0M --rayleigh_sponge true --alpha_rayleigh_uh 0 --zd_rayleigh 30e3 --dt 1secs --t_end 1mins --dt_save_to_disk Inf"
+        artifact_paths: "flame_perf_gw/*"
+        agents:
+          slurm_mem: 20GB
+
       # Inference
       - label: ":rocket: JET n-failures (inference)"
         command: "julia --color=yes --project=perf perf/jet_test_nfailures.jl --job_id jet_n_failures --target_job sphere_baroclinic_wave_rhoe_equilmoist_edmf --moist dry --precip_model nothing --rad nothing"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -59,6 +59,7 @@ allocs_limit["flame_perf_target_edmfx"] = 277568
 allocs_limit["flame_perf_target_edmf"] = 8504529520
 allocs_limit["flame_perf_target_threaded"] = 6175664
 allocs_limit["flame_perf_target_callbacks"] = 42862456
+allocs_limit["flame_perf_gw"] = 4968227104
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"


### PR DESCRIPTION
Turning on the gravity wave results in lots of allocations-- the `aquaplanet (ρe_tot) equilmoist allsky radiation monin_obukhov varying insolation gravity wave (raw_topo) high top` job allocates 185.00 GiB, which is a lot considering it only performs 162 steps.

This PR adds a flame graph, and allocation limit for a job that includes gravity wave.

This means that further developments in these kernels will be throttled by allocation tests.