### PR TITLE
Add graceful exit feature

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -45,7 +45,11 @@ if sol_res.ret_code == :simulation_crashed
 end
 # Simulation did not crash
 (; sol, walltime) = sol_res
-@assert last(sol.t) == simulation.t_end
+
+# we gracefully exited, so we won't have reached t_end
+if !CA.exit_step_loop(simulation.graceful_exit)
+    @assert last(sol.t) == simulation.t_end
+end
 CA.verify_callbacks(sol.t)
 
 if ClimaComms.iamroot(config.comms_ctx)

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -4,6 +4,7 @@ struct AtmosSimulation{
     S2 <: AbstractString,
     OW,
     OD,
+    GE,
 }
     job_id::S1
     output_dir::S2
@@ -11,4 +12,5 @@ struct AtmosSimulation{
     t_end::FT
     output_writers::OW
     integrator::OD
+    graceful_exit::GE
 end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -943,6 +943,7 @@ function get_simulation(config::AtmosConfig)
             end
         end
     end
+    graceful_exit = GracefulExit(; path = sim_info.output_dir)
 
     return AtmosSimulation(
         sim_info.job_id,
@@ -951,6 +952,7 @@ function get_simulation(config::AtmosConfig)
         sim_info.t_end,
         writers,
         integrator,
+        graceful_exit,
     )
 end
 


### PR DESCRIPTION
This PR adds a feature/struct, `GracefulExit`, that allows us to edit the file `$output_dir/graceful_exit.dat` to gracefully exit a running simulation. This will allow us to inspect the integrator at any point (that we're able to stop it).

Ideally, we could restart the simulating with another function call, ~but I think we can leave that for a separate PR~. Actually, I think calling `SciMLBase.solve!` (or maybe a function in ClimaAtmos) should be sufficient.

I'm open to improving names.

Closes #2475