### PR TITLE
Add equator-pole temperature gradient parameters for calibration

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -56,12 +56,12 @@ allocs = @allocated OrdinaryDiffEq.step!(integrator)
 allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 4384
 allocs_limit["flame_perf_target_tracers"] = 185968
-allocs_limit["flame_perf_target_edmfx"] = 298304
+allocs_limit["flame_perf_target_edmfx"] = 298688
 allocs_limit["flame_perf_target_diagnostic_edmfx"] = 630384
-allocs_limit["flame_perf_target_edmf"] = 7459435344
+allocs_limit["flame_perf_target_edmf"] = 7467397968
 allocs_limit["flame_perf_target_threaded"] = 6175664
 allocs_limit["flame_perf_target_callbacks"] = 49850232
-allocs_limit["flame_perf_gw"] = 4933596128
+allocs_limit["flame_perf_gw"] = 4937135840
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/parameterized_tendencies/radiation/held_suarez.jl
+++ b/src/parameterized_tendencies/radiation/held_suarez.jl
@@ -30,6 +30,7 @@ end
 function forcing_tendency!(Yₜ, Y, p, t, colidx, ::HeldSuarezForcing)
     (; sfc_conditions, ᶜp, ᶜσ, ᶜheight_factor, ᶜΔρT, ᶜφ, params) = p
 
+    # TODO: Don't need to enforce FT here, it should be done at param creation.
     FT = Spaces.undertype(axes(Y.c))
     R_d = FT(CAP.R_d(params))
     κ_d = FT(CAP.kappa_d(params))
@@ -37,6 +38,8 @@ function forcing_tendency!(Yₜ, Y, p, t, colidx, ::HeldSuarezForcing)
     day = FT(CAP.day(params))
     MSLP = FT(CAP.MSLP(params))
     grav = FT(CAP.grav(params))
+    ΔT_y_dry = FT(CAP.ΔT_y_dry(params))
+    ΔT_y_wet = FT(CAP.ΔT_y_wet(params))
     thermo_params = CAP.thermodynamics_params(params)
 
     z_surface =
@@ -47,10 +50,10 @@ function forcing_tendency!(Yₜ, Y, p, t, colidx, ::HeldSuarezForcing)
     k_s = 1 / (4 * day)
     k_f = 1 / day
     if :ρq_tot in propertynames(Y.c)
-        ΔT_y = FT(65)
+        ΔT_y = ΔT_y_wet
         T_equator = FT(294)
     else
-        ΔT_y = FT(60)
+        ΔT_y = ΔT_y_dry
         T_equator = FT(315)
     end
     Δθ_z = FT(10)

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -28,6 +28,9 @@ Base.@kwdef struct ClimaAtmosParameters{FT, TP, RP, IP, MPP, SFP, TCP} <: ACAP
     turbconv_params::TCP
     entr_coeff::FT = 1
     detr_coeff::FT = 0.001
+    # TODO: Figure out a better place for these held-suarez parameters
+    ΔT_y_dry::FT
+    ΔT_y_wet::FT
 end
 
 Base.eltype(::ClimaAtmosParameters{FT}) where {FT} = FT
@@ -62,6 +65,8 @@ Cd(ps::ACAP) = ps.Cd
 uh_g(ps::ACAP) = CC.Geometry.UVVector(ps.ug, ps.vg)
 entr_coeff(ps::ACAP) = ps.entr_coeff
 detr_coeff(ps::ACAP) = ps.detr_coeff
+ΔT_y_dry(ps::ACAP) = ps.ΔT_y_dry
+ΔT_y_wet(ps::ACAP) = ps.ΔT_y_wet
 
 # Forwarding CloudMicrophysics parameters
 ρ_cloud_liq(ps::ACAP) = CM.Parameters.ρ_cloud_liq(microphysics_params(ps))

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -98,7 +98,7 @@ function create_climaatmos_parameter_set(
 
     pairs = CP.get_parameter_values!(
         toml_dict,
-        ["Omega", "planet_radius", "astro_unit"],
+        ["Omega", "planet_radius", "astro_unit", "ΔT_y_dry", "ΔT_y_wet"],
         "ClimaAtmos",
     )
     pairs = (; pairs...) # convert to NamedTuple
@@ -121,6 +121,8 @@ function create_climaatmos_parameter_set(
         turbconv_params = tc_params,
         entr_coeff = FTD(parsed_args["entr_coeff"]),
         detr_coeff = FTD(parsed_args["detr_coeff"]),
+        ΔT_y_dry = FTD(pairs.ΔT_y_dry),
+        ΔT_y_wet = FTD(pairs.ΔT_y_wet),
     )
     # logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
     # CP.log_parameter_information(toml_dict, logfilepath)


### PR DESCRIPTION
The equator-pole temperature gradient parameters are currently hardcoded in the held-suarez tendency.
For our first calibration test, we need to calibrate on these, so they need to be modifiable parameters.
I have already added them to ClimaParameters.