### PR TITLE
Update default horizontal sponge configuration + fix typo in help string

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -199,7 +199,7 @@ job_id:
   help: "Uniquely identifying string for a particular job"
   value: ~
 density_upwinding:
-  help: "Denisity upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
+  help: "Density upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
   value: none
 tracer_upwinding:
   help: "Tracer upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
@@ -252,7 +252,7 @@ alpha_rayleigh_w:
   value: 1.0
 alpha_rayleigh_uh:
   help: "Rayleigh sponge coefficient for horizontal velocity"
-  value: 0.0001
+  value: 0.0
 zd_viscous:
   help: "Viscous sponge height"
   value: 15000.0

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64.yml
@@ -15,6 +15,5 @@ alpha_rayleigh_w: 10.0
 FLOAT_TYPE: "Float64"
 z_max: 45000.0
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 job_id: "longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_float64"
 moist: "equil"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_allsky_ft64.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_allsky_ft64.yml
@@ -13,6 +13,5 @@ kappa_4: 1.0e16
 idealized_insolation: false
 FLOAT_TYPE: "Float64"
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 job_id: "longrun_aquaplanet_rhoe_equil_highres_allsky_ft64"
 moist: "equil"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64.yml
@@ -12,7 +12,6 @@ h_elem: 16
 kappa_4: 1.0e16
 FLOAT_TYPE: "Float64"
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 dt_save_to_sol: "10days"
 job_id: "longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64"
 moist: "equil"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64_earth.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64_earth.yml
@@ -15,7 +15,6 @@ kappa_4: 3.0e16
 FLOAT_TYPE: "Float64"
 precip_model: "0M"
 topography: "Earth"
-alpha_rayleigh_uh: 0.0
 dt_save_to_sol: "10days"
 job_id: "longrun_aquaplanet_rhoe_equil_highres_clearsky_ft64_earth"
 moist: "equil"

--- a/config/longrun_configs/longrun_bw_rhoe_equil_highres_topography_earth.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_equil_highres_topography_earth.yml
@@ -11,6 +11,5 @@ use_reference_state: false
 kappa_4: 2.0e16
 precip_model: "0M"
 topography: "Earth"
-alpha_rayleigh_uh: 0.0
 job_id: "longrun_bw_rhoe_equil_highres_topography_earth"
 moist: "equil"

--- a/config/longrun_configs/longrun_hs_rhoe_equil_highres_topography_earth.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equil_highres_topography_earth.yml
@@ -12,6 +12,5 @@ kappa_4: 3.0e16
 forcing: "held_suarez"
 precip_model: "0M"
 topography: "Earth"
-alpha_rayleigh_uh: 0.0
 job_id: "longrun_hs_rhoe_equil_highres_topography_earth"
 moist: "equil"

--- a/config/longrun_configs/longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3.yml
@@ -13,6 +13,5 @@ forcing: "held_suarez"
 alpha_rayleigh_w: 10.0
 z_max: 45000.0
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 job_id: "longrun_hs_rhoe_equilmoist_highres_hightop_rayleigh30e3"
 moist: "equil"

--- a/config/longrun_configs/longrun_zalesak_tracer_energy_aquaplanet_rhoe_equil_highres_clearsky_ft64.yml
+++ b/config/longrun_configs/longrun_zalesak_tracer_energy_aquaplanet_rhoe_equil_highres_clearsky_ft64.yml
@@ -14,7 +14,6 @@ kappa_4: 1.0e16
 energy_upwinding: zalesak
 FLOAT_TYPE: "Float64"
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 dt_save_to_sol: "10days"
 job_id: "longrun_zalesak_tracer_energy_aquaplanet_rhoe_equil_highres_clearsky_ft64"
 moist: "equil"

--- a/config/model_configs/edmf_trmm.yml
+++ b/config/model_configs/edmf_trmm.yml
@@ -15,6 +15,7 @@ FLOAT_TYPE: "Float64"
 z_max: 16400.0
 precip_model: "1M"
 regression_test: true
+alpha_rayleigh_uh: 0.0001
 dt_save_to_sol: "5mins"
 job_id: "edmf_trmm"
 rad: "TRMM_LBA"

--- a/config/model_configs/plane_agnesi_mountain_test_stretched.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_stretched.yml
@@ -14,5 +14,4 @@ kappa_4: 1.0e6
 alpha_rayleigh_w: 0.1
 z_max: 25000.0
 topography: "Agnesi"
-alpha_rayleigh_uh: 0.0
 job_id: "plane_agnesi_mountain_test_stretched"

--- a/config/model_configs/plane_agnesi_mountain_test_uniform.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_uniform.yml
@@ -13,5 +13,4 @@ kappa_4: 1.0e6
 alpha_rayleigh_w: 0.1
 z_max: 25000.0
 topography: "Agnesi"
-alpha_rayleigh_uh: 0.0
 job_id: "plane_agnesi_mountain_test_uniform"

--- a/config/model_configs/plane_schar_mountain_test_stretched.yml
+++ b/config/model_configs/plane_schar_mountain_test_stretched.yml
@@ -15,5 +15,4 @@ kappa_4: 5.0e7
 alpha_rayleigh_w: 0.1
 z_max: 25000.0
 topography: "Schar"
-alpha_rayleigh_uh: 0.0
 job_id: "plane_schar_mountain_test_stretched"

--- a/config/model_configs/plane_schar_mountain_test_uniform.yml
+++ b/config/model_configs/plane_schar_mountain_test_uniform.yml
@@ -14,5 +14,4 @@ kappa_4: 5.0e7
 alpha_rayleigh_w: 0.1
 z_max: 25000.0
 topography: "Schar"
-alpha_rayleigh_uh: 0.0
 job_id: "plane_schar_mountain_test_uniform"

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -14,7 +14,6 @@ idealized_insolation: false
 z_max: 45000.0
 precip_model: "0M"
 regression_test: true
-alpha_rayleigh_uh: 0.0
 surface_temperature: "ZonallyAsymmetric"
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"
 moist: "equil"

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
@@ -14,6 +14,5 @@ idealized_insolation: false
 z_max: 45000.0
 precip_model: "0M"
 regression_test: true
-alpha_rayleigh_uh: 0.0
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"
 moist: "equil"

--- a/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
+++ b/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
@@ -11,7 +11,6 @@ forcing: "held_suarez"
 z_max: 45000.0
 precip_model: "0M"
 regression_test: true
-alpha_rayleigh_uh: 0.0
 viscous_sponge: true
 job_id: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge"
 moist: "equil"

--- a/config/model_configs/sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge.yml
+++ b/config/model_configs/sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge.yml
@@ -13,7 +13,6 @@ forcing: "held_suarez"
 energy_upwinding: first_order
 z_max: 45000.0
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 viscous_sponge: true
 job_id: "sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge"
 moist: "equil"

--- a/config/perf_configs/flame/perf_gw.yml
+++ b/config/perf_configs/flame/perf_gw.yml
@@ -12,6 +12,5 @@ vert_diff: "true"
 idealized_insolation: false
 z_max: 45000.0
 precip_model: "0M"
-alpha_rayleigh_uh: 0.0
 job_id: "flame_perf_gw"
 moist: "equil"


### PR DESCRIPTION
Sets default Rayleigh-sponge coefficient `alpha_rayleigh_uh` for horizontal velocities to zero. 
Fix typo in help string
Removes specification of `alpha_rayleigh_uh: 0.0` where default value is used. 
Adds `alpha_rayleigh_uh: 0.0001` to TRMM_LBA case - if necessary this sponge config can be changed in a separate PR. 

SDI: https://github.com/CliMA/ClimaAtmos.jl/issues/2002