### PR TITLE
Renaming surface condition variables

### DIFF
--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -63,11 +63,11 @@ end
 surface_state(sfc_setup_wrapper::SurfaceState, _, _, _) = sfc_setup_wrapper
 
 surface_state(
-    sfc_setup_wrapper::Function,
+    wrapped_sfc_setup::Function,
     sfc_local_geometry_values,
     int_z_values,
     t,
-) = sfc_setup_wrapper(sfc_local_geometry_values.coordinates, int_z_values, t)
+) = wrapped_sfc_setup(sfc_local_geometry_values.coordinates, int_z_values, t)
 
 # This is a hack for meeting the August 7th deadline. It is to ensure that the
 # coupler will be able to construct an integrator before overwriting its surface


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Changing the name of a variable so that it doesn't share the same name as another function


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
