### PR TITLE
add pressure work term to TKE equation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -580,7 +580,7 @@ steps:
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
-        artifact_paths: "diagnostic_edmfx_dycoms_rf01_explicitbox/*"
+        artifact_paths: "diagnostic_edmfx_dycoms_rf01_explicit_box/*"
         agents:
           slurm_mem: 20GB
 

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
@@ -23,7 +23,7 @@ y_elem: 2
 z_elem: 30 
 z_max: 1500 
 z_stretch: false
-dt: 40secs 
+dt: 20secs 
 t_end: 4hours 
 dt_save_to_disk: 10mins
 toml: [toml/diagnostic_edmfx_box.toml]

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -78,6 +78,7 @@ function precomputed_quantities(Y, atmos)
             ᶜρʲs = similar(Y.c, NTuple{n, FT}),
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
+            ᶠnh_pressure₃ʲs = similar(Y.f, NTuple{n, C3{FT}}),
         ) : (;)
     diagnostic_sgs_quantities =
         atmos.turbconv_model isa DiagnosticEDMFX ?
@@ -92,7 +93,7 @@ function precomputed_quantities(Y, atmos)
             ᶜq_totʲs = similar(Y.c, NTuple{n, FT}),
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜnh_pressureʲs = similar(Y.c, NTuple{n, CT3{FT}}),
+            ᶠnh_pressure³ʲs = similar(Y.f, NTuple{n, CT3{FT}}),
             ᶜS_q_totʲs = similar(Y.c, NTuple{n, FT}),
             ᶜS_q_tot⁰ = similar(Y.c, FT),
             ᶜS_e_totʲs_helper = similar(Y.c, NTuple{n, FT}),

--- a/src/prognostic_equations/edmfx_closures.jl
+++ b/src/prognostic_equations/edmfx_closures.jl
@@ -108,7 +108,7 @@ function edmfx_nh_pressure_tendency!(
     n = n_mass_flux_subdomains(turbconv_model)
     (; params) = p
     (; ᶠgradᵥ_ᶜΦ) = p.core
-    (; ᶜρʲs, ᶠu₃⁰) = p.precomputed
+    (; ᶜρʲs, ᶠnh_pressure₃ʲs, ᶠu₃⁰) = p.precomputed
     FT = eltype(Y)
     ᶜz = Fields.coordinate_field(Y.c).z
     z_sfc = Fields.level(Fields.coordinate_field(Y.f).z, Fields.half)
@@ -131,7 +131,7 @@ function edmfx_nh_pressure_tendency!(
         end
         updraft_top = updraft_top - z_sfc[colidx][]
 
-        @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] -= ᶠupdraft_nh_pressure(
+        @. ᶠnh_pressure₃ʲs.:($$j)[colidx] = ᶠupdraft_nh_pressure(
             params,
             p.atmos.edmfx_nh_pressure,
             ᶠlg[colidx],
@@ -144,6 +144,8 @@ function edmfx_nh_pressure_tendency!(
             ᶠu₃⁰[colidx],
             updraft_top,
         )
+
+        @. Yₜ.f.sgsʲs.:($$j).u₃[colidx] -= ᶠnh_pressure₃ʲs.:($$j)[colidx]
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds the missing pressure work term in TKE equation. Also adds subscript or superscript to nh_pressureʲ to make it clear whether it is covariant or contravariant. Changes ᶜnh_pressure to ᶠnh_pressure in diagnostic EDMF. It doesn't really matter for the diagnostic EDMF itself, but make it easier to unify diagnostic and prognostic EDMF for the TKE equation.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
