### PR TITLE
Move hydrostatic balance to gpu pipeline

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -43,17 +43,6 @@ steps:
 
     steps:
 
-      - label: ":computer: hydrostatic balance (ρe_tot)"
-        command:
-          - srun julia --color=yes --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
-        artifact_paths: "$$JOB_NAME/*"
-        agents:
-          slurm_gpus: 1
-          slurm_ntasks: 32
-          slurm_time: 24:00:00
-        env:
-          JOB_NAME: "longrun_sphere_hydrostatic_balance_rhoe"
-
       # TODO: uncomment when zalesak works
       # - label: ":computer: lim ARS zalesak baroclinic wave (ρe_tot) equilmoist high resolution"
       #   command:

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -42,6 +42,17 @@ steps:
   - group: "Targeted resolution AMIP long runs"
     steps:
 
+      - label: ":computer: hydrostatic balance (ρe_tot)"
+        command:
+          - srun julia --color=yes --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml
+        artifact_paths: "$$JOB_NAME/*"
+        agents:
+          slurm_gpus: 1
+          slurm_cpus_per_task: 4
+          slurm_time: 24:00:00
+        env:
+          JOB_NAME: "longrun_sphere_hydrostatic_balance_rhoe"
+
       - label: ":computer: dry baroclinic wave"
         command:
           - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml


### PR DESCRIPTION
This PR moves the hydrostatic balance job to the gpu pipeline, and reduces the required resources.