### PR TITLE
reduce t_end in gpu_aquaplanet_dyamond.yml

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond.yml
@@ -15,6 +15,6 @@ vert_diff: "true"
 surface_setup: "DefaultMoninObukhov" 
 rayleigh_sponge: true
 dt: "50secs" 
-t_end: "1days"
+t_end: "12hours"
 job_id: "gpu_aquaplanet_dyamond" 
 toml: [toml/longrun_aquaplanet_dyamond.toml]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
`gpu_aquaplanet_dyamond` takes ~45 minutes to complete. Together with the waiting time for a GPU, this job is ~20 minutes longer than the second longest job in ci. Therefore I reduce t_end for this job.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
