### PR TITLE
Add show method for AtmosSimulation

### DIFF
--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -12,3 +12,14 @@ struct AtmosSimulation{
     output_writers::OW
     integrator::OD
 end
+
+function Base.show(io::IO, sim::AtmosSimulation)
+    return print(
+        io,
+        "Simulation $(sim.job_id)\n",
+        "├── Output folder: $(sim.output_dir)\n",
+        "├── Start date: $(sim.start_date)\n",
+        "├── Current time: $(sim.integrator.t) seconds\n",
+        "└── Stop time: $(sim.t_end) seconds",
+    )
+end


### PR DESCRIPTION
Without a `show` method, the `AtmosSimulation` object representation is extremely verbose (in part due to the massive NCDataset output), cluttering the REPL. This `show` method is a minimal summary of the simulation (and something we can build upon in the future).

It looks like this:
```
Simulation plane_agnesi_mountain_test_stretched
├── Output folder: output/plane_agnesi_mountain_test_stretched
├── Start date: 1979-01-01T00:00:00
├── Current time: 0.0 seconds
└── Stop time: 14400.0 seconds
```