### PR TITLE
Add a threshold for diagnostic edmf updraft velocity

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -631,6 +631,42 @@ function set_diagnostic_edmf_precomputed_quantities_do_integral!(Y, p, t)
                 ρaʲu³ʲ_dataq_tot / ρaʲu³ʲ_data,
             )
 
+            # set updraft to grid-mean if vertical velocity is too small
+            if i > 2
+                @. ρaʲ_level = ifelse(
+                    (
+                        u³ʲ_data_prev_halflevel * u³ʲ_data_prev_halflevel <
+                        ∇Φ³_data_prev_level * (ρʲ_prev_level - ρ_prev_level) / ρʲ_prev_level
+                    ),
+                    0,
+                    ρaʲ_level,
+                )
+                @. u³ʲ_halflevel = ifelse(
+                    (
+                        u³ʲ_data_prev_halflevel * u³ʲ_data_prev_halflevel <
+                        ∇Φ³_data_prev_level * (ρʲ_prev_level - ρ_prev_level) / ρʲ_prev_level
+                    ),
+                    u³_halflevel,
+                    u³ʲ_halflevel,
+                )
+                @. h_totʲ_level = ifelse(
+                    (
+                        u³ʲ_data_prev_halflevel * u³ʲ_data_prev_halflevel <
+                        ∇Φ³_data_prev_level * (ρʲ_prev_level - ρ_prev_level) / ρʲ_prev_level
+                    ),
+                    h_tot_level,
+                    h_totʲ_level,
+                )
+                @. q_totʲ_level = ifelse(
+                    (
+                        u³ʲ_data_prev_halflevel * u³ʲ_data_prev_halflevel <
+                        ∇Φ³_data_prev_level * (ρʲ_prev_level - ρ_prev_level) / ρʲ_prev_level
+                    ),
+                    q_tot_level,
+                    q_totʲ_level,
+                )
+            end
+
             set_diagnostic_edmfx_draft_quantities_level!(
                 thermo_params,
                 Kʲ_level,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Detrainment at cloud top D ~ b/w, and numerical stability requires D < w/dz. This PR adds a filter that stops the updraft if w^2 < b * dz

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
