### PR TITLE
Remove spaces from cache

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -81,7 +81,6 @@ function default_cache(
     default_cache = (;
         is_init = Ref(true),
         simulation,
-        spaces,
         atmos,
         comms_ctx = ClimaComms.context(axes(Y.c)),
         sfc_setup = surface_setup(params),


### PR DESCRIPTION
Spaces don't need to be explicitly added to the cache-- that just adds to the type parameter space at no benefit since we can already get it from one of the many fields (also, we never use it!).

It looks like some of the init times are slightly improved in this PR.