### PR TITLE
Remove windows from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
GitHub action fails with

```
ERROR: LoadError: Error building `FFMPEG`:
ERROR: LoadError: Unable to open libLLVM!
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:35
  [2] (::BinaryProvider.var"#open_libllvm#124")()
    @ BinaryProvider C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\PlatformNames.jl:652
  [3] detect_cxx11_string_abi()
    @ BinaryProvider C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\PlatformNames.jl:655
  [4] detect_compiler_abi()
    @ BinaryProvider C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\PlatformNames.jl:668
  [5] top-level scope
    @ C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\PlatformNames.jl:685
  [6] include(mod::Module, _path::String)
    @ Base .\Base.jl:495
  [7] include(x::String)
    @ BinaryProvider C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\BinaryProvider.jl:1
  [8] top-level scope
    @ C:\Users\runneradmin\.julia\packages\BinaryProvider\U2dKK\src\BinaryProvider.jl:12
  [9] include
    @ .\Base.jl:495 [inlined]
 [10] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::String)
    @ Base .\loading.jl:2222
 [11] top-level scope
    @ stdin:3
```

I looked into this a little bit and there's no clear/easy fix. I am not convinced that it is worth our efforts fixing the window CI all the time, so I'd drop it (again).
