### PR TITLE
Remove types from TOML overrides

### DIFF
--- a/toml/bomex_box_rhoe.toml
+++ b/toml/bomex_box_rhoe.toml
@@ -1,4 +1,3 @@
 [C_E]
 value = 0.044
-type = "float"
 

--- a/toml/diagnostic_edmfx_box.toml
+++ b/toml/diagnostic_edmfx_box.toml
@@ -1,27 +1,20 @@
 [entr_inv_tau]
 value = 0.002
-type = "float"
 
 [entr_coeff]
 value = 0
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
-type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.6
-type = "float"
 
 [min_area_limiter_scale]
 value = 0
-type = "float"
 
 [max_area_limiter_scale]
 value = 0
-type = "float"

--- a/toml/diagnostic_edmfx_trmm_box.toml
+++ b/toml/diagnostic_edmfx_trmm_box.toml
@@ -1,31 +1,23 @@
 [precipitation_timescale]
 value = 600
-type = "float"
 
 [entr_inv_tau]
 value = 0.002
-type = "float"
 
 [entr_coeff]
 value = 0
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.6
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
-type = "float"
 
 [min_area_limiter_scale]
 value = 0
-type = "float"
 
 [max_area_limiter_scale]
 value = 0
-type = "float"

--- a/toml/flame_perf_gw.toml
+++ b/toml/flame_perf_gw.toml
@@ -1,3 +1,2 @@
 [zd_rayleigh]
 value = 30000.0
-type = "float"

--- a/toml/longrun_1M.toml
+++ b/toml/longrun_1M.toml
@@ -1,3 +1,2 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"

--- a/toml/longrun_aquaplanet_amip.toml
+++ b/toml/longrun_aquaplanet_amip.toml
@@ -1,36 +1,27 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"
 
 [precipitation_timescale]
 value = 600
-type = "float"
 
 [entr_inv_tau]
 value = 0.001
-type = "float"
 
 [entr_coeff]
 value = 0
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
-type = "float"
 
 [min_area_limiter_scale]
 value = 0
-type = "float"
 
 [max_area_limiter_scale]
 value = 0
-type = "float"

--- a/toml/longrun_aquaplanet_dyamond.toml
+++ b/toml/longrun_aquaplanet_dyamond.toml
@@ -1,8 +1,6 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
@@ -1,12 +1,9 @@
 [alpha_rayleigh_w]
 value = 10.0
-type = "float"
 
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
@@ -1,40 +1,30 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"
 
 [precipitation_timescale]
 value = 600
-type = "float"
 
 [entr_inv_tau]
 value = 0.002
-type = "float"
 
 [entr_coeff]
 value = 0
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
-type = "float"
 
 [detr_vertdiv_coeff]
 value = 0
-type = "float"
 
 [min_area_limiter_scale]
 value = 0
-type = "float"
 
 [max_area_limiter_scale]
 value = 0
-type = "float"

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
@@ -1,8 +1,6 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"

--- a/toml/longrun_hs_rhoe_dry_55km_nz63.toml
+++ b/toml/longrun_hs_rhoe_dry_55km_nz63.toml
@@ -1,8 +1,6 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 alias = "alpha_rayleigh_uh"
 value = 0.0
-type = "float"

--- a/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
+++ b/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
@@ -1,7 +1,5 @@
 [zd_rayleigh]
 value = 35000.0
-type = "float"
 
 [alpha_rayleigh_uh]
 value = 0.0
-type = "float"

--- a/toml/plane_agnesi_mountain_test_stretched.toml
+++ b/toml/plane_agnesi_mountain_test_stretched.toml
@@ -1,4 +1,3 @@
 [alpha_rayleigh_w]
 value = 0.1
-type = "float"
 

--- a/toml/plane_agnesi_mountain_test_uniform.toml
+++ b/toml/plane_agnesi_mountain_test_uniform.toml
@@ -1,4 +1,3 @@
 [alpha_rayleigh_w]
 value = 0.1
-type = "float"
 

--- a/toml/plane_schar_mountain_test_stretched.toml
+++ b/toml/plane_schar_mountain_test_stretched.toml
@@ -1,4 +1,3 @@
 [alpha_rayleigh_w]
 value = 0.1
-type = "float"
 

--- a/toml/plane_schar_mountain_test_uniform.toml
+++ b/toml/plane_schar_mountain_test_uniform.toml
@@ -1,4 +1,3 @@
 [alpha_rayleigh_w]
 value = 0.1
-type = "float"
 

--- a/toml/prognostic_edmfx_bomex_box.toml
+++ b/toml/prognostic_edmfx_bomex_box.toml
@@ -1,47 +1,35 @@
 [EDMF_surface_area]
 value = 0.1
-type = "float"
 
 [EDMF_min_area]
 value = 1.0e-5
-type = "float" 
 
 [EDMF_max_area]
 value = 0.7
-type = "float"
 
 [entr_inv_tau]
 value = 0
-type = "float"
 
 [entr_coeff]
 value = 0.1
-type = "float"
 
 [min_area_limiter_scale]
 value = 0.001
-type = "float"
 
 [min_area_limiter_power]
 value = 10
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_coeff]
 value = 2e-3
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.3
-type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.6
-type = "float"
 
 [max_area_limiter_scale]
 value = 0.01
-type = "float"

--- a/toml/prognostic_edmfx_box.toml
+++ b/toml/prognostic_edmfx_box.toml
@@ -1,39 +1,29 @@
 [EDMF_surface_area]
 value = 0.1
-type = "float"
 
 [EDMF_min_area]
 value = 1.0e-5
-type = "float"
 
 [EDMF_max_area]
 value = 0.9
-type = "float"
 
 [entr_inv_tau]
 value = 0.002
-type = "float"
 
 [entr_coeff]
 value = 0
-type = "float"
 
 [min_area_limiter_scale]
 value = 0
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_coeff]
 value = 0
-type = "float"
 
 [detr_buoy_coeff]
 value = 0
-type = "float"
 
 [max_area_limiter_scale]
 value = 0
-type = "float"

--- a/toml/prognostic_edmfx_box_advection.toml
+++ b/toml/prognostic_edmfx_box_advection.toml
@@ -1,8 +1,6 @@
 [EDMF_surface_area]
 value = 0
-type = "float"
 
 [EDMF_min_area]
 value = 1.0e-3
-type = "float"
 description = "Minimum area fraction per updraft. Parameter not described in the literature."

--- a/toml/prognostic_edmfx_dycoms_rf01_box.toml
+++ b/toml/prognostic_edmfx_dycoms_rf01_box.toml
@@ -1,47 +1,35 @@
 [EDMF_surface_area]
 value = 0.1
-type = "float"
 
 [EDMF_min_area]
 value = 1.0e-5
-type = "float" 
 
 [EDMF_max_area]
 value = 0.7
-type = "float"
 
 [entr_inv_tau]
 value = 0
-type = "float"
 
 [entr_coeff]
 value = 0.2
-type = "float"
 
 [min_area_limiter_scale]
 value = 0.01
-type = "float"
 
 [min_area_limiter_power]
 value = 100
-type = "float"
 
 [detr_inv_tau]
 value = 0
-type = "float"
 
 [detr_coeff]
 value = 1e-3
-type = "float"
 
 [detr_buoy_coeff]
 value = 0.3
-type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.5
-type = "float"
 
 [max_area_limiter_scale]
 value = 0.01
-type = "float"

--- a/toml/single_column_precipitation_test.toml
+++ b/toml/single_column_precipitation_test.toml
@@ -1,3 +1,2 @@
 [C_H]
 value = 0.0
-type = "float"

--- a/toml/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.toml
+++ b/toml/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.toml
@@ -1,3 +1,2 @@
 [C_H]
 value = 0.0
-type = "float"

--- a/toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.toml
+++ b/toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.toml
@@ -1,4 +1,3 @@
 [zd_rayleigh]
 value = 30000.0
-type = "float"
 

--- a/toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.toml
+++ b/toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res.toml
@@ -1,4 +1,3 @@
 [zd_rayleigh]
 value = 30000.0
-type = "float"
 

--- a/toml/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.toml
+++ b/toml/sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.toml
@@ -1,8 +1,6 @@
 [C_H]
 value = 0.0
-type = "float"
 
 [C_E]
 value = 1
-type = "float"
 

--- a/toml/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.toml
+++ b/toml/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.toml
@@ -1,8 +1,6 @@
 [zd_viscous]
 value = 30000.0
-type = "float"
 
 [zd_rayleigh]
 value = 30000.0
-type = "float"
 

--- a/toml/sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge.toml
+++ b/toml/sphere_ssp_first_tracer_energy_upwind_held_suarez_rhoe_equilmoist_hightop_sponge.toml
@@ -1,8 +1,6 @@
 [zd_viscous]
 value = 30000.0
-type = "float"
 
 [zd_rayleigh]
 value = 30000.0
-type = "float"
 


### PR DESCRIPTION
Types are no longer needed if the parameter exists in the default file, simplifying the syntax slightly