### PR TITLE
Add callback that estimates walltime

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -17,6 +17,7 @@ simulation = CA.get_simulation(config)
 
 import SciMLBase
 SciMLBase.step!(integrator) # compile first
+SciMLBase.step!(integrator) # compile print_walltime_estimate, which skips the first step to avoid timing compilation
 CA.call_all_callbacks!(integrator) # compile callbacks
 import Profile, ProfileCanvas
 output_dir = job_id
@@ -36,17 +37,17 @@ ProfileCanvas.html_file(joinpath(output_dir, "flame.html"), results)
 #####
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target"] = 147_520
-allocs_limit["flame_perf_target_tracers"] = 179_776
+allocs_limit["flame_perf_target"] = 148_256
+allocs_limit["flame_perf_target_tracers"] = 180_512
 allocs_limit["flame_perf_target_edmfx"] = 7_005_552
 allocs_limit["flame_perf_diagnostics"] = 25_356_928
-allocs_limit["flame_perf_target_diagnostic_edmfx"] = 1_309_968
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 1_311_040
 allocs_limit["flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"] =
     4_018_252_656
 allocs_limit["flame_perf_target_threaded"] = 1_276_864
 allocs_limit["flame_perf_target_callbacks"] = 37_277_112
-allocs_limit["flame_perf_gw"] = 3_226_428_736
-allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 1_257_712
+allocs_limit["flame_perf_gw"] = 3_226_429_472
+allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 1_258_848
 
 # Ideally, we would like to track all the allocations, but this becomes too
 # expensive there is too many of them. Here, we set the default sample rate to

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -1,5 +1,7 @@
 struct AtmosCache{
     FT <: AbstractFloat,
+    FTE,
+    WTE,
     SD,
     AM,
     NUM,
@@ -27,6 +29,12 @@ struct AtmosCache{
 }
     """Timestep of the simulation (in seconds). This is also used by callbacks and tendencies"""
     dt::FT
+
+    """End time of the simulation (in seconds). This used by callbacks"""
+    t_end::FTE
+
+    """Walltime estimate"""
+    walltime_estimate::WTE
 
     """Start date (used for insolation)."""
     start_date::SD
@@ -93,7 +101,7 @@ end
 
 # The model also depends on f_plane_coriolis_frequency(params)
 # This is a constant Coriolis frequency that is only used if space is flat
-function build_cache(Y, atmos, params, surface_setup, dt, start_date)
+function build_cache(Y, atmos, params, surface_setup, dt, t_end, start_date)
     FT = eltype(params)
 
     ᶜcoord = Fields.local_geometry_field(Y.c).coordinates
@@ -184,6 +192,8 @@ function build_cache(Y, atmos, params, surface_setup, dt, start_date)
 
     args = (
         dt,
+        t_end,
+        WallTimeEstimate(),
         start_date,
         atmos,
         numerics,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -455,7 +455,12 @@ function get_callbacks(parsed_args, sim_info, atmos, params, comms_ctx)
     FT = eltype(params)
     (; dt, output_dir) = sim_info
 
-    callbacks = ()
+    callbacks = (
+        call_every_n_steps(
+            (integrator) -> print_walltime_estimate(integrator);
+            skip_first = true,
+        ),
+    )
     dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
     if !(dt_save_to_disk == Inf)
         callbacks = (
@@ -759,6 +764,7 @@ function get_simulation(config::AtmosConfig)
         if sim_info.restart
             (Y, t_start) = get_state_restart(config.comms_ctx)
             spaces = get_spaces_restart(Y)
+            @warn "Progress estimates do not support restarted simulations"
         else
             spaces = get_spaces(config.parsed_args, params, config.comms_ctx)
             Y = ICs.atmos_state(
@@ -779,6 +785,7 @@ function get_simulation(config::AtmosConfig)
             params,
             surface_setup,
             sim_info.dt,
+            sim_info.t_end,
             sim_info.start_date,
         )
     end

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -58,6 +58,8 @@ const T2 = 290
     @. sfc_setup = (surface_state,)
     p_overwritten = CA.AtmosCache(
         p.dt,
+        simulation.t_end,
+        CA.WallTimeEstimate(),
         p.start_date,
         p.atmos,
         p.numerics,


### PR DESCRIPTION
This PR adds a callback that logs some helpful runtime information:

```
┌ Info: Progress
│   simulation_time = "21 hours, 30 minutes"
│   n_steps_completed = 129
│   wall_time_per_step = "101 milliseconds, 824 microseconds"
│   wall_time_total = "2 minutes, 26 seconds"
│   wall_time_remaining = 133.4913111176602
│   wall_time_spent = "13 seconds, 135 milliseconds"
│   percent_complete = "9.0%"
│   sypd = 16.144
│   date_now = 2023-12-14T10:42:19.127
└   estimated_finish_date = 2023-12-14T10:44:32.618
```

The callback uses a doubling backoff (we log on step 2, 4, 8, 16, 32, ...) to provide frequent estimates near the beginning of simulations, but increasingly infrequent as time goes on to avoid bloating the log (I don't want people to have to scroll through a zillion info statements in the longruns to get to the end of the log).