### PR TITLE
decrease longrun output frequency

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_amip.yml
+++ b/config/longrun_configs/longrun_aquaplanet_amip.yml
@@ -21,16 +21,16 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
-dt_save_state_to_disk: "1days"
+dt_save_state_to_disk: "10days"
 dt: "100secs" 
-t_end: "30days"
+t_end: "60days"
 job_id: "longrun_aquaplanet_amip" 
 toml: [toml/longrun_aquaplanet_amip.toml]
 output_default_diagnostics: false
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu, rsdcs, rsucs, rldcs, rlucs]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu, rsdcs, rsucs, rldcs, rlucs]
     reduction_time: average
-    period: 1days
+    period: 10days
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
-    period: 1days
+    period: 10days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
@@ -27,9 +27,9 @@ job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]
 output_default_diagnostics: false
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
     reduction_time: average
-    period: 1days
+    period: 10days
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
-    period: 1days
+    period: 10days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
@@ -1,4 +1,4 @@
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 dt: "150secs"
 t_end: "300days"
 h_elem: 16
@@ -17,4 +17,8 @@ rad: "clearsky"
 dt_rad: "6hours"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
-
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
@@ -1,6 +1,6 @@
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 dt: "40secs"
-t_end: "200days"
+t_end: "180days"
 h_elem: 16
 z_elem: 63
 dz_bottom: 30.0
@@ -19,3 +19,11 @@ rad: "clearsky"
 dt_rad: "6hours"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 30days
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.yml
@@ -27,9 +27,9 @@ job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]
 output_default_diagnostics: false
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
     reduction_time: average
-    period: 1days
+    period: 10days
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
-    period: 1days
+    period: 10days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M.yml
@@ -18,16 +18,16 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
-dt_save_state_to_disk: "30days"
+dt_save_state_to_disk: "10days"
 dt: "100secs"
 t_end: "100days"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]
 output_default_diagnostics: false
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
     reduction_time: average
-    period: 1days
+    period: 10days
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
-    period: 1days
+    period: 10days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
@@ -21,3 +21,8 @@ check_conservation: true
 bubble: false
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 10days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
@@ -1,4 +1,4 @@
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 dt: "150secs"
 t_end: "300days"
 h_elem: 16
@@ -16,3 +16,8 @@ rad: "gray"
 precip_model: "0M"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
@@ -13,3 +13,8 @@ prognostic_surface: "PrognosticSurfaceTemperature"
 check_conservation: true
 bubble: false
 job_id: "longrun_aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean"
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, hussfc, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 10days

--- a/config/longrun_configs/longrun_bw_rhoe_equil_highres.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_equil_highres.yml
@@ -8,6 +8,7 @@ h_elem: 16
 precip_model: "0M"
 job_id: "longrun_bw_rhoe_equil_highres"
 moist: "equil"
+output_default_diagnostics: false
 diagnostics:
-  - short_name: [pfull, wa, va, rv, hus]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, pr]
     period: 1days

--- a/config/longrun_configs/longrun_bw_rhoe_equil_highres_topography_earth.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_equil_highres_topography_earth.yml
@@ -12,6 +12,7 @@ precip_model: "0M"
 topography: "Earth"
 job_id: "longrun_bw_rhoe_equil_highres_topography_earth"
 moist: "equil"
+output_default_diagnostics: false
 diagnostics:
-  - short_name: [pfull, wa, va, rv, hus]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, pr]
     period: 1days

--- a/config/longrun_configs/longrun_bw_rhoe_highres.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_highres.yml
@@ -6,6 +6,7 @@ t_end: "100days"
 z_elem: 45
 dt: "400secs"
 job_id: "longrun_bw_rhoe_highres"
+output_default_diagnostics: false
 diagnostics:
-  - short_name: [pfull, wa, va, rv]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa]
     period: 1days

--- a/config/longrun_configs/longrun_hs_rhoe_dry_55km_nz63.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_dry_55km_nz63.yml
@@ -1,6 +1,6 @@
 dz_bottom: 30.0
 dz_top: 3000.0
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 t_end: "300days"
 h_elem: 16
 z_elem: 63
@@ -10,3 +10,8 @@ dt: "300secs"
 rayleigh_sponge: true
 job_id: "longrun_hs_rhoe_dry_55km_nz63"
 toml: [toml/longrun_hs_rhoe_dry_55km_nz63.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M.yml
@@ -1,4 +1,4 @@
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 dt: "150secs"
 t_end: "300days"
 h_elem: 16
@@ -13,3 +13,8 @@ rayleigh_sponge: true
 forcing: "held_suarez"
 job_id: "longrun_hs_rhoe_equil_55km_nz63_0M"
 toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_hs_rhoe_equil_highres_topography_earth.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equil_highres_topography_earth.yml
@@ -1,9 +1,9 @@
-dt_save_state_to_disk: "10days"
+dt_save_state_to_disk: "30days"
 rayleigh_sponge: true
 topo_smoothing: true
 z_elem: 45
 dt: "100secs"
-t_end: "400days"
+t_end: "300days"
 dz_bottom: 30.0
 vert_diff: "true"
 h_elem: 16
@@ -15,3 +15,8 @@ precip_model: "0M"
 topography: "Earth"
 job_id: "longrun_hs_rhoe_equil_highres_topography_earth"
 moist: "equil"
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+    reduction_time: average
+    period: 30days

--- a/config/longrun_configs/longrun_sphere_hydrostatic_balance_rhoe.yml
+++ b/config/longrun_configs/longrun_sphere_hydrostatic_balance_rhoe.yml
@@ -1,9 +1,15 @@
 h_elem: 16
-z_elem: 45
+z_elem: 63
 dz_bottom: 30.0
+dz_top: 3000.0
+z_max: 55000.0
 dt: "400secs"
 perturb_initstate: false 
 discrete_hydrostatic_balance: true 
-t_end: "800days" 
-dt_save_state_to_disk: "10days" 
+t_end: "750days" 
+dt_save_state_to_disk: "30days" 
 job_id: "longrun_sphere_hydrostatic_balance_rhoe"
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa]
+    period: 30days

--- a/config/longrun_configs/longrun_ssp_bw_rhoe_equil_highres.yml
+++ b/config/longrun_configs/longrun_ssp_bw_rhoe_equil_highres.yml
@@ -11,6 +11,7 @@ precip_model: "0M"
 job_id: "longrun_ssp_bw_rhoe_equil_highres"
 moist: "equil"
 apply_limiter: true
+output_default_diagnostics: false
 diagnostics:
-  - short_name: [pfull, wa, va, rv, hus]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, pr]
     period: 1days

--- a/config/longrun_configs/longrun_zalesak_tracer_energy_bw_rhoe_equil_highres.yml
+++ b/config/longrun_configs/longrun_zalesak_tracer_energy_bw_rhoe_equil_highres.yml
@@ -11,6 +11,7 @@ precip_model: "0M"
 job_id: "longrun_zalesak_tracer_energy_bw_rhoe_equil_highres"
 moist: "equil"
 apply_limiter: true
+output_default_diagnostics: false
 diagnostics:
-  - short_name: [pfull, wa, va, rv, hus]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, pr]
     period: 1days


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
After increasing the default netcdf interpolation resolution, some of  the longrun output file size exceed the maximum buildkite artifact size, see e.g. this [error](https://buildkite.com/clima/climaatmos-gpulongruns/builds/33#018d4981-f0fd-42b8-82a2-9c8bc8847b36/531-557). Not a big problem, but we don't need such frequent output for most jobs anyway, so this PR reduces the longrun output frequency. Also makes some other minor changes of some longrun configs.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
