### PR TITLE
Add versioninfo to MSE comparsion

### DIFF
--- a/regression_tests/regression_tests.jl
+++ b/regression_tests/regression_tests.jl
@@ -9,6 +9,8 @@ function perform_regression_tests(
     all_best_mse::AbstractDict,
     output_dir::String,
 )
+    @show versioninfo()
+
     # This is helpful for starting up new tables
     @info "Job-specific MSE table format:"
     println("all_best_mse[\"$job_id\"] = OrderedCollections.OrderedDict()")


### PR DESCRIPTION
Not a solution to unstable MSE problems, but this will print something like:
```
Julia Version 1.9.3
Commit bed2cd540a1 (2023-08-24 14:43 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 32 × Intel(R) Xeon(R) Gold 6130 CPU @ 2.10GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake-avx512)
  Threads: 1 on 32 virtual cores
Environment:
  LD_LIBRARY_PATH = /central/software/hdf5/1.12.2-ompi415//lib:/central/software/OpenMPI/4.1.5_cuda-12.2//lib:/central/software/ucx/1.14.1_cuda-12.2//lib:/central/software/CUDA/12.2/lib64:/central/software/CUDA/12.2/extras/CUPTI/lib64:/central/software/CUDA/12.2/targets/x86_64-linux/lib:/central/software/julia/1.9.3/lib
  LD_RUN_PATH = /central/software/OpenMPI/4.1.5_cuda-12.2//lib:/central/software/ucx/1.14.1_cuda-12.2//lib:/central/software/CUDA/12.2/lib64:/central/software/CUDA/12.2/extras/CUPTI/lib64:/central/software/CUDA/12.2/targets/x86_64-linux/lib
```

This can help identifying runs that are known to have MSE problems (e.g., because they are not broadwell nodes).
