### PR TITLE
Avoid unnecessary cache recomputation

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -271,7 +271,7 @@ function instead of recomputing the value yourself. Otherwise, it will be
 difficult to ensure that the duplicated computations are consistent.
 """
 function set_precomputed_quantities!(Y, p, t)
-    is_stale!(p.cache_state, Y) || return nothing
+    is_stale!(p.cache_state, Y, t) || return nothing
     (; energy_form, moisture_model, turbconv_model) = p.atmos
     thermo_params = CAP.thermodynamics_params(p.params)
     n = n_mass_flux_subdomains(turbconv_model)
@@ -320,6 +320,7 @@ function set_precomputed_quantities!(Y, p, t)
     if turbconv_model isa DiagnosticEDMFX
         set_diagnostic_edmf_precomputed_quantities!(Y, p, t)
     end
+    @. p.cache_state.Y = Y
 
     return nothing
 end

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -271,6 +271,7 @@ function instead of recomputing the value yourself. Otherwise, it will be
 difficult to ensure that the duplicated computations are consistent.
 """
 function set_precomputed_quantities!(Y, p, t)
+    is_stale!(p.cache_state, t) || return nothing
     (; energy_form, moisture_model, turbconv_model) = p.atmos
     thermo_params = CAP.thermodynamics_params(p.params)
     n = n_mass_flux_subdomains(turbconv_model)

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -271,7 +271,7 @@ function instead of recomputing the value yourself. Otherwise, it will be
 difficult to ensure that the duplicated computations are consistent.
 """
 function set_precomputed_quantities!(Y, p, t)
-    is_stale!(p.cache_state, t) || return nothing
+    is_stale!(p.cache_state, Y) || return nothing
     (; energy_form, moisture_model, turbconv_model) = p.atmos
     thermo_params = CAP.thermodynamics_params(p.params)
     n = n_mass_flux_subdomains(turbconv_model)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -545,6 +545,7 @@ function get_cache(
     simulation,
     initial_condition,
     surface_setup,
+    t_start,
 )
     _default_cache = default_cache(
         Y,
@@ -555,6 +556,7 @@ function get_cache(
         numerics,
         simulation,
         surface_setup,
+        t_start,
     )
     merge(
         _default_cache,
@@ -722,6 +724,7 @@ function get_integrator(config::AtmosConfig)
             simulation,
             initial_condition,
             surface_setup,
+            t_start,
         )
     end
     @info "Allocating cache (p): $s"


### PR DESCRIPTION
This PR defines `CacheState` and uses it to avoid unnecessary cache re-computations by setting a Bool at the beginning of each function that ClimaTimesteppers calls, and then resetting it at the end of `set_precomputed_quantities!`.

This PR should eliminate at least one call to `set_precomputed_quantities!` (the one after `Wfact!`), but in theory, this can eliminate more.