### PR TITLE
Skip progress callback for restarted simulations

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -455,12 +455,16 @@ function get_callbacks(parsed_args, sim_info, atmos, params, comms_ctx)
     FT = eltype(params)
     (; dt, output_dir) = sim_info
 
-    callbacks = (
-        call_every_n_steps(
-            (integrator) -> print_walltime_estimate(integrator);
-            skip_first = true,
-        ),
-    )
+    callbacks = ()
+    if !sim_info.restart
+        callbacks = (
+            callbacks...,
+            call_every_n_steps(
+                (integrator) -> print_walltime_estimate(integrator);
+                skip_first = true,
+            ),
+        )
+    end
     dt_save_to_disk = time_to_seconds(parsed_args["dt_save_to_disk"])
     if !(dt_save_to_disk == Inf)
         callbacks = (


### PR DESCRIPTION
Right now, for restarted simulations, the progress callback prints every two steps (e.g., here: https://buildkite.com/clima/climaatmos-ci/builds/15375#018c6f23-e3fe-4135-86ba-75f1001482c7). Since this isn't (yet) compatible with restarted simulations, I'm going to simply disable the progress callback for them. cc @szy21 