### PR TITLE
Turn orchestrate_diagnostics into a named function

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -840,12 +840,10 @@ function get_simulation(config::AtmosConfig)
     # reason, we only add one callback to the integrator, and this function takes care of
     # executing the other callbacks. This single function is orchestrate_diagnostics
 
-    orchestrate_diagnostics = let diagnostics_functions = diagnostics_functions
-        integrator -> begin
-            for d in diagnostics_functions
-                if d.cbf.n > 0 && integrator.step % d.cbf.n == 0
-                    d.f!(integrator)
-                end
+    function orchestrate_diagnostics(integrator)
+        for d in diagnostics_functions
+            if d.cbf.n > 0 && integrator.step % d.cbf.n == 0
+                d.f!(integrator)
             end
         end
     end


### PR DESCRIPTION
Partially reverts https://github.com/CliMA/ClimaAtmos.jl/commit/e6c5a84722cad443b1c56a215d1714c72157830d (but removes the `filter`).