### PR TITLE
Add barowave jfnk flame graph

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -880,6 +880,14 @@ steps:
         agents:
           slurm_mem: 24GB
 
+      - label: ":fire: Flame graph: perf target (barowave jfnk)"
+        command: >
+          julia --color=yes --project=perf perf/flame.jl
+          $PERF_CONFIG_PATH/flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
+        artifact_paths: "flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff/*"
+        agents:
+          slurm_mem: 40GB
+
       - label: ":fire: Flame graph: perf target (Threaded)"
         command: >
           julia --threads 8 --color=yes --project=perf perf/flame.jl

--- a/config/perf_configs/flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
+++ b/config/perf_configs/flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
@@ -1,0 +1,14 @@
+max_newton_iters_ode: 1
+use_krylov_method: true
+use_dynamic_krylov_rtol: false
+krylov_rtol: 0.99
+precip_model: "0M"
+vert_diff: "true"
+z_elem: 20
+dz_bottom: 100
+dt_save_to_disk: "12hours"
+initial_condition: "MoistBaroclinicWave"
+dt: "40secs"
+t_end: "12hours"
+job_id: "flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"
+moist: "equil"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -64,6 +64,8 @@ allocs_limit["flame_perf_target_tracers"] = 204288
 allocs_limit["flame_perf_target_edmfx"] = 253440
 allocs_limit["flame_perf_diagnostics"] = 3016328
 allocs_limit["flame_perf_target_diagnostic_edmfx"] = 920960
+allocs_limit["flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"] =
+    67443909648
 allocs_limit["flame_perf_target_threaded"] = 5857808
 allocs_limit["flame_perf_target_callbacks"] = 46407936
 allocs_limit["flame_perf_gw"] = 4844555632


### PR DESCRIPTION
This PR adds a flame graph for the baro wave JFNK, which is currently experiencing a lot of allocations and inference issues.