### PR TITLE
Disable nsys profiling in buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -665,9 +665,9 @@ steps:
       - label: "GPU: GPU dry baroclinic wave"
         key: "target_gpu_implicit_baroclinic_wave"
         command:
+            # nsys profile --trace=nvtx,cuda --output=target_gpu_implicit_baroclinic_wave/report
           - mkdir -p target_gpu_implicit_baroclinic_wave
           - >
-            nsys profile --trace=nvtx,cuda --output=target_gpu_implicit_baroclinic_wave/report
             julia --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}target_gpu_implicit_baroclinic_wave.yml
         artifact_paths: "target_gpu_implicit_baroclinic_wave/*"
@@ -678,10 +678,10 @@ steps:
       - label: "GPU: GPU dry baroclinic wave - 4 gpus"
         key: "target_gpu_implicit_baroclinic_wave_4process"
         command:
+            # nsys profile --trace=nvtx,cuda,mpi --output=target_gpu_implicit_baroclinic_wave_4process/report-%q{PMI_RANK}
           - mkdir -p target_gpu_implicit_baroclinic_wave_4process
           - >
             srun --cpu-bind=threads --cpus-per-task=4
-            nsys profile --trace=nvtx,cuda,mpi --output=target_gpu_implicit_baroclinic_wave_4process/report-%q{PMI_RANK}
             julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}target_gpu_implicit_baroclinic_wave_4process.yml
         artifact_paths: "target_gpu_implicit_baroclinic_wave_4process/*"
@@ -705,9 +705,9 @@ steps:
 
       - label: "GPU: gpu_aquaplanet_dyamond"
         command:
+            # nsys profile --trace=nvtx,cuda --output=gpu_aquaplanet_dyamond/report
           - mkdir -p gpu_aquaplanet_dyamond
           - >
-            nsys profile --trace=nvtx,cuda --output=gpu_aquaplanet_dyamond/report
             julia --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}gpu_aquaplanet_dyamond.yml
         artifact_paths: "gpu_aquaplanet_dyamond/*"


### PR DESCRIPTION
This PR disables nsys profiling in buildkite CI, hopefully allowing us to sidestep recent issues with GPU in CI.