### PR TITLE
Adding a plot for scaling benchmark

### DIFF
--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -27,7 +27,7 @@ parsed_args["dt"] = "50secs"
 steptimes = []
 
 # Iterate through varying number of horizontal elements
-for h_elem in 8:8:64
+for h_elem in 8:8:40
     parsed_args["h_elem"] = h_elem
     config = CA.AtmosConfig(; parsed_args)
     integrator = CA.get_integrator(config)

--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -18,7 +18,7 @@ using PrettyTables
 
 s = CA.argparse_settings()
 parsed_args = CA.parse_commandline(s);
-output_dir = "gpu_implicit_barowave_wrt_h_elem/report"
+output_dir = joinpath(parsed_args["job_id"])
 
 # Set non-varying arguments
 parsed_args["z_elem"] = 50

--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -1,11 +1,10 @@
 #=
 ```
-julia --project=examples perf/benchmark_dump.jl --output=report
+julia --project=examples perf/benchmark_dump.jl
 ```
 Or, interactively,
 ```
 julia --project=examples
-push!(ARGS, "--output", "report")
 include(joinpath("perf", "benchmark_dump.jl"));
 ```
 =#
@@ -69,5 +68,13 @@ pretty_table(
 )
 
 # Output a plot of step time scaling
-p = Plots.plot(first.(steptimes), last.(steptimes); title="Step Times v/s Horizontal Elements", xlabel="h_elem", ylabel="time (ms)", label="step time", linewidth=3)
+p = Plots.plot(
+    first.(steptimes),
+    last.(steptimes);
+    title = "Step Times v/s Horizontal Elements",
+    xlabel = "h_elem",
+    ylabel = "time (ms)",
+    label = "step time",
+    linewidth = 3,
+)
 Plots.png(p, joinpath(output_dir, "scaling.png"))


### PR DESCRIPTION
Adds a plot for step time v/s horizontal elements.

Also updates the parameters `z_elem` and `dt` to be closer to the target resolution.

## To-do
- Should the output directory be read from the commandline arguments instead of being hardcoded?

----
- [x] I have read and checked the items on the review checklist.
