### PR TITLE
Fix surface fluxes

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -379,24 +379,24 @@ function compute_diagnostics(integrator)
     if !isnothing(p.atmos.vert_diff)
         sfc_local_geometry =
             Fields.level(Fields.local_geometry_field(Y.f), Fields.half)
-        surface_ct3_unit =
-            CT3.(unit_basis_vector_data.(CT3, sfc_local_geometry))
+        surface_c3_unit =
+            C3.(unit_basis_vector_data.(C3, sfc_local_geometry))
         (; ρ_flux_uₕ, ρ_flux_h_tot) = p.sfc_conditions
         sfc_flux_momentum =
             Geometry.UVVector.(
                 adjoint.(ρ_flux_uₕ ./ Spaces.level(ᶠinterp.(Y.c.ρ), half)) .*
-                surface_ct3_unit
+                surface_c3_unit
             )
         vert_diff_diagnostic = (;
             sfc_flux_u = sfc_flux_momentum.components.data.:1,
             sfc_flux_v = sfc_flux_momentum.components.data.:2,
-            sfc_flux_energy = dot.(ρ_flux_h_tot, surface_ct3_unit),
+            sfc_flux_energy = dot.(ρ_flux_h_tot, surface_c3_unit),
         )
         if :ρq_tot in propertynames(Y.c)
             (; ρ_flux_q_tot) = p.sfc_conditions
             vert_diff_diagnostic = (;
                 vert_diff_diagnostic...,
-                sfc_evaporation = dot.(ρ_flux_q_tot, surface_ct3_unit),
+                sfc_evaporation = dot.(ρ_flux_q_tot, surface_c3_unit),
             )
         end
     else

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -379,13 +379,12 @@ function compute_diagnostics(integrator)
     if !isnothing(p.atmos.vert_diff)
         sfc_local_geometry =
             Fields.level(Fields.local_geometry_field(Y.f), Fields.half)
-        surface_c3_unit =
-            C3.(unit_basis_vector_data.(C3, sfc_local_geometry))
+        surface_c3_unit = C3.(unit_basis_vector_data.(C3, sfc_local_geometry))
         (; ρ_flux_uₕ, ρ_flux_h_tot) = p.sfc_conditions
         sfc_flux_momentum =
             Geometry.UVVector.(
                 adjoint.(ρ_flux_uₕ ./ Spaces.level(ᶠinterp.(Y.c.ρ), half)) .*
-                surface_c3_unit
+                Geometry.project.(Geometry.Covariant3Axis.(), surface_c3_unit)
             )
         vert_diff_diagnostic = (;
             sfc_flux_u = sfc_flux_momentum.components.data.:1,


### PR DESCRIPTION
Surface normal is from normalized `Covariant3Vector(1)` (as that is the contravariant basis vector)

I missed this in the review of #1856. It should only affect runs with topography.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
