### PR TITLE
add some longruns to gpu pipeline

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -91,18 +91,7 @@ steps:
           slurm_ntasks: 64
           slurm_mem_per_cpu: 16GB
           slurm_time: 24:00:00
-
-      - label: ":computer: aquaplanet equilmoist clearsky radiation + 0M microphysics"
-        command:
-          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
-        artifact_paths: "$$JOB_NAME/*"
-        agents:
-          slurm_ntasks: 64
-          slurm_mem_per_cpu: 16GB
-          slurm_time: 24:00:00
-        env:
-          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M"
-      
+    
       - label: ":computer: aquaplanet equilmoist clearsky radiation + diagnostic edmf diffusion only + 0M microphysics"
         command:
           - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -86,6 +86,17 @@ steps:
         env:
           JOB_NAME: "longrun_hs_rhoe_equil_55km_nz63_0M"
 
+      - label: ":computer: aquaplanet equilmoist clearsky radiation + 0M microphysics"
+        command:
+          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
+        artifact_paths: "$$JOB_NAME/*"
+        agents:
+          slurm_gpus: 1
+          slurm_cpus_per_task: 4
+          slurm_time: 24:00:00
+        env:
+          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M"
+
       - label: ":computer: aquaplanet equilmoist clearsky radiation + diagnostic edmf + 0M microphysics"
         command:
           - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
@@ -96,3 +107,14 @@ steps:
           slurm_time: 24:00:00
         env:
           JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M"
+      
+      - label: ":computer: aquaplanet equilmoist allsky radiation + diagnostic edmf + 0M microphysics"
+        command:
+          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
+        artifact_paths: "$$JOB_NAME/*"
+        agents:
+          slurm_gpus: 1
+          slurm_cpus_per_task: 4
+          slurm_time: 24:00:00
+        env:
+          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M"

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
@@ -1,0 +1,35 @@
+h_elem: 16
+z_max: 55000.0
+z_elem: 63
+dz_bottom: 30.0
+dz_top: 3000.0
+moist: "equil"
+precip_model: "0M"
+override_τ_precip: false
+rad: "allskywithclear"
+dt_rad: "6hours"
+surface_setup: "DefaultMoninObukhov"
+turbconv: "diagnostic_edmfx"
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
+prognostic_tke: true
+edmfx_upwinding: "first_order"
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_nh_pressure: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+rayleigh_sponge: true
+dt_save_state_to_disk: "10days"
+dt: "100secs"
+t_end: "60days"
+job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M"
+toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 1days
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+    reduction_time: average
+    period: 1days

--- a/docs/src/longruns.md
+++ b/docs/src/longruns.md
@@ -23,9 +23,20 @@ longrun_hs_rhoe_equil_55km_nz63_0M
 Moist Held Suarez. Test the moist dycore with an equilibrium state with sources and sinks.
 ```
 ```
+longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M
+
+Aquaplanet with idealized insolation, clear-sky radiation, and 0-moment microphysics.
+Use this job to test new physical components.
+```
+```
 longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M
 
 Aquaplanet with idealized insolation, clear-sky radiation, diagnostic edmf
+and 0-moment microphysics.
+```
+longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M
+
+Aquaplanet with idealized insolation, all-sky radiation, diagnostic edmf
 and 0-moment microphysics.
 ```
 
@@ -49,12 +60,6 @@ Moist baroclinic wave with the SSP timestepper.
 longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M
 
 Aquaplanet with idealized insolation, gray radiation, and 0-moment microphysics.
-```
-```
-longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M
-
-Aquaplanet with idealized insolation, clear-sky radiation, and 0-moment microphysics.
-Use this job to test new physical components.
 ```
 ```
 longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Moves aquaplanet clear-sky radiation to GPU pipeline. Also adds diagnostic edmf with all-sky radiation. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
