### PR TITLE
Add CPU/GPU reference test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -788,23 +788,23 @@ steps:
         agents:
           slurm_mem: 20GB
 
-  - group: "CUDA"
+  - group: "GPU"
     steps:
 
-      - label: "CUDA: CUDA implicit baro wave"
-        key: "cuda_implicit_barowave_ref"
+      - label: "GPU: GPU implicit baro wave"
+        key: "gpu_implicit_barowave_ref"
         command:
           - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
-          - "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id cuda_implicit_barowave_ref --dt 580secs --t_end 10days --dt_save_to_disk 2days --initial_condition DryBaroclinicWave --dt_save_to_sol Inf"
-        artifact_paths: "cuda_implicit_barowave_ref/*"
+          - "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id gpu_implicit_barowave_ref --dt 580secs --t_end 10days --dt_save_to_disk 2days --initial_condition DryBaroclinicWave --dt_save_to_sol Inf"
+        artifact_paths: "gpu_implicit_barowave_ref/*"
         agents:
           slurm_gpus: 1
 
-      - label: "CUDA: compare with CPU"
-        command: "julia --color=yes --project=examples post_processing/compare_outputs.jl --output_folder_1 sphere_baroclinic_wave_rhoe/ --output_folder_2 cuda_implicit_barowave_ref --t_end 10days --compare_state false --compare_diagnostics false"
+      - label: "GPU: compare with CPU"
+        command: "julia --color=yes --project=examples post_processing/compare_outputs.jl --output_folder_1 sphere_baroclinic_wave_rhoe/ --output_folder_2 gpu_implicit_barowave_ref --t_end 10days --compare_state false --compare_diagnostics false"
         depends_on:
           - "sphere_baroclinic_wave_rhoe"
-          - "cuda_implicit_barowave_ref"
+          - "gpu_implicit_barowave_ref"
 
   - group: "GPU Performance"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,8 +179,9 @@ steps:
           slurm_mem: 20GB
 
       - label: ":computer: baroclinic wave (ρe)"
+        key: sphere_baroclinic_wave_rhoe
         command:
-          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --dt 580secs --dt_save_to_disk 2days --initial_condition DryBaroclinicWave --regression_test true
+          - julia --color=yes --project=examples examples/hybrid/driver.jl --job_id sphere_baroclinic_wave_rhoe --dt 580secs --t_end 10days --dt_save_to_disk 2days --initial_condition DryBaroclinicWave --regression_test true
           - julia --color=yes --project=examples post_processing/remap/remap_pipeline.jl --data_dir sphere_baroclinic_wave_rhoe --out_dir sphere_baroclinic_wave_rhoe
           - julia --color=yes --project=examples post_processing/plot/plot_pipeline.jl --nc_dir sphere_baroclinic_wave_rhoe --fig_dir sphere_baroclinic_wave_rhoe --case_name dry_baroclinic_wave
           - julia --color=yes --project=examples regression_tests/test_mse.jl --job_id sphere_baroclinic_wave_rhoe --out_dir sphere_baroclinic_wave_rhoe
@@ -786,6 +787,24 @@ steps:
         artifact_paths: "edmf_bomex_consistency/*"
         agents:
           slurm_mem: 20GB
+
+  - group: "CUDA"
+    steps:
+
+      - label: "CUDA: CUDA implicit baro wave"
+        key: "cuda_implicit_barowave_ref"
+        command:
+          - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --project=examples examples/hybrid/driver.jl --job_id cuda_implicit_barowave_ref --dt 580secs --t_end 10days --dt_save_to_disk 2days --initial_condition DryBaroclinicWave --dt_save_to_sol Inf"
+        artifact_paths: "cuda_implicit_barowave_ref/*"
+        agents:
+          slurm_gpus: 1
+
+      - label: "CUDA: compare with CPU"
+        command: "julia --color=yes --project=examples post_processing/compare_outputs.jl --output_folder_1 sphere_baroclinic_wave_rhoe/ --output_folder_2 cuda_implicit_barowave_ref --t_end 10days --compare_state false --compare_diagnostics false"
+        depends_on:
+          - "sphere_baroclinic_wave_rhoe"
+          - "cuda_implicit_barowave_ref"
 
   - group: "GPU Performance"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -358,6 +358,7 @@ steps:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 2
+          slurm_mem: 20GB
 
       - label: ":computer: Prep for calling remap pipeline"
         key: "prep_remap"

--- a/post_processing/compare_outputs.jl
+++ b/post_processing/compare_outputs.jl
@@ -1,0 +1,91 @@
+import ArgParse
+using Test
+import ClimaAtmos as CA
+import ClimaComms
+import ClimaCore.InputOutput as InputOutput
+import ClimaCore.Fields as Fields
+function parse_commandline()
+    s = ArgParse.ArgParseSettings()
+    ArgParse.@add_arg_table s begin
+        "--output_folder_1"
+        help = "Output file for job 1"
+        arg_type = String
+        "--output_folder_2"
+        help = "Output file for job 2"
+        arg_type = String
+        "--t_end"
+        help = "Simulation end time. This must match the target jobs"
+        arg_type = String
+        "--compare_state"
+        help = "A bool: compare the state between output_folder_1 and output_folder_2 [`true` [default], `false`]"
+        arg_type = Bool
+        default = true
+        "--compare_diagnostics"
+        help = "A bool: compare the diagnostics between output_folder_1 and output_folder_2 [`true` [default], `false`]"
+        arg_type = Bool
+        default = true
+    end
+    parsed_args = ArgParse.parse_args(ARGS, s)
+    return (s, parsed_args)
+end
+
+(s, parsed_args) = parse_commandline()
+t_end = CA.time_to_seconds(parsed_args["t_end"])
+day = floor(Int, t_end / (60 * 60 * 24))
+sec = floor(Int, t_end % (60 * 60 * 24))
+
+function get_data(folder, name)
+    reader = InputOutput.HDF5Reader(
+        joinpath(folder, "day$day.$sec.hdf5"),
+        ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded()),
+    )
+    return InputOutput.read_field(reader, name)
+end
+Y_1 = get_data(parsed_args["output_folder_1"], "Y");
+Y_2 = get_data(parsed_args["output_folder_2"], "Y");
+D_1 = get_data(parsed_args["output_folder_1"], "diagnostics");
+D_2 = get_data(parsed_args["output_folder_2"], "diagnostics");
+
+compare(a::FV, b::FV, pn0 = "") where {FV <: Fields.FieldVector} =
+    compare(true, a, b, pn0)
+function _compare(zero_error, a::FV, b::FV, pn0 = "") where {FV}
+    for pn in propertynames(a)
+        pa = getproperty(a, pn)
+        pb = getproperty(b, pn)
+        zero_error = compare(zero_error, pa, pb, "$pn0.$pn")
+    end
+    return zero_error
+end
+
+compare(zero_error, a::FV, b::FV, pn0 = "") where {FV <: Fields.FieldVector} =
+    _compare(zero_error, a, b, pn0)
+compare(a::F, b::F, pn0 = "") where {F <: Fields.Field} =
+    compare(true, a, b, pn0)
+function compare(zero_error, a::F, b::F, pn0 = "") where {F <: Fields.Field}
+    isempty(propertynames(a)) || return _compare(zero_error, a, b, pn0)
+    err = abs.(Array(parent(a)) .- Array(parent(b)))
+    if !(maximum(err) == 0.0)
+        @warn "--- Failed field comparison $pn0"
+        @show a
+        @show b
+        @show maximum(err)
+        zero_error = false
+    end
+    return zero_error
+end
+
+@testset "Compare outputs" begin
+    @info "Comparing state vectors:"
+    if parsed_args["compare_state"]
+        @test compare(Y_1, Y_2)
+    else
+        @test_broken compare(Y_1, Y_2)
+    end
+
+    @info "Comparing diagnostics:"
+    if parsed_args["compare_diagnostics"]
+        @test compare(D_1, D_2)
+    else
+        @test_broken compare(D_1, D_2)
+    end
+end

--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -87,7 +87,7 @@ function n_steps_per_cycle_per_cb(cbs::ODE.CallbackSet, dt)
     return map(atmos_callbacks(cbs)) do cb
         cbf = callback_frequency(cb)
         if cbf isa EveryΔt
-            Int(cbf.Δt / dt)
+            Int(ceil(cbf.Δt / dt))
         elseif cbf isa EveryNSteps
             cbf.n
         else


### PR DESCRIPTION
This PR:
 - Adds a CPU/GPU job running the dry baro wave (for a reasonable amount of physical time)
 - Adds a script, `post_processing/compare_outputs.jl`, which compares the hdf5 files of two runs, prints the compared fields, and the maximum error
 - Fixes a bug where `n_steps_per_cycle_per_cb` can lead to `InexactError` exceptions

Closes #1864.