### PR TITLE
Fix job-id for consistency with existing longruns

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
@@ -12,5 +12,5 @@ surface_setup: "DefaultExchangeCoefficients"
 moist: "equil" 
 rad: "gray" 
 precip_model: "0M" 
-job_id: "longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M" 
+job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml" 
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]


### PR DESCRIPTION
Fix job id to match plot identifier.
Current main results in 
```Warning: No plot found for Val{:longrun_aquaplanet_rhoe_equil_gray_55km_nz63_0M}()```
