### PR TITLE
Make the 1M scheme more stable

### DIFF
--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
@@ -1,18 +1,37 @@
-rad: "allskywithclear"
-dt_save_to_disk: "15hours"
-rayleigh_sponge: true
-orographic_gravity_wave: "gfdl_restart"
 z_elem: 25
-dt: "400secs"
-surface_setup: "DefaultMoninObukhov"
-t_end: "15hours"
-non_orographic_gravity_wave: true
-dz_bottom: 300.0
-vert_diff: "true"
-idealized_insolation: false
 z_max: 45000.0
+dz_bottom: 300.0
+dt: "400secs"
+t_end: "24hours"
+dt_save_to_disk: "24hours"
+vert_diff: "true"
+moist: "equil"
 precip_model: "1M"
 precip_upwinding: "first_order"
+rad: "allskywithclear"
+idealized_insolation: false
+rayleigh_sponge: true
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "gfdl_restart"
+surface_setup: "DefaultMoninObukhov"
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"
-moist: "equil"
 toml: [toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.toml]
+diagnostics:
+  - short_name: cl
+    period: 6hours
+  - short_name: cli
+    period: 6hours
+  - short_name: clw
+    period: 6hours
+  - short_name: husra
+    period: 6hours
+  - short_name: hussn
+    period: 6hours
+  - short_name: ta
+    period: 6hours
+  - short_name: hus
+    period: 6hours
+  - short_name: hur
+    period: 6hours
+  - short_name: mixlgm
+    period: 6hours


### PR DESCRIPTION
This should make it possible to run the `sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res` CI case for 24 hours. Here is how the model looks at the end of that day:


![test__time_86400 0](https://github.com/CliMA/ClimaAtmos.jl/assets/1196696/a35fe9b8-bb9e-41d2-8d10-a47c4e89bd68)



I'm also testing the longruns CI job `longrun_aquaplanet_rhoe_equilmoist_nz63_0M_55km_rs35km_clearsky_tvinsolation`.