### PR TITLE
Add option to evaluate the diagnostics on the vertical levels

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -264,6 +264,9 @@ output_default_diagnostics:
 netcdf_interpolate_z_over_msl:
   help: "Interpolate diagnostics in the NetCDF files in such a way that `z` is the elevation from the sea level (as opposed to the elevation from the surface)"
   value: false
+netcdf_output_at_levels:
+  help: "Do not perform any vertical interpolation in the output NetCDF files. Instead, interpolate horizontally and output the level. This is incompatible with netcdf_interpolate_z_over_msl when topography is present."
+  value: true
 warn_allocations_diagnostics:
-  help: "When true, a dry-run for all the diagnostics is perform to check whether the functions allocate additional memory (which reduces performances)"
+  help: "When true, a dry-run for all the diagnostics is performed to check whether the functions allocate additional memory (which reduces performances)"
   value: false

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -266,7 +266,7 @@ netcdf_interpolate_z_over_msl:
   value: false
 netcdf_output_at_levels:
   help: "Do not perform any vertical interpolation in the output NetCDF files. Instead, interpolate horizontally and output the level. This is incompatible with netcdf_interpolate_z_over_msl when topography is present."
-  value: true
+  value: false
 warn_allocations_diagnostics:
   help: "When true, a dry-run for all the diagnostics is performed to check whether the functions allocate additional memory (which reduces performances)"
   value: false

--- a/config/model_configs/sphere_baroclinic_wave_rhoe.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe.yml
@@ -4,11 +4,8 @@ dt: "400secs"
 t_end: "10days"
 job_id: "sphere_baroclinic_wave_rhoe"
 diagnostics:
-  - short_name: pfull
+  - short_name: [pfull, wa, va, rv]
     period: 1days
-  - short_name: wa
+  - short_name: [pfull, wa, va, rv]
     period: 1days
-  - short_name: va
-    period: 1days
-  - short_name: rv
-    period: 1days
+    writer: h5

--- a/config/model_configs/sphere_baroclinic_wave_rhoe_topography_dcmip_rs.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe_topography_dcmip_rs.yml
@@ -9,11 +9,5 @@ dt: "200secs"
 job_id: "sphere_baroclinic_wave_rhoe_topography_dcmip_rs"
 netcdf_interpolate_z_over_msl: true
 diagnostics:
-  - short_name: pfull
-    period: 1days
-  - short_name: wa
-    period: 1days
-  - short_name: va
-    period: 1days
-  - short_name: rv
+  - short_name: [pfull, wa, va, rv]
     period: 1days

--- a/config/mpi_configs/mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky.yml
+++ b/config/mpi_configs/mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky.yml
@@ -6,3 +6,8 @@ precip_model: "0M"
 job_id: "mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky"
 dt: "400secs"
 t_end: "4days"
+# Test HDF5 writer with MPI as well
+diagnostics:
+  - short_name: [pfull, wa, va, rv]
+    period: 1days
+    writer: h5

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -28,6 +28,15 @@ identifies the period over which to compute the reduction and how often to save
 to disk. `output_name` is optional, and if provided, it identifies the name of the
 output file.
 
+For multiple diagnostics with the same specs, it is also possible to directly
+pass a vector of `short_names`, as in
+```
+diagnostics:
+  - short_name: [rhoa, ua, ta]
+    reduction_time: average
+    period: 12hours
+```
+
 The default `writer` is NetCDF. If `writer` is `nc` or `netcdf`, the output is
 remapped non-conservatively on a Cartesian grid and saved to a NetCDF file.
 Currently, only 3D fields on cubed spheres are supported.

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -370,7 +370,7 @@ function make_plots(
     simdir = SimDir(simulation_path)
 
     reduction = "average"
-    period = "12.0h"
+    period = "12h"
     short_names_3D = ["ua", "ta", "hus", "rsd", "rsu", "rld", "rlu"]
     short_names_sfc = ["hfes", "evspsbl"]
     vars_3D = [

--- a/src/diagnostics/diagnostics_utils.jl
+++ b/src/diagnostics/diagnostics_utils.jl
@@ -51,6 +51,12 @@ function descriptive_short_name(
             hours, rem_seconds = divrem(rem_seconds, 60 * 60)
             minutes, seconds = divrem(rem_seconds, 60)
 
+            # At this point, days, hours, minutes, seconds have to be integers.
+            # Let us force them to be such so that we can have a consistent string output.
+
+            days, hours, minutes, seconds =
+                map(Int, (days, hours, minutes, seconds))
+
             days > 0 && (period *= "$(days)d_")
             hours > 0 && (period *= "$(hours)h_")
             minutes > 0 && (period *= "$(minutes)m_")

--- a/src/diagnostics/hdf5_writer.jl
+++ b/src/diagnostics/hdf5_writer.jl
@@ -60,12 +60,9 @@ function write_field!(
         "standard_variable_name" => var.standard_name,
     )
 
-    # TODO: Use directly InputOutput functions
-    InputOutput.HDF5.h5writeattr(
-        hdfwriter.file.filename,
-        "fields/$(diagnostic.output_short_name)",
-        attributes,
-    )
+    for (k, v) in attributes
+        InputOutput.HDF5.write_attribute(hdfwriter.file, k, v)
+    end
 
     Base.close(hdfwriter)
     return nothing

--- a/src/diagnostics/netcdf_writer.jl
+++ b/src/diagnostics/netcdf_writer.jl
@@ -108,7 +108,8 @@ end
 """
     add_space_coordinates_maybe!(nc::NCDatasets.NCDataset,
                                  space::Spaces.AbstractSpace,
-                                 num_points)
+                                 num_points;
+                                 names)
 
 Add dimensions relevant to the `space` to the given `nc` NetCDF file. The range is
 automatically determined and the number of points is set with `num_points`, which has to be
@@ -117,6 +118,8 @@ a cubed sphere, 2 for a surface, 1 for a column.
 
 The function returns an array with the names of the relevant dimensions. (We want arrays
 because we want to preserve the order to match the one in num_points).
+
+In some cases, the names are adjustable passing the keyword `names`.
 """
 function add_space_coordinates_maybe! end
 
@@ -155,23 +158,24 @@ end
 function add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.FiniteDifferenceSpace,
-    num_points_z,
+    num_points_z;
+    names = ("z",),
 )
-    name = "z"
+    name, _... = names
     zpts = target_coordinates(space, num_points_z)
-    add_dimension_maybe!(nc, "z", zpts, units = "m")
+    add_dimension_maybe!(nc, name, zpts, units = "m", axis = "Z")
     return [name]
 end
 
 add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.AbstractSpectralElementSpace,
-    num_points,
+    num_points;
 ) = add_space_coordinates_maybe!(
     nc,
     space,
     num_points,
-    Meshes.domain(space.topology),
+    Meshes.domain(space.topology);
 )
 
 
@@ -230,12 +234,13 @@ function add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.SpectralElementSpace2D,
     num_points,
-    ::Domains.RectangleDomain,
+    ::Domains.RectangleDomain;
+    names = ("x", "y"),
 )
-    xname, yname = ("x", "y")
+    xname, yname = names
     xpts, ypts = target_coordinates(space, num_points)
-    add_dimension_maybe!(nc, "x", xpts; units = "m")
-    add_dimension_maybe!(nc, "y", ypts; units = "m")
+    add_dimension_maybe!(nc, "x", xpts; units = "m", axis = "X")
+    add_dimension_maybe!(nc, "y", ypts; units = "m", axis = "Y")
     return [xname, yname]
 end
 
@@ -244,11 +249,12 @@ function add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.SpectralElementSpace1D,
     num_points,
-    ::Domains.IntervalDomain,
+    ::Domains.IntervalDomain;
+    names = ("x",),
 )
-    xname = "x"
+    xname, _... = names
     xpts = target_coordinates(space, num_points)
-    add_dimension_maybe!(nc, "x", xpts; units = "m")
+    add_dimension_maybe!(nc, "x", xpts; units = "m", axis = "X")
     return [xname]
 end
 
@@ -257,12 +263,13 @@ function add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.SpectralElementSpace2D,
     num_points,
-    ::Domains.SphereDomain,
+    ::Domains.SphereDomain;
+    names = ("lon", "lat"),
 )
-    longname, latname = ("lon", "lat")
+    longname, latname = names
     longpts, latpts = target_coordinates(space, num_points)
-    add_dimension_maybe!(nc, "lon", longpts; units = "degrees_east")
-    add_dimension_maybe!(nc, "lat", latpts; units = "degrees_north")
+    add_dimension_maybe!(nc, "lon", longpts; units = "degrees_east", axis = "X")
+    add_dimension_maybe!(nc, "lat", latpts; units = "degrees_north", axis = "Y")
     return [longname, latname]
 end
 
@@ -273,6 +280,7 @@ function add_space_coordinates_maybe!(
     space::Spaces.ExtrudedFiniteDifferenceSpace,
     num_points;
     interpolated_surface = nothing,
+    disable_vertical_interpolation = false,
 )
 
     hdims_names = vdims_names = []
@@ -295,25 +303,35 @@ function add_space_coordinates_maybe!(
         vdims_names =
             add_space_coordinates_maybe!(nc, vertical_space, num_points_vertic)
     else
-        vdims_names = add_space_coordinates_maybe!(
-            nc,
-            vertical_space,
-            num_points_vertic,
-            interpolated_surface;
-            depending_on_dimensions = hdims_names,
-        )
+        if disable_vertical_interpolation
+            vdims_names = add_space_coordinates_maybe!(
+                nc,
+                vertical_space,
+                num_points_vertic,
+                names = ("z_reference",),
+            )
+        else
+            vdims_names = add_space_coordinates_maybe!(
+                nc,
+                vertical_space,
+                num_points_vertic,
+                interpolated_surface;
+                depending_on_dimensions = hdims_names,
+            )
+        end
     end
 
     return (hdims_names..., vdims_names...)
 end
 
-# Ignore the interpolated_surface keyword in the general case (we only case about the
-# specialized one for extruded spaces)
+# Ignore the interpolated_surface/disable_vertical_interpolation keywords in the general
+# case (we only case about the specialized one for extruded spaces)
 add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space,
     num_points;
     interpolated_surface = nothing,
+    disable_vertical_interpolation = false,
 ) = add_space_coordinates_maybe!(nc::NCDatasets.NCDataset, space, num_points)
 
 # Elevation with topography
@@ -432,6 +450,12 @@ struct NetCDFWriter{T, TS}
 
     # Whether to treat z as altitude over the surface or the sea level or over the surface
     interpolate_z_over_msl::Bool
+
+    # Do not interpolate on the z direction, instead evaluate on the levels.
+    # This is incompatible with interpolate_z_over_msl when topography is present.
+    # When disable_vertical_interpolation is true, the num_points on the vertical direction
+    # is ignored.
+    disable_vertical_interpolation::Bool
 end
 
 """
@@ -461,27 +485,42 @@ Keyword arguments
                             be altitude from the surface (in meters). `z` becomes a
                             multidimensional array that returns the altitude for the given
                             horizontal coordinates.
+- `disable_vertical_interpolation`: Do not interpolate on the z direction, instead evaluate
+                                    at on levels. This is incompatible with
+                                    interpolate_z_over_msl when topography is present. When
+                                    disable_vertical_interpolation is true, the num_points
+                                    on the vertical direction is ignored.
 - `compression_level`: How much to compress the output NetCDF file (0 is no compression, 9
   is maximum compression).
 
 """
 function NetCDFWriter(;
-    hypsography,
+    spaces,
     num_points = (90, 40, 50),
     interpolate_z_over_msl = false,
+    disable_vertical_interpolation = false,
     compression_level = 9,
 )
+    space = spaces.center_space
+    hypsography = space.hypsography
 
-    # We have to deal with the pesky topography. This is a little annoying to deal with
-    # because it couples the horizontal and the vertical dimensions, so it doesn't fit the
-    # common paradigm for all the other dimensions. Moreover, with topography, we need need
-    # to perform an interpolation for the surface.
+    # When we are interpolating on the vertical direction, we have to deal with the pesky
+    # topography. This is a little annoying to deal with because it couples the horizontal
+    # and the vertical dimensions, so it doesn't fit the common paradigm for all the other
+    # dimensions. Moreover, with topography, we need to perform an interpolation for the
+    # surface.
 
     # We have to deal with the surface only if we are not interpolating the topography and
     # if our topography is non-trivial
     if hypsography isa Grids.Flat || interpolate_z_over_msl
         interpolated_surface = nothing
     elseif hypsography isa Hypsography.LinearAdaption
+        disable_vertical_interpolation &&
+            interpolate_z_over_msl &&
+            error(
+                "Cannot disable vertical interpolation and interpolate over MSL at the same time",
+            )
+
         horizontal_space = axes(hypsography.surface)
         hpts = target_coordinates(horizontal_space, num_points)
         hcoords = hcoords_from_horizontal_space(
@@ -497,6 +536,22 @@ function NetCDFWriter(;
         error("Cannot process hysography $hypsography")
     end
 
+    if disable_vertical_interpolation
+        # It is a little tricky to override the number of vertical points because we don't
+        # know if the vertical direction is the 2nd (as in a plane) or 3rd index (as in a
+        # box or sphere). To set this value, we check if we are on a plane or not
+
+        # TODO: Get the number of dimensions directly from the space
+        num_horiz_dimensions =
+            Spaces.horizontal_space(space) isa Spaces.SpectralElementSpace1D ?
+            1 : 2
+
+        num_vpts = Meshes.nelements(Grids.vertical_topology(space).mesh)
+
+        @warn "Disabling vertical interpolation, the provided number of points is ignored (using $num_vpts)"
+        num_points = Tuple([num_points[1:num_horiz_dimensions]..., num_vpts])
+    end
+
     return NetCDFWriter{typeof(num_points), typeof(interpolated_surface)}(
         Dict(),
         num_points,
@@ -504,6 +559,7 @@ function NetCDFWriter(;
         interpolated_surface,
         Dict(),
         interpolate_z_over_msl,
+        disable_vertical_interpolation,
     )
 end
 
@@ -534,6 +590,12 @@ function write_field!(
 
     # TODO: Expand this once we support spatial reductions
     if !haskey(writer.remappers, var.short_name)
+
+        # hpts, vpts are ranges of numbers
+        # hcoords, zcoords are ranges of Geometry.Points
+
+        zcoords = []
+
         if is_horizontal_space
             hpts = target_coordinates(space, writer.num_points)
             vpts = []
@@ -541,13 +603,25 @@ function write_field!(
             hpts, vpts = target_coordinates(space, writer.num_points)
         end
 
-        # zcoords is going to be empty for a 2D horizontal slice
-        zcoords = [Geometry.ZPoint(p) for p in vpts]
         hcoords = hcoords_from_horizontal_space(
             horizontal_space,
             Meshes.domain(horizontal_space.topology),
             hpts,
         )
+
+        # When we disable vertical_interpolation, we override the vertical points with
+        # the reference values for the vertical space.
+        if writer.disable_vertical_interpolation && !is_horizontal_space
+            # We need Array(parent()) because we want an array of values, not a DataLayout
+            # of Points
+            vpts = Array(
+                parent(
+                    space.grid.vertical_grid.center_local_geometry.coordinates,
+                ),
+            )
+        end
+
+        zcoords = [Geometry.ZPoint(p) for p in vpts]
 
         writer.remappers[var.short_name] = Remapper(hcoords, zcoords, space)
     end
@@ -581,6 +655,7 @@ function write_field!(
         space,
         writer.num_points;
         writer.interpolated_surface,
+        writer.disable_vertical_interpolation,
     )
 
     if haskey(nc, "$(var.short_name)")

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -592,61 +592,76 @@ function get_diagnostics(parsed_args, atmos_model, spaces)
         "netcdf" => netcdf_writer,
     )
 
-    diagnostics = map(yaml_diagnostics) do yaml_diag
-        # Return "nothing" if "reduction_time" is not in the YAML block
-        #
-        # We also normalize everything to lowercase, so that can accept "max" but
-        # also "Max"
-        reduction_time_yaml =
-            lowercase(get(yaml_diag, "reduction_time", "nothing"))
-
-        if !haskey(ALLOWED_REDUCTIONS, reduction_time_yaml)
-            error("reduction $reduction_time_yaml not implemented")
-        else
-            reduction_time_func, pre_output_hook! =
-                ALLOWED_REDUCTIONS[reduction_time_yaml]
-        end
-
-        writer_ext = lowercase(get(yaml_diag, "writer", "nothing"))
-
-        if !haskey(ALLOWED_WRITERS, writer_ext)
-            error("writer $writer_ext not implemented")
-        else
-            writer = ALLOWED_WRITERS[writer_ext]
-        end
-
+    diagnostics_ragged = map(yaml_diagnostics) do yaml_diag
+        short_names = yaml_diag["short_name"]
         output_name = get(yaml_diag, "output_name", nothing)
 
-        haskey(yaml_diag, "period") ||
-            error("period keyword required for diagnostics")
+        if short_names isa Vector
+            isnothing(output_name) || error(
+                "Diagnostics: cannot have multiple short_names while specifying output_name",
+            )
+        else
+            short_names = [short_names]
+        end
 
-        period_seconds = time_to_seconds(yaml_diag["period"])
+        ret_value = map(short_names) do short_name
+            # Return "nothing" if "reduction_time" is not in the YAML block
+            #
+            # We also normalize everything to lowercase, so that can accept "max" but
+            # also "Max"
+            reduction_time_yaml =
+                lowercase(get(yaml_diag, "reduction_time", "nothing"))
 
-        if isnothing(output_name)
-            output_name = CAD.descriptive_short_name(
-                CAD.get_diagnostic_variable(yaml_diag["short_name"]),
-                period_seconds,
-                reduction_time_func,
-                pre_output_hook!,
+            if !haskey(ALLOWED_REDUCTIONS, reduction_time_yaml)
+                error("reduction $reduction_time_yaml not implemented")
+            else
+                reduction_time_func, pre_output_hook! =
+                    ALLOWED_REDUCTIONS[reduction_time_yaml]
+            end
+
+            writer_ext = lowercase(get(yaml_diag, "writer", "nothing"))
+
+            if !haskey(ALLOWED_WRITERS, writer_ext)
+                error("writer $writer_ext not implemented")
+            else
+                writer = ALLOWED_WRITERS[writer_ext]
+            end
+
+            haskey(yaml_diag, "period") ||
+                error("period keyword required for diagnostics")
+
+            period_seconds = time_to_seconds(yaml_diag["period"])
+
+            if isnothing(output_name)
+                output_short_name = CAD.descriptive_short_name(
+                    CAD.get_diagnostic_variable(short_name),
+                    period_seconds,
+                    reduction_time_func,
+                    pre_output_hook!,
+                )
+            end
+
+            if isnothing(reduction_time_func)
+                compute_every = period_seconds
+            else
+                compute_every = :timestep
+            end
+
+            return CAD.ScheduledDiagnosticTime(
+                variable = CAD.get_diagnostic_variable(short_name),
+                output_every = period_seconds,
+                compute_every = compute_every,
+                reduction_time_func = reduction_time_func,
+                pre_output_hook! = pre_output_hook!,
+                output_writer = writer,
+                output_short_name = output_short_name,
             )
         end
-
-        if isnothing(reduction_time_func)
-            compute_every = period_seconds
-        else
-            compute_every = :timestep
-        end
-
-        return CAD.ScheduledDiagnosticTime(
-            variable = CAD.get_diagnostic_variable(yaml_diag["short_name"]),
-            output_every = period_seconds,
-            compute_every = compute_every,
-            reduction_time_func = reduction_time_func,
-            pre_output_hook! = pre_output_hook!,
-            output_writer = writer,
-            output_short_name = output_name,
-        )
+        return ret_value
     end
+
+    # Flatten the array of arrays of diagnostics
+    diagnostics = vcat(diagnostics_ragged...)
 
     if parsed_args["output_default_diagnostics"]
         return [
@@ -819,6 +834,13 @@ function get_simulation(config::AtmosConfig)
             get_diagnostics(config.parsed_args, atmos, spaces)
     end
     @info "initializing diagnostics: $s"
+
+    length(diagnostics) > 0 && @info "Computing diagnostics:"
+
+    for diag in diagnostics
+        writer = nameof(typeof(diag.output_writer))
+        @info "- $(diag.output_short_name) ($writer)"
+    end
 
     # First, we convert all the ScheduledDiagnosticTime into ScheduledDiagnosticIteration,
     # ensuring that there is consistency in the timestep and the periods and translating

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -552,7 +552,7 @@ function get_sim_info(config::AtmosConfig)
     return sim
 end
 
-function get_diagnostics(parsed_args, atmos_model, hypsography)
+function get_diagnostics(parsed_args, atmos_model, spaces)
 
     # We either get the diagnostics section in the YAML file, or we return an empty list
     # (which will result in an empty list being created by the map below)
@@ -577,8 +577,9 @@ function get_diagnostics(parsed_args, atmos_model, hypsography)
 
     hdf5_writer = CAD.HDF5Writer()
     netcdf_writer = CAD.NetCDFWriter(;
-        hypsography,
+        spaces,
         interpolate_z_over_msl = parsed_args["netcdf_interpolate_z_over_msl"],
+        disable_vertical_interpolation = parsed_args["netcdf_output_at_levels"],
     )
     writers = (hdf5_writer, netcdf_writer)
 
@@ -814,11 +815,8 @@ function get_simulation(config::AtmosConfig)
 
     # Initialize diagnostics
     s = @timed_str begin
-        diagnostics, writers = get_diagnostics(
-            config.parsed_args,
-            atmos,
-            spaces.center_space.hypsography,
-        )
+        diagnostics, writers =
+            get_diagnostics(config.parsed_args, atmos, spaces)
     end
     @info "initializing diagnostics: $s"
 


### PR DESCRIPTION
This PR introduces a new option `netcdf_output_at_levels`. When this configuration is set to true, the output diagnostics for the NetCDF files are evaluated on the vertical levels (as opposed to a collection of prescribed vertical points). This option is incompatible with `netcdf_interpolate_z_over_msl` (which is used to interpret `z` as elevation from mean sea level as opposed to elevation from the surface).

This feature is implemented using the very same infrastructure used for the general case with vertical interpolation but passing as target points the grid points. As a result, the vertical interpolation still happens and floating point arithmetic leads to evaluation that might not precisely on the grid centers, but within 0.01 % of it (as empirically measured). I chose this approach because it is much simpler to implement than not doing the interpolation at all. 

As a bonus, this PR adds the option to have a list of `short_name` in the `diagnostic` section of the YAML file, as in
```
diagnostics:
  - short_name: [pfull, wa, ra, rv]
    period: 1days
```
It also fixes https://github.com/CliMA/ClimaAtmos.jl/issues/2505.