### PR TITLE
Add 1-moment microphysics coupled to grid-mean state to longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -91,7 +91,7 @@ steps:
           slurm_ntasks: 64
           slurm_mem_per_cpu: 16GB
           slurm_time: 24:00:00
-    
+
       - label: ":computer: aquaplanet equilmoist clearsky radiation + diagnostic edmf diffusion only + 0M microphysics"
         command:
           - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
@@ -125,10 +125,21 @@ steps:
         env:
           JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth"
 
+      - label: ":computer: aquaplanet equilmoist clearsky radiation + 1M microphysics"
+        command:
+          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
+        artifact_paths: "$$JOB_NAME/*"
+        agents:
+          slurm_ntasks: 64
+          slurm_mem_per_cpu: 16GB
+          slurm_time: 24:00:00
+        env:
+          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_1M"
+
   - group: "Low resolution long runs"
 
     steps:
-          
+
       - label: ":computer: low resolution aquaplanet equilmoist clearsky radiation + time-varying insolation + slab ocean"
         command:
           - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
@@ -169,7 +180,7 @@ steps:
           slurm_time: 24:00:00
         env:
           JOB_NAME: "longrun_aquaplanet_amip"
-  
+
   - group: "atmos-only coupler runs"
 
     steps:

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_1M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_1M.yml
@@ -1,0 +1,22 @@
+dt: "120secs"
+t_end: "10days"
+h_elem: 16
+z_elem: 63
+dz_bottom: 30.0
+dz_top: 3000.0
+z_max: 55000.0
+rayleigh_sponge: true
+moist: "equil"
+precip_model: "1M"
+surface_setup: "DefaultMoninObukhov"
+vert_diff: "FriersonDiffusion"
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
+rad: "clearsky"
+dt_rad: "6hours"
+job_id: "longrun_1M"
+toml: [toml/longrun_1M.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [cl, cli, clw, husra, hussn, ta, hus, hur, lmix]
+    period: 2days

--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -375,3 +375,17 @@ It is assummed that some fraction ``\alpha`` of snow is melted during the proces
 ```math
 \frac{d}{dt} \rho e = \rho \mathcal{S}_{acc} ((1+\alpha) I_{liq} - \alpha I_{ice} + \Phi)
 ```
+
+### Stability and positivity
+
+All source terms are individually limited such that they don't exceed the
+  available tracer specific humidity.
+```math
+\mathcal{S}_{x \rightarrow y} = min(\mathcal{S}_{x \rightarrow y}, \frac{q_{x}}{dt})
+```
+This will not ensure positivity because the sum of all source terms,
+  combined with the advection tendency,
+  could still drive the solution to negative numbers.
+It should however help mitigate some of the problems.
+The source terms functions treat negative specific humidities as zeros,
+  so the simulations should be stable even with small negative numbers.

--- a/docs/src/longruns.md
+++ b/docs/src/longruns.md
@@ -71,7 +71,7 @@ and 0-moment microphysics.
 ```
 longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean
 
-Aquaplanet with slab ocean with time-varying insolation, clear-sky radiation, 
+Aquaplanet with slab ocean with time-varying insolation, clear-sky radiation,
 and 0-moment microphysics.
 Test if the coupled system conserves energy and water.
 Test if the time-varying insolation yields reasonable results.
@@ -81,6 +81,12 @@ longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth
 
 Aquaplanet with idealized insolation, clear-sky radiation, 0-moment microphysics, and
 Earth topography. Use this job to test topography related features.
+```
+```
+longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_1M
+
+Aquaplanet with idealized insolation, clear-sky radiation, 1-moment microphysics.
+Use this job to test 1-moment microphysics related features.
 ```
 ```
 longrun_bw_rhoe_equil_highres_topography_earth

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -17,9 +17,17 @@ function set_precipitation_precomputed_quantities!(Y, p, t)
     cmp = CAP.microphysics_params(p.params)
 
     # compute the precipitation terminal velocity [m/s]
-    @. ᶜwᵣ =
-        CM1.terminal_velocity(cmp.pr, cmp.tv.rain, Y.c.ρ, Y.c.ρq_rai / Y.c.ρ)
-    @. ᶜwₛ =
-        CM1.terminal_velocity(cmp.ps, cmp.tv.snow, Y.c.ρ, Y.c.ρq_sno / Y.c.ρ)
+    @. ᶜwᵣ = CM1.terminal_velocity(
+        cmp.pr,
+        cmp.tv.rain,
+        Y.c.ρ,
+        abs(Y.c.ρq_rai / Y.c.ρ),
+    )
+    @. ᶜwₛ = CM1.terminal_velocity(
+        cmp.ps,
+        cmp.tv.snow,
+        Y.c.ρ,
+        abs(Y.c.ρq_sno / Y.c.ρ),
+    )
     return nothing
 end

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -221,6 +221,8 @@ NVTX.@annotate function tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
     # TODO: Figure out why caching the duplicated tendencies in ᶜtemp_scalar
     # triggers allocations.
     for (ᶜρχₜ, ᶜ∇²χ, χ_name) in matching_subfields(Yₜ.c, ᶜ∇²specific_tracers)
+        ν₄_scalar =
+            ifelse(χ_name in (:q_rai, :q_sno), 0.1 * ν₄_scalar, ν₄_scalar)
         @. ᶜρχₜ -= ν₄_scalar * wdivₕ(Y.c.ρ * gradₕ(ᶜ∇²χ))
         if !(χ_name in (:q_rai, :q_sno))
             @. Yₜ.c.ρ -= ν₄_scalar * wdivₕ(Y.c.ρ * gradₕ(ᶜ∇²χ))

--- a/toml/longrun_1M.toml
+++ b/toml/longrun_1M.toml
@@ -1,0 +1,3 @@
+[zd_rayleigh]
+value = 35000.0
+type = "float"


### PR DESCRIPTION
This PR adds the 1-moment microphysics to the longruns. The simulation can run for about 24 days before crashing. I'll be looking into it in the upcoming days. But maybe this is good enough to also start testing on the GPU and/or with topography?

There are some negative numbers in the simulations and sometimes they are too big for comfort. I'll be looking into that.

The actual heavy lifting regarding the boundary conditions for precipitation was done here: https://github.com/CliMA/ClimaAtmos.jl/pull/2626

On top of that here I'm:
- decreasing the hyperdiffusion for precipitation
- limiting the precipitation tendencies individually by tracer/dt. This does not guarantee the positivity, but it's at least some approximation of what could be needed.
- allowing the negative precipitation tracers to be advected