### PR TITLE
Up julia version in scaling pipeline

### DIFF
--- a/.buildkite/scaling/pipeline.sh
+++ b/.buildkite/scaling/pipeline.sh
@@ -67,7 +67,7 @@ done
 # set up environment and agents
 cat << EOM
 env:
-  JULIA_VERSION: "1.8.5"
+  JULIA_VERSION: "1.9.3"
   MPICH_VERSION: "4.0.0"
   OPENMPI_VERSION: "4.1.1"
   MPI_IMPL: "$mpi_impl"


### PR DESCRIPTION
This got missed during the upgrade to 1.9 and is required to get the scaling pipeline working again.

[Relevant build](https://buildkite.com/clima/climaatmos-scaling/builds/511) 