### PR TITLE
Make TKE initial condition dependent on prognostic_tke

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -444,7 +444,7 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_bomex_box
           --initial_condition Bomex --subsidence Bomex --edmf_coriolis Bomex --ls_adv Bomex --surface_setup Bomex
-          --turbconv diagnostic_edmfx --edmfx_entr_detr true --edmfx_sgs_flux true
+          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_upwinding first_order --edmfx_entr_detr true --edmfx_sgs_flux true
           --moist equil
           --config box --hyperdiff true --kappa_4 1e12
           --x_max 1e5 --y_max 1e5 --x_elem 2 --y_elem 2 --z_elem 60 --z_max 3e3 --z_stretch false
@@ -457,11 +457,11 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_dycoms_rf01_box
           --initial_condition DYCOMS_RF01 --subsidence DYCOMS --edmf_coriolis DYCOMS_RF01 --rad DYCOMS_RF01 --surface_setup DYCOMS_RF01
-          --turbconv diagnostic_edmfx --edmfx_entr_detr true --edmfx_sgs_flux true
+          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_upwinding first_order --edmfx_entr_detr true --edmfx_sgs_flux true
           --moist equil
           --config box --hyperdiff true --kappa_4 1e12
           --x_max 1e5 --y_max 1e5 --x_elem 2 --y_elem 2 --z_elem 30 --z_max 1500 --z_stretch false
-          --dt 6secs --t_end 4hours --dt_save_to_disk 2mins
+          --dt 10secs --t_end 4hours --dt_save_to_disk 2mins
         artifact_paths: "diagnostic_edmfx_dycoms_rf01_box/*"
         agents:
           slurm_mem: 20GB
@@ -470,7 +470,7 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_rico_box
           --initial_condition Rico --subsidence Rico --ls_adv Rico --surface_setup Rico
-          --turbconv diagnostic_edmfx --edmfx_entr_detr true --edmfx_sgs_flux true
+          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_upwinding first_order --edmfx_entr_detr true --edmfx_sgs_flux true
           --moist equil
           --config box --hyperdiff true --kappa_4 1e12
           --x_max 1e5 --y_max 1e5 --x_elem 2 --y_elem 2 --z_elem 100 --z_max 4e3 --z_stretch false
@@ -495,7 +495,7 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl --job_id diagnostic_edmfx_aquaplanet_tke
           --vert_diff true --surface_setup DefaultExchangeCoefficients --rad gray
-          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_upwinding first_order --edmfx_entr_detr true
+          --turbconv diagnostic_edmfx --prognostic_tke true --edmfx_upwinding first_order --edmfx_entr_detr true --edmfx_sgs_flux true
           --moist equil --precip_model 0M
           --dt 100secs --t_end 3hours --dt_save_to_disk 600secs
         artifact_paths: "diagnostic_edmfx_aquaplanet_tke/*"

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -631,7 +631,9 @@ end
 The `InitialCondition` described in [Soares2004](@cite), but with a
 hydrostatically balanced pressure profile.
 """
-struct Soares <: InitialCondition end
+Base.@kwdef struct Soares <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 """
     Bomex
@@ -639,7 +641,9 @@ struct Soares <: InitialCondition end
 The `InitialCondition` described in [Holland1973](@cite), but with a hydrostatically
 balanced pressure profile.
 """
-struct Bomex <: InitialCondition end
+Base.@kwdef struct Bomex <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 """
     LifeCycleTan2018
@@ -647,7 +651,9 @@ struct Bomex <: InitialCondition end
 The `InitialCondition` described in [Tan2018](@cite), but with a hydrostatically
 balanced pressure profile.
 """
-struct LifeCycleTan2018 <: InitialCondition end
+Base.@kwdef struct LifeCycleTan2018 <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 """
     ARM_SGP
@@ -655,7 +661,9 @@ struct LifeCycleTan2018 <: InitialCondition end
 The `InitialCondition` described in [Brown2002](@cite), but with a
 hydrostatically balanced pressure profile.
 """
-struct ARM_SGP <: InitialCondition end
+Base.@kwdef struct ARM_SGP <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 for IC in (:Soares, :Bomex, :LifeCycleTan2018, :ARM_SGP)
     θ_func_name = Symbol(IC, :_θ_liq_ice)
@@ -663,6 +671,7 @@ for IC in (:Soares, :Bomex, :LifeCycleTan2018, :ARM_SGP)
     u_func_name = Symbol(IC, :_u)
     tke_func_name = Symbol(IC, :_tke_prescribed)
     @eval function (initial_condition::$IC)(params)
+        (; prognostic_tke) = initial_condition
         FT = eltype(params)
         thermo_params = CAP.thermodynamics_params(params)
         p_0 = FT(
@@ -688,7 +697,9 @@ for IC in (:Soares, :Bomex, :LifeCycleTan2018, :ARM_SGP)
                     q_tot(z),
                 ),
                 velocity = Geometry.UVector(u(z)),
-                turbconv_state = EDMFState(; tke = tke(z)),
+                turbconv_state = EDMFState(;
+                    tke = prognostic_tke ? FT(0) : tke(z),
+                ),
             )
         end
         return local_state
@@ -701,7 +712,9 @@ end
 The `InitialCondition` described in [Stevens2005](@cite), but with a
 hydrostatically balanced pressure profile.
 """
-struct DYCOMS_RF01 <: InitialCondition end
+Base.@kwdef struct DYCOMS_RF01 <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 """
     DYCOMS_RF02
@@ -719,6 +732,7 @@ for IC in (:Dycoms_RF01, :Dycoms_RF02)
     v_func_name = Symbol(IC, IC == :Dycoms_RF01 ? :_v0 : :_v)
     tke_func_name = Symbol(IC, :_tke_prescribed)
     @eval function (initial_condition::$IC_Type)(params)
+        (; prognostic_tke) = initial_condition
         FT = eltype(params)
         thermo_params = CAP.thermodynamics_params(params)
         p_0 = FT(101780.0)
@@ -741,7 +755,9 @@ for IC in (:Dycoms_RF01, :Dycoms_RF02)
                     q_tot(z),
                 ),
                 velocity = Geometry.UVVector(u(z), v(z)),
-                turbconv_state = EDMFState(; tke = tke(z)),
+                turbconv_state = EDMFState(;
+                    tke = prognostic_tke ? FT(0) : tke(z),
+                ),
             )
         end
         return local_state
@@ -754,9 +770,12 @@ end
 The `InitialCondition` described in [Rauber2007](cite), but with a hydrostatically
 balanced pressure profile.
 """
-struct Rico <: InitialCondition end
+Base.@kwdef struct Rico <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 function (initial_condition::Rico)(params)
+    (; prognostic_tke) = initial_condition
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
     p_0 = FT(101540.0)
@@ -779,7 +798,7 @@ function (initial_condition::Rico)(params)
                 q_tot(z),
             ),
             velocity = Geometry.UVVector(u(z), v(z)),
-            turbconv_state = EDMFState(; tke = tke(z)),
+            turbconv_state = EDMFState(; tke = prognostic_tke ? FT(0) : tke(z)),
         )
     end
     return local_state
@@ -791,9 +810,12 @@ end
 The `InitialCondition` described in [Grabowski2006](@cite), but with a
 hydrostatically balanced pressure profile.
 """
-struct TRMM_LBA <: InitialCondition end
+Base.@kwdef struct TRMM_LBA <: InitialCondition
+    prognostic_tke::Bool = false
+end
 
 function (initial_condition::TRMM_LBA)(params)
+    (; prognostic_tke) = initial_condition
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
     p_0 = FT(99130.0)
@@ -834,7 +856,7 @@ function (initial_condition::TRMM_LBA)(params)
                 q_tot(z),
             ),
             velocity = Geometry.UVVector(u(z), v(z)),
-            turbconv_state = EDMFState(; tke = tke(z)),
+            turbconv_state = EDMFState(; tke = prognostic_tke ? FT(0) : tke(z)),
         )
     end
     return local_state

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -288,7 +288,6 @@ function get_initial_condition(parsed_args)
                 parsed_args["perturb_initstate"],
             )
         elseif parsed_args["initial_condition"] in [
-            "IsothermalProfile",
             "Nieuwstadt",
             "GABLS",
             "GATE_III",
@@ -300,6 +299,12 @@ function get_initial_condition(parsed_args)
             "DYCOMS_RF02",
             "Rico",
             "TRMM_LBA",
+        ]
+            return getproperty(ICs, Symbol(parsed_args["initial_condition"]))(
+                parsed_args["prognostic_tke"],
+            )
+        elseif parsed_args["initial_condition"] in [
+            "IsothermalProfile",
             "AgnesiHProfile",
             "DryDensityCurrentProfile",
             "RisingThermalBubbleProfile",


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Make the TKE initial condition in EDMF cases dependent on whether TKE is prognostic or not. If it is prognostic, set the initial condition to zero.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
