### PR TITLE
add vertical divergence to diagnostic edmf detrainment

### DIFF
--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -26,7 +26,7 @@ y_elem: 2
 z_elem: 82
 z_max: 16400
 z_stretch: false
-dt: 600secs
+dt: 300secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -29,7 +29,7 @@ z_elem: 30
 z_max: 16400
 dz_bottom: 50
 dz_top: 2000
-dt: 600secs
+dt: 300secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -38,8 +38,6 @@ function precomputed_quantities(Y, atmos)
             !(atmos.turbconv_model isa DiagnosticEDMFX)
     @assert !(atmos.moisture_model isa DryModel) ||
             !(atmos.turbconv_model isa PrognosticEDMFX)
-    @assert !(atmos.edmfx_detr_model isa ConstantAreaDetrainment) ||
-            !(atmos.turbconv_model isa DiagnosticEDMFX)
     @assert isnothing(atmos.turbconv_model) || isnothing(atmos.vert_diff)
     TST = thermo_state_type(atmos.moisture_model, FT)
     SCT = SurfaceConditions.surface_conditions_type(atmos, FT)

--- a/toml/diagnostic_edmfx_box.toml
+++ b/toml/diagnostic_edmfx_box.toml
@@ -1,6 +1,6 @@
 [entr_tau]
 alias = "entr_tau"
-value = 0.001
+value = 0.002
 type = "float"
 
 [entr_coeff]
@@ -15,7 +15,12 @@ type = "float"
 
 [detr_buoy_coeff]
 alias = "detr_buoy_coeff"
-value = 0
+value = 0.12
+type = "float"
+
+[detr_vertdiv_coeff]
+alias = "detr_vertdiv_coeff"
+value = 0.6
 type = "float"
 
 [min_area_limiter_scale]

--- a/toml/diagnostic_edmfx_trmm_box.toml
+++ b/toml/diagnostic_edmfx_trmm_box.toml
@@ -5,7 +5,7 @@ type = "float"
 
 [entr_tau]
 alias = "entr_tau"
-value = 0.001
+value = 0.002
 type = "float"
 
 [entr_coeff]
@@ -16,6 +16,11 @@ type = "float"
 [detr_tau]
 alias = "detr_tau"
 value = 0
+type = "float"
+
+[detr_vertdiv_coeff]
+alias = "detr_vertdiv_coeff"
+value = 0.6
 type = "float"
 
 [detr_buoy_coeff]
@@ -30,5 +35,5 @@ type = "float"
 
 [max_area_limiter_scale]
 alias = "max_area_limiter_scale"
-value = 0.01
+value = 0
 type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Add vertical divergence to detrainment for diagnostic edmf. Hopefully this will help constrain area fraction to some extent. To make things easier, for the integral we first get u^3,j, and use it and the u^3,j at the previous level to calculate the divergence. We also need updraft density \rho^j, which we don't have, so we use grid-mean density as an approximation. Given it's just for the closure, I think it's fine.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
