### PR TITLE
add entrainment and detrainment limiter to diagnostic edmf

### DIFF
--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -12,7 +12,7 @@ edmfx_sgs_diffusive_flux: true
 moist: equil 
 precip_model: 0M
 override_τ_precip: false
-dt: 10secs 
+dt: 50secs 
 t_end: 1hours 
 dt_save_to_disk: 600secs
 toml: [toml/diagnostic_edmfx_trmm_box.toml]

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -25,7 +25,7 @@ y_elem: 2
 z_elem: 60 
 z_max: 3e3 
 z_stretch: false
-dt: "200secs" 
+dt: "100secs" 
 t_end: "6hours" 
 dt_save_to_disk: "10mins"
 toml: [toml/diagnostic_edmfx_box.toml]

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -25,7 +25,7 @@ y_elem: 2
 z_elem: 30 
 z_max: 1500 
 z_stretch: false
-dt: 200secs
+dt: 100secs
 t_end: 4hours 
 dt_save_to_disk: 10mins
 toml: [toml/diagnostic_edmfx_box.toml]

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -25,7 +25,7 @@ y_elem: 2
 z_elem: 100
 z_max: 4e3
 z_stretch: false
-dt: 200secs
+dt: 100secs
 t_end: 8hours
 dt_save_to_disk: 10mins
 toml: [toml/diagnostic_edmfx_trmm_box.toml]

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -26,7 +26,7 @@ y_elem: 2
 z_elem: 82
 z_max: 16400
 z_stretch: false
-dt: 300secs
+dt: 200secs
 t_end: 6hours
 dt_save_to_disk: 10mins
 FLOAT_TYPE: "Float64"

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -206,8 +206,12 @@ function set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
             get_physical_w(ᶜu, ᶜlg),
             TD.relative_humidity(thermo_params, ᶜts⁰),
             FT(0),
-            dt,
             p.atmos.edmfx_entr_model,
+        )
+        @. ᶜentrʲs.:($$j) = limit_entrainment(
+            ᶜentrʲs.:($$j),
+            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+            dt,
         )
         @. ᶜvert_div = ᶜdivᵥ(ᶠinterp(ᶜρʲs.:($$j)) * ᶠu³ʲs.:($$j)) / ᶜρʲs.:($$j)
         @. ᶜdetrʲs.:($$j) = detrainment(
@@ -226,8 +230,12 @@ function set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
             FT(0),
             ᶜentrʲs.:($$j),
             ᶜvert_div,
-            dt,
             p.atmos.edmfx_detr_model,
+        )
+        @. ᶜdetrʲs.:($$j) = limit_detrainment(
+            ᶜdetrʲs.:($$j),
+            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+            dt,
         )
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Limits diagnostic edmf entrainment and detrainment to w / dz. Also refactors the limiter on entrainment and detrainment.

Right now I am limiting both entrainment and detrainment to w / dz for diagnostic edmf. I am not sure if it makes sense for detrainment, as this makes it small when w goes to zero near the cloud top, but I think we want detrainment to be large there. I'll need to think more about it. For entrainment, I can't use this upper limit at the first level, as w is zero and limiting it will result in zero entrainment, and zero area fraction throughout the column. So it's a bit ugly:( Another way is to calculate w at the next level first then use that for the limiter, but this can potentially result in different entrainment for w and tracers, which I would like to avoid unless we have to. Other than these issues this PR is ready for review.

Some time ago I increased the entrainment to make the timestep more limited by mass flux. The simulations didn't fail but the results look pretty noisy. I reduced dt here to make the results look slightly smoother. We can revisit this after we treat mass flux implicitly.

Closes #2407 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
