### PR TITLE
add mixing length to diagnostics

### DIFF
--- a/post_processing/remap/remap_helpers.jl
+++ b/post_processing/remap/remap_helpers.jl
@@ -188,6 +188,8 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
             defVar(nc, "draft_cloud_fraction", FT, cspace, ("time",))
         nc_draft_area = defVar(nc, "draft_area_fraction", FT, cspace, ("time",))
         nc_cloudfrac = defVar(nc, "cloud_fraction", FT, cspace, ("time",))
+        nc_tke = defVar(nc, "tke", FT, cspace, ("time",))
+        nc_mixing_length = defVar(nc, "mixing_length", FT, cspace, ("time",))
     end
 
     # time
@@ -267,6 +269,8 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
         nc_draft_cloudfrac[:, 1] = diag.draft_cloud_fraction
         nc_draft_area[:, 1] = diag.draft_area
         nc_cloudfrac[:, 1] = diag.cloud_fraction
+        nc_tke[:, 1] = diag.env_tke
+        nc_mixing_length[:, 1] = diag.env_mixing_length
     end
     close(nc)
 
@@ -334,7 +338,7 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
         rad_flux_clear_variables = String[]
     end
     if :draft_q_tot in propertynames(diag)
-        draft_variables = [
+        edmf_variables = [
             "draft_qt",
             "draft_RH",
             "draft_cloud_ice",
@@ -343,9 +347,11 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
             "draft_cloud_fraction",
             "draft_area_fraction",
             "cloud_fraction",
+            "tke",
+            "mixing_length",
         ]
     else
-        draft_variables = String[]
+        edmf_variables = String[]
     end
 
     netcdf_variables = vcat(
@@ -355,7 +361,7 @@ function remap2latlon(filein, data_dir, remap_tmpdir, weightfile, nlat, nlon)
         sfc_flux_variables,
         rad_flux_variables,
         rad_flux_clear_variables,
-        draft_variables,
+        edmf_variables,
     )
     apply_remap(datafile_latlon, datafile_cc, weightfile, netcdf_variables)
     rm(datafile_cc)

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -293,7 +293,7 @@ function compute_diagnostics(integrator)
         TD.has_condensate(thermo_params, ts) && area > 1e-3 ? FT(1) : FT(0)
 
     if p.atmos.turbconv_model isa EDMFX
-        (; ᶜspecific⁰, ᶜu⁰, ᶜts⁰) = p
+        (; ᶜspecific⁰, ᶜu⁰, ᶜts⁰, ᶜmixing_length) = p
         (; ᶜu⁺, ᶜts⁺, ᶜa⁺, ᶜa⁰) = output_sgs_quantities(Y, p, t)
         env_diagnostics = (;
             common_diagnostics(ᶜu⁰, ᶜts⁰)...,
@@ -305,6 +305,7 @@ function compute_diagnostics(integrator)
                 ᶜts⁰,
             ),
             tke = ᶜspecific⁰.tke,
+            mixing_length = ᶜmixing_length,
         )
         draft_diagnostics = (;
             common_diagnostics(ᶜu⁺, ᶜts⁺)...,
@@ -323,7 +324,7 @@ function compute_diagnostics(integrator)
             ) .+ ᶜa⁺ .* cloud_fraction.(ᶜts⁺, ᶜa⁺),
         )
     elseif p.atmos.turbconv_model isa DiagnosticEDMFX
-        (; ᶜtke⁰) = p
+        (; ᶜtke⁰, ᶜmixing_length) = p
         (; ᶜu⁺, ᶜts⁺, ᶜa⁺) = output_diagnostic_sgs_quantities(Y, p, t)
         env_diagnostics = (;
             cloud_fraction = get_cloud_fraction.(
@@ -333,6 +334,7 @@ function compute_diagnostics(integrator)
                 ᶜts,
             ),
             tke = ᶜtke⁰,
+            mixing_length = ᶜmixing_length,
         )
         draft_diagnostics = (;
             common_diagnostics(ᶜu⁺, ᶜts⁺)...,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds mixing length to hdf5 output. Adds TKE and mixing length to remapped netcdf output. This would be useful for debugging.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
