### PR TITLE
remove some gpu jobs from ci

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -638,29 +638,6 @@ steps:
           - "sphere_baroclinic_wave_rhoe"
           - "gpu_baroclinic_wave_rhoe"
 
-      - label: "GPU: HS (ρe) hightop"
-        key: "gpu_held_suarez_rhoe_hightop"
-        command: >
-          julia --color=yes --project=examples examples/hybrid/driver.jl
-          --config_file $PERF_CONFIG_PATH/gpu_held_suarez_rhoe_hightop.yml
-        artifact_paths: "gpu_held_suarez_rhoe_hightop/*"
-        agents:
-          slurm_gpus: 1
-
-      - label: "GPU: compare HS (ρe) hightop with CPU"
-        command: >
-          tar xvf sphere_held_suarez_rhoe_hightop/hdf5_files.tar -C sphere_held_suarez_rhoe_hightop
-
-          tar xvf gpu_held_suarez_rhoe_hightop/hdf5_files.tar -C gpu_held_suarez_rhoe_hightop
-
-          julia --color=yes --project=examples post_processing/compare_outputs.jl
-          --output_folder_1 sphere_held_suarez_rhoe_hightop/
-          --output_folder_2 gpu_held_suarez_rhoe_hightop/
-          --t_end 8days --compare_state false
-        depends_on:
-          - "sphere_held_suarez_rhoe_hightop"
-          - "gpu_held_suarez_rhoe_hightop"
-
       - label: "GPU: GPU dry baroclinic wave"
         key: "target_gpu_implicit_baroclinic_wave"
         command:

--- a/config/perf_configs/gpu_held_suarez_rhoe_hightop.yml
+++ b/config/perf_configs/gpu_held_suarez_rhoe_hightop.yml
@@ -1,8 +1,0 @@
-z_max: 45000
-z_elem: 25 
-dz_bottom: 300 
-forcing: "held_suarez" 
-job_id: "gpu_held_suarez_rhoe_hightop" 
-dt: "400secs"
-t_end: "8days" 
-dt_save_state_to_disk: "4days"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Removes some gpu jobs:

- `gpu_held_suarez_rhoe_hightop` and the comparison as we have a comparison for baroclinic wave. Actually, the comparison has been failing, see the broken test in the most recent [build](https://buildkite.com/clima/climaatmos-ci/builds/16952#018de942-a672-4d31-88f7-b1d4186fe1ea/165-233). Is it useful to keep the comparison?
- `gpu_implicit_barowave_wrt_h_elem`: it's the same as `gpu_implicit_barowave` except for `dt_save_state_to_disk`

These jobs don't seem very useful to me. @charleskawczynski @sriharshakandala What do you think? As a side note, the resolutions for the GPU performance jobs are `z_elem: 25 h_elem: 12`. Where do we get the resolution from?

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
