### PR TITLE
If TOML path is not found, try prepending pkgdir to the path

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -232,8 +232,8 @@ subsidence:
   help: "Subsidence [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `DYCOMS`]"
   value: ~
 toml:
-  help: "TOML file(s) used to override model parameters"
-  value: []
+  help: "TOML file used to override model parameters"
+  value: ~
 prognostic_tke:
   help: "A flag for prognostic TKE [`false` (default), `true`]"
   value: false

--- a/config/gpu_configs/central_gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
+++ b/config/gpu_configs/central_gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
@@ -13,4 +13,4 @@ precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
 job_id: "central_gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km"
-toml: [toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml]
+toml: toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml

--- a/config/gpu_configs/gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
+++ b/config/gpu_configs/gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
@@ -13,4 +13,4 @@ precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
 job_id: "gpu_hs_rhoe_equilmoist_nz63_0M_55km_rs35km"
-toml: [toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml]
+toml: toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml

--- a/config/longrun_configs/longrun_aquaplanet_amip.yml
+++ b/config/longrun_configs/longrun_aquaplanet_amip.yml
@@ -24,4 +24,4 @@ dt: "10secs"
 t_end: "1days"
 FLOAT_TYPE: "Float64"
 job_id: "longrun_aquaplanet_amip" 
-toml: [toml/longrun_aquaplanet_amip.toml]
+toml: toml/longrun_aquaplanet_amip.toml

--- a/config/longrun_configs/longrun_aquaplanet_dyamond.yml
+++ b/config/longrun_configs/longrun_aquaplanet_dyamond.yml
@@ -17,4 +17,4 @@ dt: "50secs"
 t_end: "1days"
 FLOAT_TYPE: "Float64"
 job_id: "longrun_aquaplanet_dyamond" 
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: toml/longrun_aquaplanet_dyamond.toml

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_ft64.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_ft64.yml
@@ -15,4 +15,4 @@ z_max: 45000.0
 precip_model: "0M"
 job_id: "longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_ft64"
 moist: "equil"
-toml: [toml/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_ft64.toml]
+toml: toml/longrun_aquaplanet_rhoe_equil_clearsky_highres_hightop_rayleigh35e3_ft64.toml

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M.yml
@@ -14,4 +14,4 @@ moist: "equil"
 rad: "gray" 
 precip_model: "0M" 
 job_id: "longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M" 
-toml: [toml/longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M.toml]
+toml: toml/longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M.toml

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.yml
@@ -15,4 +15,4 @@ surface_setup: "DefaultMoninObukhov"
 vert_diff: "true"
 rad: "clearsky"
 job_id: "longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky"
-toml: [toml/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.toml]
+toml: toml/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.toml

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky_tvinsolation.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky_tvinsolation.yml
@@ -17,5 +17,5 @@ rad: "clearsky"
 idealized_insolation: false
 dt_rad: "1hours"
 job_id: "longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky_tvinsolation"
-toml: [toml/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.toml]
+toml: toml/longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky.toml
 

--- a/config/longrun_configs/longrun_compressible_edmf_trmm.yml
+++ b/config/longrun_configs/longrun_compressible_edmf_trmm.yml
@@ -14,4 +14,4 @@ rayleigh_sponge: true
 job_id: "longrun_compressible_edmf_trmm" 
 dt: "0.2secs" 
 t_end: "3.8hours"
-toml: [longrun_compressible_edmf_trmm.toml]
+toml: longrun_compressible_edmf_trmm.toml

--- a/config/longrun_configs/longrun_hs_rhoe_dry_nz63_55km_rs35km.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_dry_nz63_55km_rs35km.yml
@@ -10,4 +10,4 @@ forcing: "held_suarez"
 dt: "300secs"
 rayleigh_sponge: true
 job_id: "longrun_hs_rhoe_dry_nz63_55km_rs35km"
-toml: [toml/longrun_hs_rhoe_dry_nz63_55km_rs35km.toml]
+toml: toml/longrun_hs_rhoe_dry_nz63_55km_rs35km.toml

--- a/config/longrun_configs/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.yml
@@ -13,4 +13,4 @@ precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
 job_id: "longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km"
-toml: [toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml]
+toml: toml/longrun_hs_rhoe_equilmoist_nz63_0M_55km_rs35km.toml

--- a/config/model_configs/bomex_box_rhoe.yml
+++ b/config/model_configs/bomex_box_rhoe.yml
@@ -16,4 +16,4 @@ z_max: 3000.0
 ls_adv: "Bomex"
 job_id: "bomex_box_rhoe"
 moist: "equil"
-toml: [toml/bomex_box_rhoe.toml]
+toml: toml/bomex_box_rhoe.toml

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -29,4 +29,4 @@ dt: 10secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"
-toml: [toml/diagnostic_edmfx_trmm_box.toml]
+toml: toml/diagnostic_edmfx_trmm_box.toml

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -30,4 +30,4 @@ dt: 10secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"
-toml: [toml/diagnostic_edmfx_trmm_box.toml]
+toml: toml/diagnostic_edmfx_trmm_box.toml

--- a/config/model_configs/edmf_trmm.yml
+++ b/config/model_configs/edmf_trmm.yml
@@ -18,4 +18,4 @@ regression_test: true
 dt_save_to_sol: "5mins"
 job_id: "edmf_trmm"
 rad: "TRMM_LBA"
-toml: [toml/edmf_trmm.toml]
+toml: toml/edmf_trmm.toml

--- a/config/model_configs/edmfx_adv_test_box.yml
+++ b/config/model_configs/edmfx_adv_test_box.yml
@@ -20,4 +20,4 @@ dt: "10secs"
 t_end: "3600secs"
 dt_save_to_disk: "100secs"
 FLOAT_TYPE: "Float64"
-toml: [toml/edmfx_box_advection.toml]
+toml: toml/edmfx_box_advection.toml

--- a/config/model_configs/edmfx_bomex_box.yml
+++ b/config/model_configs/edmfx_bomex_box.yml
@@ -27,4 +27,4 @@ perturb_initstate: false
 dt: "1secs"
 t_end: "10800secs"
 dt_save_to_disk: "10secs"
-toml: [toml/edmfx_box.toml]
+toml: toml/edmfx_box.toml

--- a/config/model_configs/edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/edmfx_dycoms_rf01_box.yml
@@ -26,4 +26,4 @@ z_stretch: false
 dt: 1secs
 t_end: 2400secs
 dt_save_to_disk: 2secs
-toml: [toml/edmfx_box.toml]
+toml: toml/edmfx_box.toml

--- a/config/model_configs/edmfx_gabls_box.yml
+++ b/config/model_configs/edmfx_gabls_box.yml
@@ -26,4 +26,4 @@ t_end: "9hours"
 dt_save_to_disk: "10mins"
 perturb_initstate: false
 FLOAT_TYPE: "Float64"
-toml: [toml/edmfx_box.toml]
+toml: toml/edmfx_box.toml

--- a/config/model_configs/edmfx_rico_box.yml
+++ b/config/model_configs/edmfx_rico_box.yml
@@ -27,4 +27,4 @@ perturb_initstate: false
 dt: "1secs"
 t_end: "10800secs"
 dt_save_to_disk: "10secs"
-toml: [toml/edmfx_box.toml]
+toml: toml/edmfx_box.toml

--- a/config/model_configs/edmfx_trmm_box.yml
+++ b/config/model_configs/edmfx_trmm_box.yml
@@ -27,4 +27,4 @@ dt: 1secs
 t_end: 2hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"
-toml: [toml/edmfx_box.toml]
+toml: toml/edmfx_box.toml

--- a/config/model_configs/plane_agnesi_mountain_test_stretched.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_stretched.yml
@@ -14,4 +14,4 @@ kappa_4: 1.0e6
 z_max: 25000.0
 topography: "Agnesi"
 job_id: "plane_agnesi_mountain_test_stretched"
-toml: [toml/plane_agnesi_mountain_test_stretched.toml]
+toml: toml/plane_agnesi_mountain_test_stretched.toml

--- a/config/model_configs/plane_agnesi_mountain_test_uniform.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_uniform.yml
@@ -13,4 +13,4 @@ kappa_4: 1.0e6
 z_max: 25000.0
 topography: "Agnesi"
 job_id: "plane_agnesi_mountain_test_uniform"
-toml: [toml/plane_agnesi_mountain_test_uniform.toml]
+toml: toml/plane_agnesi_mountain_test_uniform.toml

--- a/config/model_configs/plane_schar_mountain_test_stretched.yml
+++ b/config/model_configs/plane_schar_mountain_test_stretched.yml
@@ -15,4 +15,4 @@ kappa_4: 5.0e7
 z_max: 25000.0
 topography: "Schar"
 job_id: "plane_schar_mountain_test_stretched"
-toml: [toml/plane_schar_mountain_test_stretched.toml]
+toml: toml/plane_schar_mountain_test_stretched.toml

--- a/config/model_configs/plane_schar_mountain_test_uniform.yml
+++ b/config/model_configs/plane_schar_mountain_test_uniform.yml
@@ -14,4 +14,4 @@ kappa_4: 5.0e7
 z_max: 25000.0
 topography: "Schar"
 job_id: "plane_schar_mountain_test_uniform"
-toml: [toml/plane_schar_mountain_test_uniform.toml]
+toml: toml/plane_schar_mountain_test_uniform.toml

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -16,4 +16,4 @@ regression_test: true
 surface_temperature: "ZonallyAsymmetric"
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"
 moist: "equil"
-toml: [toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.toml]
+toml: toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.toml

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
@@ -15,4 +15,4 @@ precip_model: "0M"
 regression_test: true
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"
 moist: "equil"
-toml: [toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.toml]
+toml: toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.toml

--- a/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
@@ -8,4 +8,4 @@ dt: "40secs"
 t_end: "12hours"
 job_id: "sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"
 moist: "equil"
-toml: [toml/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.toml]
+toml: toml/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.toml

--- a/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
+++ b/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
@@ -12,5 +12,5 @@ regression_test: true
 viscous_sponge: true
 job_id: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge"
 moist: "equil"
-toml: [toml/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.toml]
+toml: toml/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.toml
 output_default_diagnostics: true

--- a/config/perf_configs/flame_perf_gw.yml
+++ b/config/perf_configs/flame_perf_gw.yml
@@ -1,9 +1,8 @@
 dz_bottom: 300.0
 rayleigh_sponge: true
-toml:
-  - "toml/flame_perf_gw.toml"
-orographic_gravity_wave: "raw_topo"
+toml: toml/flame_perf_gw.toml
+orographic_gravity_wave: raw_topo
 idealized_insolation: false
 non_orographic_gravity_wave: true
-job_id: "flame_perf_gw"
+job_id: flame_perf_gw
 z_max: 45000.0

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -430,11 +430,12 @@ function AtmosConfig(config::Dict; comms_ctx = nothing)
 
     # Check that config["toml"] is a filepath and the file does not exist
     if config["toml"] isa AbstractString && !isfile(config["toml"])
-        @info "Could not find TOML file at path $(joinpath(pwd(), config["toml"]))"
-        prepend_path = joinpath(dirname(@__FILE__), "..", "..", config["toml"])
-        if isfile(prepend_path)
-            @info "Prepending `pkgdir(CA)` to relative TOML file path"
-            config["toml"] = prepend_path
+        @info "Could not find TOML file at path `$(joinpath(pwd(), config["toml"]))`"
+        toml_path_in_atmos_dir =
+            joinpath(dirname(@__FILE__), "..", "..", config["toml"])
+        if isfile(toml_path_in_atmos_dir)
+            @info "Using parameter file at `$toml_path_in_atmos_dir`"
+            config["toml"] = toml_path_in_atmos_dir
         end
     end
     toml_dict = CP.create_toml_dict(FT; override_file = config["toml"])

--- a/test/config_test.yml
+++ b/test/config_test.yml
@@ -1,0 +1,1 @@
+toml: "test/parameter_tests.toml"

--- a/test/parameter_tests.jl
+++ b/test/parameter_tests.jl
@@ -26,7 +26,7 @@ default_args = CA.cli_defaults(CA.argparse_settings())
 end
 
 @testset "Test unique aliases" begin
-    config_dict = Dict("toml" => ["parameter_tests.toml"])
+    config_dict = Dict("toml" => "parameter_tests.toml")
     config = CA.AtmosConfig(config_dict)
     @test_throws ErrorException CP.get_parameter_values!(
         config.toml_dict,
@@ -37,7 +37,7 @@ end
 @testset "Test all parameter tomls in toml/" begin
     toml_path = joinpath("..", "toml")
     for toml in readdir(toml_path)
-        config_dict = Dict("toml" => [joinpath(toml_path, toml)])
+        config_dict = Dict("toml" => joinpath(toml_path, toml))
         config = CA.AtmosConfig(config_dict)
         # Ensure that there are no errors
         @test CA.create_parameter_set(config) isa

--- a/test/parameter_tests.toml
+++ b/test/parameter_tests.toml
@@ -8,22 +8,7 @@ value = 0
 type = "float"
 alias = "same_alias"
 
-[y_elem]
-value = 0
+[C_E]
+alias = "C_E"
+value = 99
 type = "float"
-alias = "y_elem"
-
-[dt_save_to_disk]
-value = "5mins"
-type = "string"
-alias = "dt_save_to_disk"
-
-[dt]
-value = "10secs"
-type = "string"
-alias = "dt"
-
-[z_elem]
-value = 60
-type = "integer"
-alias = "z_elem"


### PR DESCRIPTION
This is needed to fix #2167, where configurations in `config` that used a TOML file could only be run from `pkgdir(CA)`. 

Content
- prepend `pkgdir(CA)` to the TOML path if the given TOML path does not point to a file.
- Remove support for multiple TOML files. I don't think that this is useful, and if anything could cause issues.
- 
