### PR TITLE
change edmfx sgs mass flux to advect a*tracer

### DIFF
--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -18,7 +18,10 @@ edmfx_detr_model:
   help: "EDMFX detrainment closure.  [`nothing` (default), `PiGroups`, `Generalized`, `GeneralizedHarmonics`]"
   value: ~
 edmfx_upwinding:
-  help: "EDMFX upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
+  help: "EDMFX upwinding mode [`none` (default), `first_order`, `third_order`]"
+  value: none
+edmfx_sgsflux_upwinding:
+  help: "EDMFX SGS mass flux upwinding mode [`none` (default), `first_order`, `third_order`]"
   value: none
 edmfx_sgs_mass_flux:
   help: "If set to true, it switches on EDMFX SGS mass flux.  [`true`, `false` (default)]"

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -14,69 +14,75 @@ function edmfx_sgs_mass_flux_tendency!(
 )
 
     n = n_mass_flux_subdomains(turbconv_model)
-    (; edmfx_upwinding) = p.atmos.numerics
+    (; edmfx_sgsflux_upwinding) = p.atmos.numerics
     (; ᶠu³, ᶜh_tot, ᶜspecific) = p.precomputed
-    (; ᶠu³ʲs) = p.precomputed
-    (; ᶜρa⁰, ᶠu³⁰, ᶜh_tot⁰, ᶜq_tot⁰) = p.precomputed
+    (; ᶠu³ʲs, ᶜρʲs) = p.precomputed
+    (; ᶜρa⁰, ᶜρ⁰, ᶠu³⁰, ᶜh_tot⁰, ᶜq_tot⁰) = p.precomputed
     (; dt) = p.simulation
     ᶜJ = Fields.local_geometry_field(Y.c).J
 
     if p.atmos.edmfx_sgs_mass_flux
         # energy
         ᶠu³_diff_colidx = p.scratch.ᶠtemp_CT3[colidx]
-        ᶜh_tot_diff_colidx = ᶜq_tot_diff_colidx = p.scratch.ᶜtemp_scalar[colidx]
+        ᶜa_scalar_colidx = p.scratch.ᶜtemp_scalar[colidx]
         for j in 1:n
             @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
-            @. ᶜh_tot_diff_colidx =
-                Y.c.sgsʲs.:($$j).h_tot[colidx] - ᶜh_tot[colidx]
+            @. ᶜa_scalar_colidx =
+                (Y.c.sgsʲs.:($$j).h_tot[colidx] - ᶜh_tot[colidx]) *
+                draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
             vertical_transport!(
                 Yₜ.c.ρe_tot[colidx],
                 ᶜJ[colidx],
-                Y.c.sgsʲs.:($j).ρa[colidx],
+                ᶜρʲs.:($j)[colidx],
                 ᶠu³_diff_colidx,
-                ᶜh_tot_diff_colidx,
+                ᶜa_scalar_colidx,
                 dt,
-                edmfx_upwinding,
+                edmfx_sgsflux_upwinding,
             )
         end
         @. ᶠu³_diff_colidx = ᶠu³⁰[colidx] - ᶠu³[colidx]
-        @. ᶜh_tot_diff_colidx = ᶜh_tot⁰[colidx] - ᶜh_tot[colidx]
+        @. ᶜa_scalar_colidx =
+            (ᶜh_tot⁰[colidx] - ᶜh_tot[colidx]) *
+            draft_area(ᶜρa⁰[colidx], ᶜρ⁰[colidx])
         vertical_transport!(
             Yₜ.c.ρe_tot[colidx],
             ᶜJ[colidx],
-            ᶜρa⁰[colidx],
+            ᶜρ⁰[colidx],
             ᶠu³_diff_colidx,
-            ᶜh_tot_diff_colidx,
+            ᶜa_scalar_colidx,
             dt,
-            edmfx_upwinding,
+            edmfx_sgsflux_upwinding,
         )
 
         if !(p.atmos.moisture_model isa DryModel)
             # specific humidity
             for j in 1:n
                 @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
-                @. ᶜq_tot_diff_colidx =
-                    Y.c.sgsʲs.:($$j).q_tot[colidx] - ᶜspecific.q_tot[colidx]
+                @. ᶜa_scalar_colidx =
+                    (Y.c.sgsʲs.:($$j).q_tot[colidx] - ᶜspecific.q_tot[colidx]) *
+                    draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
                 vertical_transport!(
                     Yₜ.c.ρq_tot[colidx],
                     ᶜJ[colidx],
-                    Y.c.sgsʲs.:($j).ρa[colidx],
+                    ᶜρʲs.:($j)[colidx],
                     ᶠu³_diff_colidx,
-                    ᶜq_tot_diff_colidx,
+                    ᶜa_scalar_colidx,
                     dt,
-                    edmfx_upwinding,
+                    edmfx_sgsflux_upwinding,
                 )
             end
             @. ᶠu³_diff_colidx = ᶠu³⁰[colidx] - ᶠu³[colidx]
-            @. ᶜq_tot_diff_colidx = ᶜq_tot⁰[colidx] - ᶜspecific.q_tot[colidx]
+            @. ᶜa_scalar_colidx =
+                (ᶜq_tot⁰[colidx] - ᶜspecific.q_tot[colidx]) *
+                draft_area(ᶜρa⁰[colidx], ᶜρ⁰[colidx])
             vertical_transport!(
                 Yₜ.c.ρq_tot[colidx],
                 ᶜJ[colidx],
-                ᶜρa⁰[colidx],
+                ᶜρ⁰[colidx],
                 ᶠu³_diff_colidx,
-                ᶜq_tot_diff_colidx,
+                ᶜa_scalar_colidx,
                 dt,
-                edmfx_upwinding,
+                edmfx_sgsflux_upwinding,
             )
         end
     end
@@ -96,27 +102,29 @@ function edmfx_sgs_mass_flux_tendency!(
 )
 
     n = n_mass_flux_subdomains(turbconv_model)
-    (; edmfx_upwinding) = p.atmos.numerics
+    (; edmfx_sgsflux_upwinding) = p.atmos.numerics
     (; ᶠu³, ᶜh_tot, ᶜspecific) = p.precomputed
-    (; ᶜρaʲs, ᶠu³ʲs, ᶜh_totʲs, ᶜq_totʲs) = p.precomputed
+    (; ᶜρaʲs, ᶜρʲs, ᶠu³ʲs, ᶜh_totʲs, ᶜq_totʲs) = p.precomputed
     (; dt) = p.simulation
     ᶜJ = Fields.local_geometry_field(Y.c).J
 
     if p.atmos.edmfx_sgs_mass_flux
         # energy
         ᶠu³_diff_colidx = p.scratch.ᶠtemp_CT3[colidx]
-        ᶜh_tot_diff_colidx = ᶜq_tot_diff_colidx = p.scratch.ᶜtemp_scalar[colidx]
+        ᶜa_scalar_colidx = p.scratch.ᶜtemp_scalar[colidx]
         for j in 1:n
             @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
-            @. ᶜh_tot_diff_colidx = ᶜh_totʲs.:($$j)[colidx] - ᶜh_tot[colidx]
+            @. ᶜa_scalar_colidx =
+                (ᶜh_totʲs.:($$j)[colidx] - ᶜh_tot[colidx]) *
+                draft_area(ᶜρaʲs.:($$j)[colidx], ᶜρʲs.:($$j)[colidx])
             vertical_transport!(
                 Yₜ.c.ρe_tot[colidx],
                 ᶜJ[colidx],
-                ᶜρaʲs.:($j)[colidx],
+                ᶜρʲs.:($j)[colidx],
                 ᶠu³_diff_colidx,
-                ᶜh_tot_diff_colidx,
+                ᶜa_scalar_colidx,
                 dt,
-                edmfx_upwinding,
+                edmfx_sgsflux_upwinding,
             )
         end
 
@@ -124,16 +132,17 @@ function edmfx_sgs_mass_flux_tendency!(
             # specific humidity
             for j in 1:n
                 @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
-                @. ᶜq_tot_diff_colidx =
-                    ᶜq_totʲs.:($$j)[colidx] - ᶜspecific.q_tot[colidx]
+                @. ᶜa_scalar_colidx =
+                    (ᶜq_totʲs.:($$j)[colidx] - ᶜspecific.q_tot[colidx]) *
+                    draft_area(ᶜρaʲs.:($$j)[colidx], ᶜρʲs.:($$j)[colidx])
                 vertical_transport!(
                     Yₜ.c.ρq_tot[colidx],
                     ᶜJ[colidx],
-                    ᶜρaʲs.:($j)[colidx],
+                    ᶜρʲs.:($j)[colidx],
                     ᶠu³_diff_colidx,
-                    ᶜq_tot_diff_colidx,
+                    ᶜa_scalar_colidx,
                     dt,
-                    edmfx_upwinding,
+                    edmfx_sgsflux_upwinding,
                 )
             end
         end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -89,6 +89,8 @@ function get_numerics(parsed_args)
     tracer_upwinding = Val(Symbol(parsed_args["tracer_upwinding"]))
     density_upwinding = Val(Symbol(parsed_args["density_upwinding"]))
     edmfx_upwinding = Val(Symbol(parsed_args["edmfx_upwinding"]))
+    edmfx_sgsflux_upwinding =
+        Val(Symbol(parsed_args["edmfx_sgsflux_upwinding"]))
 
     limiter =
         parsed_args["apply_limiter"] ? Limiters.QuasiMonotoneLimiter : nothing
@@ -99,6 +101,7 @@ function get_numerics(parsed_args)
         tracer_upwinding,
         density_upwinding,
         edmfx_upwinding,
+        edmfx_sgsflux_upwinding,
         limiter,
         test_dycore_consistency = test_dycore,
         use_reference_state = parsed_args["use_reference_state"],

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -267,13 +267,22 @@ struct TestDycoreConsistency end
 
 Base.broadcastable(x::AbstractPerformanceMode) = tuple(x)
 
-Base.@kwdef struct AtmosNumerics{EN_UP, TR_UP, DE_UP, ED_UP, DYCORE, LIM}
+Base.@kwdef struct AtmosNumerics{
+    EN_UP,
+    TR_UP,
+    DE_UP,
+    ED_UP,
+    ED_SG_UP,
+    DYCORE,
+    LIM,
+}
 
     """Enable specific upwinding schemes for specific equations"""
     energy_upwinding::EN_UP
     tracer_upwinding::TR_UP
     density_upwinding::DE_UP
     edmfx_upwinding::ED_UP
+    edmfx_sgsflux_upwinding::ED_SG_UP
 
     """Add NaNs to certain equations to track down problems"""
     test_dycore_consistency::DYCORE


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Also adds an option for the numerical scheme for edmfx sgs mass flux. (Note: This PR is only changing the numerics of sgs mass flux. I will have another PR soon that adds a divergence term in GeneralizedDetrainment, adds a few more cases, and maybe changes the default detrainment for all the cases.)

Closes #2335 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
