### PR TITLE
use mem-per-cpu in longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -218,7 +218,7 @@ steps:
         command: "julia --color=yes --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml"
         artifact_paths: "$$JOB_NAME/*"
         agents:
-          slurm_mem: 20GB
+          slurm_mem_per_cpu: 20GB
           slurm_time: 24:00:00
         env: 
           JOB_NAME: "longrun_compressible_edmf_trmm"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The turbconv job wasn't getting run because it used conflicting mem flags, see https://github.com/CliMA/slurm-buildkite/issues/47

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
