### PR TITLE
Update upwinding based on FCT

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -190,9 +190,6 @@ viscous_sponge:
 job_id:
   help: "Uniquely identifying string for a particular job"
   value: ~
-density_upwinding:
-  help: "Density upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
-  value: none
 tracer_upwinding:
   help: "Tracer upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
   value: none

--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -357,8 +357,10 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, colidx)
     (; ᶜspecific, ᶠu³, ᶜK, ᶜts, ᶜp, ᶜΦ, ᶠgradᵥ_ᶜΦ, ᶜρ_ref, ᶜp_ref) = p
     (; ∂ᶜK_∂ᶜuₕ, ∂ᶜK_∂ᶠu₃, ᶠp_grad_matrix, ᶜadvection_matrix) = p
     (; ᶜdiffusion_h_matrix, ᶜdiffusion_u_matrix, params) = p
-    (; energy_upwinding, density_upwinding) = p.atmos.numerics
-    (; tracer_upwinding, precip_upwinding) = p.atmos.numerics
+    # use CD2 for implicit, upwinding correction goes in explicit part
+    energy_upwinding = Val(:none)
+    tracer_upwinding = Val(:none)
+    (; precip_upwinding) = p.atmos.numerics # precipitation is always upwinded (rain always falls)
 
     FT = Spaces.undertype(axes(Y.c))
     CTh = CTh_vector_type(axes(Y.c))
@@ -401,7 +403,6 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, colidx)
         -(ᶜadvdivᵥ_matrix()) ⋅
         DiagonalMatrixRow(ᶠwinterp(ᶜJ[colidx], ᶜρ[colidx]))
 
-    @assert density_upwinding == Val(:none)
     if use_derivative(topography_flag)
         ∂ᶜρ_err_∂ᶜuₕ = matrix[@name(c.ρ), @name(c.uₕ)]
         @. ∂ᶜρ_err_∂ᶜuₕ[colidx] =
@@ -620,7 +621,6 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, colidx)
             ᶜwₚ = MatrixFields.get_field(p, wₚ_name)
             ᶠlg = Fields.local_geometry_field(Y.f)
 
-            @assert upwinding != Val(:none)
             is_third_order = upwinding == Val(:third_order)
             UpwindMatrixRowType =
                 is_third_order ? QuaddiagonalMatrixRow : BidiagonalMatrixRow

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -93,7 +93,6 @@ function get_numerics(parsed_args)
     energy_upwinding = Val(Symbol(parsed_args["energy_upwinding"]))
     tracer_upwinding = Val(Symbol(parsed_args["tracer_upwinding"]))
     precip_upwinding = Val(Symbol(parsed_args["precip_upwinding"]))
-    density_upwinding = Val(Symbol(parsed_args["density_upwinding"]))
     edmfx_upwinding = Val(Symbol(parsed_args["edmfx_upwinding"]))
     edmfx_sgsflux_upwinding =
         Val(Symbol(parsed_args["edmfx_sgsflux_upwinding"]))
@@ -105,7 +104,6 @@ function get_numerics(parsed_args)
         energy_upwinding,
         tracer_upwinding,
         precip_upwinding,
-        density_upwinding,
         edmfx_upwinding,
         edmfx_sgsflux_upwinding,
         limiter,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -333,7 +333,6 @@ Base.@kwdef struct AtmosNumerics{
     EN_UP,
     TR_UP,
     PR_UP,
-    DE_UP,
     ED_UP,
     ED_SG_UP,
     DYCORE,
@@ -344,7 +343,6 @@ Base.@kwdef struct AtmosNumerics{
     energy_upwinding::EN_UP
     tracer_upwinding::TR_UP
     precip_upwinding::PR_UP
-    density_upwinding::DE_UP
     edmfx_upwinding::ED_UP
     edmfx_sgsflux_upwinding::ED_SG_UP
 


### PR DESCRIPTION
This PR updates the upwinding to use CD2 in the implicit and a correction term (FCT-CD2) for the explicit tendency.

Co-authored by @dennisYatunin.