### PR TITLE
Make tracer vert adv always explicit

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -67,14 +67,14 @@ NVTX.@annotate function horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
 end
 
 NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
-    (; turbconv_model) = p.atmos
+    (; moisture_model, turbconv_model) = p.atmos
     n = n_prognostic_mass_flux_subdomains(turbconv_model)
     advect_tke = use_prognostic_tke(turbconv_model)
     point_type = eltype(Fields.coordinate_field(Y.c))
     (; dt) = p
     ᶜJ = Fields.local_geometry_field(Y.c).J
     (; ᶜf) = p.core
-    (; ᶜu, ᶠu³, ᶜK) = p.precomputed
+    (; ᶜh_tot, ᶜu, ᶠu³, ᶜK) = p.precomputed
     (; edmfx_upwinding) = n > 0 || advect_tke ? p.atmos.numerics : all_nothing
     (; ᶜuʲs, ᶜKʲs) = n > 0 ? p.precomputed : all_nothing
     (; ᶠu³⁰) = advect_tke ? p.precomputed : all_nothing
@@ -108,10 +108,9 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 
     Fields.bycolumn(axes(Y.c)) do colidx
-        if :ρe_tot in propertynames(Yₜ.c)
-            (; ᶜh_tot) = p.precomputed
+        # Upwinding corrections to active tracers (e_tot and q_tot)
+        if energy_upwinding != Val(:none)
             for (coeff, upwinding) in ((1, energy_upwinding), (-1, Val(:none)))
-                energy_upwinding isa Val{:none} && continue
                 vertical_transport!(
                     coeff,
                     Yₜ.c.ρe_tot[colidx],
@@ -124,26 +123,35 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
                 )
             end
         end
-        for (ᶜρχₜ, ᶜχ, χ_name) in matching_subfields(Yₜ.c, ᶜspecific)
-            χ_name == :e_tot && continue
+        if !(moisture_model isa DryModel) && tracer_upwinding != Val(:none)
             for (coeff, upwinding) in ((1, tracer_upwinding), (-1, Val(:none)))
-                tracer_upwinding isa Val{:none} && continue
                 vertical_transport!(
                     coeff,
-                    ᶜρχₜ[colidx],
+                    Yₜ.c.ρq_tot[colidx],
                     ᶜJ[colidx],
                     Y.c.ρ[colidx],
                     ᶠu³[colidx],
-                    ᶜχ[colidx],
+                    ᶜspecific.q_tot[colidx],
                     dt,
                     upwinding,
                 )
             end
         end
 
-    end
+        # Full vertical advection of passive tracers (q_liq, q_rai, etc.)
+        for (ᶜρχₜ, ᶜχ, χ_name) in matching_subfields(Yₜ.c, ᶜspecific)
+            χ_name in (:e_tot, :q_tot) && continue
+            vertical_transport!(
+                ᶜρχₜ[colidx],
+                ᶜJ[colidx],
+                Y.c.ρ[colidx],
+                ᶠu³[colidx],
+                ᶜχ[colidx],
+                dt,
+                tracer_upwinding,
+            )
+        end
 
-    Fields.bycolumn(axes(Y.c)) do colidx
         @. Yₜ.c.uₕ[colidx] -=
             ᶜinterp(
                 ᶠω¹²[colidx] ×


### PR DESCRIPTION
Closes #2510. @dennisYatunin, I think you meant to include `q_liq`/`q_ice` to be non-passive tracers, as I believe they would play a role in the dynamics for non-equilibrium cases, so I left those where they are. I didn't see any other tracers that needed to be moved in `update_implicit_equation_jacobian!`, but maybe @dennisYatunin can double check my work.