### PR TITLE
Use ClimaComms at-elapsed

### DIFF
--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -1,7 +1,6 @@
 import Random
 Random.seed!(1234)
 import ClimaAtmos as CA
-using CUDA
 import ClimaComms
 using Plots
 using PrettyTables
@@ -27,17 +26,9 @@ for h_elem in 8:8:40
     n_steps = 10
     comms_ctx = ClimaComms.context(integrator.u.c)
     device = ClimaComms.device(comms_ctx)
-    if device isa ClimaComms.CUDADevice
-        e = CUDA.@elapsed begin
-            s = CA.@timed_str begin
-                CA.benchmark_step!(integrator, Y₀, n_steps) # run
-            end
-        end
-    else
-        e = @elapsed begin
-            s = CA.@timed_str begin
-                CA.benchmark_step!(integrator, Y₀, n_steps) # run
-            end
+    e = ClimaComms.@elapsed device begin
+        s = CA.@timed_str begin
+            CA.benchmark_step!(integrator, Y₀, n_steps) # run
         end
     end
     @info "Ran step! $n_steps times in $s, ($(CA.prettytime(e/n_steps*1e9)) per step)"


### PR DESCRIPTION
This PR switches to using the `ClimaComms.@elapsed`, which behaves the same as the replaced code. This removes an explicit direct dependency on CUDA in the perf folder.