### PR TITLE
Use depth-limited type printing for non-interactive runs

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,3 +1,8 @@
+# When Julia 1.10+ is used interactively, stacktraces contain reduced type information to make them shorter.
+# On the other hand, the full type information is printed when julia is not run interactively. 
+# Given that ClimaCore objects are heavily parametrized, non-abbreviated stacktraces are hard to read,
+# so we force abbreviated stacktraces even in non-interactive runs.
+# (See also Base.type_limited_string_from_context())
 redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import ClimaAtmos as CA
 import Random

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -1,3 +1,4 @@
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import ClimaAtmos as CA
 import Random
 Random.seed!(1234)


### PR DESCRIPTION
Otherwise, our error logs are unusable. For example: https://buildkite.com/clima/climaatmos-ci/builds/15974#018d1e6b-fdf0-4b56-ad4c-5488f66aee1c. I'd paste the error in here, but it'd be obnoxious. It's over 2 million characters, and that's only a fraction of the log (buildkite requires you to download it if you want to see the whole thing.

@simonbyrne can/should we put this into a ClimaCore `__init__` function instead? Otherwise I'd say we should add this here, and any other repo that uses ClimaCore. It is only one line though, and maybe it's better that we do it explicitly per repo.