### PR TITLE
Change edmf entrainment closure

### DIFF
--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -35,6 +35,9 @@ debugging_tc:
 entr_coeff:
   help: "Entrainment coefficient"
   value: 1.0
+entr_tau:
+  help: "Entrainment timescale"
+  value: 900.0
 detr_coeff:
   help: "Detrainment coefficient"
   value: 0.001

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -205,7 +205,7 @@ function set_diagnostic_edmf_precomputed_quantities!(Y, p, t)
         ρʲ_int_level = Fields.field_values(Fields.level(ᶜρʲ, 1))
 
         @. u³ʲ_int_halflevel = CT3(
-            Geometry.WVector($(FT(0.01)), local_geometry_int_halflevel),
+            Geometry.WVector($(FT(0)), local_geometry_int_halflevel),
             local_geometry_int_halflevel,
         )
         @. h_totʲ_int_level = sgs_scalar_first_interior_bc(

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -29,6 +29,7 @@ Base.@kwdef struct ClimaAtmosParameters{FT, TP, RP, IP, MPP, SFP, TCP, SP} <:
     turbconv_params::TCP
     sponge_params::SP
     entr_coeff::FT = 1
+    entr_tau::FT = 900
     detr_coeff::FT = 0.001
     # TODO: Figure out a better place for these held-suarez parameters
     ΔT_y_dry::FT
@@ -80,6 +81,7 @@ f(ps::ACAP) = ps.f
 Cd(ps::ACAP) = ps.Cd
 uh_g(ps::ACAP) = CC.Geometry.UVVector(ps.ug, ps.vg)
 entr_coeff(ps::ACAP) = ps.entr_coeff
+entr_tau(ps::ACAP) = ps.entr_tau
 detr_coeff(ps::ACAP) = ps.detr_coeff
 ΔT_y_dry(ps::ACAP) = ps.ΔT_y_dry
 ΔT_y_wet(ps::ACAP) = ps.ΔT_y_wet

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -143,6 +143,7 @@ function create_climaatmos_parameter_set(
         surfacefluxes_params = surf_flux_params,
         turbconv_params = tc_params,
         entr_coeff = FTD(parsed_args["entr_coeff"]),
+        entr_tau = FTD(parsed_args["entr_tau"]),
         detr_coeff = FTD(parsed_args["detr_coeff"]),
         ΔT_y_dry = FTD(pairs.ΔT_y_dry),
         ΔT_y_wet = FTD(pairs.ΔT_y_wet),

--- a/src/prognostic_equations/edmfx_closures.jl
+++ b/src/prognostic_equations/edmfx_closures.jl
@@ -152,6 +152,7 @@ function pi_groups_entr_detr(
         g = CAP.grav(params)
 
         entr_coeff = CAP.entr_coeff(params)
+        entr_tau = CAP.entr_tau(params)
         detr_coeff = CAP.detr_coeff(params)
 
         turbconv_params = CAP.turbconv_params(params)
@@ -189,7 +190,7 @@ function pi_groups_entr_detr(
         # TODO - Temporary: Switch to Π groups after simple tests are done
         # (kinematic, bubble, Bomex)
         # and/or we can calibrate things in ClimaAtmos
-        entr = max(0, min(entr_coeff * ᶜwʲ / (ᶜz - z_sfc), 1 / dt))
+        entr = max(0, min(1 / entr_tau, 1 / dt))
         detr = max(0, min(detr_coeff * ᶜwʲ, 1 / dt))
 
         return (; entr, detr)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Uses a constant timescale (default 900s) for entrainment, as suggested by @tapios. Also sets u^3 at the surface to zero in diagnostic edmf. Closes #2055.

cc @trontrytel. If this causes problems in prognostic edmf, we can make the default entrainment dependent on diagnostic or prognostic edmf.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
