### PR TITLE
increase t_end for rico

### DIFF
--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -22,6 +22,6 @@ y_elem: 2
 z_elem: 100
 z_max: 4e3
 z_stretch: false
-dt: 5secs
-t_end: 6hours
+dt: 10secs
+t_end: 8hours
 dt_save_to_disk: 10mins

--- a/post_processing/contours_and_profiles.jl
+++ b/post_processing/contours_and_profiles.jl
@@ -381,7 +381,7 @@ function contours_and_profiles(output_dir, ref_job_id = nothing)
     has_sgs = hasproperty(time_series[1][2], :draft_area)
 
     negative_values_allowed_names =
-        (:u_velocity, :v_velocity, :w_velocity, :buoyancy)
+        (:u_velocity, :v_velocity, :w_velocity, :buoyancy, :specific_enthalpy)
 
     env_or_gm = has_sgs ? :env : :gm
     draft_or_gm = has_sgs ? :draft : :gm


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Increases dt to 10 secs t_end to 8 hours for rico. Also allows enthalpy to be negative in plotting.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
