### PR TITLE
Leverage ClimaTimeSteppers post callbacks

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -57,7 +57,6 @@ NVTX.@annotate function turb_conv_affect_filter!(integrator)
     Y = integrator.u
     tc_params = CAP.turbconv_params(param_set)
 
-    set_precomputed_quantities!(Y, p, t) # sets ᶜts for set_edmf_surface_bc
     Fields.bycolumn(axes(Y.c)) do colidx
         state = TC.tc_column_state(Y, p, nothing, colidx, t)
         grid = TC.Grid(state)
@@ -75,8 +74,6 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
     Y = integrator.u
     p = integrator.p
     t = integrator.t
-
-    set_precomputed_quantities!(Y, p, t) # sets ᶜts and sfc_conditions
 
     (; ᶜts, sfc_conditions, params, env_thermo_quad) = p
     (; idealized_insolation, idealized_h2o, idealized_clouds) = p
@@ -254,8 +251,6 @@ NVTX.@annotate function compute_diagnostics(integrator)
     (; params, env_thermo_quad) = p
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
-
-    set_precomputed_quantities!(Y, p, t) # sets ᶜu, ᶜK, ᶜts, ᶜp, & SGS analogues
 
     (; ᶜu, ᶜK, ᶜts, ᶜp, sfc_conditions) = p
     dycore_diagnostic = (;

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -7,7 +7,6 @@ import ClimaCore: Fields, Geometry
 NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
     fill_with_nans!(p)
     Yₜ .= zero(eltype(Yₜ))
-    set_precomputed_quantities!(Y, p, t)
     Fields.bycolumn(axes(Y.c)) do colidx
         implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         if p.turbconv_model isa TurbulenceConvection.EDMFModel

--- a/src/prognostic_equations/implicit/wfact.jl
+++ b/src/prognostic_equations/implicit/wfact.jl
@@ -60,7 +60,6 @@ end
 
 NVTX.@annotate function Wfact!(W, Y, p, dtγ, t)
     fill_with_nans!(p)
-    set_precomputed_quantities!(Y, p, t)
     Fields.bycolumn(axes(Y.c)) do colidx
         Wfact!(W, Y, p, dtγ, t, colidx)
     end

--- a/src/prognostic_equations/limited_tendencies.jl
+++ b/src/prognostic_equations/limited_tendencies.jl
@@ -14,7 +14,6 @@ import ClimaCore.Fields: ColumnField
 
 NVTX.@annotate function limited_tendency!(Yₜ, Y, p, t)
     Yₜ .= zero(eltype(Yₜ))
-    set_precomputed_quantities!(Y, p, t)
     horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
     tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
     return nothing

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -892,18 +892,12 @@ function get_integrator(config::AtmosConfig)
 
     # We need to ensure the precomputed quantities are indeed precomputed
 
-    # TODO: Remove this when we can assume that the precomputed_quantities are in sync with
-    # the state
-    sync_precomputed = call_every_n_steps(
-        (int) -> set_precomputed_quantities!(int.u, int.p, int.t),
-    )
-
     # The generic constructor for SciMLBase.CallbackSet has to split callbacks into discrete
     # and continuous. This is not hard, but can introduce significant latency. However, all
     # the callbacks in ClimaAtmos are discrete_callbacks, so we directly pass this
     # information to the constructor
     continuous_callbacks = tuple()
-    discrete_callbacks = (callback..., sync_precomputed, diagnostic_callbacks)
+    discrete_callbacks = (callback..., diagnostic_callbacks)
 
     s = @timed_str begin
         all_callbacks =

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -721,6 +721,8 @@ function args_integrator(parsed_args, Y, p, tspan, ode_algo, callback)
                     # Can we just pass implicit_tendency! and jac_prototype etc.?
                     lim! = limiters_func!,
                     dss!,
+                    post_explicit! = set_precomputed_quantities!,
+                    post_implicit! = set_precomputed_quantities!,
                 )
             else
                 SciMLBase.SplitFunction(implicit_func, remaining_tendency!)

--- a/src/time_stepper/hc_ars343.jl
+++ b/src/time_stepper/hc_ars343.jl
@@ -27,6 +27,7 @@ function CTS.step_u!(
     @. U = u
     lim!(U, p, t_exp, u)
     dss!(U, p, t_exp)
+    post_explicit!(U, p, t_exp)
     T_lim!(T_lim[i], U, p, t_exp)
     T_exp!(T_exp[i], U, p, t_exp)
 

--- a/src/time_stepper/imex_ark.jl
+++ b/src/time_stepper/imex_ark.jl
@@ -49,7 +49,7 @@ function CTS.step_u!(
             end
 
             dss!(U, p, t_exp)
-            i ≠ 1 && post_explicit!(U, p, t_exp)
+            post_explicit!(U, p, t_exp)
 
             if !iszero(a_imp[i, i]) # Implicit solve
                 @assert !isnothing(newtons_method)

--- a/src/time_stepper/imex_ssprk.jl
+++ b/src/time_stepper/imex_ssprk.jl
@@ -43,14 +43,14 @@ function CTS.step_u!(
         end
 
         dss!(U_exp, p, t_exp)
-        # i ≠ 1 && post_explicit!(U_exp, p, t_exp) # TODO: is this needed?
+        # post_explicit!(U_exp, p, t_exp) # TODO: is this needed?
 
         @. U = U_exp
         for j in 1:(i - 1)
             iszero(a_imp[i, j]) && continue
             @. U += dt * a_imp[i, j] * T_imp[j]
         end
-        i ≠ 1 && post_explicit!(U, p, t_exp) # TODO: is this the correct placement? is t_exp correct here?
+        post_explicit!(U, p, t_exp) # TODO: is this the correct placement? is t_exp correct here?
 
         if !iszero(a_imp[i, i]) # Implicit solve
             @assert !isnothing(newtons_method)


### PR DESCRIPTION
This PR leverages the ClimaTimeSteppers `post_explicit!` and `post_implicit!` callbacks, in order to remove an unnecessary call to `set_precomputed_quantities!`. Removing them altogether broke (https://buildkite.com/clima/climaatmos-ci/builds/13092), so this PR is removing them incrementally.

 - Making `post_explicit!` and `post_implicit!` call `set_precomputed_quantities!` results: https://buildkite.com/clima/climaatmos-ci/builds/13139#018abdb6-8fe4-4f4b-8f0a-b7279b15f8f4 (passes)
 - Removing `set_precomputed_quantities!` from `T_imp!`, `T_lim!` and `Wfact` results: https://buildkite.com/clima/climaatmos-ci/builds/13158 (failed)
 - Removing `set_precomputed_quantities!` from `T_imp!` and `Wfact` results: https://buildkite.com/clima/climaatmos-ci/builds/13161 (failed)
 - 