### PR TITLE
Add RSS memory usage to reporting

### DIFF
--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -1,4 +1,5 @@
 import ClimaTimeSteppers as CTS
+import Base.Sys: maxrss
 
 struct EfficiencyStats{TS <: Tuple, WT}
     tspan::TS
@@ -74,6 +75,10 @@ function solve_atmos!(simulation)
         return AtmosSolveResults(nothing, :simulation_crashed, nothing)
     finally
         # Close all the files opened by the writers
+
+        maxrss_str = prettymemory(maxrss())
+        @info "Memory currently used by the process (RSS): $maxrss_str"
+
         foreach(CAD.close, output_writers)
     end
 end

--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -77,7 +77,7 @@ function solve_atmos!(simulation)
         # Close all the files opened by the writers
 
         maxrss_str = prettymemory(maxrss())
-        @info "Memory currently used by the process (RSS): $maxrss_str"
+        @info "Memory currently used (after solve!) by the process (RSS): $maxrss_str"
 
         foreach(CAD.close, output_writers)
     end


### PR DESCRIPTION
Adds a final reporting about RSS memory used. In rough agreement with `seff`:

E.g., https://buildkite.com/clima/climaatmos-ci/builds/15445#018c8357-b898-47de-b3fc-d5e488a21f1a reports `10.66 GiB`, `seff` reports `10.48 GB`  for the job (38982458)