### PR TITLE
Resolution -> size kwarg, fix deprecation warning

### DIFF
--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -119,7 +119,7 @@ function make_plots_generic(
     vars_left_to_plot = length(vars)
 
     # Define fig, grid, and grid_pos, used below. (Needed for scope)
-    makefig() = CairoMakie.Figure(resolution = (900, 300 * MAX_NUM_ROWS))
+    makefig() = CairoMakie.Figure(; size = (900, 300 * MAX_NUM_ROWS))
     gridlayout() =
         map(1:MAX_PLOTS_PER_PAGE) do i
             row = mod(div(i - 1, MAX_NUM_COLS), MAX_NUM_ROWS) + 1
@@ -273,7 +273,7 @@ function make_plots(::Val{:single_column_precipitation_test}, simulation_path)
 
     # We first prepare the axes with all the nice labels with ClimaAnalysis, then we use
     # CairoMakie to add the additional lines.
-    fig = CairoMakie.Figure(resolution = (1200, 600))
+    fig = CairoMakie.Figure(; size = (1200, 600))
 
     p_loc = [1, 1]
 

--- a/post_processing/plot_scaling_results.jl
+++ b/post_processing/plot_scaling_results.jl
@@ -71,7 +71,7 @@ num_ticks = 4
 min_tick, max_tick = extrema(sypd_clima_atmos)
 tick_size = (max_tick - min_tick) / num_ticks
 
-fig = Figure(resolution = (1200, 900))
+fig = Figure(; size = (1200, 900))
 Makie.Label(
     fig[begin - 1, 1:2],
     "$resolution scaling";


### PR DESCRIPTION
This PR fixes some warnings in the log:

```
┌ Warning: Found `resolution` in the theme when creating a `Scene`. The `resolution` keyword for `Scene`s and `Figure`s has been deprecated. Use `Figure(; size = ...` or `Scene(; size = ...)` instead, which better reflects that this is a unitless size and not a pixel resolution. The key could also come from `set_theme!` calls or related theming functions.
```