### PR TITLE
Fix h-scaling plots

### DIFF
--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -73,5 +73,7 @@ p = Plots.plot(
     ylabel = "time (ms)",
     label = "step time",
     linewidth = 3,
+    left_margin = 20Plots.mm,
+    bottom_margin = 10Plots.mm,
 )
 Plots.png(p, joinpath(output_dir, "scaling.png"))


### PR DESCRIPTION
I can't see the x/y axes in the h-scaling plots, this PR should fix that. The plot looks fine when I run locally but, for some reason, it's pretty truncated on the buildkite artifacts.