### PR TITLE
Lower jet inference limit

### DIFF
--- a/perf/jet_test_nfailures.jl
+++ b/perf/jet_test_nfailures.jl
@@ -26,7 +26,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 833
+    n_allowed_failures = 256
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures
         @info "Please update the n-failures to $n"


### PR DESCRIPTION
This PR lowers the jet inference limit. I think the upgrade to Julia 1.9 fixed a bunch of these issues.