### PR TITLE
overwrite duplicate diagnostics

### DIFF
--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -152,8 +152,14 @@ function add_diagnostic_variable!(;
     comments = "",
     compute!,
 )
-    haskey(ALL_DIAGNOSTICS, short_name) &&
-        error("diagnostic $short_name already defined")
+    haskey(ALL_DIAGNOSTICS, short_name) && @warn(
+        "overwriting diagnostic `$short_name` entry containing fields\n" *
+        "$(map(
+            field -> "$(getfield(ALL_DIAGNOSTICS[short_name], field))",
+            filter(field -> field != :compute!, fieldnames(DiagnosticVariable)),
+        ))"
+    )
+
 
     ALL_DIAGNOSTICS[short_name] = DiagnosticVariable(;
         short_name,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Instead of raising an error when a user tries to add a diagnostic that already exists, this PR warns the user and overwrites the existing diagnostic with the new entry.

closes #2709
