### PR TITLE
Fix method ambiguities in column_mapreduce

### DIFF
--- a/src/parameterized_tendencies/radiation/indefinite_integral_and_mapreduce.jl
+++ b/src/parameterized_tendencies/radiation/indefinite_integral_and_mapreduce.jl
@@ -98,7 +98,7 @@ column_mapreduce!(
     op::O,
     reduced_field::Fields.Field,
     fields::Fields.Field...,
-) where {F, O} = column_mapreduce!(
+) where {F, O} = column_mapreduce_device!(
     ClimaComms.device(reduced_field),
     fn,
     op,
@@ -106,7 +106,7 @@ column_mapreduce!(
     fields...,
 )
 
-function column_mapreduce!(
+function column_mapreduce_device!(
     ::ClimaComms.CUDADevice,
     fn::F,
     op::O,
@@ -147,7 +147,7 @@ column_mapreduce_kernel!(
     fields::Fields.FiniteDifferenceField...,
 ) where {F, O} = _column_mapreduce!(fn, op, reduced_field, fields...)
 
-function column_mapreduce!(
+function column_mapreduce_device!(
     ::ClimaComms.AbstractCPUDevice,
     fn::F,
     op::O,
@@ -162,7 +162,7 @@ function column_mapreduce!(
     return nothing
 end
 
-column_mapreduce!(
+column_mapreduce_device!(
     ::ClimaComms.AbstractCPUDevice,
     fn::F,
     op::O,


### PR DESCRIPTION
Fixes 3 method ambiguities introduced in #1936. The ambiguities were between different methods of `column_mapreduce!`, and I fixed them by renaming some of the methods.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
