### PR TITLE
Add toggle for prognostic TKE and fix TKE advection

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -450,7 +450,7 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_aquaplanet
           --vert_diff true --surface_setup DefaultExchangeCoefficients --rad gray
-          --turbconv diagnostic_edmfx --edmfx_entr_detr true
+          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_entr_detr true
           --moist equil --precip_model 0M
           --dt 400secs --t_end 1days --dt_save_to_disk 12hours
         artifact_paths: "diagnostic_edmfx_aquaplanet/*"

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -103,7 +103,6 @@ function precomputed_quantities(Y, atmos)
                 Y.c,
                 NTuple{n, NamedTuple{(:entr, :detr), NTuple{2, FT}}},
             ),
-            ᶜρa⁰ = similar(Y.c, FT),
             ᶠu³⁰ = similar(Y.f, CT3{FT}),
             ᶜu⁰ = similar(Y.c, C123{FT}),
             ᶜtke⁰ = similar(Y.c, FT),

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -9,11 +9,11 @@ import ClimaCore.Geometry as Geometry
 function horizontal_advection_tendency!(Yₜ, Y, p, t)
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
     (; ᶜu, ᶜK, ᶜp, ᶜΦ, ᶜp_ref) = p
-    if p.atmos.turbconv_model isa EDMFX
-        (; ᶜu⁰, ᶜuʲs) = p
-    end
-    if p.atmos.turbconv_model isa DiagnosticEDMFX
+    if p.atmos.turbconv_model isa AbstractEDMF
         (; ᶜu⁰) = p
+    end
+    if p.atmos.turbconv_model isa EDMFX
+        (; ᶜuʲs) = p
     end
 
     @. Yₜ.c.ρ -= divₕ(Y.c.ρ * ᶜu)
@@ -42,11 +42,7 @@ function horizontal_advection_tendency!(Yₜ, Y, p, t)
         end
     end
 
-    if p.atmos.turbconv_model isa EDMFX
-        @. Yₜ.c.sgs⁰.ρatke -= divₕ(Y.c.sgs⁰.ρatke * ᶜu⁰)
-    end
-
-    if p.atmos.turbconv_model isa DiagnosticEDMFX
+    if use_prognostic_tke(p.atmos.turbconv_model)
         @. Yₜ.c.sgs⁰.ρatke -= divₕ(Y.c.sgs⁰.ρatke * ᶜu⁰)
     end
 
@@ -79,15 +75,25 @@ function horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
 end
 
 function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
-    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    (; turbconv_model) = p.atmos
+    n = n_prognostic_mass_flux_subdomains(turbconv_model)
+    advect_tke = use_prognostic_tke(turbconv_model)
+    is_total_energy = p.atmos.energy_form isa TotalEnergy
     point_type = eltype(Fields.coordinate_field(Y.c))
+    (; dt) = p.simulation
     ᶜJ = Fields.local_geometry_field(Y.c).J
     (; ᶜu, ᶠu³, ᶜK, ᶜf) = p
+    (; edmfx_upwinding) = n > 0 || advect_tke ? p : all_nothing
+    (; ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜρʲs, ᶜspecificʲs) = n > 0 ? p : all_nothing
+    (; ᶜp, ᶜp_ref, ᶜρ_ref, ᶠgradᵥ_ᶜΦ) = n > 0 ? p : all_nothing
+    (; ᶜh_totʲs) = n > 0 && is_total_energy ? p : all_nothing
+    (; ᶠu³⁰) = advect_tke ? p : all_nothing
+    ᶜρa⁰ = advect_tke ? (n > 0 ? p.ᶜρa⁰ : Y.c.ρ) : nothing
+    ᶜtke⁰ = advect_tke ? (n > 0 ? p.ᶜspecific⁰.tke : p.ᶜtke⁰) : nothing
+    ᶜ1 = p.ᶜtemp_scalar
     ᶜω³ = p.ᶜtemp_CT3
     ᶠω¹² = p.ᶠtemp_CT12
-    if p.atmos.turbconv_model isa EDMFX
-        ᶠω¹²ʲs = p.ᶠtemp_CT12ʲs
-    end
+    ᶠω¹²ʲs = p.ᶠtemp_CT12ʲs
 
     if point_type <: Geometry.Abstract3DPoint
         @. ᶜω³ = curlₕ(Y.c.uₕ)
@@ -95,83 +101,93 @@ function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         @. ᶜω³ = zero(ᶜω³)
     end
 
-    @. ᶠω¹² = ᶠcurlᵥ(Y.c.uₕ)
-    if p.atmos.turbconv_model isa EDMFX
-        for j in 1:n
-            @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
-        end
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. ᶠω¹²[colidx] = ᶠcurlᵥ(Y.c.uₕ[colidx])
+    end
+    for j in 1:n
+        @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
     end
     @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
-    if p.atmos.turbconv_model isa EDMFX
-        for j in 1:n
-            @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
-        end
+    for j in 1:n
+        @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 
-    @. Yₜ.c.uₕ -=
-        ᶜinterp(ᶠω¹² × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
-        (ᶜf + ᶜω³) × CT12(ᶜu)
-    @. Yₜ.f.u₃ -= ᶠω¹² × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
-
-    if p.atmos.turbconv_model isa EDMFX
-        (; ᶜp, ᶜp_ref, ᶜρ_ref, ᶠgradᵥ_ᶜΦ) = p
-        (; ᶠu³ʲs, ᶜuʲs, ᶜKʲs, ᶜρʲs, ᶜspecificʲs, edmfx_upwinding) = p
-        (; dt) = p.simulation
-        ᶜ1 = p.ᶜtemp_scalar
-        ᶜh_totʲs = p.atmos.energy_form isa TotalEnergy ? p.ᶜh_totʲs : nothing
+    Fields.bycolumn(axes(Y.c)) do colidx
+        @. Yₜ.c.uₕ[colidx] -=
+            ᶜinterp(
+                ᶠω¹²[colidx] ×
+                (ᶠinterp(Y.c.ρ[colidx] * ᶜJ[colidx]) * ᶠu³[colidx]),
+            ) / (Y.c.ρ[colidx] * ᶜJ[colidx]) +
+            (ᶜf[colidx] + ᶜω³[colidx]) × CT12(ᶜu[colidx])
+        @. Yₜ.f.u₃[colidx] -=
+            ᶠω¹²[colidx] × ᶠinterp(CT12(ᶜu[colidx])) + ᶠgradᵥ(ᶜK[colidx])
 
         for j in 1:n
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-                ᶠω¹²ʲs.:($$j) × ᶠinterp(CT12(ᶜuʲs.:($$j))) + ᶠgradᵥ(ᶜKʲs.:($$j))
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -=
+            @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] -=
+                ᶠω¹²ʲs.:($$j)[colidx] × ᶠinterp(CT12(ᶜuʲs.:($$j)[colidx])) +
+                ᶠgradᵥ(ᶜKʲs.:($$j)[colidx])
+
+            # TODO: Move this to implicit_vertical_advection_tendency!.
+            @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] -=
                 (
-                    ᶠgradᵥ(ᶜp - ᶜp_ref) +
-                    ᶠinterp(ᶜρʲs.:($$j) - ᶜρ_ref) * ᶠgradᵥ_ᶜΦ
-                ) / ᶠinterp(ᶜρʲs.:($$j))
+                    ᶠgradᵥ(ᶜp[colidx] - ᶜp_ref[colidx]) +
+                    ᶠinterp(ᶜρʲs.:($$j)[colidx] - ᶜρ_ref[colidx]) *
+                    ᶠgradᵥ_ᶜΦ[colidx]
+                ) / ᶠinterp(ᶜρʲs.:($$j)[colidx])
         end
 
-        Fields.bycolumn(axes(Y.c.ρ)) do colidx
-            for j in 1:n
+        # TODO: Move this to implicit_vertical_advection_tendency!.
+        for j in 1:n
+            @. ᶜ1[colidx] = one(Y.c.ρ[colidx])
+            vertical_transport!(
+                Yₜ.c.sgsʲs.:($j).ρa[colidx],
+                ᶜJ[colidx],
+                Y.c.sgsʲs.:($j).ρa[colidx],
+                ᶠu³ʲs.:($j)[colidx],
+                ᶜ1[colidx],
+                dt,
+                edmfx_upwinding,
+            )
 
-                @. ᶜ1[colidx] = one(Y.c.ρ[colidx])
+            if :ρae_tot in propertynames(Yₜ.c.sgsʲs.:($j))
                 vertical_transport!(
-                    Yₜ.c.sgsʲs.:($j).ρa[colidx],
+                    Yₜ.c.sgsʲs.:($j).ρae_tot[colidx],
                     ᶜJ[colidx],
                     Y.c.sgsʲs.:($j).ρa[colidx],
                     ᶠu³ʲs.:($j)[colidx],
-                    ᶜ1[colidx],
+                    ᶜh_totʲs.:($j)[colidx],
                     dt,
                     edmfx_upwinding,
                 )
+            end
 
-                if :ρae_tot in propertynames(Yₜ.c.sgsʲs.:($j))
-                    vertical_transport!(
-                        Yₜ.c.sgsʲs.:($j).ρae_tot[colidx],
-                        ᶜJ[colidx],
-                        Y.c.sgsʲs.:($j).ρa[colidx],
-                        ᶠu³ʲs.:($j)[colidx],
-                        ᶜh_totʲs.:($j)[colidx],
-                        dt,
-                        edmfx_upwinding,
-                    )
-                end
-
-                for (ᶜρaχʲₜ, ᶜχʲ, χ_name) in
-                    matching_subfields(Yₜ.c.sgsʲs.:($j), ᶜspecificʲs.:($j))
-                    χ_name == :e_tot && continue
-                    vertical_transport!(
-                        ᶜρaχʲₜ[colidx],
-                        ᶜJ[colidx],
-                        Y.c.sgsʲs.:($j).ρa[colidx],
-                        ᶠu³ʲs.:($j)[colidx],
-                        ᶜχʲ[colidx],
-                        dt,
-                        edmfx_upwinding,
-                    )
-                end
+            for (ᶜρaχʲₜ, ᶜχʲ, χ_name) in
+                matching_subfields(Yₜ.c.sgsʲs.:($j), ᶜspecificʲs.:($j))
+                χ_name == :e_tot && continue
+                vertical_transport!(
+                    ᶜρaχʲₜ[colidx],
+                    ᶜJ[colidx],
+                    Y.c.sgsʲs.:($j).ρa[colidx],
+                    ᶠu³ʲs.:($j)[colidx],
+                    ᶜχʲ[colidx],
+                    dt,
+                    edmfx_upwinding,
+                )
             end
         end
+
+        # TODO: Move this to implicit_vertical_advection_tendency!.
+        if use_prognostic_tke(turbconv_model) # advect_tke triggers allocations
+            vertical_transport!(
+                Yₜ.c.sgs⁰.ρatke[colidx],
+                ᶜJ[colidx],
+                ᶜρa⁰[colidx],
+                ᶠu³⁰[colidx],
+                ᶜtke⁰[colidx],
+                dt,
+                edmfx_upwinding,
+            )
+        end
     end
-    return nothing
 end

--- a/src/solver/cli_options.jl
+++ b/src/solver/cli_options.jl
@@ -108,6 +108,10 @@ function argparse_settings()
         "--turbconv_case"
         help = "The case run by Turbulence convection scheme [`Bomex` (default), `Bomex`, `DYCOMS_RF01`, `TRMM_LBA`, `GABLS`]"
         arg_type = String
+        "--prognostic_tke"
+        help = "Whether the turbulence convection scheme uses prognostic or prescribed TKE [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         "--hyperdiff"
         help = "Hyperdiffusion [`ClimaHyperdiffusion` (or `true`; default), `none` (or `false`)]"
         arg_type = String

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -322,12 +322,13 @@ function get_turbconv_model(
             turbconv_params,
         )
     elseif turbconv == "edmfx"
-        EDMFX{turbconv_params.updraft_number}(turbconv_params.min_area)
+        N = turbconv_params.updraft_number
+        TKE = parsed_args["prognostic_tke"]
+        EDMFX{N, TKE}(turbconv_params.min_area)
     elseif turbconv == "diagnostic_edmfx"
-        DiagnosticEDMFX{turbconv_params.updraft_number}(
-            FT(0.1),
-            turbconv_params.min_area,
-        )
+        N = turbconv_params.updraft_number
+        TKE = parsed_args["prognostic_tke"]
+        DiagnosticEDMFX{N, TKE}(FT(0.1), turbconv_params.min_area)
     else
         nothing
     end

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -221,3 +221,7 @@ macro timed_str(ex)
         "$(prettytime(stats.time*1e9)) ($(Base.gc_alloc_count(stats.gcstats)) allocations: $(prettymemory(stats.gcstats.allocd)))"
     end
 end
+
+struct AllNothing end
+const all_nothing = AllNothing()
+Base.getproperty(::AllNothing, ::Symbol) = nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds the `--prognostic_tke` command-line option, which currently just toggles the advection of TKE. It also adds the vertical advection of TKE and cleans up the advection tendency functions. Related to #1916.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add a boolean type parameter to `EDMFX` and `DiagnosticEDFMX`, and set it to `parsed_args["prognostic_tke"]`.
- Define the `use_prognostic_tke` function to extract this type parameter (or to return `false` when there is no `turbconv_model`).
- Modify `horizontal_advection_tendency!` as follows:
    - Unify the horizontal advection of TKE for `EDMFX` and `DiagnosticEDFMX`.
    - Ensure that TKE is only advected when `use_prognostic_tke` returns `true`.
- Modify `explicit_vertical_advection_tendency!` as follows:
    - Extract all cached values at the beginning of this function.
    - Wrap all vertical operations in calls to `bycolumn`. Since there are two sets of vertical operations separated by horizontal operations, two calls to `bycolumn` are needed.
    - Add the vertical advection of TKE.
    - Ensure that TKE is only advected when `use_prognostic_tke` returns `true`.
    - Add comments to indicate which parts of this function will need to be moved to `implicit_vertical_advection_tendency!`.
- Add `--prognostic_tke true` to the `diagnostic_edmfx_aquaplanet` job. Since the initial TKE is 0 for this job, the simulation will not crash when TKE is advected.
- Remove `ᶜρa⁰` from the cache for `DiagnosticEDMFX` because it is not being used (we approximate it with `Y.c.ρ`).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
