### PR TITLE
Treat idealized_{insolation,clouds} as idealized_h20

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -132,19 +132,12 @@ function additional_cache(
 )
     (; precip_model, forcing_type, radiation_mode, turbconv_model) = atmos
 
-    idealized_insolation = parsed_args["idealized_insolation"]
-    @assert idealized_insolation in (true, false)
-    idealized_clouds = parsed_args["idealized_clouds"]
-    @assert idealized_clouds in (true, false)
-
     radiation_cache = if radiation_mode isa RRTMGPI.AbstractRRTMGPMode
         radiation_model_cache(
             Y,
             default_cache,
             params,
             radiation_mode;
-            idealized_insolation,
-            idealized_clouds,
             data_loader = rrtmgp_data_loader,
         )
     else

--- a/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
+++ b/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
@@ -90,15 +90,23 @@ array2data(
 abstract type AbstractRRTMGPMode end
 struct GrayRadiation <: AbstractRRTMGPMode
     idealized_h2o::Bool
+    idealized_insolation::Bool
+    idealized_clouds::Bool
 end
 struct ClearSkyRadiation <: AbstractRRTMGPMode
     idealized_h2o::Bool
+    idealized_insolation::Bool
+    idealized_clouds::Bool
 end
 struct AllSkyRadiation <: AbstractRRTMGPMode
     idealized_h2o::Bool
+    idealized_insolation::Bool
+    idealized_clouds::Bool
 end
 struct AllSkyRadiationWithClearSkyDiagnostics <: AbstractRRTMGPMode
     idealized_h2o::Bool
+    idealized_insolation::Bool
+    idealized_clouds::Bool
 end
 
 """

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -33,12 +33,10 @@ function radiation_model_cache(
     radiation_mode::RRTMGPI.AbstractRRTMGPMode = RRTMGPI.ClearSkyRadiation();
     interpolation = RRTMGPI.BestFit(),
     bottom_extrapolation = RRTMGPI.SameAsInterpolation(),
-    idealized_insolation = true,
-    idealized_clouds = false,
     data_loader,
 )
     context = ClimaComms.context(axes(Y.c))
-    (; idealized_h2o) = radiation_mode
+    (; idealized_h2o, idealized_insolation, idealized_clouds) = radiation_mode
     FT = Spaces.undertype(axes(Y.c))
     rrtmgp_params = CAP.rrtmgp_params(params)
     if idealized_h2o && radiation_mode isa RRTMGPI.GrayRadiation

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -181,6 +181,10 @@ end
 function get_radiation_mode(parsed_args, ::Type{FT}) where {FT}
     idealized_h2o = parsed_args["idealized_h2o"]
     @assert idealized_h2o in (true, false)
+    idealized_insolation = parsed_args["idealized_insolation"]
+    @assert idealized_insolation in (true, false)
+    idealized_clouds = parsed_args["idealized_clouds"]
+    @assert idealized_clouds in (true, false)
     radiation_name = parsed_args["rad"]
     @assert radiation_name in (
         nothing,
@@ -193,13 +197,29 @@ function get_radiation_mode(parsed_args, ::Type{FT}) where {FT}
         "TRMM_LBA",
     )
     return if radiation_name == "clearsky"
-        RRTMGPI.ClearSkyRadiation(idealized_h2o)
+        RRTMGPI.ClearSkyRadiation(
+            idealized_h2o,
+            idealized_insolation,
+            idealized_clouds,
+        )
     elseif radiation_name == "gray"
-        RRTMGPI.GrayRadiation(idealized_h2o)
+        RRTMGPI.GrayRadiation(
+            idealized_h2o,
+            idealized_insolation,
+            idealized_clouds,
+        )
     elseif radiation_name == "allsky"
-        RRTMGPI.AllSkyRadiation(idealized_h2o)
+        RRTMGPI.AllSkyRadiation(
+            idealized_h2o,
+            idealized_insolation,
+            idealized_clouds,
+        )
     elseif radiation_name == "allskywithclear"
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics(idealized_h2o)
+        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics(
+            idealized_h2o,
+            idealized_insolation,
+            idealized_clouds,
+        )
     elseif radiation_name == "DYCOMS_RF01"
         RadiationDYCOMS_RF01{FT}()
     elseif radiation_name == "TRMM_LBA"


### PR DESCRIPTION
This commit puts `idealized_insoluation` and `idealized_clouds` on the same footing as `idealized_h20`. As a result, it also removes the need to use `parsed_args` in the computation of the cache.
