### PR TITLE
Fix some type piracy

### DIFF
--- a/src/TurbulenceConvection_deprecated/Fields.jl
+++ b/src/TurbulenceConvection_deprecated/Fields.jl
@@ -34,9 +34,6 @@ const CenterFields = Union{
     CC.Fields.CenterFiniteDifferenceField,
 }
 
-Base.@propagate_inbounds Base.getindex(field::FDFields, i::Integer) =
-    Base.getproperty(field, i)
-
 Base.@propagate_inbounds Base.getindex(field::CenterFields, i::Cent) =
     Base.getindex(CC.Fields.field_values(field), i.i)
 Base.@propagate_inbounds Base.setindex!(field::CenterFields, v, i::Cent) =

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -358,9 +358,9 @@ values of the first updraft.
 function output_diagnostic_sgs_quantities(Y, p, t)
     thermo_params = CAP.thermodynamics_params(p.params)
     (; ᶜρaʲs, ᶜtsʲs) = p
-    ᶠu³⁺ = p.ᶠu³ʲs[1]
+    ᶠu³⁺ = p.ᶠu³ʲs.:1
     ᶜu⁺ = @. (C123(Y.c.uₕ) + C123(ᶜinterp(ᶠu³⁺)))
-    ᶜts⁺ = @. ᶜtsʲs[1]
-    ᶜa⁺ = @. draft_area(ᶜρaʲs[1], TD.air_density(thermo_params, ᶜts⁺))
+    ᶜts⁺ = @. ᶜtsʲs.:1
+    ᶜa⁺ = @. draft_area(ᶜρaʲs.:1, TD.air_density(thermo_params, ᶜts⁺))
     return (; ᶜu⁺, ᶠu³⁺, ᶜts⁺, ᶜa⁺)
 end


### PR DESCRIPTION
This PR:
 - Removes overloading of Fields on Integers (which is type piracy, and results in invalidations)
 - Applies the minimalistic fixes by interpolating integers into getproperty calls.

As a compromise, this PR only removes `getindex` on `Field`s and `Integer`s:
```julia
Base.@propagate_inbounds Base.getindex(field::FDFields, i::Integer) =
    Base.getproperty(field, i)
```
Which is the worst of the type pirated methods. The next will be for `Base.getindex(field::FaceFields, i::CCO.PlusHalf)` and `Base.setindex!(field::FaceFields, v, i::CCO.PlusHalf)`, however, that requires adding `Spaces.level` and such to a lot of places, which is just a bit more work.