### PR TITLE
Update config and initialization code for DYAMOND configuration

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond.yml
@@ -1,4 +1,4 @@
-h_elem: 60
+h_elem: 30
 z_max: 55000.0
 z_elem: 63
 dz_bottom: 30.0
@@ -15,6 +15,6 @@ rayleigh_sponge: true
 dt_save_to_disk: "3hours"
 dt: "50secs" 
 t_end: "1days"
-FLOAT_TYPE: "Float64"
+FLOAT_TYPE: "Float32"
 job_id: "gpu_aquaplanet_dyamond" 
 toml: [toml/longrun_aquaplanet_dyamond.toml]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR makes the following temporary changes:

- Use Float32 for DYAMOND configuration. This helps with kernel metadata size issues.
- Reduce `h_elems` to 30. This helps with the memory footprint on the A100 GPU.
- Compute `pressure2ozone` interpolation during initialization on the CPU for GPU runs.

These temporary changes will help continue finding and debugging potential downstream issues on a single GPU process while fixing known memory footprint and efficiency issues in parallel. The changes can be reverted once appropriate fixes are merged.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
