### PR TITLE
limit area fraction in entrainment and detrainment limiter

### DIFF
--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -23,7 +23,7 @@ y_elem: 2
 z_elem: 30 
 z_max: 1500 
 z_stretch: false
-dt: 6secs 
+dt: 10secs 
 t_end: 4hours 
 dt_save_to_disk: 2mins
 toml: [toml/diagnostic_edmfx_box.toml]

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -112,7 +112,8 @@ function entrainment(
     turbconv_params = CAP.turbconv_params(params)
     a_min = TCP.min_area(turbconv_params)
     min_area_limiter =
-        min_area_limiter_scale * exp(-min_area_limiter_power * (ᶜaʲ - a_min))
+        min_area_limiter_scale *
+        exp(-min_area_limiter_power * (max(ᶜaʲ, 0) - a_min))
     entr = min(
         entr_inv_tau + entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) + min_area_limiter,
         1 / dt,
@@ -144,7 +145,8 @@ function entrainment(
     turbconv_params = CAP.turbconv_params(params)
     a_min = TCP.min_area(turbconv_params)
     min_area_limiter =
-        min_area_limiter_scale * exp(-min_area_limiter_power * (ᶜaʲ - a_min))
+        min_area_limiter_scale *
+        exp(-min_area_limiter_power * (max(ᶜaʲ, 0) - a_min))
     entr = min(
         entr_inv_tau + entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) + min_area_limiter,
         1 / dt,
@@ -262,12 +264,13 @@ function detrainment(
     turbconv_params = CAP.turbconv_params(params)
     a_max = TCP.max_area(turbconv_params)
     max_area_limiter =
-        max_area_limiter_scale * exp(-max_area_limiter_power * (a_max - ᶜaʲ))
+        max_area_limiter_scale *
+        exp(-max_area_limiter_power * (a_max - min(ᶜaʲ, 1)))
     detr = min(
         detr_inv_tau +
         detr_coeff * abs(ᶜwʲ) +
         detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
-        max(eps(FT), abs((ᶜwʲ - ᶜw⁰))) +
+        max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) +
         max_area_limiter,
         1 / dt,
     )
@@ -299,12 +302,13 @@ function detrainment(
     turbconv_params = CAP.turbconv_params(params)
     a_max = TCP.max_area(turbconv_params)
     max_area_limiter =
-        max_area_limiter_scale * exp(-max_area_limiter_power * (a_max - ᶜaʲ))
+        max_area_limiter_scale *
+        exp(-max_area_limiter_power * (a_max - min(ᶜaʲ, 1)))
     detr = min(
         detr_inv_tau +
         detr_coeff * abs(ᶜwʲ) +
         detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
-        max(eps(FT), abs((ᶜwʲ - ᶜw⁰))) +
+        max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) +
         max_area_limiter,
         1 / dt,
     )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Limit the area fraction in the entrainment and detrainment limiter so the exponential function wouldn't go to infinity.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
