### PR TITLE
Increase memory for GPU implicit barowave moist

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -715,6 +715,7 @@ steps:
           --config_file $PERF_CONFIG_PATH/gpu_implicit_barowave_moist.yml
         artifact_paths: "gpu_implicit_barowave_moist/*"
         agents:
+          slurm_mem: 16G
           slurm_gpus: 1
 
       - label: "Perf: CPU implicit baro wave"


### PR DESCRIPTION
This job fails often. I think that the reason is because of memory. 

The job requires approximately 8 GB (Job ID: 39125167 used at least 7.77 GB), so with 8 GB, the job occasionally fails, as in 

https://buildkite.com/clima/climaatmos-ci/builds/15665#018cdb4d-f572-4b9a-a20a-997b6f9191f2
