### PR TITLE
separate edmfx sgs mass and diffusive fluxes

### DIFF
--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -35,6 +35,9 @@ edmfx_upwinding:
 debugging_tc:
   help: "Save most of the tc aux state to HDF5 file [`false` (default), `true`]"
   value: false
-edmfx_sgs_flux:
-  help: "If set to true, it switches on EDMFX SGS flux.  [`true`, `false` (default)]"
+edmfx_sgs_mass_flux:
+  help: "If set to true, it switches on EDMFX SGS mass flux.  [`true`, `false` (default)]"
+  value: false
+edmfx_sgs_diffusive_flux:
+  help: "If set to true, it switches on EDMFX SGS diffusive flux.  [`true`, `false` (default)]"
   value: false

--- a/config/longrun_configs/longrun_aquaplanet_amip.yml
+++ b/config/longrun_configs/longrun_aquaplanet_amip.yml
@@ -16,7 +16,8 @@ edmfx_upwinding: "first_order"
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 dt_save_to_disk: "3hours"
 dt: "10secs" 

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_tke.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_tke.yml
@@ -8,7 +8,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil 
 precip_model: 0M
 dt: 10secs 

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -11,7 +11,8 @@ edmfx_upwinding: "first_order"
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: "equil"
 config: "box" 
 hyperdiff: "true" 

--- a/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
@@ -11,7 +11,8 @@ edmfx_upwinding: "first_order"
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: "equil"
 config: "box" 
 hyperdiff: "true" 

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -10,7 +10,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil
 config: box 
 hyperdiff: "true" 

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -8,7 +8,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true 
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil
 config: box
 hyperdiff: "true"

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -10,7 +10,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil
 precip_model: "0M"
 config: box

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -9,7 +9,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil
 apply_limiter: false
 precip_model: "0M"

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -9,7 +9,8 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantTimescale" 
 edmfx_detr_model: "ConstantCoefficient" 
 edmfx_nh_pressure: true
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 moist: equil
 apply_limiter: false
 precip_model: "0M"

--- a/config/model_configs/edmfx_bomex_box.yml
+++ b/config/model_configs/edmfx_bomex_box.yml
@@ -8,7 +8,8 @@ turbconv: "edmfx"
 edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantCoefficient"
 edmfx_detr_model: "ConstantCoefficient"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: false
 prognostic_tke: false
 moist: "equil"

--- a/config/model_configs/edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/edmfx_dycoms_rf01_box.yml
@@ -8,7 +8,8 @@ turbconv: edmfx
 edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantCoefficient"
 edmfx_detr_model: "ConstantCoefficient"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: false
 prognostic_tke: false
 moist: equil

--- a/config/model_configs/edmfx_gabls_box.yml
+++ b/config/model_configs/edmfx_gabls_box.yml
@@ -6,7 +6,8 @@ turbconv: "edmfx"
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "ConstantCoefficient"
 edmfx_detr_model: "ConstantCoefficient"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: false
 prognostic_tke: false
 moist: "equil"

--- a/config/model_configs/edmfx_rico_box.yml
+++ b/config/model_configs/edmfx_rico_box.yml
@@ -7,7 +7,8 @@ turbconv: "edmfx"
 edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantCoefficient"
 edmfx_detr_model: "ConstantCoefficient"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: false
 prognostic_tke: false
 moist: "equil"

--- a/config/model_configs/edmfx_trmm_box.yml
+++ b/config/model_configs/edmfx_trmm_box.yml
@@ -6,7 +6,8 @@ turbconv: edmfx
 edmfx_upwinding: first_order
 edmfx_entr_model: "ConstantCoefficient"
 edmfx_detr_model: "ConstantCoefficient"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: false
 prognostic_tke: false
 moist: equil

--- a/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_edmfx.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_edmfx.yml
@@ -8,6 +8,7 @@ turbconv: "edmfx"
 ode_algo: "SSP33ShuOsher"
 precip_model: "0M"
 reference_job_id: "sphere_baroclinic_wave_rhoe_equilmoist"
-edmfx_sgs_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
 job_id: "sphere_baroclinic_wave_rhoe_equilmoist_edmfx"
 moist: "equil"

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -35,7 +35,22 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
         radiation_tendency!(Yₜ, Y, p, t, colidx, p.radiation_model)
         edmfx_entr_detr_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
-        edmfx_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
+        edmfx_sgs_mass_flux_tendency!(
+            Yₜ,
+            Y,
+            p,
+            t,
+            colidx,
+            p.atmos.turbconv_model,
+        )
+        edmfx_sgs_diffusive_flux_tendency!(
+            Yₜ,
+            Y,
+            p,
+            t,
+            colidx,
+            p.atmos.turbconv_model,
+        )
         edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
         edmfx_tke_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)
         explicit_sgs_flux_tendency!(Yₜ, Y, p, t, colidx, p.turbconv_model)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -29,8 +29,11 @@ function get_atmos(config::AtmosConfig, params)
     edmfx_entr_model = get_entrainment_model(parsed_args)
     edmfx_detr_model = get_detrainment_model(parsed_args)
 
-    edmfx_sgs_flux = parsed_args["edmfx_sgs_flux"]
-    @assert edmfx_sgs_flux in (false, true)
+    edmfx_sgs_mass_flux = parsed_args["edmfx_sgs_mass_flux"]
+    @assert edmfx_sgs_mass_flux in (false, true)
+
+    edmfx_sgs_diffusive_flux = parsed_args["edmfx_sgs_diffusive_flux"]
+    @assert edmfx_sgs_diffusive_flux in (false, true)
 
     edmfx_nh_pressure = parsed_args["edmfx_nh_pressure"]
     @assert edmfx_nh_pressure in (false, true)
@@ -50,7 +53,8 @@ function get_atmos(config::AtmosConfig, params)
         advection_test,
         edmfx_entr_model,
         edmfx_detr_model,
-        edmfx_sgs_flux,
+        edmfx_sgs_mass_flux,
+        edmfx_sgs_diffusive_flux,
         edmfx_nh_pressure,
         precip_model,
         forcing_type,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -280,7 +280,8 @@ Base.@kwdef struct AtmosModel{
     AT,
     EEM,
     EDM,
-    ESF,
+    ESMF,
+    ESDF,
     ENP,
     TCM,
     NOGW,
@@ -305,7 +306,8 @@ Base.@kwdef struct AtmosModel{
     advection_test::AT = nothing
     edmfx_entr_model::EEM = nothing
     edmfx_detr_model::EDM = nothing
-    edmfx_sgs_flux::ESF = nothing
+    edmfx_sgs_mass_flux::ESMF = nothing
+    edmfx_sgs_diffusive_flux::ESDF = nothing
     edmfx_nh_pressure::ENP = nothing
     turbconv_model::TCM = nothing
     non_orographic_gravity_wave::NOGW = nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Separates edmfx sgs mass and diffusive fluxes into two functions, and adds a flag for each of them. I think this will make testing edmfx better as we can switch off the fluxes separately. It will also make testing implicit solver easier.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
