### PR TITLE
Add function to call callbacks and precompile

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -9,6 +9,7 @@ integrator = CA.get_integrator(config)
 
 import OrdinaryDiffEq
 OrdinaryDiffEq.step!(integrator) # compile first
+CA.call_all_callbacks!(integrator) # compile callbacks
 import Profile, ProfileCanvas
 (; output_dir, job_id) = integrator.p.simulation
 output_dir = job_id


### PR DESCRIPTION
This PR:
 - Adds a function, `precompile_atmos` to precompile `step!` and all callbacks. This should improve our understanding of the log in that the reported timings will be mostly runtime, and exclude compiletime.
 - Adds a function `call_all_callbacks!` (called by `precompile_atmos`), closes #1823.