### PR TITLE
add a simple edmf test case

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -544,6 +544,14 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":genie: Prognostic EDMFX simple plume test in a column"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_simpleplume_column.yml
+        artifact_paths: "prognostic_edmfx_simpleplume_column/*"
+        agents:
+          slurm_mem: 20GB
+
       - label: ":genie: Prognostic EDMFX GABLS in a box"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl

--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -5,6 +5,9 @@ turbconv:
 advection_test:
   help: "Switches off all grid-scale and subgrid-scale momentum tendencies [`false` (default), `true`]"
   value: false
+gs_tendency:
+  help: "Turns on all grid-scale tendencies [`true` (default), `false`]"
+  value: true
 edmf_coriolis:
   help: "EDMF coriolis [`nothing` (default), `Bomex`,`LifeCycleTan2018`,`Rico`,`ARM_SGP`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
   value: ~

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -1,0 +1,29 @@
+job_id: "prognostic_edmfx_simpleplume_column"
+initial_condition: "SimplePlume"
+surface_setup: "SimplePlume"
+turbconv: "prognostic_edmfx"
+gs_tendency: false
+edmfx_upwinding: first_order
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+prognostic_tke: true
+moist: "equil"
+config: "column"
+z_max: 4e3
+z_elem: 80
+z_stretch: false
+perturb_initstate: false
+dt: "1secs"
+t_end: "6hours"
+dt_save_to_disk: "10mins"
+toml: [toml/prognostic_edmfx_simpleplume.toml]
+netcdf_output_at_levels: true
+netcdf_interpolation_num_points: [2, 2, 80]
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl]
+    period: 10mins
+  - short_name: [arup, waup, taup, rhoaup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
+    period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -896,6 +896,7 @@ EDMFBoxPlots = Union{
     Val{:prognostic_edmfx_dycoms_rf01_box},
     Val{:prognostic_edmfx_rico_column},
     Val{:prognostic_edmfx_trmm_column},
+    Val{:prognostic_edmfx_simpleplume_column},
 }
 
 """

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -43,6 +43,7 @@ include(joinpath("utils", "discrete_hydrostatic_balance.jl"))
 
 include(joinpath("prognostic_equations", "pressure_work.jl"))
 include(joinpath("prognostic_equations", "zero_velocity.jl"))
+include(joinpath("prognostic_equations", "zero_gridscale_tendency.jl"))
 
 include(joinpath("prognostic_equations", "implicit", "implicit_tendency.jl"))
 include(joinpath("prognostic_equations", "implicit", "implicit_solver.jl"))

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -571,6 +571,34 @@ function (initial_condition::MoistAdiabaticProfileEDMFX)(params)
     return local_state
 end
 
+"""
+    SimplePlume(; perturb = true)
+
+An `InitialCondition` with a moist adiabatic temperature profile
+"""
+Base.@kwdef struct SimplePlume <: InitialCondition
+    prognostic_tke::Bool = false
+end
+
+function (initial_condition::SimplePlume)(params)
+    function local_state(local_geometry)
+        FT = eltype(params)
+        thermo_params = CAP.thermodynamics_params(params)
+        temp_profile = DryAdiabaticProfile{FT}(thermo_params, FT(310), FT(290))
+
+        (; z) = local_geometry.coordinates
+        T, p = temp_profile(thermo_params, z)
+        q_tot = FT(0)
+
+        return LocalState(;
+            params,
+            geometry = local_geometry,
+            thermo_state = TD.PhaseEquil_pTq(thermo_params, p, T, q_tot),
+            turbconv_state = EDMFState(; tke = FT(0)),
+        )
+    end
+    return local_state
+end
 ##
 ## EDMF Test Cases
 ##

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -33,6 +33,10 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
         # NOTE: This will zero out all monmentum tendencies in the edmfx advection test
         # please DO NOT add additional velocity tendencies after this function
         zero_velocity_tendency!(Yₜ, Y, p, t, colidx)
+
+        # NOTE: This will zero out all grid-scale tendencies in the simple edmfx test
+        # please DO NOT add additional grid-scale tendencies after this function
+        zero_gridscale_tendency!(Yₜ, Y, p, t, colidx)
     end
     return nothing
 end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -79,6 +79,10 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
         # NOTE: This will zero out all momentum tendencies in the edmfx advection test
         # please DO NOT add additional velocity tendencies after this function
         zero_velocity_tendency!(Yₜ, Y, p, t, colidx)
+
+        # NOTE: This will zero out all grid-scale tendencies in the simple edmfx test
+        # please DO NOT add additional grid-scale tendencies after this function
+        zero_gridscale_tendency!(Yₜ, Y, p, t, colidx)
     end
     # TODO: make bycolumn-able
     non_orographic_gravity_wave_tendency!(

--- a/src/prognostic_equations/zero_gridscale_tendency.jl
+++ b/src/prognostic_equations/zero_gridscale_tendency.jl
@@ -1,0 +1,17 @@
+###
+### simple edmfx test 
+###
+
+function zero_gridscale_tendency!(Yₜ, Y, p, t, colidx)
+    # turn off all grid-scale tendencies in the simple edmfx test
+    if !p.atmos.gs_tendency
+        @. Yₜ.c.ρ[colidx] = 0
+        @. Yₜ.c.uₕ[colidx] = C12(0, 0)
+        @. Yₜ.f.u₃[colidx] = C3(0)
+        @. Yₜ.c.ρe_tot[colidx] = 0
+        for ρχ_name in filter(is_tracer_var, propertynames(Y.c))
+            @. Yₜ.c.:($$ρχ_name)[colidx] = 0
+        end
+    end
+    return nothing
+end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -26,6 +26,9 @@ function get_atmos(config::AtmosConfig, params)
     advection_test = parsed_args["advection_test"]
     @assert advection_test in (false, true)
 
+    gs_tendency = parsed_args["gs_tendency"]
+    @assert gs_tendency in (false, true)
+
     edmfx_entr_model = get_entrainment_model(parsed_args)
     edmfx_detr_model = get_detrainment_model(parsed_args)
 
@@ -53,6 +56,7 @@ function get_atmos(config::AtmosConfig, params)
         ls_adv = get_large_scale_advection_model(parsed_args, FT),
         edmf_coriolis = get_edmf_coriolis(parsed_args, FT),
         advection_test,
+        gs_tendency,
         edmfx_entr_model,
         edmfx_detr_model,
         edmfx_sgs_mass_flux,
@@ -317,6 +321,7 @@ function get_initial_condition(parsed_args)
         "DYCOMS_RF02",
         "Rico",
         "TRMM_LBA",
+        "SimplePlume",
     ]
         return getproperty(ICs, Symbol(parsed_args["initial_condition"]))(
             parsed_args["prognostic_tke"],

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -327,6 +327,7 @@ Base.@kwdef struct AtmosModel{
     LA,
     EC,
     AT,
+    GT,
     EEM,
     EDM,
     ESMF,
@@ -356,6 +357,7 @@ Base.@kwdef struct AtmosModel{
     ls_adv::LA = nothing
     edmf_coriolis::EC = nothing
     advection_test::AT = nothing
+    gs_tendency::GT = nothing
     edmfx_entr_model::EEM = nothing
     edmfx_detr_model::EDM = nothing
     edmfx_sgs_mass_flux::ESMF = nothing

--- a/src/surface_conditions/surface_setups.jl
+++ b/src/surface_conditions/surface_setups.jl
@@ -230,3 +230,18 @@ function (::TRMM_LBA)(params)
     end
     return surface_state
 end
+
+struct SimplePlume end
+function (::SimplePlume)(params)
+    FT = eltype(params)
+    T = FT(310)
+    p = FT(101500)
+    q_vap = FT(0.02245)
+    θ_flux = FT(8e-3)
+    q_flux = FT(0)
+    z0 = FT(1e-4)
+    ustar = FT(0.28)
+    fluxes = θAndQFluxes(; θ_flux, q_flux)
+    parameterization = MoninObukhov(; z0, fluxes, ustar)
+    return SurfaceState(; parameterization, T, p, q_vap)
+end

--- a/toml/prognostic_edmfx_simpleplume.toml
+++ b/toml/prognostic_edmfx_simpleplume.toml
@@ -1,0 +1,47 @@
+[EDMF_surface_area]
+value = 0.1
+type = "float"
+
+[EDMF_min_area]
+value = 1.0e-5
+type = "float" 
+
+[EDMF_max_area]
+value = 0.7
+type = "float"
+
+[entr_inv_tau]
+value = 0.0001
+type = "float"
+
+[entr_coeff]
+value = 0
+type = "float"
+
+[min_area_limiter_scale]
+value = 0
+type = "float"
+
+[min_area_limiter_power]
+value = 10
+type = "float"
+
+[detr_inv_tau]
+value = 0
+type = "float"
+
+[detr_coeff]
+value = 0
+type = "float"
+
+[detr_buoy_coeff]
+value = 0.3
+type = "float"
+
+[detr_vertdiv_coeff]
+value = 0
+type = "float"
+
+[max_area_limiter_scale]
+value = 0.01
+type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a simple plume test case for edmf. This includes adding a flag for turning off grid-scale tendencies. It would be useful for testing the numerics for edmf.

Closes #2706 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
