### PR TITLE
Remove unused --coupled CLI option

### DIFF
--- a/src/solver/cli_options.jl
+++ b/src/solver/cli_options.jl
@@ -102,10 +102,6 @@ function argparse_settings()
         help = "Bulk transfer coefficient"
         arg_type = Float64
         default = Float64(0.0044)
-        "--coupled"
-        help = "Coupled simulation [`false` (default), `true`]"
-        arg_type = Bool
-        default = false
         "--turbconv"
         help = "Turbulence convection scheme [`nothing` (default), `edmf`]"
         arg_type = String


### PR DESCRIPTION
## Purpose 
Closes #1894 

## Content
- Removed unused `--coupled` CLI option

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
