### PR TITLE
Move vertical advection of TKE to the implicit tendency

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -74,20 +74,15 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     (; params) = p
     (; dt) = p
     ᶜJ = Fields.local_geometry_field(Y.c).J
-    (; ᶜf, ᶜΦ) = p.core
+    (; ᶜf) = p.core
     (; ᶜu, ᶠu³, ᶜK) = p.precomputed
     (; edmfx_upwinding) = n > 0 || advect_tke ? p.atmos.numerics : all_nothing
-    (; ᶜp, ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜρʲs) = n > 0 ? p.precomputed : all_nothing
-    (; ᶜp_ref, ᶜρ_ref, ᶠgradᵥ_ᶜΦ) = n > 0 ? p.core : all_nothing
-    (; ᶠu³⁰) = advect_tke ? p.precomputed : all_nothing
-    ᶜρa⁰ = advect_tke ? (n > 0 ? p.precomputed.ᶜρa⁰ : Y.c.ρ) : nothing
-    ᶜρ⁰ = advect_tke ? (n > 0 ? p.precomputed.ᶜρ⁰ : Y.c.ρ) : nothing
-    ᶜtke⁰ = advect_tke ? p.precomputed.ᶜtke⁰ : nothing
+    (; ᶜuʲs, ᶠu³ʲs, ᶜKʲs, ᶜρʲs) = n > 0 ? p.precomputed : all_nothing
+    (; ᶠgradᵥ_ᶜΦ) = n > 0 ? p.core : all_nothing
     ᶜa_scalar = p.scratch.ᶜtemp_scalar
     ᶜω³ = p.scratch.ᶜtemp_CT3
     ᶠω¹² = p.scratch.ᶠtemp_CT12
     ᶠω¹²ʲs = p.scratch.ᶠtemp_CT12ʲs
-    FT = Spaces.undertype(axes(Y.c))
 
     if point_type <: Geometry.Abstract3DPoint
         @. ᶜω³ = curlₕ(Y.c.uₕ)
@@ -167,21 +162,6 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
                 Yₜ.c.sgsʲs.:($j).q_tot[colidx],
                 ᶠu³ʲs.:($j)[colidx],
                 Y.c.sgsʲs.:($j).q_tot[colidx],
-                edmfx_upwinding,
-            )
-        end
-
-        # TODO: Move this to implicit_vertical_advection_tendency!.
-        if use_prognostic_tke(turbconv_model) # advect_tke triggers allocations
-            @. ᶜa_scalar[colidx] =
-                ᶜtke⁰[colidx] * draft_area(ᶜρa⁰[colidx], ᶜρ⁰[colidx])
-            vertical_transport!(
-                Yₜ.c.sgs⁰.ρatke[colidx],
-                ᶜJ[colidx],
-                ᶜρ⁰[colidx],
-                ᶠu³⁰[colidx],
-                ᶜa_scalar[colidx],
-                dt,
                 edmfx_upwinding,
             )
         end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR moves the vertical advection of TKE from `explicit_vertical_advection_tendency!` to `implicit_vertical_advection_tendency!`. After this is merged in, we will also move the dissipation of TKE to the implicit tendency.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
