### PR TITLE
separate precomputed quantities in 3 funcs

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -154,7 +154,7 @@ end
 """
     set_velocity_at_top!(Y, turbconv_model)
 
-Modifies `Y.f.u₃` so that `u₃` is 0 at the model top. 
+Modifies `Y.f.u₃` so that `u₃` is 0 at the model top.
 """
 function set_velocity_at_top!(Y, turbconv_model)
     top_u₃ = Fields.level(
@@ -340,7 +340,9 @@ NVTX.@annotate function set_precomputed_quantities!(Y, p, t)
     SurfaceConditions.update_surface_conditions!(Y, p, t)
 
     if turbconv_model isa PrognosticEDMFX
-        set_prognostic_edmf_precomputed_quantities!(Y, p, ᶠuₕ³, t)
+        set_prognostic_edmf_precomputed_quantities_environment!(Y, p, ᶠuₕ³, t)
+        set_prognostic_edmf_precomputed_quantities_draft_and_bc!(Y, p, ᶠuₕ³, t)
+        set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
     end
 
     if turbconv_model isa DiagnosticEDMFX


### PR DESCRIPTION
Following what we discussed @szy21 , @Sbozzolo  this PR splits prognostic edmfx precomputed quantities into 3 steps
1) updating environment
2) updating updraft thermo state and BC
3) updating the closures.

I'm not sure if it actually makes anything better though. Or if you want to split the individual closures. 