### PR TITLE
move mixing length calculation to callback

### DIFF
--- a/src/cache/cloud_fraction.jl
+++ b/src/cache/cloud_fraction.jl
@@ -22,6 +22,10 @@ function set_cloud_fraction!(Y, p, ::Union{EquilMoistModel, NonEquilMoistModel})
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
     (; ᶜts, ᶜp, ᶜmixing_length, ᶜcloud_fraction) = p.precomputed
+    (; turbconv_model) = p.atmos
+    if isnothing(turbconv_model)
+        compute_gm_mixing_length!(ᶜmixing_length, Y, p)
+    end
 
     coeff = FT(2.1) # TODO - move to parameters
     @. ᶜcloud_fraction = quad_loop(

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -346,10 +346,11 @@ NVTX.@annotate function set_precomputed_quantities!(Y, p, t)
         SurfaceConditions.update_surface_conditions!(Y, p, t)
     end
 
-    if isnothing(turbconv_model)
-        (; ᶜmixing_length) = p.precomputed
-        compute_gm_mixing_length!(ᶜmixing_length, Y, p)
-    end
+    # TODO: It is too slow to calculate mixing length at every timestep
+    # if isnothing(turbconv_model)
+    #     (; ᶜmixing_length) = p.precomputed
+    #     compute_gm_mixing_length!(ᶜmixing_length, Y, p)
+    # end
 
     if turbconv_model isa PrognosticEDMFX
         set_prognostic_edmf_precomputed_quantities_draft_and_bc!(Y, p, ᶠuₕ³, t)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Calculating the mixing length at every time step makes the dycore simulations two times slower. It is mostly from the buoyancy gradient calculation. This PR temporarily moves it to a callback.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
