### PR TITLE
Improve stack traces in offline perf scripts

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -1,3 +1,4 @@
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import Random
 Random.seed!(1234)
 import ClimaAtmos as CA

--- a/perf/benchmark_dump.jl
+++ b/perf/benchmark_dump.jl
@@ -1,3 +1,4 @@
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import Random
 Random.seed!(1234)
 import ClimaAtmos as CA

--- a/perf/benchmark_step.jl
+++ b/perf/benchmark_step.jl
@@ -11,6 +11,7 @@ push!(ARGS, "--h_elem", "6")
 include(joinpath("perf", "benchmark_step.jl"));
 ```
 =#
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import Random
 Random.seed!(1234)
 import ClimaAtmos as CA

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -1,3 +1,4 @@
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 import YAML
 
 """


### PR DESCRIPTION
This PR adds more NVTX annotations, and should improve the performance stack traces with depth-limited types.

cc @bloops 