### PR TITLE
make scaling pipeline plot on failure

### DIFF
--- a/.buildkite/scaling/pipeline.sh
+++ b/.buildkite/scaling/pipeline.sh
@@ -198,7 +198,8 @@ fi
 done
 
 cat << EOM
-    - wait
+    - wait: ~
+      continue_on_failure: true
 
     - label: ":chart_with_upwards_trend:"
       key: "cpu_scaling_plots_$res-resolution"
@@ -218,7 +219,8 @@ EOM
 done
 
 cat << EOM
-  - wait
+  - wait: ~
+    continue_on_failure: true
 
   - label: ":broom: clean up config files" 
     command: "rm -rf $parent_folder"


### PR DESCRIPTION
The plotting jobs in the scaling pipeline don't run if a prior job fails, this needs to be fixed.

Test scaling build: https://buildkite.com/clima/climaatmos-scaling/builds/506#018a427c-39c0-45f1-a03c-0a44b6a7c722