### PR TITLE
decrease output frequency of edmf jobs

### DIFF
--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -543,8 +543,8 @@ function make_plots(::EDMFBoxPlots, simulation_path)
     simdir = SimDir(simulation_path)
 
     short_names = ["ua", "wa", "thetaa", "taup", "haup", "waup", "tke", "arup"]
-    reduction = "average"
-    period = "10m"
+    reduction = "inst"
+    period = "30m"
     vars = [
         get(simdir; short_name, reduction, period) for short_name in short_names
     ]

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -291,13 +291,8 @@ function default_diagnostics(::PrognosticEDMFX; output_writer)
         "lmix",
     ]
 
-    tenmin_averages(short_names...; output_writer) = common_diagnostics(
-        10 * 60,
-        (+),
-        output_writer,
-        short_names...;
-        pre_output_hook! = average_pre_output_hook!,
-    )
+    thirtymin_insts(short_names...; output_writer) =
+        common_diagnostics(30 * 60, nothing, output_writer, short_names...;)
 
     edmfx_draft_diagnostics = [
         "arup",
@@ -327,7 +322,7 @@ function default_diagnostics(::PrognosticEDMFX; output_writer)
     ]
 
     return [
-        tenmin_averages(edmfx_tenmin_diagnostics...; output_writer)...,
+        thirtymin_insts(edmfx_tenmin_diagnostics...; output_writer)...,
         daily_averages(edmfx_draft_diagnostics...; output_writer)...,
         daily_averages(edmfx_env_diagnostics...; output_writer)...,
     ]
@@ -366,13 +361,8 @@ function default_diagnostics(::DiagnosticEDMFX; output_writer)
         "lmix",
     ]
 
-    tenmin_averages(short_names...; output_writer) = common_diagnostics(
-        10 * 60,
-        (+),
-        output_writer,
-        short_names...;
-        pre_output_hook! = average_pre_output_hook!,
-    )
+    thirtymin_insts(short_names...; output_writer) =
+        common_diagnostics(30 * 60, nothing, output_writer, short_names...;)
 
 
     diagnostic_edmfx_draft_diagnostics = [
@@ -390,7 +380,7 @@ function default_diagnostics(::DiagnosticEDMFX; output_writer)
     diagnostic_edmfx_env_diagnostics = ["waen", "tke", "lmix"]
 
     return [
-        tenmin_averages(
+        thirtymin_insts(
             diagnostic_edmfx_tenmin_diagnostics...;
             output_writer,
         )...,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Temporary decreases output frequency for edmf jobs as the interpolation is slow. Also switches to instant diagnostic for edmf jobs.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
