### PR TITLE
Update long-run builds and add summary of scheduled diagnostics.

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
@@ -11,7 +11,9 @@ rayleigh_sponge: true
 moist: "equil"
 precip_model: "0M"
 surface_setup: "DefaultMoninObukhov"
-vert_diff: "true"
+vert_diff: "FriersonDiffusion"
+implicit_diffusion: true
+max_newton_iters_ode: 2
 rad: "clearsky"
 dt_rad: "6hours"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
@@ -11,7 +11,9 @@ rayleigh_sponge: true
 moist: "equil"
 precip_model: "0M"
 surface_setup: "DefaultMoninObukhov"
-vert_diff: "true"
+vert_diff: "FriersonDiffusion"
+implicit_diffusion: true
+max_newton_iters_ode: 2
 rad: "clearsky"
 idealized_insolation: false
 dt_rad: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
@@ -7,7 +7,9 @@ rayleigh_sponge: true
 z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
-vert_diff: "true" 
+vert_diff: "FriersonDiffusion" 
+implicit_diffusion: true
+max_newton_iters_ode: 2
 surface_setup: "DefaultExchangeCoefficients" 
 moist: "equil" 
 rad: "gray" 

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
@@ -4,7 +4,9 @@ t_end: "100days"
 moist: "equil"
 precip_model: "0M"
 surface_setup: "DefaultMoninObukhov"
-vert_diff: "true"
+vert_diff: "FriersonDiffusion"
+implicit_diffusion: true
+max_newton_iters_ode: 2
 rad: "clearsky"
 idealized_insolation: false
 dt_rad: "1hours"

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -835,6 +835,11 @@ function get_simulation(config::AtmosConfig)
     diagnostic_counters = Dict()
 
     # NOTE: The diagnostics_callbacks are not called at the initial timestep
+    length(diagnostics) > 0 && @info "Computing diagnostics (output every):"
+    for diag in diagnostics
+        @info "- $(diag.variable.short_name) ($(diag.output_every) s)"
+    end
+
     s = @timed_str begin
         diagnostics_functions = CAD.get_callbacks_from_diagnostics(
             diagnostics_iterations,


### PR DESCRIPTION
Follow up PR to #2349. 
Uses the new stability dependent diffusion option introduced in PR2349 to the long-run pipeline. (Affects aquaplanet long-run cases)

Updates `type_getters` to summarize + print list of scheduled diagnostics. 
Diagnostics summary : @Sbozzolo. 