### PR TITLE
Skip rrtmgp callback in ode init

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -505,8 +505,10 @@ function get_callbacks(parsed_args, simulation, atmos, params)
         else
             FT(time_to_seconds(parsed_args["dt_rad"]))
         end
-        callbacks =
-            (callbacks..., call_every_dt(rrtmgp_model_callback!, dt_rad))
+        callbacks = (
+            callbacks...,
+            call_every_dt(rrtmgp_model_callback!, dt_rad, skip_first = true),
+        )
     end
 
     if atmos.turbconv_model isa TC.EDMFModel


### PR DESCRIPTION
This PR changes the RRTMGP callback to skip on integrator initialization. I was looking into reducing latency, and found that this accounts for 97% of `integrator = ODE.init(...)` (for cases with rrtmgp radiation). If this is behavior changing, then we should first think about whether this change makes sense (we can always call this callback after getting the integrator in the driver, or make a wrapper that does it), but I like the change at the very least because it decouples getting the integrator from doing computations. For example, if someone is debugging a job that has rrtmgp, but they want to call some other tendency, it doesn't make sense to do all of these extra computations.