### PR TITLE
use a_max for diagnostic edmf area filter

### DIFF
--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -103,6 +103,8 @@ function edmfx_sgs_mass_flux_tendency!(
     turbconv_model::DiagnosticEDMFX,
 )
 
+    turbconv_params = CAP.turbconv_params(p.params)
+    a_max = CAP.max_area(turbconv_params)
     n = n_mass_flux_subdomains(turbconv_model)
     (; edmfx_sgsflux_upwinding) = p.atmos.numerics
     (; ᶠu³, ᶜh_tot, ᶜspecific) = p.precomputed
@@ -126,7 +128,7 @@ function edmfx_sgs_mass_flux_tendency!(
                 min(
                     min(
                         draft_area(ᶜρaʲs.:($$j)[colidx], ᶜρʲs.:($$j)[colidx]),
-                        FT(0.3),
+                        a_max,
                     ),
                     FT(0.02) / max(
                         Geometry.WVector(
@@ -161,7 +163,7 @@ function edmfx_sgs_mass_flux_tendency!(
                                 ᶜρaʲs.:($$j)[colidx],
                                 ᶜρʲs.:($$j)[colidx],
                             ),
-                            FT(0.3),
+                            a_max,
                         ),
                         FT(0.02) / max(
                             Geometry.WVector(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Replaces the hard-coded number in diagnostic edmf sgs mass flux area fraction limiter with parameter a_max.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
