### PR TITLE
add constant detrainment option

### DIFF
--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -27,7 +27,7 @@ edmfx_entr_model:
   help: "EDMFX entrainment closure.  [`nothing` (default), `PiGroups`, `ConstantCoefficent`, `ConstantTimescale`]"
   value: ~
 edmfx_detr_model:
-  help: "EDMFX detrainment closure.  [`nothing` (default), `PiGroups`, `ConstantCoefficent`]"
+  help: "EDMFX detrainment closure.  [`nothing` (default), `PiGroups`, `ConstantCoefficent`, `ConstantTimescale`]"
   value: ~
 edmfx_upwinding:
   help: "EDMFX upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -22,6 +22,7 @@ Base.@kwdef struct ClimaAtmosParameters{FT, TP, RP, IP, MPP, SFP, TCP} <: ACAP
     planet_radius::FT
     astro_unit::FT
     entr_tau::FT
+    detr_tau::FT
     entr_coeff::FT
     detr_coeff::FT
     C_E::FT

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -314,3 +314,25 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, colidx, turbconv_model::EDMFX)
     end
     return nothing
 end
+
+function detrainment(
+    params,
+    ᶜz::FT,
+    z_sfc::FT,
+    ᶜp::FT,
+    ᶜρ::FT,
+    buoy_flux_surface::FT,
+    ᶜaʲ::FT,
+    ᶜwʲ::FT,
+    ᶜRHʲ::FT,
+    ᶜbuoyʲ::FT,
+    ᶜw⁰::FT,
+    ᶜRH⁰::FT,
+    ᶜbuoy⁰::FT,
+    dt::FT,
+    ::ConstantTimescaleDetrainment,
+) where {FT}
+    detr_tau = CAP.detr_tau(params)
+    detr = min(1 / detr_tau, 1 / dt)
+    return detr
+end

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -391,6 +391,8 @@ function get_detrainment_model(parsed_args)
         ConstantCoefficientDetrainment()
     elseif detr_model == "ConstantCoefficientHarmonics"
         ConstantCoefficientHarmonicsDetrainment()
+    elseif detr_model == "ConstantTimescale"
+        ConstantTimescaleDetrainment()
     else
         error("Invalid entr_model $(entr_model)")
     end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -188,6 +188,7 @@ struct NoDetrainment <: AbstractDetrainmentModel end
 struct PiGroupsDetrainment <: AbstractDetrainmentModel end
 struct ConstantCoefficientDetrainment <: AbstractDetrainmentModel end
 struct ConstantCoefficientHarmonicsDetrainment <: AbstractDetrainmentModel end
+struct ConstantTimescaleDetrainment <: AbstractDetrainmentModel end
 
 abstract type AbstractQuadratureType end
 struct LogNormalQuad <: AbstractQuadratureType end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds constant timescale detrainment, as suggested by Tapio. I tried running bomex with constant timescale entrainment and detrainment with the same time scale, and the results look terrible (see comments), so I didn't change the configuration file in the end. But this option is still good to have for testing as it is the simplest detrainment closure.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
