### PR TITLE
add vertical divergence to detrainment closure

### DIFF
--- a/config/model_configs/prognostic_edmfx_bomex_box.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_box.yml
@@ -7,7 +7,7 @@ surface_setup: "Bomex"
 turbconv: "prognostic_edmfx"
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
-edmfx_detr_model: "ConstantArea"
+edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
@@ -27,4 +27,4 @@ perturb_initstate: false
 dt: "10secs"
 t_end: "6hours"
 dt_save_to_disk: "10mins"
-toml: [toml/prognostic_edmfx_box.toml]
+toml: [toml/prognostic_edmfx_bomex_box.toml]

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -36,6 +36,7 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT} <: ATCP
     detr_tau::FT
     detr_coeff::FT
     detr_buoy_coeff::FT
+    detr_vertdiv_coeff::FT
     min_area_limiter_scale::FT
     min_area_limiter_power::FT
     max_area_limiter_scale::FT

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -268,6 +268,7 @@ function detrainment(
     detr_inv_tau = CAP.detr_tau(turbconv_params)
     detr_coeff = CAP.detr_coeff(turbconv_params)
     detr_buoy_coeff = CAP.detr_buoy_coeff(turbconv_params)
+    detr_vertdiv_coeff = CAP.detr_vertdiv_coeff(turbconv_params)
     max_area_limiter_scale = CAP.max_area_limiter_scale(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
     a_max = CAP.max_area(turbconv_params)
@@ -275,13 +276,16 @@ function detrainment(
     max_area_limiter =
         max_area_limiter_scale *
         exp(-max_area_limiter_power * (a_max - min(ᶜaʲ, 1)))
-    detr = min(
-        detr_inv_tau +
-        detr_coeff * abs(ᶜwʲ) +
-        detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
-        max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) +
-        max_area_limiter,
-        1 / dt,
+    detr = max(
+        min(
+            detr_inv_tau +
+            detr_coeff * abs(ᶜwʲ) +
+            detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
+            max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) - detr_vertdiv_coeff * ᶜvert_div +
+            max_area_limiter,
+            1 / dt,
+        ),
+        0,
     )
     return detr
 end
@@ -309,6 +313,7 @@ function detrainment(
     detr_inv_tau = CAP.detr_tau(turbconv_params)
     detr_coeff = CAP.detr_coeff(turbconv_params)
     detr_buoy_coeff = CAP.detr_buoy_coeff(turbconv_params)
+    detr_vertdiv_coeff = CAP.detr_vertdiv_coeff(turbconv_params)
     max_area_limiter_scale = CAP.max_area_limiter_scale(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
     a_max = CAP.max_area(turbconv_params)
@@ -316,13 +321,16 @@ function detrainment(
     max_area_limiter =
         max_area_limiter_scale *
         exp(-max_area_limiter_power * (a_max - min(ᶜaʲ, 1)))
-    detr = min(
-        detr_inv_tau +
-        detr_coeff * abs(ᶜwʲ) +
-        detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
-        max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) +
-        max_area_limiter,
-        1 / dt,
+    detr = max(
+        min(
+            detr_inv_tau +
+            detr_coeff * abs(ᶜwʲ) +
+            detr_buoy_coeff * abs(min(ᶜbuoyʲ - ᶜbuoy⁰, 0)) /
+            max(eps(FT), abs(ᶜwʲ - ᶜw⁰)) - detr_vertdiv_coeff * ᶜvert_div +
+            max_area_limiter,
+            1 / dt,
+        ),
+        0,
     )
     return detr * FT(2) * hm_limiter(ᶜaʲ)
 end

--- a/toml/prognostic_edmfx_bomex_box.toml
+++ b/toml/prognostic_edmfx_bomex_box.toml
@@ -20,17 +20,17 @@ type = "float"
 
 [entr_coeff]
 alias = "entr_coeff"
-value = 0.2
+value = 0.1
 type = "float"
 
 [min_area_limiter_scale]
 alias = "min_area_limiter_scale"
-value = 0.01
+value = 0.001
 type = "float"
 
 [min_area_limiter_power]
 alias = "min_area_limiter_power"
-value = 100
+value = 10
 type = "float"
 
 [detr_tau]
@@ -40,7 +40,7 @@ type = "float"
 
 [detr_coeff]
 alias = "detr_coeff"
-value = 1e-3
+value = 2e-3
 type = "float"
 
 [detr_buoy_coeff]
@@ -50,7 +50,7 @@ type = "float"
 
 [detr_vertdiv_coeff]
 alias = "detr_vertdiv_coeff"
-value = 0.5
+value = 0.6
 type = "float"
 
 [max_area_limiter_scale]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds vertical divergence term to detrainment closure and scales it with `detr_vertdiv_coeff`. Changes bomex to use `GeneralizedDetrainment` to make it ready for calibration.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
