### PR TITLE
Refactor callbacks, define `cycle!`

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -165,7 +165,8 @@ if config.parsed_args["regression_test"]
     )
 end
 
-
+@info "Callback verification, n_expected_calls: $(CA.n_expected_calls(integrator))"
+@info "Callback verification, n_measured_calls: $(CA.n_measured_calls(integrator))"
 
 if config.parsed_args["check_conservation"]
     FT = Spaces.undertype(axes(sol.u[end].c.ρ))

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -53,14 +53,14 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 @info "`allocs ($job_id)`: $(allocs)"
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target"] = 4320
-allocs_limit["flame_perf_target_tracers"] = 185904
-allocs_limit["flame_perf_target_edmfx"] = 277568
-allocs_limit["flame_perf_target_diagnostic_edmfx"] = 10288
-allocs_limit["flame_perf_target_edmf"] = 8504529520
+allocs_limit["flame_perf_target"] = 4384
+allocs_limit["flame_perf_target_tracers"] = 185968
+allocs_limit["flame_perf_target_edmfx"] = 277760
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 10480
+allocs_limit["flame_perf_target_edmf"] = 7326724944
 allocs_limit["flame_perf_target_threaded"] = 6175664
-allocs_limit["flame_perf_target_callbacks"] = 42897376
-allocs_limit["flame_perf_gw"] = 4968227104
+allocs_limit["flame_perf_target_callbacks"] = 42862920
+allocs_limit["flame_perf_gw"] = 4887558624
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -1,0 +1,97 @@
+import DiffEqCallbacks
+#####
+##### Callback helpers
+#####
+
+function call_every_n_steps(f!, n = 1; skip_first = false, call_at_end = false)
+    previous_step = Ref(0)
+    cb! = AtmosCallback(f!, EveryNSteps(n))
+    return ODE.DiscreteCallback(
+        (u, t, integrator) ->
+            (previous_step[] += 1) % n == 0 ||
+                (call_at_end && t == integrator.sol.prob.tspan[2]),
+        cb!;
+        initialize = (cb, u, t, integrator) -> skip_first || cb!(integrator),
+        save_positions = (false, false),
+    )
+end
+
+function call_every_dt(f!, dt; skip_first = false, call_at_end = false)
+    cb! = AtmosCallback(f!, EveryΔt(dt))
+    next_t = Ref{typeof(dt)}()
+    affect! = function (integrator)
+        cb!(integrator)
+
+        t = integrator.t
+        t_end = integrator.sol.prob.tspan[2]
+        next_t[] = max(t, next_t[] + dt)
+        if call_at_end
+            next_t[] = min(next_t[], t_end)
+        end
+    end
+    return ODE.DiscreteCallback(
+        (u, t, integrator) -> t >= next_t[],
+        affect!;
+        initialize = (cb, u, t, integrator) -> begin
+            skip_first || cb!(integrator)
+            t_end = integrator.sol.prob.tspan[2]
+            next_t[] =
+                (call_at_end && t < t_end) ? min(t_end, t + dt) : t + dt
+        end,
+        save_positions = (false, false),
+    )
+end
+
+callback_from_affect(x::AtmosCallback) = x
+function callback_from_affect(affect!)
+    for p in propertynames(affect!)
+        x = getproperty(affect!, p)
+        if x isa AtmosCallback
+            return x
+        elseif x isa DiffEqCallbacks.SavedValues
+            return x
+        end
+    end
+    error("Callback not found in $(affect!)")
+end
+function atmos_callbacks(cbs::ODE.CallbackSet)
+    all_cbs = [cbs.continuous_callbacks..., cbs.discrete_callbacks...]
+    callback_objs = map(cb -> callback_from_affect(cb.affect!), all_cbs)
+    filter!(x -> !(x isa DiffEqCallbacks.SavedValues), callback_objs)
+    return callback_objs
+end
+
+n_measured_calls(integrator) = n_measured_calls(integrator.callback)
+n_measured_calls(cbs::ODE.CallbackSet) =
+    map(x -> x.n_measured_calls, atmos_callbacks(cbs))
+
+n_expected_calls(integrator) = n_expected_calls(
+    integrator.callback,
+    integrator.dt,
+    integrator.sol.prob.tspan,
+)
+n_expected_calls(cbs::ODE.CallbackSet, dt, tspan) =
+    map(x -> n_expected_calls(x, dt, tspan), atmos_callbacks(cbs))
+
+n_steps_per_cycle(integrator) =
+    n_steps_per_cycle(integrator.callback, integrator.dt)
+function n_steps_per_cycle(cbs::ODE.CallbackSet, dt)
+    nspc = n_steps_per_cycle_per_cb(cbs, dt)
+    return isempty(nspc) ? 1 : lcm(nspc)
+end
+
+n_steps_per_cycle_per_cb(integrator) =
+    n_steps_per_cycle_per_cb(integrator.callback, integrator.dt)
+
+function n_steps_per_cycle_per_cb(cbs::ODE.CallbackSet, dt)
+    return map(atmos_callbacks(cbs)) do cb
+        cbf = callback_frequency(cb)
+        if cbf isa EveryΔt
+            Int(cbf.Δt / dt)
+        elseif cbf isa EveryNSteps
+            cbf.n
+        else
+            error("Uncaught case")
+        end
+    end
+end

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -14,42 +14,7 @@ import Dates
 using Insolation: instantaneous_zenith_angle
 import ClimaCore.Fields: ColumnField
 
-function call_every_n_steps(f!, n = 1; skip_first = false, call_at_end = false)
-    previous_step = Ref(0)
-    return ODE.DiscreteCallback(
-        (u, t, integrator) ->
-            (previous_step[] += 1) % n == 0 ||
-                (call_at_end && t == integrator.sol.prob.tspan[2]),
-        f!;
-        initialize = (cb, u, t, integrator) -> skip_first || f!(integrator),
-        save_positions = (false, false),
-    )
-end
-
-function call_every_dt(f!, dt; skip_first = false, call_at_end = false)
-    next_t = Ref{typeof(dt)}()
-    affect! = function (integrator)
-        f!(integrator)
-
-        t = integrator.t
-        t_end = integrator.sol.prob.tspan[2]
-        next_t[] = max(t, next_t[] + dt)
-        if call_at_end
-            next_t[] = min(next_t[], t_end)
-        end
-    end
-    return ODE.DiscreteCallback(
-        (u, t, integrator) -> t >= next_t[],
-        affect!;
-        initialize = (cb, u, t, integrator) -> begin
-            skip_first || f!(integrator)
-            t_end = integrator.sol.prob.tspan[2]
-            next_t[] =
-                (call_at_end && t < t_end) ? min(t_end, t + dt) : t + dt
-        end,
-        save_positions = (false, false),
-    )
-end
+include("callback_helpers.jl")
 
 function dss_callback!(integrator)
     Y = integrator.u

--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -124,3 +124,22 @@ function benchmark_step!(integrator, Y₀, n_steps = 10)
     end
     return nothing
 end
+
+"""
+    cycle!(integrator; n_cycles = 1)
+
+Run `step!` the least common multiple times
+for all callbacks. i.e., all callbacks will
+have been called at least `n_cycles` times.
+
+`cycle!` is the true atomic unit for performance,
+because, unlike `step!`, it takes all callbacks
+into account.
+"""
+function cycle!(integrator; n_cycles = 1)
+    n_steps = n_steps_per_cycle(integrator) * n_cycles
+    for i in 1:n_steps
+        ODE.step!(integrator)
+    end
+    return nothing
+end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -728,6 +728,8 @@ function get_integrator(config::AtmosConfig)
         callback = get_callbacks(config.parsed_args, simulation, atmos, params)
     end
     @info "get_callbacks: $s"
+    @info "n_steps_per_cycle_per_cb: $(n_steps_per_cycle_per_cb(callback, simulation.dt))"
+    @info "n_steps_per_cycle: $(n_steps_per_cycle(callback, simulation.dt))"
     tspan = (t_start, simulation.t_end)
     s = @timed_str begin
         integrator_args, integrator_kwargs = args_integrator(


### PR DESCRIPTION
This PR defines `cycle!`, which is the true atomic unit for performance. Unfortunately, `cycle!` can sometimes require running `step!` many times when callback frequencies have large common multiple frequencies.

This is causing the flame scripts to OOM, so I'll tackle that separately since some of this PR shares needs to fix #1823.