### PR TITLE
Fix leaky tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using SafeTestsets
 using Test
 
-@safetestset "Aqua" begin
-    @time include("utilities.jl")
-    @time include("parameter_tests.jl")
-    @time include("aqua.jl")
-end
+#! format: off
+@safetestset "Aqua" begin @time include("aqua.jl") end
+@safetestset "Utilities" begin @time include("utilities.jl") end
+@safetestset "Parameter tests" begin @time include("parameter_tests.jl") end
+#! format: on
 
 nothing


### PR DESCRIPTION
This PR wraps each of the tests in safe testsets. The existing problem is that later tests can use (or even rely on) variables from earlier tests.