### PR TITLE
Use SetDivergence boundary conditions for precipitation

### DIFF
--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
@@ -4,7 +4,9 @@ dz_bottom: 300.0
 dt: "400secs"
 t_end: "24hours"
 dt_save_state_to_disk: "24hours"
-vert_diff: "true"
+vert_diff: "FriersonDiffusion"
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
 moist: "equil"
 precip_model: "1M"
 precip_upwinding: "first_order"

--- a/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_impvdiff.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist_impvdiff.yml
@@ -2,12 +2,12 @@ precip_model: "0M"
 vert_diff: "true"
 z_elem: 20
 dz_bottom: 100
-dt_save_state_to_disk: "6days"
+dt_save_state_to_disk: "4days"
 initial_condition: "MoistBaroclinicWave"
 implicit_diffusion: true
 max_newton_iters_ode: 2
 dt: "400secs"
-t_end: "6days"
+t_end: "4days"
 job_id: "sphere_baroclinic_wave_rhoe_equilmoist_impvdiff"
 moist: "equil"
 toml: [toml/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.toml]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -306,7 +306,7 @@ version = "0.5.6"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "Static", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "e43923b57aa6abea8df2b59e1318f5598e715bf0"
+git-tree-sha1 = "541bf25a8adc3c7ddf8d45a96149964f5cfbb074"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 version = "0.11.9"
 weakdeps = ["Krylov"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -311,7 +311,7 @@ version = "0.5.6"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "Static", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "e43923b57aa6abea8df2b59e1318f5598e715bf0"
+git-tree-sha1 = "541bf25a8adc3c7ddf8d45a96149964f5cfbb074"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 version = "0.11.9"
 weakdeps = ["Krylov"]

--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -609,16 +609,9 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, colidx)
                 ᶜdiffusion_u_matrix[colidx] - (I,)
         end
 
-        # TODO: Add support for SetDivergence to DivergenceF2C.
-        ᶜdivᵥ_ρqₚ = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(FT(0))),
-            # bottom = Operators.SetDivergence(FT(0)),
-        )
-        ᶜdivᵥ_ρqₚ_matrix = MatrixFields.operator_matrix(ᶜdivᵥ_ρqₚ)
-
         ᶜprecip_advection_matrix = ᶜadvection_matrix
         @. ᶜprecip_advection_matrix[colidx] =
-            -(ᶜdivᵥ_ρqₚ_matrix()) ⋅
+            -(ᶜprecipdivᵥ_matrix()) ⋅
             DiagonalMatrixRow(ᶠwinterp(ᶜJ[colidx], ᶜρ[colidx]))
 
         precip_info = (

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -165,47 +165,34 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         # using first order upwind and free outflow bottom boundary condition
 
         ᶠu³ₚ = p.scratch.ᶠtemp_CT3
-        ᶜqₚ = p.scratch.ᶜtemp_scalar
-        lgf = Fields.local_geometry_field(Y.f)
-        FT = Spaces.undertype(axes(Y.c))
+        ᶠlg = Fields.local_geometry_field(Y.f)
 
         @. ᶠu³ₚ[colidx] =
-            FT(-1) *
-            ᶠinterp(p.precomputed.ᶜwᵣ[colidx]) *
-            CT3(unit_basis_vector_data(CT3, lgf[colidx]))
-        @. ᶜqₚ[colidx] = Y.c.ρq_rai[colidx] / Y.c.ρ[colidx]
-
-        # TODO: Add support for SetDivergence to DivergenceF2C.
-        ᶜdivᵥ_ρqₚ = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(FT(0))),
-            # bottom = Operators.SetDivergence(FT(0)),
-        )
-
+            ᶠinterp(-p.precomputed.ᶜwᵣ[colidx]) *
+            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx]))
         vertical_transport!(
             Yₜ.c.ρq_rai[colidx],
             ᶜJ[colidx],
             Y.c.ρ[colidx],
             ᶠu³ₚ[colidx],
-            ᶜqₚ[colidx],
+            ᶜspecific.q_rai[colidx],
             dt,
             precip_upwinding,
-            ᶜdivᵥ_ρqₚ,
+            ᶜprecipdivᵥ,
         )
 
         @. ᶠu³ₚ[colidx] =
-            FT(-1) *
-            ᶠinterp(p.precomputed.ᶜwₛ[colidx]) *
-            CT3(unit_basis_vector_data(CT3, lgf[colidx]))
-        @. ᶜqₚ[colidx] = Y.c.ρq_sno[colidx] / Y.c.ρ[colidx]
+            ᶠinterp(-p.precomputed.ᶜwₛ[colidx]) *
+            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx]))
         vertical_transport!(
             Yₜ.c.ρq_sno[colidx],
             ᶜJ[colidx],
             Y.c.ρ[colidx],
             ᶠu³ₚ[colidx],
-            ᶜqₚ[colidx],
+            ᶜspecific.q_sno[colidx],
             dt,
             precip_upwinding,
-            ᶜdivᵥ_ρqₚ,
+            ᶜprecipdivᵥ,
         )
     end
 

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -25,7 +25,11 @@ const ᶜdivᵥ = Operators.DivergenceF2C()
 const ᶜadvdivᵥ = Operators.DivergenceF2C(
     bottom = Operators.SetValue(CT3(0)),
     top = Operators.SetValue(CT3(0)),
-) # divergence applied to advective fluxes is zero at the boundaries
+) # Tracers do not have advective fluxes through the top and bottom cell faces
+const ᶜprecipdivᵥ = Operators.DivergenceF2C(
+    top = Operators.SetValue(CT3(0)),
+    bottom = Operators.SetDivergence(0),
+) # Precipitation has no flux at the top, but it has free outflow at the bottom
 const ᶜgradᵥ = Operators.GradientF2C()
 
 # TODO: Implement proper extrapolation instead of simply reusing the first
@@ -73,6 +77,7 @@ const ᶠfct_zalesak = Operators.FCTZalesak(
 const ᶜinterp_matrix = MatrixFields.operator_matrix(ᶜinterp)
 const ᶜdivᵥ_matrix = MatrixFields.operator_matrix(ᶜdivᵥ)
 const ᶜadvdivᵥ_matrix = MatrixFields.operator_matrix(ᶜadvdivᵥ)
+const ᶜprecipdivᵥ_matrix = MatrixFields.operator_matrix(ᶜprecipdivᵥ)
 const ᶠinterp_matrix = MatrixFields.operator_matrix(ᶠinterp)
 const ᶠwinterp_matrix = MatrixFields.operator_matrix(ᶠwinterp)
 const ᶠgradᵥ_matrix = MatrixFields.operator_matrix(ᶠgradᵥ)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR replaces the `NullBoundaryCondition()` at the bottom of the `DivergenceF2C` operator for precipitation with a `SetDivergence(0)` boundary condition. This should slightly change the results for simulations with 1-moment microphysics.

This also slightly simplifies the definition of the implicit tendency for precipitation, and it fixes an issue with how ClimaCore v0.11.9 was added to the manifest files.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
