### PR TITLE
Inline information about registered diagnostics

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -834,9 +834,14 @@ function get_simulation(config::AtmosConfig)
 
     length(diagnostics) > 0 && @info "Computing diagnostics:"
 
-    for diag in diagnostics
-        writer = nameof(typeof(diag.output_writer))
-        @info "- $(diag.output_short_name) ($writer)"
+    for writer in writers
+        writer_str = nameof(typeof(writer))
+        diags_with_writer =
+            filter((x) -> getproperty(x, :output_writer) == writer, diagnostics)
+        diags_outputs = [
+            getproperty(diag, :output_short_name) for diag in diags_with_writer
+        ]
+        @info "$writer_str: $diags_outputs"
     end
 
     # First, we convert all the ScheduledDiagnosticTime into ScheduledDiagnosticIteration,


### PR DESCRIPTION
To reduce number of lines output.

Looks like:
```
[ Info: Computing diagnostics:
[ Info: HDF5Writer: pfull_inst, wa_inst, va_inst, rv_inst
[ Info: NetCDFWriter: orog_inst, ts_1d_average, ta_1d_average, thetaa_1d_average, ha_1d_average, pfull_1d_average, rhoa_1d_average, ua_1d_average, va_1d_average, wa_1d_average, hfes_1d_average, ts_1d_max, ts_1d_min, pfull_inst, wa_inst, va_inst, rv_inst
```

Closes #2519