### PR TITLE
Add support for comparison plots

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -41,15 +41,15 @@ allocs_limit = Dict()
 allocs_limit["flame_perf_target"] = 275_800
 allocs_limit["flame_perf_target_tracers"] = 305_776
 allocs_limit["flame_perf_target_edmfx"] = 7_005_552
-allocs_limit["flame_perf_diagnostics"] = 108876856
-allocs_limit["flame_perf_target_diagnostic_edmfx"] = 531_000
+allocs_limit["flame_perf_diagnostics"] = 108_877_816
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 401_944
 allocs_limit["flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"] =
     4_018_252_656
-allocs_limit["flame_perf_target_frierson"] = 8_030_551_088
+allocs_limit["flame_perf_target_frierson"] = 4_015_545_328
 allocs_limit["flame_perf_target_threaded"] = 1_276_864
 allocs_limit["flame_perf_target_callbacks"] = 394_984
 allocs_limit["flame_perf_gw"] = 3_268_961_856
-allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 445_664
+allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 299_616
 allocs_limit["flame_gpu_implicit_barowave_moist"] = 4_178_384
 # Ideally, we would like to track all the allocations, but this becomes too
 # expensive there is too many of them. Here, we set the default sample rate to


### PR DESCRIPTION
With this PR, `make_plots` can now also produce a PDF report that compares multiple outputs. 
Suppose you ran the simulation `aquaplanet` three times and the output is in `output/run1`, `output/run2`, `output/run3`. 
With `make_plots(Val(:aquaplent), "output/run1")` the usual PDF report is generated. But with With `make_plots(Val(:aquaplent), ["output/run1", "output/run2", "output/run3")`  the same report is generated but with the output from the three simulations side-by-side.

For example, for two simulations, the output would look something like:
![image](https://github.com/CliMA/ClimaAtmos.jl/assets/9167485/af46dc43-af2f-4a4e-9e16-a96fc0a1b8e3)
(In this case the two columns are identical because I didn't have two datasets to compare, so I compared twice the same data).

For the time being, no check is performed that the two folders have the same output variables. 
