### PR TITLE
Add auto-debug feature

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -406,6 +406,12 @@ steps:
           --config_file $CONFIG_PATH/test_io.yml
         artifact_paths: "test_io/*"
 
+      - label: ":computer: Test auto-debug"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl
+          --config_file $CONFIG_PATH/test_auto_debug.yml
+        artifact_paths: "test_auto_debug/*"
+
       - label: ":computer: MPI io test"
         command: >
           srun julia --color=yes --project=examples examples/hybrid/driver.jl

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -262,3 +262,9 @@ netcdf_output_at_levels:
 warn_allocations_diagnostics:
   help: "When true, a dry-run for all the diagnostics is performed to check whether the functions allocate additional memory (which reduces performances)"
   value: false
+run_mode:
+  help: "[Productionrun,AutoDebugRun]"
+  value: "ProductionRun"
+simulate_crash:
+  help: "Bool used in AutoDebugRun to simulate a crashed simulation (for testing)"
+  value: false

--- a/config/model_configs/test_auto_debug.yml
+++ b/config/model_configs/test_auto_debug.yml
@@ -1,0 +1,6 @@
+dt: "1secs"
+t_end: "100secs"
+auto_debug: true
+simulate_crash: true
+job_id: "test_auto_debug"
+dt_save_state_to_disk: "10secs"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -13,6 +13,11 @@ if !(@isdefined config)
 end
 simulation = CA.get_simulation(config)
 (; integrator) = simulation
+if CA.get_run_mode(integrator) isa CA.AutoDebugRun
+    include(joinpath(pkgdir(CA), "post_processing", "auto_debug_plots.jl"))
+    CA.get_run_mode(integrator).auto_plot =
+        integrator -> auto_debug_plots(integrator)
+end
 sol_res = CA.solve_atmos!(simulation)
 
 (; atmos, params) = integrator.p

--- a/post_processing/auto_debug_plots.jl
+++ b/post_processing/auto_debug_plots.jl
@@ -1,0 +1,154 @@
+import ClimaAtmos as CA
+import ClimaComms
+import ClimaCore.InputOutput
+import ClimaCore.Fields
+import ClimaCore.Spaces
+import CairoMakie as MK
+import REPL.TerminalMenus as TM
+function auto_debug_plots(integrator)
+    debugger = CA.get_run_mode(integrator)
+    comms_ctx = ClimaComms.context(integrator.u.c)
+    (; dt, t) = integrator
+    auto_debug_plots(debugger, comms_ctx, dt, t)
+end
+
+hdf5day(t) = floor(Int, t / (60 * 60 * 24))
+hdf5sec(t) = floor(Int, t % (60 * 60 * 24))
+hdf5filename(output_dir, t) =
+    joinpath(output_dir, "day$(hdf5day(t)).$(hdf5sec(t)).hdf5")
+
+isinfornans(x) = isnan(x) || isinf(x)
+function auto_debug_lat_long(space, colidx)
+    col_space = Spaces.column(space, colidx)
+    ᶜlg_col = Fields.local_geometry_field(col_space).coordinates
+    (ᶜlg_col.lat, ᶜlg_col.long)
+end
+
+"""
+    get_suspect_columns
+
+Find suspect columns. Notes:
+ - they can vary per variable
+ - they are likely those that explode the earliest in time
+ - its possible that a field may contain very large numbers,
+   resulting in a a crashed simulation, before Inf or NaNs
+   are reached.
+
+So, per variable, we find the first column to exhibit
+exploding behavior (+Inf, -Inf, NaN). To do this, we
+march forward in time:
+ - If a variable does _not_ have Inf/NaNs anywhere, then find
+   the column with the extrema.
+ - If a variable has multiple Inf/NaNs, stop, and use the last
+   extrema.
+ - If a variable has Inf/NaNs in a single column, use that column
+   and stop.
+"""
+function get_suspect_columns(debugger, comms_ctx, dt, t_end)
+    if comms_ctx isa ClimaComms.CUDADevice
+        @error "get_suspect_columns functionally using ByColumn, which is not supported on the GPU."
+        return
+    end
+    # prob_cols = Dict()
+    sus_cols_min = Dict()
+    sus_cols_max = Dict()
+
+    (; t_boost_diagnostics, output_dir) = debugger
+    YT = map(t_boost_diagnostics:dt:t_end) do t
+        reader = InputOutput.HDF5Reader(hdf5filename(output_dir, t), comms_ctx)
+        Y = InputOutput.read_field(reader, "Y")
+        _t = InputOutput.HDF5.read_attribute(reader.file, "time")
+        close(reader)
+        @assert t == _t "Time mismatch"
+        (Y, _t)
+    end
+    Ys = first.(YT)
+    times = last.(YT)
+    reached_inf_or_nans = Dict()
+    for prop_chain in Fields.property_chains(first(Ys))
+        var_name = join(prop_chain, "_")
+        reached_inf_or_nans[var_name] = false
+        for (Y, t) in zip(Ys, times) # loop in time
+            if reached_inf_or_nans[var_name]
+                break
+            end
+            var = Fields.single_field(Y, prop_chain)
+            # First, look for Inf / NaNs
+            c = CA.count_columns(var, f -> any(x -> isinfornans(x), f))
+            # Let's store c in (sus_cols_min,sus_cols_max) so that
+            # we know what case we're in:
+            #  - No NaNs
+            #  - A single column with NaNs
+            #  - Multiple columns with NaNs
+            if c == 0
+                (colidx, found) =
+                    CA.find_column(var, f -> any(x -> x == minimum(var), f))
+                sus_cols_min[var_name] = (colidx, c)
+                (colidx, found) =
+                    CA.find_column(var, f -> any(x -> x == maximum(var), f))
+                sus_cols_max[var_name] = (colidx, c)
+            elseif c == 1
+                (colidx, found) =
+                    CA.find_column(var, f -> any(x -> isinfornans(x), f))
+                sus_cols_min[var_name] = (colidx, c)
+                (colidx, found) =
+                    CA.find_column(var, f -> any(x -> isinfornans(x), f))
+                sus_cols_max[var_name] = (colidx, c)
+                reached_inf_or_nans[var_name] = true
+                break
+            else
+                reached_inf_or_nans[var_name] = true
+                break
+            end
+        end
+    end
+
+    return (Ys, times, sus_cols_min, sus_cols_max)
+end
+
+function auto_debug_plots(debugger, comms_ctx, dt, t)
+    (Ys, times, sus_cols_min, sus_cols_max) =
+        get_suspect_columns(debugger, comms_ctx, dt, t)
+    multiple_times_per_line_plot(debugger, Ys, times, sus_cols_min, "min")
+    multiple_times_per_line_plot(debugger, Ys, times, sus_cols_max, "max")
+end
+
+function multiple_times_per_line_plot(debugger, Ys, times, sus_cols, name)
+    (; output_dir) = debugger
+
+    @info "Plotting for $name in $output_dir"
+    Nt = length(times)
+    ps = Fields.property_chains(first(Ys))
+    Nvars = length(ps)
+    fig = MK.Figure(; size = (1200, 600))
+    axs = map(collect(enumerate(ps))) do (i, prop_chain)
+        var_name = join(prop_chain, "_")
+        ylabel_nt = i == 1 ? (; ylabel = "z [km]") : (;)
+        col_idx, c = sus_cols[var_name]
+        title = "$name @ col , count(Inf/Nan)=$c"
+        MK.Axis(fig[1, i]; ylabel_nt..., xlabel = "$var_name", title)
+    end
+
+    for (i, prop_chain) in enumerate(ps)
+        var_name = join(prop_chain, "_")
+        for (j, (Y, t)) in enumerate(zip(Ys, times)) # loop in time
+            var = Fields.single_field(Y, prop_chain)
+            (colidx, c) = sus_cols[var_name]
+            ϕcol = Fields.column(var, colidx)
+            MK.lines!(
+                axs[i],
+                vec(parent(ϕcol)),
+                vec(parent(Fields.coordinate_field(ϕcol).z)) ./ 1e3;
+                color = t,
+                colormap = :viridis,
+                colorrange = (minimum(times), maximum(times)),
+            )
+        end
+    end
+    MK.Colorbar(
+        fig[1, Nvars + 1];
+        limits = (minimum(times), maximum(times)),
+        colormap = :viridis,
+    )
+    MK.save(joinpath(output_dir, "suspect_cols_$name.png"), fig)
+end

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -118,6 +118,7 @@ include(joinpath("solver", "model_getters.jl")) # high-level (using parsed_args)
 include(joinpath("solver", "type_getters.jl"))
 include(joinpath("solver", "yaml_helper.jl"))
 include(joinpath("solver", "solve.jl"))
+include(joinpath("solver", "auto_debug.jl"))
 
 include(joinpath("parameters", "create_parameters.jl"))
 

--- a/src/solver/auto_debug.jl
+++ b/src/solver/auto_debug.jl
@@ -1,0 +1,195 @@
+import Random
+"""
+    AutoDebugRun
+
+A type to dispatch for solving in auto-debug mode.
+
+To run this interactively, you can use
+
+julia --project=examples
+```julia
+using Revise; if !("--config_file" in ARGS)
+    push!(ARGS, "--config_file")
+    push!(ARGS, "config/model_configs/test_auto_debug.yml")
+end; include("examples/hybrid/driver.jl")
+```
+"""
+Base.@kwdef mutable struct AutoDebugRun
+    """ Bool indicating that the simulation crashed. """
+    crashed::Bool = false
+    """ Simulation time that the simulation crashed. """
+    t_fail::Float64 = 0
+    """ Simulation restart time to replay crashed simulation. """
+    t_start_replay::Float64 = 0
+    """ Simulation time to start boosting diagnostics. """
+    t_boost_diagnostics::Float64 = 0
+    """ Cache for dt_save_state_to_disk. """
+    dt_save_state_to_disk::Float64
+    """ Cached integrator step. """
+    step_crash::Int = 0
+    """ Cache for output_dir. """
+    output_dir::String
+    """ Minimum number of steps to replay. """
+    n_min_steps_to_replay::Int = 10
+    """ The portion of simulation time to replay. For example, for 0.8 we replay the last 80% from `t_last_restart` to `t_fail`. """
+    replay_factor::Float64 = 0.8
+    """ Auto-debug plotting function. """
+    auto_plot::Function = (integrator) -> nothing
+    """ Simulate crash at nsteps = 10 for testing purposes. """
+    simulate_crash::Bool = false
+    """ Bool indicating that we are in replay. """
+    in_replay::Bool = false
+end
+
+import ClimaCore.Fields as Fields
+function find_column(f::Fields.Field, cond)
+    _colidx = Fields.ColumnIndex((-1, -1), -1)
+    Fields.bycolumn(axes(f)) do colidx
+        if cond(f[colidx])
+            _colidx = colidx
+        end
+    end
+    found = _colidx.h ≠ -1
+    return (_colidx, found)
+end
+function count_columns(f::Fields.Field, cond)::Int
+    c = 0
+    Fields.bycolumn(axes(f)) do colidx
+        if cond(f[colidx])
+            c += 1
+        end
+    end
+    return c
+end
+
+
+function reset_to_last_restart!(integrator, debugger::AutoDebugRun)
+
+    t = debugger.t_start_replay
+    # Read restart data:
+    (; u, p) = integrator
+    day = floor(Int, t / (60 * 60 * 24))
+    sec = floor(Int, t % (60 * 60 * 24))
+    (; output_dir) = debugger
+    @info "Replaying crashed simulation from HDF5 file on day $day second $sec"
+    mkpath(joinpath(output_dir))
+    restart_file = joinpath(output_dir, "day$day.$sec.hdf5")
+    comms_ctx = ClimaComms.context(integrator.u.c)
+    reader = InputOutput.HDF5Reader(restart_file, comms_ctx)
+    Y = InputOutput.read_field(reader, "Y")
+    t_start = InputOutput.HDF5.read_attribute(reader.file, "time")
+    @assert t == t_start
+    integrator.t = t_start
+    integrator.step = Int(integrator.t / integrator.dt)
+
+    # Restart state:
+    @. u = Y
+    # Re-compute cache
+    CA.set_precomputed_quantities!(u, p, t)
+    # Base.close(reader) # is this needed?
+    return nothing
+end
+
+function export_state(debugger::AutoDebugRun, t)
+    if debugger.in_replay
+        return t ≥ debugger.t_boost_diagnostics
+    else
+        return false
+    end
+end
+
+function replay!(integrator, debugger)
+    while !isempty(integrator.tstops) && integrator.step != integrator.stepstop
+        Random.seed!(1234)
+        SciMLBase.step!(integrator)
+        if debugger.simulate_crash && integrator.step == 30
+            @warn "Simulating crash (during replay)..."
+            error("Simulating crash for testing purposes")
+        end
+    end
+    return nothing
+end
+
+function solve_run_mode!(integrator, debugger::AutoDebugRun)
+    @info "Solving in debug mode, does not support restarted simulations."
+    @info "Re-setting random seed for step-wise reproducibility"
+
+    while !isempty(integrator.tstops) && integrator.step != integrator.stepstop
+        Random.seed!(1234)
+        try
+            SciMLBase.step!(integrator)
+            if debugger.simulate_crash && integrator.step == 30
+                @warn "Simulating crash..."
+                error("Simulating crash for testing purposes")
+            end
+            # maybe_graceful_exit(integrator)
+            # TODO Add MPI support (use watchdog file)
+            # if comms_ctx.err_code == 1
+            #     error("Someone else crashed")
+            # end
+        catch e1
+            # comms_ctx.err_code = 1
+            debugger.crashed = true
+            debugger.t_fail = integrator.t
+            debugger.step_crash = integrator.step
+            try
+                reset_to_last_restart!(integrator, debugger)
+                debugger.in_replay = true
+                replay!(integrator, debugger)
+            catch e2
+                @error "ClimaAtmos simulation crashed. Stacktrace for failed simulation" exception =
+                    (e2, catch_backtrace())
+            end
+            debugger.auto_plot(integrator)
+            break # break out of while-loop
+        end
+
+        # Update debugger
+        (; t, dt) = integrator
+        (; dt_save_state_to_disk) = debugger
+        # Update t_start_replay
+        #  - assumes t_start = 0
+        t_start = t * 0
+        n_steps = Int(t / dt)
+        i = findlast(n -> t - n * dt_save_state_to_disk > 0, 0:n_steps)
+        n_replay_steps =
+            count(n -> t - n * dt_save_state_to_disk > 0, 0:n_steps)
+
+        # It may be that a simulation exports and then
+        # crashes on the very next step, making the replay
+        # window very short (maybe even only one step).
+        # So, let's ensure that we have at least a N steps
+        # since the last replay, if not, let's replay from
+        # one back.
+        t_last_restart = if isnothing(i)
+            t_start
+        elseif i == 0
+            zero(dt_save_state_to_disk)
+        else
+            # t_last_step
+            # Replay from two dt_save_state_to_disk's ago.
+            j =
+                (i + debugger.n_min_steps_to_replay) * dt_save_state_to_disk > t ? (i - 1) : i
+            j * dt_save_state_to_disk
+        end
+        # TODO: the logic would be much easier if we
+        #       instead specified `nsteps_save_state_to_disk`,
+        #       or converted to this very early.
+        t_last_step = Int(t_last_restart / dt)
+
+        # TODO: should this instead be 80% between
+        #       t_last_restart and t_fail? A good choice
+        #       depends on dt_save_state_to_disk, the speed of
+        #       the physics, and (maybe) t_fail?
+        debugger.t_start_replay = t_last_restart
+        (; replay_factor) = debugger
+        debugger.t_boost_diagnostics = t_last_restart # can this be logically/heuristically improved?
+        # debugger.t_boost_diagnostics = if n_replay_steps > 10
+        #     t_last_restart*(1-replay_factor)+t*replay_factor
+        # else
+        #     t_last_restart
+        # end
+    end
+    finalize!(integrator)
+    return integrator.sol
+end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -563,3 +563,12 @@ function AtmosConfig(config::Dict; comms_ctx = nothing)
     PA = typeof(config)
     return AtmosConfig{FT, TD, PA, C}(toml_dict, config, comms_ctx)
 end
+
+abstract type AbstractRunMode end
+
+"""
+    ProductionRun
+
+A singleton type to dispatch for solving in production mode.
+"""
+struct ProductionRun <: AbstractRunMode end


### PR DESCRIPTION
This PR adds an "auto-debug" feature. Enabling this feature via the `run_mode` toml argument will run the simulation with some modifications:

 - A call to `Random.seed!` is called before each and every step, to ensure reproducibility.
 - When a simulation crashes, it is automatically "replays" the crash, starting from N (a given parameter) `dt_save_state_to_disk`'s ago but with a higher temporal diagnostic frequency.
 - This replay occurs inside a try-catch block and, once caught, we search for the most problematic columns (those with Inf / NaNs) and plot them for all state variables.
 - We then gracefully exit with the integrator.
