### PR TITLE
change alpha_rayleigh_uh to zero in longruns

### DIFF
--- a/toml/longrun_aquaplanet_amip.toml
+++ b/toml/longrun_aquaplanet_amip.toml
@@ -3,6 +3,11 @@ alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
 
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"
+
 [precipitation_timescale]
 alias = "τ_precip"
 value = 600

--- a/toml/longrun_aquaplanet_dyamond.toml
+++ b/toml/longrun_aquaplanet_dyamond.toml
@@ -2,3 +2,8 @@
 alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
+
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
@@ -8,3 +8,7 @@ alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
 
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
@@ -3,6 +3,11 @@ alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
 
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"
+
 [precipitation_timescale]
 alias = "τ_precip"
 value = 600

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
@@ -2,3 +2,8 @@
 alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
+
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"

--- a/toml/longrun_compressible_edmf_trmm.toml
+++ b/toml/longrun_compressible_edmf_trmm.toml
@@ -1,5 +1,0 @@
-[zd_rayleigh]
-alias = "zd_rayleigh"
-value = 15000
-type = "float"
-

--- a/toml/longrun_hs_rhoe_dry_55km_nz63.toml
+++ b/toml/longrun_hs_rhoe_dry_55km_nz63.toml
@@ -2,3 +2,8 @@
 alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
+
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"

--- a/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
+++ b/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
@@ -1,10 +1,9 @@
-[alpha_rayleigh_w]
-alias = "alpha_rayleigh_w"
-value = 10.0
-type = "float"
-
 [zd_rayleigh]
 alias = "zd_rayleigh"
 value = 35000.0
 type = "float"
 
+[alpha_rayleigh_uh]
+alias = "alpha_rayleigh_uh"
+value = 0.0
+type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
@akshaysridhar found that the default of rayleigh sponge coefficient of u_h is not zero. I have a [PR](https://github.com/CliMA/CLIMAParameters.jl/pull/160) in CLIMAParameters that changes this. While waiting for new releases, this PR changes the parameter in longruns to test if the simulations are still working.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
