### PR TITLE
removes unnecessary variables from get_spaces_restart

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -263,13 +263,7 @@ end
 function get_spaces_restart(Y)
     center_space = axes(Y.c)
     face_space = axes(Y.f)
-    hspace = Spaces.horizontal_space(center_space)
-    horizontal_mesh = hspace.topology.mesh
-    quad = horizontal_mesh.ne + 1
-    vertical_mesh = Spaces.vertical_topology(center_space).mesh
-    z_max = vertical_mesh.domain.coord_max.z
-    z_elem = length(vertical_mesh.faces) - 1
-    return (; center_space, face_space, horizontal_mesh, quad, z_max, z_elem)
+    return (; center_space, face_space)
 end
 
 function get_state_restart(comms_ctx)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

Removes unnecessary variables from get_spaces_restart so that the function works with box simulations.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
