### PR TITLE
Clean up warnings in docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -6,7 +6,7 @@ ClimaAtmos.TurbulenceConvection.Parameters
 
 ## Initial conditions
 
-### General 
+### General
 
 ```@docs
 ClimaAtmos.InitialConditions.InitialCondition

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -18,10 +18,8 @@ alias = "grav"
 value = 9.81
 type = "float"
 ```
-For more info on formatting the TOML, see [here]([https://clima.github.io/CLIMAParameters.jl/dev/toml/](https://clima.github.io/CLIMAParameters.jl/dev/toml/)). 
+For more info on formatting the TOML, see [here](https://clima.github.io/CLIMAParameters.jl/dev/toml/).
 
-
-# After CLI Removal:
 Once you have created your parameter file (`parameters.toml`), you must create a separate YAML configuration file (`config.yaml`).
 In the config file, enter:
 ```
@@ -30,13 +28,3 @@ toml: parameters.toml
 In order to run the model, type: `julia --project=examples --config_file config.yaml`.
 Note that the `--config_file` argument can take several config files, so if you have a separate config file you would like to use,
 you can simply add it to the end of the command line arguments. Alternatively, you can just add your TOML config to the existing config file.
-
-# Pre-CLI removal:
-To run the model, you can either initialize the model interactively from the Julia REPL or from the command-line.
-From the command-line at the top-level CA directory, just run `julia --project=examples --toml path/to/toml`
-
-If running the model interactively, you can change `ARGS` and append `["--toml", "path/to/toml"]`.
-Alternatively, you can create the `parsed_args` dictionary and manually alter it yourself: `parsed_args["toml"] = "path/to/toml"`.
-
-If you are just overriding a parameter, you can just create the model config and run the model! 
-If you add a new parameter, you need to alter the [ClimaAtmosParameters]([https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/parameters/Parameters.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/parameters/Parameters.jl#L13)) struct to include your parameter. This can temporarily be done at the top level if you need to test something quickly, but if you want to merge the code, it is best to place your new parameter inside one of the nested parameter structs.

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -561,7 +561,7 @@ end
 """
     GABLS
 
-The `InitialCondition` described in [Kosovic2000](cite), but with a hydrostatically
+The `InitialCondition` described in [Kosovic2000](@cite), but with a hydrostatically
 balanced pressure profile.
 """
 Base.@kwdef struct GABLS <: InitialCondition
@@ -777,7 +777,7 @@ end
 """
     Rico
 
-The `InitialCondition` described in [Rauber2007](cite), but with a hydrostatically
+The `InitialCondition` described in [Rauber2007](@cite), but with a hydrostatically
 balanced pressure profile.
 """
 Base.@kwdef struct Rico <: InitialCondition


### PR DESCRIPTION
The documentation is generated with a few warnings and one error (see, e.g., https://github.com/CliMA/ClimaAtmos.jl/actions/runs/6101954504/job/16559376893#step:5:8).

The error is due to an incompatibility between `doctest` and `CitationBibliography`. I reported the problem upstream. The error is not fatal.