### PR TITLE
add option for 0 or 1 cloud fraction

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -183,6 +183,9 @@ apply_limiter:
 precip_model:
   help: "Precipitation model [`nothing` (default), `0M`]"
   value: ~
+cloud_model:
+  help: "Cloud model [`grid_scale`, `quadrature` (default)]"
+  value: "quadrature"
 perf_mode:
   help: "A flag for analyzing performance [`PerfStandard` (default), `PerfExperimental`]"
   value: "PerfStandard"

--- a/config/longrun_configs/longrun_aquaplanet_dyamond.yml
+++ b/config/longrun_configs/longrun_aquaplanet_dyamond.yml
@@ -5,6 +5,7 @@ dz_bottom: 30.0
 dz_top: 3000.0
 moist: "equil" 
 precip_model: "0M" 
+cloud_model: "grid_scale"
 rad: "allskywithclear" 
 idealized_insolation: false
 dt_rad: "1hours"

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -12,6 +12,7 @@ vert_diff: "true"
 idealized_insolation: false
 z_max: 45000.0
 precip_model: "0M"
+cloud_model: "grid_scale"
 regression_test: true
 surface_temperature: "ZonallyAsymmetric"
 job_id: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -38,7 +38,7 @@ end
 function cloud_fraction_model_callback!(integrator)
     Y = integrator.u
     p = integrator.p
-    set_cloud_fraction!(Y, p, p.atmos.moisture_model)
+    set_cloud_fraction!(Y, p, p.atmos.moisture_model, p.atmos.cloud_model)
 end
 
 NVTX.@annotate function rrtmgp_model_callback!(integrator)
@@ -46,7 +46,7 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
     p = integrator.p
     t = integrator.t
 
-    (; ᶜts, sfc_conditions) = p.precomputed
+    (; ᶜts, ᶜcloud_fraction, sfc_conditions) = p.precomputed
     (; params) = p
     (; idealized_insolation, idealized_h2o, idealized_clouds) = p.radiation
     (; insolation_tuple, ᶠradiation_flux, radiation_model) = p.radiation
@@ -164,12 +164,19 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
             radiation_model.center_cloud_fraction,
             axes(Y.c),
         )
-        # multiply by 1000 to convert from kg/m^2 to g/m^2
+        # RRTMGP needs lwp and iwp in g/m^2
+        kg_to_g_factor = 1000
         @. ᶜlwp =
-            1000 * Y.c.ρ * TD.liquid_specific_humidity(thermo_params, ᶜts) * ᶜΔz
+            kg_to_g_factor *
+            Y.c.ρ *
+            TD.liquid_specific_humidity(thermo_params, ᶜts) *
+            ᶜΔz / max(ᶜcloud_fraction, eps(FT))
         @. ᶜiwp =
-            1000 * Y.c.ρ * TD.ice_specific_humidity(thermo_params, ᶜts) * ᶜΔz
-        @. ᶜfrac = ifelse(TD.has_condensate(thermo_params, ᶜts), 1, 0 * ᶜΔz)
+            kg_to_g_factor *
+            Y.c.ρ *
+            TD.ice_specific_humidity(thermo_params, ᶜts) *
+            ᶜΔz / max(ᶜcloud_fraction, eps(FT))
+        @. ᶜfrac = ᶜcloud_fraction
     end
 
     RRTMGPI.update_fluxes!(radiation_model)

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -242,6 +242,17 @@ function get_precipitation_model(parsed_args)
     end
 end
 
+function get_cloud_model(parsed_args)
+    cloud_model = parsed_args["cloud_model"]
+    return if cloud_model == "grid_scale"
+        GridScaleCloud()
+    elseif cloud_model == "quadrature"
+        QuadratureCloud()
+    else
+        error("Invalid cloud_model $(cloud_model)")
+    end
+end
+
 function get_forcing_type(parsed_args)
     forcing = parsed_args["forcing"]
     @assert forcing in (nothing, "held_suarez")

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -16,6 +16,7 @@ function get_atmos(config::AtmosConfig, params)
     FT = eltype(config)
     moisture_model = get_moisture_model(parsed_args)
     precip_model = get_precipitation_model(parsed_args)
+    cloud_model = get_cloud_model(parsed_args)
     radiation_mode = get_radiation_mode(parsed_args, FT)
     forcing_type = get_forcing_type(parsed_args)
 
@@ -57,6 +58,7 @@ function get_atmos(config::AtmosConfig, params)
         edmfx_sgs_diffusive_flux,
         edmfx_nh_pressure,
         precip_model,
+        cloud_model,
         forcing_type,
         turbconv_model = get_turbconv_model(FT, parsed_args, turbconv_params),
         non_orographic_gravity_wave = get_non_orographic_gravity_wave_model(

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -11,6 +11,10 @@ struct NoPrecipitation <: AbstractPrecipitationModel end
 struct Microphysics0Moment <: AbstractPrecipitationModel end
 struct Microphysics1Moment <: AbstractPrecipitationModel end
 
+abstract type AbstractCloudModel end
+struct GridScaleCloud <: AbstractCloudModel end
+struct QuadratureCloud <: AbstractCloudModel end
+
 abstract type AbstractModelConfig end
 struct SingleColumnModel <: AbstractModelConfig end
 struct SphericalModel <: AbstractModelConfig end
@@ -343,6 +347,7 @@ Base.@kwdef struct AtmosModel{
     PEM,
     MM,
     PM,
+    CM,
     F,
     S,
     RM,
@@ -370,6 +375,7 @@ Base.@kwdef struct AtmosModel{
     perf_mode::PEM = nothing
     moisture_model::MM = nothing
     precip_model::PM = nothing
+    cloud_model::CM = nothing
     forcing_type::F = nothing
     subsidence::S = nothing
     radiation_mode::RM = nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a cloud model which specifies whether the cloud properties are calculated from grid-scale or quadratures. Currently this is only used for cloud fraction, but we can use it for liquid water and ice too. Also changes the radiation input to cloud fraction and in-cloud lwp and iwp.

Closes #2054 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
