### PR TITLE
Update precipitation tendency to fix boundary condition

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -193,9 +193,6 @@ job_id:
 tracer_upwinding:
   help: "Tracer upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
   value: none
-precip_upwinding:
-  help: "Precipitation upwinding mode [`none` (default), `first_order` , `third_order`]"
-  value: none
 energy_upwinding:
   help: "Energy upwinding mode [`none` (default), `first_order` , `third_order`, `boris_book`, `zalesak`]"
   value: none

--- a/config/model_configs/single_column_precipitation_test.yml
+++ b/config/model_configs/single_column_precipitation_test.yml
@@ -10,7 +10,6 @@ dt_save_state_to_disk: "500secs"
 dt_cloud_fraction: "60secs"
 moist: "nonequil"
 precip_model: "1M"
-precip_upwinding: "first_order"
 vert_diff: "FriersonDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.yml
@@ -9,7 +9,6 @@ implicit_diffusion: true
 approximate_linear_solve_iters: 2
 moist: "equil"
 precip_model: "1M"
-precip_upwinding: "first_order"
 rad: "allskywithclear"
 idealized_insolation: false
 rayleigh_sponge: true

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -125,7 +125,6 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
     ᶜJ = Fields.local_geometry_field(Y.c).J
     (; ᶠgradᵥ_ᶜΦ, ᶜρ_ref, ᶜp_ref) = p.core
     (; ᶜh_tot, ᶜspecific, ᶠu³, ᶜp) = p.precomputed
-    (; precip_upwinding) = p.atmos.numerics
 
     @. Yₜ.c.ρ[colidx] -=
         ᶜdivᵥ(ᶠwinterp(ᶜJ[colidx], Y.c.ρ[colidx]) * ᶠu³[colidx])
@@ -156,37 +155,18 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t, colidx)
         # Advection of precipitation with the mean flow
         # is done with other passive tracers in the explicit tendency.
         # Here we add the advection with precipitation terminal velocity
-        # using first order upwind and free outflow bottom boundary condition
+        # using downward biasing and free outflow bottom boundary condition
 
-        ᶠu³ₚ = p.scratch.ᶠtemp_CT3
         ᶠlg = Fields.local_geometry_field(Y.f)
-
-        @. ᶠu³ₚ[colidx] =
-            ᶠinterp(-p.precomputed.ᶜwᵣ[colidx]) *
-            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx]))
-        vertical_transport!(
-            Yₜ.c.ρq_rai[colidx],
-            ᶜJ[colidx],
-            Y.c.ρ[colidx],
-            ᶠu³ₚ[colidx],
-            ᶜspecific.q_rai[colidx],
-            dt,
-            precip_upwinding,
-            ᶜprecipdivᵥ,
+        @. Yₜ.c.ρq_rai[colidx] -= ᶜprecipdivᵥ(
+            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx])) *
+            ᶠwinterp(ᶜJ[colidx], Y.c.ρ[colidx]) *
+            ᶠright_bias(-p.precomputed.ᶜwᵣ[colidx] * ᶜspecific.q_rai[colidx]),
         )
-
-        @. ᶠu³ₚ[colidx] =
-            ᶠinterp(-p.precomputed.ᶜwₛ[colidx]) *
-            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx]))
-        vertical_transport!(
-            Yₜ.c.ρq_sno[colidx],
-            ᶜJ[colidx],
-            Y.c.ρ[colidx],
-            ᶠu³ₚ[colidx],
-            ᶜspecific.q_sno[colidx],
-            dt,
-            precip_upwinding,
-            ᶜprecipdivᵥ,
+        @. Yₜ.c.ρq_sno[colidx] -= ᶜprecipdivᵥ(
+            CT3(unit_basis_vector_data(CT3, ᶠlg[colidx])) *
+            ᶠwinterp(ᶜJ[colidx], Y.c.ρ[colidx]) *
+            ᶠright_bias(-p.precomputed.ᶜwₛ[colidx] * ᶜspecific.q_sno[colidx]),
         )
     end
 

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -92,7 +92,6 @@ function get_numerics(parsed_args)
 
     energy_upwinding = Val(Symbol(parsed_args["energy_upwinding"]))
     tracer_upwinding = Val(Symbol(parsed_args["tracer_upwinding"]))
-    precip_upwinding = Val(Symbol(parsed_args["precip_upwinding"]))
     edmfx_upwinding = Val(Symbol(parsed_args["edmfx_upwinding"]))
     edmfx_sgsflux_upwinding =
         Val(Symbol(parsed_args["edmfx_sgsflux_upwinding"]))
@@ -103,7 +102,6 @@ function get_numerics(parsed_args)
     numerics = AtmosNumerics(;
         energy_upwinding,
         tracer_upwinding,
-        precip_upwinding,
         edmfx_upwinding,
         edmfx_sgsflux_upwinding,
         limiter,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -329,20 +329,11 @@ struct Implicit <: AbstractTimesteppingMode end
 
 struct QuasiMonotoneLimiter end # For dispatching to use the ClimaCore QuasiMonotoneLimiter.
 
-Base.@kwdef struct AtmosNumerics{
-    EN_UP,
-    TR_UP,
-    PR_UP,
-    ED_UP,
-    ED_SG_UP,
-    DYCORE,
-    LIM,
-}
+Base.@kwdef struct AtmosNumerics{EN_UP, TR_UP, ED_UP, ED_SG_UP, DYCORE, LIM}
 
     """Enable specific upwinding schemes for specific equations"""
     energy_upwinding::EN_UP
     tracer_upwinding::TR_UP
-    precip_upwinding::PR_UP
     edmfx_upwinding::ED_UP
     edmfx_sgsflux_upwinding::ED_SG_UP
 

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -22,15 +22,18 @@ const wcurlₕ = Operators.WeakCurl()
 
 const ᶜinterp = Operators.InterpolateF2C()
 const ᶜdivᵥ = Operators.DivergenceF2C()
+const ᶜgradᵥ = Operators.GradientF2C()
+
+# Tracers do not have advective fluxes through the top and bottom cell faces.
 const ᶜadvdivᵥ = Operators.DivergenceF2C(
     bottom = Operators.SetValue(CT3(0)),
     top = Operators.SetValue(CT3(0)),
-) # Tracers do not have advective fluxes through the top and bottom cell faces
-const ᶜprecipdivᵥ = Operators.DivergenceF2C(
-    top = Operators.SetValue(CT3(0)),
-    bottom = Operators.SetDivergence(0),
-) # Precipitation has no flux at the top, but it has free outflow at the bottom
-const ᶜgradᵥ = Operators.GradientF2C()
+)
+
+# Precipitation has no flux at the top, but it has free outflow at the bottom.
+const ᶜprecipdivᵥ = Operators.DivergenceF2C(top = Operators.SetValue(CT3(0)))
+
+const ᶠright_bias = Operators.RightBiasedC2F() # for free outflow in ᶜprecipdivᵥ
 
 # TODO: Implement proper extrapolation instead of simply reusing the first
 # interior value at the surface.
@@ -78,6 +81,7 @@ const ᶜinterp_matrix = MatrixFields.operator_matrix(ᶜinterp)
 const ᶜdivᵥ_matrix = MatrixFields.operator_matrix(ᶜdivᵥ)
 const ᶜadvdivᵥ_matrix = MatrixFields.operator_matrix(ᶜadvdivᵥ)
 const ᶜprecipdivᵥ_matrix = MatrixFields.operator_matrix(ᶜprecipdivᵥ)
+const ᶠright_bias_matrix = MatrixFields.operator_matrix(ᶠright_bias)
 const ᶠinterp_matrix = MatrixFields.operator_matrix(ᶠinterp)
 const ᶠwinterp_matrix = MatrixFields.operator_matrix(ᶠwinterp)
 const ᶠgradᵥ_matrix = MatrixFields.operator_matrix(ᶠgradᵥ)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR changes the advection of precipitation at terminal velocity to use the `RightBiasC2F()` operator instead of the `vertical_transport!` function. This fixes the instability from the bottom boundary condition that we have been seeing in simulations with one-moment microphysics.

This also removes `precip_upwinding` from the `config`, since we will always use the first-order downward biasing operator `RightBiasC2F()`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
