### PR TITLE
fix entrainment and detrainment in TKE equation

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -371,13 +371,7 @@ function set_diagnostic_edmf_precomputed_quantities_do_integral!(Y, p, t)
 
             # We don't have an upper limit to entrainment for the first level 
             # (calculated at i=2), as the vertical at the first level is zero
-            if i == 2
-                @. entrʲ_prev_level = limit_entrainment(
-                    entrʲ_prev_level,
-                    draft_area(ρaʲ_prev_level, ρʲ_prev_level),
-                    dt,
-                )
-            else
+            if i > 2
                 @. entrʲ_prev_level = limit_entrainment(
                     entrʲ_prev_level,
                     draft_area(ρaʲ_prev_level, ρʲ_prev_level),
@@ -388,6 +382,11 @@ function set_diagnostic_edmf_precomputed_quantities_do_integral!(Y, p, t)
                     dz_prev_level,
                 )
             end
+            @. entrʲ_prev_level = limit_entrainment(
+                entrʲ_prev_level,
+                draft_area(ρaʲ_prev_level, ρʲ_prev_level),
+                dt,
+            )
 
             # TODO: use updraft top instead of scale height
             @. nh_pressure³ʲ_prev_halflevel = ᶠupdraft_nh_pressure(
@@ -517,6 +516,15 @@ function set_diagnostic_edmf_precomputed_quantities_do_integral!(Y, p, t)
                 p.atmos.edmfx_detr_model,
             )
 
+            @. detrʲ_prev_level = limit_detrainment(
+                detrʲ_prev_level,
+                draft_area(ρaʲ_prev_level, ρʲ_prev_level),
+                get_physical_w(
+                    u³ʲ_prev_halflevel,
+                    local_geometry_prev_halflevel,
+                ),
+                dz_prev_level,
+            )
             @. detrʲ_prev_level = limit_detrainment(
                 detrʲ_prev_level,
                 draft_area(ρaʲ_prev_level, ρʲ_prev_level),

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -50,11 +50,14 @@ function edmfx_tke_tendency!(
         # entrainment and detraiment
         # using ᶜu⁰ and local geometry results in allocation
         for j in 1:n
+            ᶜρaʲ_colidx =
+                turbconv_model isa PrognosticEDMFX ?
+                Y.c.sgsʲs.:($j).ρa[colidx] : p.precomputed.ᶜρaʲs.:($j)[colidx]
             @. Yₜ.c.sgs⁰.ρatke[colidx] +=
-                ᶜρa⁰[colidx] * (
-                    ᶜentrʲs.:($$j)[colidx] * 1 / 2 * norm_sqr(
+                ᶜρaʲ_colidx * (
+                    ᶜdetrʲs.:($$j)[colidx] * 1 / 2 * norm_sqr(
                         ᶜinterp(ᶠu³⁰[colidx]) - ᶜinterp(ᶠu³ʲs.:($$j)[colidx]),
-                    ) - ᶜdetrʲs.:($$j)[colidx] * ᶜtke⁰[colidx]
+                    ) - ᶜentrʲs.:($$j)[colidx] * ᶜtke⁰[colidx]
                 )
         end
         # pressure work


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fixes a bug in the entrainment production and detrainment loss in the TKE equation. This is now consistent with the design doc. Also limits entrainment and detrainment by both w/dz and 1/dt to be safe. We can remove unnecessary limiters later.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
