### PR TITLE
remove precipitation timescale hack

### DIFF
--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -13,6 +13,7 @@ edmfx_sgs_flux: true
 moist: equil
 apply_limiter: false
 precip_model: "0M"
+override_τ_precip: false
 config: box
 hyperdiff: "true"
 kappa_4: 1e12
@@ -27,3 +28,4 @@ dt: 10secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"
+toml: [toml/diagnostic_edmfx_trmm_box.toml]

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -39,7 +39,7 @@ function q_tot_precipitation_sources(
             m_prs,
             TD.PhasePartition(t_prs, ts),
             TD.q_vap_saturation(t_prs, ts),
-        ) / 10,  # to be fixed after we get rid of parameter overwrites
+        ),
     )
 end
 

--- a/toml/diagnostic_edmfx_trmm_box.toml
+++ b/toml/diagnostic_edmfx_trmm_box.toml
@@ -1,0 +1,4 @@
+[precipitation_timescale]
+alias = "τ_precip"
+value = 100
+type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Removes the temporary hack in `q_tot_precipitation_sources`, adds `τ_precip` to diagnostic edmf trmm.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
