### PR TITLE
Add back get_integrator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.17.1"
+version = "0.17.2"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -260,7 +260,7 @@ weakdeps = ["SparseArrays"]
 deps = ["ArgParse", "ArtifactWrappers", "Artifacts", "AtmosphericProfilesLibrary", "CLIMAParameters", "ClimaComms", "ClimaCore", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "Krylov", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "SciMLBase", "StaticArrays", "Statistics", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.17.1"
+version = "0.17.2"
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "MPI"]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -305,7 +305,7 @@ weakdeps = ["SparseArrays"]
 deps = ["ArgParse", "ArtifactWrappers", "Artifacts", "AtmosphericProfilesLibrary", "CLIMAParameters", "ClimaComms", "ClimaCore", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "Krylov", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "SciMLBase", "StaticArrays", "Statistics", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.17.1"
+version = "0.17.2"
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "MPI"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -316,7 +316,7 @@ weakdeps = ["SparseArrays"]
 deps = ["ArgParse", "ArtifactWrappers", "Artifacts", "AtmosphericProfilesLibrary", "CLIMAParameters", "ClimaComms", "ClimaCore", "ClimaTimeSteppers", "CloudMicrophysics", "Colors", "Dates", "Dierckx", "DiffEqBase", "DiffEqCallbacks", "DocStringExtensions", "FastGaussQuadrature", "ImageFiltering", "Insolation", "Interpolations", "IntervalSets", "Krylov", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "SciMLBase", "StaticArrays", "Statistics", "StatsBase", "SurfaceFluxes", "Test", "Thermodynamics", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.17.1"
+version = "0.17.2"
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "MPI"]

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -949,3 +949,12 @@ function get_simulation(config::AtmosConfig)
         integrator,
     )
 end
+
+# Compatibility with old get_integrator
+function get_integrator(config::AtmosConfig)
+    Base.depwarn(
+        "get_integrator is deprecated, use get_simulation instead",
+        :get_integrator,
+    )
+    return get_simulation(config).integrator
+end


### PR DESCRIPTION
`get_integrator` got removed in #2179. This PR adds it back (with a deprecation notice). This PR also bumps ClimaAtmos to 0.17.2 to avoid breaking packages that use `get_integrator`.