### PR TITLE
Shrink EnvBuoyGradVars

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -763,7 +763,6 @@ function set_diagnostic_edmf_precomputed_quantities_env_closures!(Y, p, t)
         thermo_params,
         moisture_model,
         EnvBuoyGradVars(
-            thermo_params,
             ᶜts,
             projected_vector_buoy_grad_vars(
                 C3,

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -264,7 +264,6 @@ function set_prognostic_edmf_precomputed_quantities_closures!(Y, p, t)
         thermo_params,
         moisture_model,
         EnvBuoyGradVars(
-            thermo_params,
             ᶜts⁰,
             projected_vector_buoy_grad_vars(
                 C3,

--- a/src/prognostic_equations/gm_sgs_closures.jl
+++ b/src/prognostic_equations/gm_sgs_closures.jl
@@ -37,7 +37,6 @@ function compute_gm_mixing_length!(ᶜmixing_length, Y, p)
         thermo_params,
         p.atmos.moisture_model,
         EnvBuoyGradVars(
-            thermo_params,
             ᶜts,
             projected_vector_buoy_grad_vars(
                 C3,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -131,76 +131,19 @@ Base.broadcastable(x::BuoyGradMean) = tuple(x)
 
 Variables used in the environmental buoyancy gradient computation.
 """
-Base.@kwdef struct EnvBuoyGradVars{FT}
-    "temperature in the saturated part"
-    t_sat::FT
-    "vapor specific humidity  in the saturated part"
-    qv_sat::FT
-    "total specific humidity in the saturated part"
-    qt_sat::FT
-    "liquid specific humidity in the saturated part"
-    ql_sat::FT
-    "ice specific humidity in the saturated part"
-    qi_sat::FT
-    "potential temperature in the saturated part"
-    θ_sat::FT
-    "liquid ice potential temperature in the saturated part"
-    θ_liq_ice_sat::FT
-    "reference pressure"
-    p::FT
-    "cloud fraction"
-    en_cld_frac::FT
-    "density"
-    ρ::FT
-    "virtual potential temperature gradient in the non saturated part"
+Base.@kwdef struct EnvBuoyGradVars{FT, TS}
+    ts::TS
     ∂θv∂z_unsat::FT
-    "total specific humidity gradient in the saturated part"
     ∂qt∂z_sat::FT
-    "liquid ice potential temperature gradient in the saturated part"
     ∂θl∂z_sat::FT
 end
 
 function EnvBuoyGradVars(
-    thermo_params,
     ts::TD.ThermodynamicState,
     ∂θv∂z_unsat_∂qt∂z_sat_∂θl∂z_sat,
 )
     (; ∂θv∂z_unsat, ∂qt∂z_sat, ∂θl∂z_sat) = ∂θv∂z_unsat_∂qt∂z_sat_∂θl∂z_sat
-    return EnvBuoyGradVars(thermo_params, ts, ∂θv∂z_unsat, ∂qt∂z_sat, ∂θl∂z_sat)
-end
-
-function EnvBuoyGradVars(
-    thermo_params,
-    ts::TD.ThermodynamicState,
-    ∂θv∂z_unsat::FT,
-    ∂qt∂z_sat::FT,
-    ∂θl∂z_sat::FT,
-) where {FT}
-    t_sat = TD.air_temperature(thermo_params, ts)
-    qv_sat = TD.vapor_specific_humidity(thermo_params, ts)
-    qt_sat = TD.total_specific_humidity(thermo_params, ts)
-    ql_sat = TD.liquid_specific_humidity(thermo_params, ts)
-    qi_sat = TD.ice_specific_humidity(thermo_params, ts)
-    θ_sat = TD.dry_pottemp(thermo_params, ts)
-    θ_liq_ice_sat = TD.liquid_ice_pottemp(thermo_params, ts)
-    p = TD.air_pressure(thermo_params, ts)
-    en_cld_frac = ifelse(TD.has_condensate(thermo_params, ts), 1, 0)
-    ρ = TD.air_density(thermo_params, ts)
-    return EnvBuoyGradVars{FT}(
-        t_sat,
-        qv_sat,
-        qt_sat,
-        ql_sat,
-        qi_sat,
-        θ_sat,
-        θ_liq_ice_sat,
-        p,
-        en_cld_frac,
-        ρ,
-        ∂θv∂z_unsat,
-        ∂qt∂z_sat,
-        ∂θl∂z_sat,
-    )
+    return EnvBuoyGradVars(ts, ∂θv∂z_unsat, ∂qt∂z_sat, ∂θl∂z_sat)
 end
 
 Base.eltype(::EnvBuoyGradVars{FT}) where {FT} = FT


### PR DESCRIPTION
This PR reduces the number of fields in `EnvBuoyGradVars` in order to reduce the loads/stores in the buoyancy kernel. This should be better on gpus, too.