### PR TITLE
Do not buffer NetCDF writes

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
@@ -1,5 +1,5 @@
 dt_save_state_to_disk: "10days"
-dt: "150secs" 
+dt: "150secs"
 t_end: "300days"
 h_elem: 16
 z_max: 55000.0
@@ -7,12 +7,12 @@ rayleigh_sponge: true
 z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
-vert_diff: "FriersonDiffusion" 
+vert_diff: "FriersonDiffusion"
 implicit_diffusion: true
 max_newton_iters_ode: 2
-surface_setup: "DefaultExchangeCoefficients" 
-moist: "equil" 
-rad: "gray" 
-precip_model: "0M" 
-job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml" 
+surface_setup: "DefaultExchangeCoefficients"
+moist: "equil"
+rad: "gray"
+precip_model: "0M"
+job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]

--- a/src/diagnostics/netcdf_writer.jl
+++ b/src/diagnostics/netcdf_writer.jl
@@ -702,4 +702,7 @@ function write_field!(
     elseif length(dim_names) == 1
         v[time_index, :] = interpolated_field
     end
+
+    # Write data to disk
+    NCDatasets.sync(writer.open_files[output_path])
 end


### PR DESCRIPTION
This fixes the problem reported by @akshaysridhar by forcing a write to disk every time we save new NetCDF ouput. Normally, NetCDF buffers writes, and the actual writing happens upon closing the file. It seems that sometimes the write doesn't happen, so the data is never really saved. This ensures that the data is saved to disk every time is ready.

@akshaysridhar, could you please double check that this fixes the issue?

