### PR TITLE
gpu target runs: pass --cpus-per-task to srun

### DIFF
--- a/.buildkite/gpu_pipeline/pipeline.yml
+++ b/.buildkite/gpu_pipeline/pipeline.yml
@@ -49,7 +49,7 @@ steps:
           - mkdir -p target_gpu_implicit_baroclinic_wave
           - >
             nsys profile --trace=nvtx,mpi,cuda,osrt --output=target_gpu_implicit_baroclinic_wave/report
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}target_gpu_implicit_baroclinic_wave.yml
         artifact_paths: "target_gpu_implicit_baroclinic_wave/*"
         agents:
@@ -61,7 +61,7 @@ steps:
           - mkdir -p gpu_aquaplanet_dyamond
           - >
             nsys profile --trace=nvtx,mpi,cuda,osrt --output=gpu_aquaplanet_dyamond/report
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}gpu_aquaplanet_dyamond.yml
         artifact_paths: "gpu_aquaplanet_dyamond/*"
         agents:
@@ -74,7 +74,7 @@ steps:
           - mkdir -p gpu_hs_rhoe_equil_55km_nz63_0M
           - >
             nsys profile --trace=nvtx,mpi,cuda,osrt --output=gpu_hs_rhoe_equil_55km_nz63_0M/report
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}gpu_hs_rhoe_equil_55km_nz63_0M.yml
         artifact_paths: "gpu_hs_rhoe_equil_55km_nz63_0M/*"
         agents:
@@ -86,9 +86,9 @@ steps:
         command:
           - mkdir -p gpu_hs_rhoe_equil_55km_nz63_0M_4process
           - >
-            srun --cpu-bind=cores
+            srun --cpu-bind=threads --cpus-per-task=4
             nsys profile --trace=nvtx,mpi,cuda,osrt --output=gpu_hs_rhoe_equil_55km_nz63_0M_4process/report-%q{PMI_RANK}
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}gpu_hs_rhoe_equil_55km_nz63_0M_4process.yml
         artifact_paths: "gpu_hs_rhoe_equil_55km_nz63_0M_4process/*"
         agents:
@@ -101,9 +101,9 @@ steps:
         command:
           - mkdir -p target_gpu_implicit_baroclinic_wave_4process
           - >
-            srun --cpu-bind=cores
+            srun --cpu-bind=threads --cpus-per-task=4
             nsys profile --trace=osrt,nvtx,cuda,mpi,ucx --output=target_gpu_implicit_baroclinic_wave_4process/report-%q{PMI_RANK}
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}target_gpu_implicit_baroclinic_wave_4process.yml
         artifact_paths: "target_gpu_implicit_baroclinic_wave_4process/*"
         agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -657,15 +657,16 @@ steps:
         command:
           - mkdir -p target_gpu_implicit_baroclinic_wave_4process
           - >
-            srun
+            srun --cpu-bind=threads --cpus-per-task=4
             nsys profile --trace=nvtx,cuda,mpi --output=target_gpu_implicit_baroclinic_wave_4process/report-%q{PMI_RANK}
-            julia --color=yes --project=examples examples/hybrid/driver.jl
+            julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}target_gpu_implicit_baroclinic_wave_4process.yml
         artifact_paths: "target_gpu_implicit_baroclinic_wave_4process/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
           slurm_ntasks: 4
           slurm_mem: 32G
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -405,6 +405,8 @@ steps:
           julia --color=yes --project=examples --threads=8 examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/test_io.yml
         artifact_paths: "test_io/*"
+        agents:
+          slurm_cpus_per_task: 8
 
       - label: ":computer: MPI io test"
         command: >


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Apparently the `--cpus-per-task` arguments in `sbatch` are _not_ passed to `srun`. This seems to avoid catastrophic fall offs in scaling when the machine is busy.

run before change: https://buildkite.com/clima/climaatmos-target-gpu-simulations/builds/186
- moist HS 4xA100: sypd: 1.4577044490289248

run after change: https://buildkite.com/clima/climaatmos-target-gpu-simulations/builds/187
- moist HS 4xA100: sypd: 4.996379365801879

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
