### PR TITLE
fix docs plugin error

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,11 +5,12 @@ using Base.CoreLogging
 using DocumenterCitations
 
 disable_logging(Base.CoreLogging.Info) # Hide doctest's `@info` printing
-doctest(ClimaAtmos)
+bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"))
+
+doctest(ClimaAtmos; plugins = [bib])
 disable_logging(Base.CoreLogging.BelowMinLevel) # Re-enable all logging
 
 include("make_diagnostic_table.jl")
-bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"))
 makedocs(;
     plugins = [bib],
     modules = [ClimaAtmos],


### PR DESCRIPTION
I think that `bib` needs to be passed into the `plugin` kwarg for `doctest`

[Current Main](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/6402119280/job/17378222720#step:5:8) (Merge #2186) still produces errors.

[Current Branch](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/6409310195/job/17400227907#step:5:8) does not have errors. There are some warnings related to specific citations.