### PR TITLE
Avoid FieldVector outer constructor inference

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -54,14 +54,14 @@ allocs = @allocated SciMLBase.step!(integrator)
 @info "`allocs ($job_id)`: $(allocs)"
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target"] = 4384
-allocs_limit["flame_perf_target_tracers"] = 204016
-allocs_limit["flame_perf_target_edmfx"] = 304064
-allocs_limit["flame_perf_target_diagnostic_edmfx"] = 685456
-allocs_limit["flame_perf_target_edmf"] = 12459299664
+allocs_limit["flame_perf_target"] = 4256
+allocs_limit["flame_perf_target_tracers"] = 203888
+allocs_limit["flame_perf_target_edmfx"] = 274832
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 662032
+allocs_limit["flame_perf_target_edmf"] = 12031972048
 allocs_limit["flame_perf_target_threaded"] = 6175664
-allocs_limit["flame_perf_target_callbacks"] = 49850536
-allocs_limit["flame_perf_gw"] = 4985829472
+allocs_limit["flame_perf_target_callbacks"] = 45111592
+allocs_limit["flame_perf_gw"] = 4911463328
 
 if allocs < allocs_limit[job_id] * buffer
     @info "TODO: lower `allocs_limit[$job_id]` to: $(allocs)"

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -508,11 +508,10 @@ function save_to_disk_func(integrator)
     hdfwriter = InputOutput.HDF5Writer(output_file, p.comms_ctx)
     InputOutput.HDF5.write_attribute(hdfwriter.file, "time", t) # TODO: a better way to write metadata
     InputOutput.write!(hdfwriter, Y, "Y")
-    InputOutput.write!(
-        hdfwriter,
-        Fields.FieldVector(; pairs(diagnostic)...),
-        "diagnostics",
-    )
+    FT = Spaces.undertype(axes(Y.c))
+    values = map(Fields.wrap, diagnostic)
+    fv = Fields.FieldVector{FT}(values)
+    InputOutput.write!(hdfwriter, fv, "diagnostics")
     Base.close(hdfwriter)
     return nothing
 end


### PR DESCRIPTION
I realized that most of the allocations in the callbacks are actually coming from _inference_ in the FieldVector outer constructor:

<img width="1896" alt="Screen Shot 2023-09-19 at 11 08 19 AM" src="https://github.com/CliMA/ClimaAtmos.jl/assets/1880641/9600dd17-4862-4730-8180-6e5d19a163d8">

This PR should (hopefully) avoid this, by calling the outer constructor where the undertype is pre-specified.