### PR TITLE
Add option for disabling progress logging

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -259,3 +259,6 @@ netcdf_output_at_levels:
 warn_allocations_diagnostics:
   help: "When true, a dry-run for all the diagnostics is performed to check whether the functions allocate additional memory (which reduces performances)"
   value: false
+log_progress:
+  help: "Log simulation progress, including wall-time estimates"
+  value: true

--- a/config/default_configs/default_perf.yml
+++ b/config/default_configs/default_perf.yml
@@ -13,3 +13,4 @@ precip_model: "0M"
 dt_save_to_sol: "Inf"
 rad: "allskywithclear"
 warn_allocations_diagnostics: true
+log_progress: false

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -443,7 +443,8 @@ function get_callbacks(parsed_args, sim_info, atmos, params, comms_ctx)
     (; dt, output_dir) = sim_info
 
     callbacks = ()
-    if !sim_info.restart
+    if parsed_args["log_progress"] && !sim_info.restart
+        @info "Progress logging enabled."
         callbacks = (
             callbacks...,
             call_every_n_steps(


### PR DESCRIPTION
According to our flame graphs, the use of `CompoundPeriod`'s is the leading allocator (due to https://github.com/JuliaLang/julia/issues/52873), so this PR adds an option for disabling progress logging, and we disable it for our performance runs.

We'd like to further reduce GC needs, which could be impacting https://github.com/CliMA/ClimaAtmos.jl/issues/2222.