### PR TITLE
Remove dss callback

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -16,20 +16,6 @@ import ClimaCore.Fields: ColumnField
 
 include("callback_helpers.jl")
 
-NVTX.@annotate function dss_callback!(integrator)
-    Y = integrator.u
-    ghost_buffer = integrator.p.ghost_buffer
-    if integrator.p.do_dss
-        Spaces.weighted_dss_start2!(Y.c, ghost_buffer.c)
-        Spaces.weighted_dss_start2!(Y.f, ghost_buffer.f)
-        Spaces.weighted_dss_internal2!(Y.c, ghost_buffer.c)
-        Spaces.weighted_dss_internal2!(Y.f, ghost_buffer.f)
-        Spaces.weighted_dss_ghost2!(Y.c, ghost_buffer.c)
-        Spaces.weighted_dss_ghost2!(Y.f, ghost_buffer.f)
-    end
-    return nothing
-end
-
 horizontal_integral_at_boundary(f, lev) = sum(
     Spaces.level(f, lev) ./ Fields.dz_field(axes(Spaces.level(f, lev))) .* 2,
 )

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -477,9 +477,6 @@ function get_callbacks(parsed_args, simulation, atmos, params)
     (; dt) = simulation
 
     callbacks = ()
-    if startswith(parsed_args["ode_algo"], "ODE.")
-        callbacks = (callbacks..., call_every_n_steps(dss_callback!))
-    end
     dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
     if !(dt_save_to_disk == Inf)
         callbacks = (


### PR DESCRIPTION
This PR removes the dss callback, which is never used (the timestepper calls `dss!`)-- we now kind of depend on these post-explicit and post-implicit callback hooks, so there's probably a few more things that we can clean up. Also, I don't think it's likely that we can ever go back to using OrdinaryDiffEq with these requirements, so we can probably remove some of that code, too.