### PR TITLE
Avoid potential InexactError in `n_steps_per_cycle_per_cb`

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -60,7 +60,7 @@ allocs_limit["flame_perf_target_edmfx"] = 296000
 allocs_limit["flame_perf_target_diagnostic_edmfx"] = 11376
 allocs_limit["flame_perf_target_edmf"] = 7388656464
 allocs_limit["flame_perf_target_threaded"] = 6175664
-allocs_limit["flame_perf_target_callbacks"] = 43994936
+allocs_limit["flame_perf_target_callbacks"] = 43995240
 allocs_limit["flame_perf_gw"] = 4908807392
 
 if allocs < allocs_limit[job_id] * buffer

--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -87,7 +87,7 @@ function n_steps_per_cycle_per_cb(cbs::ODE.CallbackSet, dt)
     return map(atmos_callbacks(cbs)) do cb
         cbf = callback_frequency(cb)
         if cbf isa EveryΔt
-            Int(cbf.Δt / dt)
+            Int(ceil(cbf.Δt / dt))
         elseif cbf isa EveryNSteps
             cbf.n
         else


### PR DESCRIPTION
This fixes some jobs that are failing (they're passing because they're `soft_fail: true`