### PR TITLE
Add simple simulation progress callback

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -154,7 +154,7 @@ dt_save_to_sol:
   help: "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"
   value: "1days"
 dt_show_progress:
-  help: "Time between displaying progress update"
+  help: "Simulation time between displaying progress update. Examples: [`600secs`, `1mins`, `Inf` (do not display)]"
   value: "600secs"
 moist:
   help: "Moisture model [`dry` (default), `equil`, `non_equil`]"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -153,6 +153,9 @@ dt_save_restart:
 dt_save_to_sol:
   help: "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"
   value: "1days"
+dt_show_progress:
+  help: "Time between displaying progress update"
+  value: "600secs"
 moist:
   help: "Moisture model [`dry` (default), `equil`, `non_equil`]"
   value: "dry"

--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -17,7 +17,17 @@ function call_every_n_steps(f!, n = 1; skip_first = false, call_at_end = false)
     )
 end
 
-function call_every_dt(f!, dt; skip_first = false, call_at_end = false)
+function call_every_dt(
+    f!,
+    dt;
+    skip_first = false,
+    call_at_end = false,
+    initialize = (cb, u, t, integrator) -> begin
+        skip_first || cb!(integrator)
+        t_end = integrator.sol.prob.tspan[2]
+        next_t[] = (call_at_end && t < t_end) ? min(t_end, t + dt) : t + dt
+    end,
+)
     cb! = AtmosCallback(f!, EveryΔt(dt))
     @assert dt ≠ Inf "Adding callback that never gets called!"
     next_t = Ref{typeof(dt)}()
@@ -34,12 +44,7 @@ function call_every_dt(f!, dt; skip_first = false, call_at_end = false)
     return ODE.DiscreteCallback(
         (u, t, integrator) -> t >= next_t[],
         affect!;
-        initialize = (cb, u, t, integrator) -> begin
-            skip_first || cb!(integrator)
-            t_end = integrator.sol.prob.tspan[2]
-            next_t[] =
-                (call_at_end && t < t_end) ? min(t_end, t + dt) : t + dt
-        end,
+        initialize,
         save_positions = (false, false),
     )
 end

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -23,35 +23,42 @@ Returns a callback to display simulation information.
 Adapted from ClimaTimeSteppers.jl #89.
 """
 function display_status_callback!(::Type{tType}) where {tType}
-    # start_time = UInt64(0.0)
-    # prev_time = UInt64(0.0)
-    # prev_t = tType(0.0)
-    # eta = tType(0.0)
-    # speed = tType(0.0)
-    # is_first_step = true
+    # start_time = Ref{Float64}()
+    # prev_time = Ref{Float64}()
+    # time = Ref{Float64}()
+
+    # prev_t = Ref{tType}()
+    # eta = Ref{tType}()
+    # speed = Ref{tType}()
+    # is_not_first_step = Ref{Bool}()
+    # eta_string = Ref{String}()
+    # output_string = Ref{String}()
 
     function affect!(integrator)
         # t_end = maximum(integrator.tstops.valtree)
         # nsteps = ceil(Int64, t_end / integrator.dt)
         # t = integrator.t
         # step = ceil(Int64, t / integrator.dt)
-        # time = time_ns() / 1e9
-        # speed = (time - prev_time) / (t - prev_t)
-        # eta = speed * (t_end - t)
-        # eta_string = eta == Inf ? "..." : string(round(Int64, eta)) * " seconds"
+        # time[] = time_ns() / 1e9
+        # speed[] = (time[] - prev_time[]) / (t - prev_t[])
+        # eta[] = speed[] * (t_end - t)
+        # # eta_string[] = eta[] == Inf ? "..." : string(round(eta[])) * " seconds"
 
-        # if is_first_step
-        #     is_first_step = false
-        #     start_time = time
+        # if !is_not_first_step[]
+        #     is_not_first_step[] = true
+        #     start_time[] = time[]
         # end
-        # @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u d")) \n\
-        # Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n\
-        # Walltime: $(round(time - start_time, digits=2)) seconds; \
-        # Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\
+        # output_string[] = "dssda"
+        # println(output_string[])
+        println("")
+        # $(Dates.format(Dates.now(), "HH:MM:SS:ss u d")) \n")
+        # println("Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n ")
+        # Walltime: $(round(time[] - start_time[], digits=2)) seconds; \
+        # Time/Step: $(round(speed[] * integrator.dt, digits=2)) seconds \n")
         # Time Remaining: $eta_string"
     
-        # prev_t = t
-        # prev_time = time
+        # prev_t[] = t
+        # prev_time[] = time[]
         return nothing
     end
     return affect!

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -62,9 +62,9 @@ function display_status_callback!()
             start_time[] = time[]
         else
             @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u-d")) \n\
-            Timestep: $(step[]) / $(nsteps[]); Simulation Time: $(t[]); \n\
+            Timestep: $(step[]) / $(nsteps[]); Simulation Time: $(t[]) seconds \n\
             Walltime: $(round(time[] - start_time[], digits=2)) seconds; Time/Step: $(round(time[] - prev_time[], digits=2)) \n\
-            Time Remaining: $(round(eta[])) seconds"
+            Time Remaining: $(Int64(round(eta[]))) seconds"
         end
         prev_t[] = t[]
         prev_time[] = time[]

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -25,13 +25,13 @@ Given typeof(dt), returns a callback to display:
  - estimated wallclock time remaining.
 Adapted from ClimaTimeSteppers.jl #89.
 """
-function display_status_callback!(::Type{tType}) where {tType}
+function display_status_callback!()
     start_time = Ref{Float64}()
     prev_time = Ref{Float64}()
     time = Ref{Float64}()
-    prev_t = Ref{tType}()
-    t = Ref{tType}()
-    t_end = Ref{tType}()
+    prev_t = Ref{Float64}()
+    t = Ref{Float64}()
+    t_end = Ref{Float64}()
     # milliseconds
     speed = Ref{Float64}()
     eta = Ref{Float64}()
@@ -51,14 +51,12 @@ function display_status_callback!(::Type{tType}) where {tType}
         speed[] = (time[] - prev_time[]) / (t[] - prev_t[])
         eta[] = speed[] * (t_end[] - t[])
         if is_first_step[]
-            println("Time Remaining: ...")
+            @info "Time Remaining: ..."
             is_first_step[] = false
             start_time[] = time[]
         else
-            println(
-                "$(round(t[] / t_end[] * 100, digits=2))% complete in $(round(time[] - start_time[], digits=2)) seconds",
-            )
-            println("Time Remaining: $(round(eta[], digits=2)) seconds")
+            @info "$(round(t[] / t_end[] * 100, digits=2))% complete in $(round(time[] - start_time[], digits=2)) seconds"
+            @info "Time Remaining: $(round(eta[], digits=2)) seconds"
         end
         prev_t[] = t[]
         prev_time[] = time[]

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -37,9 +37,15 @@ function display_status_callback!()
     speed = Ref{Float64}()
     is_first_step = Ref{Bool}()
 
+    nsteps = Ref{Int64}()
+    step = Ref{Int64}()
+
+
     function initialize(_, _, _, integrator)
         is_first_step[] = true
         t_end[] = integrator.p.simulation.t_end
+        step[] = 0
+        nsteps[] = ceil(Int, t_end[] / integrator.dt)
     end
 
     function affect!(integrator)
@@ -49,15 +55,16 @@ function display_status_callback!()
         time[] = time_ns() / 1e9
         speed[] = (time[] - prev_time[]) / (t[] - prev_t[])
         eta[] = speed[] * (t_end[] - t[])
+        step[] += 1
         if is_first_step[]
             # @info "Time Remaining: ..."
             is_first_step[] = false
             start_time[] = time[]
         else
-            @info "Time Remaining: $(round(eta[], digits=2)) seconds\n\
-            $(round(t[] / t_end[] * 100, digits=2))% \
-            complete in $(round(time[] - start_time[], digits=2)) \
-            seconds"
+            @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u-d")) \n\
+            Timestep: $(step[]) / $(nsteps[]); Simulation Time: $(t[]); \n\
+            Walltime: $(round(time[] - start_time[], digits=2)) seconds; Time/Step: $(round(time[] - prev_time[], digits=2)) \n\
+            Time Remaining: $(round(eta[])) seconds"
         end
         prev_t[] = t[]
         prev_time[] = time[]

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -58,7 +58,7 @@ function display_status_callback!()
             @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u-d")) \n\
             Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n\
             Walltime: $(round(time - start_time, digits=2)) seconds; \
-            Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\ "
+            Time/Step: $(round(speed * integrator.dt, digits=2)) seconds"
             # Time Remaining: $(Int64(round(eta))) seconds"
         end
         prev_t = t

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -26,15 +26,15 @@ Given typeof(dt), returns a callback to display:
 Adapted from ClimaTimeSteppers.jl #89.
 """
 function display_status_callback!()
-    start_time = Ref{Float64}()
-    prev_time = Ref{Float64}()
-    time = Ref{Float64}()
     prev_t = Ref{Float64}()
     t = Ref{Float64}()
     t_end = Ref{Float64}()
-    # milliseconds
-    speed = Ref{Float64}()
+
+    start_time = Ref{Float64}()
+    prev_time = Ref{Float64}()
+    time = Ref{Float64}()
     eta = Ref{Float64}()
+    speed = Ref{Float64}()
     is_first_step = Ref{Bool}()
 
     function initialize(_, _, _, integrator)
@@ -51,17 +51,18 @@ function display_status_callback!()
         speed[] = (time[] - prev_time[]) / (t[] - prev_t[])
         eta[] = speed[] * (t_end[] - t[])
         if is_first_step[]
-            @info "Time Remaining: ..."
+            # @info "Time Remaining: ..."
             is_first_step[] = false
             start_time[] = time[]
         else
-            @info "$(round(t[] / t_end[] * 100, digits=2))% complete in $(round(time[] - start_time[], digits=2)) seconds"
-            @info "Time Remaining: $(round(eta[], digits=2)) seconds"
+            @info "Time Remaining: $(round(eta[], digits=2)) seconds\n\
+            $(round(t[] / t_end[] * 100, digits=2))% \
+            complete in $(round(time[] - start_time[], digits=2)) \
+            seconds"
         end
         prev_t[] = t[]
         prev_time[] = time[]
     end
-
     return initialize, affect!
 end
 

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -58,8 +58,8 @@ function display_status_callback!()
             @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u-d")) \n\
             Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n\
             Walltime: $(round(time - start_time, digits=2)) seconds; \
-            Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\
-            Time Remaining: $(Int64(round(eta))) seconds"
+            Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\ "
+            # Time Remaining: $(Int64(round(eta))) seconds"
         end
         prev_t = t
         prev_time = time

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -39,7 +39,6 @@ function display_status_callback!()
 
     function initialize(_, _, _, integrator)
         is_first_step[] = true
-        prev_time[] = time_ns() / 1e9
         t_end[] = integrator.p.simulation.t_end
     end
 

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -23,35 +23,36 @@ Returns a callback to display simulation information.
 Adapted from ClimaTimeSteppers.jl #89.
 """
 function display_status_callback!(::Type{tType}) where {tType}
-    start_time = UInt64(0.0)
-    prev_time = UInt64(0.0)
-    prev_t = tType(0.0)
-    eta = tType(0.0)
-    speed = tType(0.0)
-    is_first_step = true
+    # start_time = UInt64(0.0)
+    # prev_time = UInt64(0.0)
+    # prev_t = tType(0.0)
+    # eta = tType(0.0)
+    # speed = tType(0.0)
+    # is_first_step = true
 
     function affect!(integrator)
-        t_end = maximum(integrator.tstops.valtree)
-        nsteps = ceil(Int64, t_end / integrator.dt)
-        t = integrator.t
-        step = ceil(Int64, t / integrator.dt)
-        time = time_ns() / 1e9
-        speed = (time - prev_time) / (t - prev_t)
-        eta = speed * (t_end - t)
-        eta_string = eta == Inf ? "..." : string(round(Int64, eta)) * "seconds"
+        # t_end = maximum(integrator.tstops.valtree)
+        # nsteps = ceil(Int64, t_end / integrator.dt)
+        # t = integrator.t
+        # step = ceil(Int64, t / integrator.dt)
+        # time = time_ns() / 1e9
+        # speed = (time - prev_time) / (t - prev_t)
+        # eta = speed * (t_end - t)
+        # eta_string = eta == Inf ? "..." : string(round(Int64, eta)) * " seconds"
 
-        if is_first_step
-            is_first_step = false
-            start_time = time
-        end
-        @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u d")) \n\
-        Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n\
-        Walltime: $(round(time - start_time, digits=2)) seconds; \
-        Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\
-        Time Remaining: $eta_string"
+        # if is_first_step
+        #     is_first_step = false
+        #     start_time = time
+        # end
+        # @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u d")) \n\
+        # Timestep: $(step) / $(nsteps); Simulation Time: $(t) seconds \n\
+        # Walltime: $(round(time - start_time, digits=2)) seconds; \
+        # Time/Step: $(round(speed * integrator.dt, digits=2)) seconds \n\
+        # Time Remaining: $eta_string"
     
-        prev_t = t
-        prev_time = time
+        # prev_t = t
+        # prev_time = time
+        return nothing
     end
     return affect!
 end

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -17,12 +17,9 @@ import ClimaCore.Fields: ColumnField
 include("callback_helpers.jl")
 
 """
-    display_status_callback!(::Type{tType})
+    display_status_callback!()
 
-Given typeof(dt), returns a callback to display:
- - percentage of work completed, 
- - total wallclock time elapsed,
- - estimated wallclock time remaining.
+Returns a callback to display simulation information.
 Adapted from ClimaTimeSteppers.jl #89.
 """
 function display_status_callback!()
@@ -63,7 +60,8 @@ function display_status_callback!()
         else
             @info "$(Dates.format(Dates.now(), "HH:MM:SS:ss u-d")) \n\
             Timestep: $(step[]) / $(nsteps[]); Simulation Time: $(t[]) seconds \n\
-            Walltime: $(round(time[] - start_time[], digits=2)) seconds; Time/Step: $(round(time[] - prev_time[], digits=2)) \n\
+            Walltime: $(round(time[] - start_time[], digits=2)) seconds; \
+            Time/Step: $(round(speed[] * integrator.dt, digits=2)) seconds \n\
             Time Remaining: $(Int64(round(eta[]))) seconds"
         end
         prev_t[] = t[]

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -16,6 +16,47 @@ import ClimaCore.Fields: ColumnField
 
 include("callback_helpers.jl")
 
+"""
+    display_status_callback!(::Type{tType})
+
+Given typeof(dt), returns a callback to display:
+ - percentage of work completed, 
+ - total wallclock time elapsed,
+ - estimated wallclock time remaining.
+Adapted from ClimaTimeSteppers.jl #89.
+"""
+function display_status_callback!(::Type{tType}) where {tType}
+    start_time = Ref{Float64}()
+    prev_time = Ref{Float64}()
+    current_time = Ref{Float64}()
+    prev_t = Ref{tType}()
+    # milliseconds
+    speed = Ref{Float64}()
+    eta = Ref{Float64}()
+    is_first_step = Ref{Bool}(true)
+
+    return function (integrator)
+        # speed = wallclock time / simulation time
+        # Print ETA = speed * remaining simulation time
+        t = integrator.t
+        t_end = integrator.p.simulation.t_end
+        current_time[] = round(time_ns()) / 1e9
+        speed[] = (current_time[] - prev_time[]) / (t - prev_t[])
+        eta[] = speed[] * (t_end - t)
+        if is_first_step[]
+            println("Time Remaining: ...")
+            is_first_step[] = false
+            start_time[] = current_time[]
+        else
+            println(Dates.now())
+            println("$(round(t / t_end * 100, digits=2))% complete in $(round(current_time[] - start_time[], digits=2)) seconds")
+            println("Time Remaining: $(round(eta[], digits=2)) seconds")
+        end
+        prev_t[] = t
+        prev_time[] = current_time[]
+    end
+end
+
 function dss_callback!(integrator)
     Y = integrator.u
     ghost_buffer = integrator.p.ghost_buffer

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -501,6 +501,18 @@ function get_callbacks(parsed_args, simulation, atmos, params)
             (callbacks..., call_every_dt(save_restart_func, dt_save_restart))
     end
 
+    dt_show_progress = time_to_seconds(parsed_args["dt_show_progress"])
+    if !(dt_show_progress == Inf)
+        callbacks = (
+            callbacks...,
+            call_every_dt(
+                display_status_callback!(typeof(dt)),
+                dt_show_progress;
+                skip_first = true,
+            ),
+        )
+    end
+
     if is_distributed(simulation.comms_ctx)
         callbacks = (
             callbacks...,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -503,12 +503,14 @@ function get_callbacks(parsed_args, simulation, atmos, params)
 
     dt_show_progress = time_to_seconds(parsed_args["dt_show_progress"])
     if !(dt_show_progress == Inf)
+        initialize, affect! = display_status_callback!(typeof(dt))
         callbacks = (
             callbacks...,
             call_every_dt(
-                display_status_callback!(typeof(dt)),
+                affect!,
                 dt_show_progress;
                 skip_first = true,
+                initialize,
             ),
         )
     end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -503,7 +503,7 @@ function get_callbacks(parsed_args, simulation, atmos, params)
 
     dt_show_progress = time_to_seconds(parsed_args["dt_show_progress"])
     if !(dt_show_progress == Inf)
-        initialize, affect! = display_status_callback!(typeof(dt))
+        initialize, affect! = display_status_callback!()
         callbacks = (
             callbacks...,
             call_every_dt(

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -503,14 +503,12 @@ function get_callbacks(parsed_args, simulation, atmos, params)
 
     dt_show_progress = time_to_seconds(parsed_args["dt_show_progress"])
     if !(dt_show_progress == Inf)
-        initialize, affect! = display_status_callback!()
         callbacks = (
             callbacks...,
             call_every_dt(
-                affect!,
+                display_status_callback!(typeof(dt)),
                 dt_show_progress;
                 skip_first = true,
-                initialize,
             ),
         )
     end


### PR DESCRIPTION
## Content
Adds a callback `display_status_callback!()` which prints:
 - percentage of work completed, 
 - total wallclock time elapsed,
 - estimated wallclock time remaining.

Also adds a config argument `dt_show_progress`, which determines the frequency of the callback.
