### PR TITLE
Assorted small improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   docbuild:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/lookahead.yml
+++ b/.github/workflows/lookahead.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -68,8 +68,9 @@ if CA.is_distributed(config.comms_ctx)
         Y = sol.u[1]
         center_space = axes(Y.c)
         horz_space = Spaces.horizontal_space(center_space)
-        horz_topology = horz_space.topology
-        Nq = Quadratures.degrees_of_freedom(horz_space.quadrature_style)
+        horz_topology = Spaces.topology(horz_space)
+        quadrature_style = Spaces.quadrature_style(horz_space)
+        Nq = Quadratures.degrees_of_freedom(quadrature_style)
         nlocalelems = Topologies.nlocalelems(horz_topology)
         ncols_per_process = nlocalelems * Nq * Nq
         scaling_file =

--- a/post_processing/common_utils.jl
+++ b/post_processing/common_utils.jl
@@ -7,8 +7,9 @@ function export_scaling_file(sol, output_dir, walltime, comms_ctx, nprocs)
         Y = sol.u[1]
         center_space = axes(Y.c)
         horz_space = Spaces.horizontal_space(center_space)
-        horz_topology = horz_space.topology
-        Nq = Quadratures.degrees_of_freedom(horz_space.quadrature_style)
+        horz_topology = Spaces.topology(horz_space)
+        quadrature_style = Spaces.quadrature_style(horz_space)
+        Nq = Quadratures.degrees_of_freedom(quadrature_style)
         nlocalelems = Topologies.nlocalelems(horz_topology)
         ncols_per_process = nlocalelems * Nq * Nq
         scaling_file =

--- a/post_processing/remap/remap_helpers.jl
+++ b/post_processing/remap/remap_helpers.jl
@@ -29,14 +29,14 @@ function create_weightfile(
 )
     # space info to generate nc raw data
     hspace = cspace.horizontal_space
-    Nq =
-        Quadratures.degrees_of_freedom(cspace.horizontal_space.quadrature_style)
+    quadrature_style = Spaces.quadrature_style(cspace.horizontal_space)
+    Nq = Quadratures.degrees_of_freedom(quadrature_style)
     # create a temporary dir for intermediate data
     mktempdir() do tmp
         mkpath(tmp)
         # write out our cubed sphere mesh
         meshfile_cc = joinpath(tmp, "mesh_cubedsphere.g")
-        ClimaCoreTempestRemap.write_exodus(meshfile_cc, hspace.topology)
+        ClimaCoreTempestRemap.write_exodus(meshfile_cc, Spaces.topology(hspace))
         meshfile_rll = joinpath(tmp, "mesh_rll.g")
         ClimaCoreTempestRemap.rll_mesh(meshfile_rll; nlat = nlat, nlon = nlon)
         meshfile_overlap = joinpath(tmp, "mesh_overlap.g")

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -137,7 +137,8 @@ function build_cache(Y, atmos, params, surface_setup, sim_info)
     end
     ᶜf = @. CT3(Geometry.WVector(ᶜf))
 
-    quadrature_style = Spaces.horizontal_space(axes(Y.c)).quadrature_style
+    quadrature_style =
+        Spaces.quadrature_style(Spaces.horizontal_space(axes(Y.c)))
     do_dss = quadrature_style isa Quadratures.GLL
     ghost_buffer =
         !do_dss ? (;) :

--- a/src/diagnostics/netcdf_writer.jl
+++ b/src/diagnostics/netcdf_writer.jl
@@ -129,7 +129,8 @@ function target_coordinates(
 
     num_points_z = num_points[]
     FT = Spaces.undertype(space)
-    vert_domain = space.topology.mesh.domain
+    topology = Spaces.topology(space)
+    vert_domain = topology.mesh.domain
     z_min, z_max = FT(vert_domain.coord_min.z), FT(vert_domain.coord_max.z)
     # We floor z_min to avoid having to deal with the singular value z = 0.
     z_min = max(z_min, 100)
@@ -159,14 +160,14 @@ add_space_coordinates_maybe!(
     nc,
     space,
     num_points,
-    Meshes.domain(space.topology);
+    Meshes.domain(Spaces.topology(space));
 )
 
 
 # For the horizontal space, we also have to look at the domain, so we define another set of
 # functions that dispatches over the domain
 target_coordinates(space::Spaces.AbstractSpectralElementSpace, num_points) =
-    target_coordinates(space, num_points, Meshes.domain(space.topology))
+    target_coordinates(space, num_points, Meshes.domain(Spaces.topology(space)))
 
 # Box
 function target_coordinates(
@@ -333,7 +334,7 @@ function add_space_coordinates_maybe!(
 
     add_dimension_maybe!(nc, name, reference_altitudes; units = "m", axis = "Z")
 
-    z_top = space.topology.mesh.domain.coord_max.z
+    z_top = Spaces.topology(space).mesh.domain.coord_max.z
 
     # Prepare output array
     desired_shape = (size(interpolated_surface)..., num_points_z)
@@ -501,7 +502,7 @@ function NetCDFWriter(;
     compression_level = 9,
 )
     space = spaces.center_space
-    hypsography = space.hypsography
+    hypsography = Spaces.grid(space).hypsography
 
     # When we are interpolating on the vertical direction, we have to deal with the pesky
     # topography. This is a little annoying to deal with because it couples the horizontal
@@ -518,7 +519,7 @@ function NetCDFWriter(;
         hpts = target_coordinates(horizontal_space, num_points)
         hcoords = hcoords_from_horizontal_space(
             horizontal_space,
-            horizontal_space.topology.mesh.domain,
+            Spaces.topology(horizontal_space).mesh.domain,
             hpts,
         )
         vcoords = []
@@ -596,7 +597,7 @@ function write_field!(
 
         hcoords = hcoords_from_horizontal_space(
             horizontal_space,
-            Meshes.domain(horizontal_space.topology),
+            Meshes.domain(Spaces.topology(horizontal_space)),
             hpts,
         )
 

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -13,8 +13,9 @@ hyperdiffusion_cache(Y, atmos) =
 hyperdiffusion_cache(Y, hyperdiff::Nothing, _) = (;)
 
 function hyperdiffusion_cache(Y, hyperdiff::ClimaHyperdiffusion, turbconv_model)
-    do_dss =
-        Spaces.horizontal_space(axes(Y.c)).quadrature_style isa Quadratures.GLL
+    quadrature_style =
+        Spaces.quadrature_style(Spaces.horizontal_space(axes(Y.c)))
+    do_dss = quadrature_style isa Quadratures.GLL
     FT = eltype(Y)
     n = n_mass_flux_subdomains(turbconv_model)
 

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -213,6 +213,11 @@ end
             "moist" => "equil",
             "rad" => "clearsky",
             "turbconv" => "diagnostic_edmfx",
+            # NOTE: We do not output diagnostics because it leads to problems with Ubuntu on
+            # GitHub actions taking too long to run (for unknown reasons). If you need this,
+            # remove the following line and check that the test runs in less than a few
+            # minutes on GitHub
+            "output_default_diagnostics" => false,
         ),
     )
     simulation = CA.get_simulation(config)


### PR DESCRIPTION
I was trying to debug the issue with a test taking forever to run on ubuntu on GitHub and I ended up cleaning a few small things. I identified the problem with the interpolating the diagnostics. I don't still don't know why this takes so long on GitHub: it is approximately 1000x slower than everywhere else. I verified that the package versions are identical (between a "good" run and a "bad" one). In any case, we don't need any diagnostic for the specific test, so I disabled them. 

The main real change in this PR is to reduce the number of syncs that are forced for NetCDF files. `sync` (= flush) was introduced because when running on a GPU, the NetCDF file will be buffered until the end of the run. This was problematic for simulations that are interrupted for any reason (all the data is lost). 

Now, `sync` is called once per cycle, ie, once all the diagnostics are called, accumulated, and reduced.

Working (ie, fast) build: https://github.com/CliMA/ClimaAtmos.jl/actions/runs/7759147548/job/21162571999