### PR TITLE
change entrainment dt limiter

### DIFF
--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -80,7 +80,7 @@ function entrainment(
                 abs(ᶜwʲ) / (ᶜz - z_sfc) * (
                     -4.013288 - 0.000968 * Π₁ + 0.356974 * Π₃ - 0.403124 * Π₄ + 1.503261 * Π₆
                 ),
-                1 / dt,
+                (1 - ᶜaʲ) / max(ᶜaʲ, eps(FT)) / dt,
             ),
         )
 
@@ -115,9 +115,14 @@ function entrainment(
     min_area_limiter =
         min_area_limiter_scale *
         exp(-min_area_limiter_power * (max(ᶜaʲ, 0) - a_min))
-    entr = min(
-        entr_inv_tau + entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) + min_area_limiter,
-        1 / dt,
+    entr = max(
+        0,
+        min(
+            entr_inv_tau +
+            entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) +
+            min_area_limiter,
+            (1 - ᶜaʲ) / max(ᶜaʲ, eps(FT)) / dt,
+        ),
     )
     return entr
 end
@@ -149,9 +154,14 @@ function entrainment(
     min_area_limiter =
         min_area_limiter_scale *
         exp(-min_area_limiter_power * (max(ᶜaʲ, 0) - a_min))
-    entr = min(
-        entr_inv_tau + entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) + min_area_limiter,
-        1 / dt,
+    entr = max(
+        0,
+        min(
+            entr_inv_tau +
+            entr_coeff * abs(ᶜwʲ) / (ᶜz - z_sfc) +
+            min_area_limiter,
+            (1 - ᶜaʲ) / max(ᶜaʲ, eps(FT)) / dt,
+        ),
     )
     return entr * FT(2) * hm_limiter(ᶜaʲ)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Change the entrainment limiter from 1 / dt to (1 - a) / a / dt. This makes more sense to me.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
