### PR TITLE
fix k_star in TKE boundary condition

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -61,7 +61,7 @@ allocs_limit["flame_perf_target_diagnostic_edmfx"] = 631408
 allocs_limit["flame_perf_target_edmf"] = 7469388624
 allocs_limit["flame_perf_target_threaded"] = 6175664
 allocs_limit["flame_perf_target_callbacks"] = 49850536
-allocs_limit["flame_perf_gw"] = 4937135840
+allocs_limit["flame_perf_gw"] = 4937136096
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/TurbulenceConvection_deprecated/Parameters.jl
+++ b/src/TurbulenceConvection_deprecated/Parameters.jl
@@ -23,6 +23,7 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, MP, SFP} <: ATCP
     min_area::FT
     tke_ed_coeff::FT
     tke_diss_coeff::FT
+    tke_surf_scale::FT
     static_stab_coeff::FT
     Prandtl_number_scale::FT
     Prandtl_number_0::FT

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -66,13 +66,13 @@ function surface_flux_tke(
 )
     c_d = TCP.tke_diss_coeff(turbconv_params)
     c_m = TCP.tke_ed_coeff(turbconv_params)
-    vkc = TCP.von_karman_const(turbconv_params)
+    k_star² = TCP.tke_surf_scale(turbconv_params)
     speed = Geometry._norm(
         CA.CT12(u_int, interior_local_geometry),
         interior_local_geometry,
     )
     c3_unit = C3(unit_basis_vector_data(C3, surface_local_geometry))
-    return ρ_int * (1 - c_d * c_m * vkc^4) * ustar^2 * speed * c3_unit
+    return ρ_int * (1 - c_d * c_m * k_star²^2) * ustar^2 * speed * c3_unit
 end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fix a bug of the wrong constant is used in the TKE boundary condition.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
