### PR TITLE
Call `set_precomputed_quantities!` in `step!`, remove from callbacks

### DIFF
--- a/post_processing/post_processing_funcs.jl
+++ b/post_processing/post_processing_funcs.jl
@@ -277,7 +277,6 @@ function postprocessing_plane(sol, output_dir, p)
     )
 
     Y = sol.u[end]
-    CA.set_precomputed_quantities!(Y, p, sol.t[end]) # sets ᶜts and ᶜu
 
     ## Plots for last timestep
     function gen_plot_plane(

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -57,7 +57,6 @@ NVTX.@annotate function turb_conv_affect_filter!(integrator)
     Y = integrator.u
     tc_params = CAP.turbconv_params(param_set)
 
-    set_precomputed_quantities!(Y, p, t) # sets ᶜts for set_edmf_surface_bc
     Fields.bycolumn(axes(Y.c)) do colidx
         state = TC.tc_column_state(Y, p, nothing, colidx, t)
         grid = TC.Grid(state)
@@ -75,8 +74,6 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
     Y = integrator.u
     p = integrator.p
     t = integrator.t
-
-    set_precomputed_quantities!(Y, p, t) # sets ᶜts and sfc_conditions
 
     (; ᶜts, sfc_conditions, params, env_thermo_quad) = p
     (; idealized_insolation, idealized_h2o, idealized_clouds) = p
@@ -254,8 +251,6 @@ NVTX.@annotate function compute_diagnostics(integrator)
     (; params, env_thermo_quad) = p
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
-
-    set_precomputed_quantities!(Y, p, t) # sets ᶜu, ᶜK, ᶜts, ᶜp, & SGS analogues
 
     (; ᶜu, ᶜK, ᶜts, ᶜp, sfc_conditions) = p
     dycore_diagnostic = (;

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -895,20 +895,12 @@ function get_integrator(config::AtmosConfig)
     diagnostic_callbacks =
         call_every_n_steps(orchestrate_diagnostics, skip_first = true)
 
-    # We need to ensure the precomputed quantities are indeed precomputed
-
-    # TODO: Remove this when we can assume that the precomputed_quantities are in sync with
-    # the state
-    sync_precomputed = call_every_n_steps(
-        (int) -> set_precomputed_quantities!(int.u, int.p, int.t),
-    )
-
     # The generic constructor for SciMLBase.CallbackSet has to split callbacks into discrete
     # and continuous. This is not hard, but can introduce significant latency. However, all
     # the callbacks in ClimaAtmos are discrete_callbacks, so we directly pass this
     # information to the constructor
     continuous_callbacks = tuple()
-    discrete_callbacks = (callback..., sync_precomputed, diagnostic_callbacks)
+    discrete_callbacks = (callback..., diagnostic_callbacks)
 
     s = @timed_str begin
         all_callbacks =

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -726,6 +726,8 @@ function args_integrator(parsed_args, Y, p, tspan, ode_algo, callback)
                     # Can we just pass implicit_tendency! and jac_prototype etc.?
                     lim! = limiters_func!,
                     dss!,
+                    post_explicit! = set_precomputed_quantities!,
+                    post_implicit! = set_precomputed_quantities!,
                 )
             else
                 SciMLBase.SplitFunction(implicit_func, remaining_tendency!)

--- a/src/time_stepper/hc_ars343.jl
+++ b/src/time_stepper/hc_ars343.jl
@@ -37,7 +37,7 @@ function CTS.step_u!(
     lim!(U, p, t_exp, u)
     @. U += dt * a_exp[i, 1] * T_exp[1]
     dss!(U, p, t_exp)
-    post_explicit!(U, p, t_exp)
+    # post_explicit!(U, p, t_exp)
 
     @. temp = U # used in closures
     let i = i
@@ -52,7 +52,7 @@ function CTS.step_u!(
                 T_imp!.Wfact(jacobian, Ui, p, dt * a_imp[i, i], t_imp)
             end
         call_post_implicit! = Ui -> begin
-            post_implicit!(Ui, p, t_imp)
+            # post_implicit!(Ui, p, t_imp)
         end
         CTS.solve_newton!(
             newtons_method,
@@ -79,7 +79,7 @@ function CTS.step_u!(
     @. U += dt * a_exp[i, 2] * T_exp[2]
     @. U += dt * a_imp[i, 2] * T_imp[2]
     dss!(U, p, t_exp)
-    post_explicit!(U, p, t_exp)
+    # post_explicit!(U, p, t_exp)
 
     @. temp = U # used in closures
     let i = i
@@ -94,7 +94,7 @@ function CTS.step_u!(
                 T_imp!.Wfact(jacobian, Ui, p, dt * a_imp[i, i], t_imp)
             end
         call_post_implicit! = Ui -> begin
-            post_implicit!(Ui, p, t_imp)
+            # post_implicit!(Ui, p, t_imp)
         end
         CTS.solve_newton!(
             newtons_method,
@@ -123,7 +123,7 @@ function CTS.step_u!(
     @. U += dt * a_imp[i, 2] * T_imp[2]
     @. U += dt * a_imp[i, 3] * T_imp[3]
     dss!(U, p, t_exp)
-    post_explicit!(U, p, t_exp)
+    # post_explicit!(U, p, t_exp)
 
     @. temp = U # used in closures
     let i = i
@@ -138,7 +138,7 @@ function CTS.step_u!(
                 T_imp!.Wfact(jacobian, Ui, p, dt * a_imp[i, i], t_imp)
             end
         call_post_implicit! = Ui -> begin
-            post_implicit!(Ui, p, t_imp)
+            # post_implicit!(Ui, p, t_imp)
         end
         CTS.solve_newton!(
             newtons_method,
@@ -172,6 +172,6 @@ function CTS.step_u!(
     @. u += dt * b_imp[3] * T_imp[3]
     @. u += dt * b_imp[4] * T_imp[4]
     dss!(u, p, t_final)
-    post_explicit!(u, p, t_final)
+    # post_explicit!(u, p, t_final)
     return u
 end

--- a/src/time_stepper/hc_ars343.jl
+++ b/src/time_stepper/hc_ars343.jl
@@ -172,6 +172,6 @@ function CTS.step_u!(
     @. u += dt * b_imp[3] * T_imp[3]
     @. u += dt * b_imp[4] * T_imp[4]
     dss!(u, p, t_final)
-    # post_explicit!(u, p, t_final)
+    post_explicit!(u, p, t_final)
     return u
 end

--- a/src/time_stepper/imex_ssprk.jl
+++ b/src/time_stepper/imex_ssprk.jl
@@ -6,6 +6,7 @@ function CTS.step_u!(
 )
     (; u, p, t, dt, alg) = integrator
     (; T_lim!, T_exp!, T_imp!, lim!, dss!) = f
+    (; post_explicit!, post_implicit!) = f
     (; tableau, newtons_method) = alg
     (; a_imp, b_imp, c_exp, c_imp) = tableau
     (; U, U_lim, U_exp, T_lim, T_exp, T_imp, temp, β, γ, newtons_method_cache) =
@@ -108,6 +109,7 @@ function CTS.step_u!(
     end
 
     dss!(u, p, t_final)
+    post_explicit!(u, p, t_final)
 
     return u
 end


### PR DESCRIPTION
This PR adds a call to `set_precomputed_quantities!` in `step!` and removes all of them from the callbacks. This PR cherry-picked the first commit in #2175, but is somewhat separate in that this PR will potentially be behavior changing.

Once this PR is merged (assuming there are no changes, or they are negligible), we should be able to follow through with closing out #2015.