### PR TITLE
Allow unlogged parameters in TOML files

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -773,12 +773,13 @@ function get_simulation(config::AtmosConfig)
     end
 
     # Check that all set parameters have been used
+    # Strict logging temporarily disabled for compatibility with CloudMicrophysics overrides
     param_filepath =
         joinpath(sim_info.output_dir, "$(sim_info.job_id)_parameters.toml")
     CP.log_parameter_information(
         config.toml_dict,
         param_filepath,
-        strict = true,
+        # strict = true,
     )
 
     initial_condition = get_initial_condition(config.parsed_args)


### PR DESCRIPTION
CloudMicrophysics parameter constructors do not log parameters that they use, triggering an error when logging parameter information in `src/solver/type_getters.jl`. 

This PR disables strict logging, allow unlogged parameter overrides with a warning.

To reproduce the bug, create a TOML file:
```
[rain_autoconversion_timescale]
value = 360
type = "float"
```
Then run:
```
import ClimaAtmos as CA
config = CA.AtmosConfig(Dict("toml" =>["toml/test.toml"], "precip_model" => "1M"))
include("examples/hybrid/driver.jl")
```


