### PR TITLE
add rho tendencies from qt diffusion in EDMF

### DIFF
--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -188,14 +188,17 @@ function edmfx_sgs_diffusive_flux_tendency!(
 
         if !(p.atmos.moisture_model isa DryModel)
             # specific humidity
+            ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
             ᶜdivᵥ_ρq_tot = Operators.DivergenceF2C(
                 top = Operators.SetValue(C3(FT(0))),
                 bottom = Operators.SetValue(
                     sfc_conditions.ρ_flux_q_tot[colidx],
                 ),
             )
-            @. Yₜ.c.ρq_tot[colidx] -=
+            @. ᶜρχₜ_diffusion[colidx] =
                 ᶜdivᵥ_ρq_tot(-(ᶠρaK_h[colidx] * ᶠgradᵥ(ᶜq_tot⁰[colidx])))
+            @. Yₜ.c.ρq_tot[colidx] -= ᶜρχₜ_diffusion[colidx]
+            @. Yₜ.c.ρ[colidx] -= ᶜρχₜ_diffusion[colidx]
         end
 
         # momentum
@@ -249,15 +252,18 @@ function edmfx_sgs_diffusive_flux_tendency!(
 
         if !(p.atmos.moisture_model isa DryModel)
             # specific humidity
+            ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
             ᶜdivᵥ_ρq_tot = Operators.DivergenceF2C(
                 top = Operators.SetValue(C3(FT(0))),
                 bottom = Operators.SetValue(
                     sfc_conditions.ρ_flux_q_tot[colidx],
                 ),
             )
-            @. Yₜ.c.ρq_tot[colidx] -= ᶜdivᵥ_ρq_tot(
+            @. ᶜρχₜ_diffusion[colidx] = ᶜdivᵥ_ρq_tot(
                 -(ᶠρaK_h[colidx] * ᶠgradᵥ(ᶜspecific.q_tot[colidx])),
             )
+            @. Yₜ.c.ρq_tot[colidx] -= ᶜρχₜ_diffusion[colidx]
+            @. Yₜ.c.ρ[colidx] -= ᶜρχₜ_diffusion[colidx]
         end
 
         # momentum


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds the missing tendencies to \rho from vertical diffusion of qt in EDMF.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
