### PR TITLE
Improve `buoyancy_gradients` design

### DIFF
--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -1,6 +1,7 @@
 module ClimaAtmos
 
 using NVTX, Colors
+import Thermodynamics as TD
 
 include(joinpath("parameters", "Parameters.jl"))
 import .Parameters as CAP

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -759,17 +759,12 @@ function set_diagnostic_edmf_precomputed_quantities_env_closures!(Y, p, t)
     @. ᶜu⁰ = C123(Y.c.uₕ) + ᶜinterp(C123(ᶠu³⁰))
 
     @. ᶜlinear_buoygrad = buoyancy_gradients(
-        params,
+        BuoyGradMean(),
+        thermo_params,
         moisture_model,
-        EnvBuoyGrad(
-            BuoyGradMean(),
-            TD.air_temperature(thermo_params, ᶜts),                           # t_sat
-            TD.vapor_specific_humidity(thermo_params, ᶜts),                   # qv_sat
-            q_tot,                                                            # qt_sat
-            TD.liquid_specific_humidity(thermo_params, ᶜts),
-            TD.ice_specific_humidity(thermo_params, ᶜts),
-            TD.dry_pottemp(thermo_params, ᶜts),                               # θ_sat
-            TD.liquid_ice_pottemp(thermo_params, ᶜts),                        # θ_liq_ice_sat
+        EnvBuoyGradVars(
+            thermo_params,
+            ᶜts,
             projected_vector_data(
                 C3,
                 ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts))),
@@ -781,9 +776,6 @@ function set_diagnostic_edmf_precomputed_quantities_env_closures!(Y, p, t)
                 ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts))),
                 ᶜlg,
             ),                                                                 # ∂θl∂z_sat
-            ᶜp,                                                                # p
-            ifelse(TD.has_condensate(thermo_params, ᶜts), 1, 0),               # en_cld_frac
-            Y.c.ρ,                                                             # ρ
         ),
     )
 

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -239,17 +239,12 @@ function set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
 
     # First order approximation: Use environmental mean fields.
     @. ᶜlinear_buoygrad = buoyancy_gradients(
-        params,
+        BuoyGradMean(),
+        thermo_params,
         moisture_model,
-        EnvBuoyGrad(
-            BuoyGradMean(),
-            TD.air_temperature(thermo_params, ᶜts⁰),                           # t_sat
-            TD.vapor_specific_humidity(thermo_params, ᶜts⁰),                   # qv_sat
-            ᶜq_tot⁰,                                                           # qt_sat
-            TD.liquid_specific_humidity(thermo_params, ᶜts⁰),
-            TD.ice_specific_humidity(thermo_params, ᶜts⁰),
-            TD.dry_pottemp(thermo_params, ᶜts⁰),                               # θ_sat
-            TD.liquid_ice_pottemp(thermo_params, ᶜts⁰),                        # θ_liq_ice_sat
+        EnvBuoyGradVars(
+            thermo_params,
+            ᶜts⁰,
             projected_vector_data(
                 C3,
                 ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts⁰))),
@@ -261,9 +256,6 @@ function set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
                 ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts⁰))),
                 ᶜlg,
             ),                                                                 # ∂θl∂z_sat
-            ᶜp,                                                                # p
-            ifelse(TD.has_condensate(thermo_params, ᶜts⁰), 1, 0),              # en_cld_frac
-            ᶜρ⁰,                                                               # ρ
         ),
     )
 

--- a/src/prognostic_equations/gm_sgs_closures.jl
+++ b/src/prognostic_equations/gm_sgs_closures.jl
@@ -33,35 +33,27 @@ function compute_gm_mixing_length!(ᶜmixing_length, Y, p)
 
     ᶜlinear_buoygrad = p.scratch.ᶜtemp_scalar
     @. ᶜlinear_buoygrad = buoyancy_gradients(
-        params,
+        BuoyGradMean(),
+        thermo_params,
         p.atmos.moisture_model,
-        EnvBuoyGrad(
-            BuoyGradMean(),
-            TD.air_temperature(thermo_params, ᶜts),           # t_sat
-            TD.vapor_specific_humidity(thermo_params, ᶜts),   # qv_sat
-            TD.total_specific_humidity(thermo_params, ᶜts),   # qt_sat
-            TD.liquid_specific_humidity(thermo_params, ᶜts),  # q_liq
-            TD.ice_specific_humidity(thermo_params, ᶜts),     # q_ice
-            TD.dry_pottemp(thermo_params, ᶜts),               # θ_sat
-            TD.liquid_ice_pottemp(thermo_params, ᶜts),        # θ_liq_ice_sat
+        EnvBuoyGradVars(
+            thermo_params,
+            ᶜts,
             projected_vector_data(
                 C3,
                 ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts))),
                 ᶜlg,
-            ),                                               # ∂θv∂z_unsat
+            ),                                                                 # ∂θv∂z_unsat
             projected_vector_data(
                 C3,
                 ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts))),
                 ᶜlg,
-            ),                                               # ∂qt∂z_sat
+            ),            # ∂qt∂z_sat
             projected_vector_data(
                 C3,
                 ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts))),
                 ᶜlg,
-            ),                                               # ∂θl∂z_sat
-            ᶜp,                                              # p
-            ifelse(TD.has_condensate(thermo_params, ᶜts), 1, 0),# en_cld_frac
-            Y.c.ρ,                                           # ρ
+            ),                                                                 # ∂θl∂z_sat
         ),
     )
 


### PR DESCRIPTION
This PR does two things:
 - Renames  `EnvBuoyGrad` to `EnvBuoyGradVars` and defines `EnvBuoyGrad` as a singleton for dispatching. This is a bit simpler of a pattern being that, in the existing design, `EnvBuoyGrad` contains all of the variables for all `AbstractEnvBuoyGradClosure` specializations. This does mean that we need to pass an extra variable around, but that one is solely used for dispatch. Being that we currently have only one concrete subtype of `AbstractEnvBuoyGradClosure`, we could just do away with the extra parameter and duplicate structs, but I thought that adding the additional parameter wasn't too painful so that we can easily extend / dispatch.
 - Modifies the outer constructor of `EnvBuoyGradVars` to take a thermo state. This should hopefully improve the memory loads, since the thermo function calls can all occur in registers after the thermo state is loaded. Alternatively, we could make `EnvBuoyGradVars` simply hold the thermo state ( or just bypass that altogether ), but then those thermo call would need to be sprinkled in `buoyancy_gradients` and `buoyancy_gradient_chain_rule`, and it's not clear to me that that is worth the additional compute, not to mention it may just make the code look a bit more complicated.