### PR TITLE
Make initial conditions independent of the parameter struct

### DIFF
--- a/src/initial_conditions/atmos_state.jl
+++ b/src/initial_conditions/atmos_state.jl
@@ -66,7 +66,7 @@ energy_variables(ls) = (;
     ρe_tot = ls.ρ * (
         TD.internal_energy(ls.thermo_params, ls.thermo_state) +
         norm_sqr(ls.velocity) / 2 +
-        CAP.grav(ls.params) * ls.geometry.coordinates.z
+        ls.grav * ls.geometry.coordinates.z
     )
 )
 
@@ -121,7 +121,7 @@ function turbconv_center_variables(ls, turbconv_model::PrognosticEDMFX, gs_vars)
     ρa = ls.ρ * a_draft / n
     mse =
         TD.specific_enthalpy(ls.thermo_params, ls.thermo_state) +
-        CAP.grav(ls.params) * ls.geometry.coordinates.z
+        ls.grav * ls.geometry.coordinates.z
     q_tot = TD.total_specific_humidity(ls.thermo_params, ls.thermo_state)
     sgsʲs = ntuple(_ -> (; ρa = ρa, mse = mse, q_tot = q_tot), Val(n))
     return (; sgs⁰, sgsʲs)

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -896,9 +896,8 @@ struct PrecipitatingColumn <: InitialCondition end
 prescribed_prof(::Type{FT}, z_mid, z_max, val) where {FT} =
     z -> z < z_max ? FT(val) * exp(-(z - FT(z_mid))^2 / 2 / FT(1e3)^2) : FT(0)
 
-function PrecipitatingColumn(params)
-    FT = eltype(params)
-    thermo_params = CAP.thermodynamics_params(params)
+function PrecipitatingColumn(grav, thermo_params)
+    FT = eltype(thermo_params)
     p_0 = FT(101300.0)
     qᵣ = prescribed_prof(FT, 2000, 5000, 1e-6)
     qₛ = prescribed_prof(FT, 5000, 8000, 2e-6)
@@ -918,8 +917,9 @@ function PrecipitatingColumn(params)
             TD.PhasePartition(q_tot(z), qₗ(z), qᵢ(z)),
         )
         return LocalState(;
-            params,
             geometry = local_geometry,
+            grav,
+            thermo_params,
             thermo_state = ts,
             velocity = Geometry.UVVector(u(z), v(z)),
             turbconv_state = nothing,

--- a/src/initial_conditions/local_state.jl
+++ b/src/initial_conditions/local_state.jl
@@ -51,7 +51,7 @@ function LocalState(;
     turbconv_state = nothing,
     precip_state = nothing,
 )
-    FT = typeof(grav)
+    FT = eltype(thermo_params)
     return LocalState(
         geometry,
         grav,

--- a/src/initial_conditions/local_state.jl
+++ b/src/initial_conditions/local_state.jl
@@ -23,7 +23,6 @@ are set to 0.
 """
 struct LocalState{
     FT,
-    P <: CAP.ClimaAtmosParameters{FT},
     G <: Geometry.LocalGeometry{<:Any, <:Any, FT},
     TS <: TD.ThermodynamicState{FT},
     V <: Geometry.LocalVector{FT},
@@ -31,8 +30,8 @@ struct LocalState{
     PS <: PrecipState{FT},
     TP,
 }
-    params::P
     geometry::G
+    grav::FT
     thermo_state::TS
     velocity::V
     turbconv_state::TC
@@ -44,23 +43,24 @@ struct LocalState{
 end
 
 function LocalState(;
-    params,
     geometry,
+    grav,
+    thermo_params,
     thermo_state,
     velocity = nothing,
     turbconv_state = nothing,
     precip_state = nothing,
 )
-    FT = eltype(params)
+    FT = typeof(grav)
     return LocalState(
-        params,
         geometry,
+        grav,
         thermo_state,
         isnothing(velocity) ? Geometry.UVVector(FT(0), FT(0)) : velocity,
         isnothing(turbconv_state) ? NoTurbconvState{FT}() : turbconv_state,
         isnothing(precip_state) ? NoPrecipState{FT}() : precip_state,
-        CAP.thermodynamics_params(params),
-        TD.air_density(CAP.thermodynamics_params(params), thermo_state),
+        thermo_params,
+        TD.air_density(thermo_params, thermo_state),
     )
 end
 

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -300,7 +300,9 @@ function get_initial_condition(parsed_args, params)
     ic = getproperty(ICs, Symbol(parsed_args["initial_condition"]))
     thermo_params = CAP.thermodynamics_params(params)
     grav = CAP.grav(params)
-    if parsed_args["initial_condition"] in
+    if parsed_args["initial_condition"] == "PrecipitatingColumn"
+        return ic(grav, thermo_params)
+    elseif parsed_args["initial_condition"] in
        ["DecayingProfile", "MoistAdiabaticProfileEDMFX"]
         return ic(grav, thermo_params, parsed_args["perturb_initstate"])
     elseif parsed_args["initial_condition"] in
@@ -326,7 +328,6 @@ function get_initial_condition(parsed_args, params)
         "DYCOMS_RF02",
         "Rico",
         "TRMM_LBA",
-        "PrecipitatingColumn",
     ]
         return ic(grav, thermo_params, parsed_args["prognostic_tke"])
     elseif parsed_args["initial_condition"] in [

--- a/src/utils/discrete_hydrostatic_balance.jl
+++ b/src/utils/discrete_hydrostatic_balance.jl
@@ -38,7 +38,7 @@ function set_discrete_hydrostatic_balanced_state!(Y, p)
     end
     ᶜlocal_geometry = Fields.local_geometry_field(Y.c)
     ls(params, thermo_state, geometry, velocity) =
-        ICs.LocalState(; params, thermo_state, geometry, velocity)
+        ICs.LocalState(; grav = CAP.grav(params), thermo_params = CAP.thermodynamics_params(params), thermo_state, geometry, velocity)
     @. Y.c = merge(
         Y.c,
         ICs.energy_variables(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
We want to slowly decouple the parameter struct from function calls and pass parameter values individually or at least more compactly. Initial conditions is a good initial example of this.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
Apply changes to EDMF initial conditions

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Change LocalState to include `grav` and `thermo_params` instead of `params`
- Remove most InitialConditions structs
- Change InitialConditions functions to take in only the necessary parameters
- Change `get_initial_conditions` to match the new structure

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
