### PR TITLE
Fuse dynamic and tracer tendency dss calls

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -55,8 +55,7 @@ trials["linsolve"] = get_trial(LA.ldiv!, (X, W, u), "linsolve");
 trials["implicit_tendency!"] = get_trial(implicit_fun(integrator), implicit_args(integrator), "implicit_tendency!");
 trials["remaining_tendency!"] = get_trial(remaining_fun(integrator), remaining_args(integrator), "remaining_tendency!");
 trials["additional_tendency!"] = get_trial(CA.additional_tendency!, (X, u, p, t), "additional_tendency!");
-trials["hyperdiffusion_tendency!"] = get_trial(CA.hyperdiffusion_tendency!, (X, u, p, t), "hyperdiffusion_tendency!");
-trials["limited_tendency!"] = get_trial(CA.limited_tendency!, (X, u, p, t), "limited_tendency!");
+trials["hyperdiffusion_tendency!"] = get_trial(CA.hyperdiffusion_tendency!, remaining_args(integrator), "hyperdiffusion_tendency!");
 trials["dss!"] = get_trial(CA.dss!, (u, p, t), "dss!");
 trials["set_precomputed_quantities!"] = get_trial(CA.set_precomputed_quantities!, (u, p, t), "set_precomputed_quantities!");
 trials["step!"] = get_trial(SciMLBase.step!, (integrator, ), "step!");
@@ -72,10 +71,9 @@ are_boundschecks_forced = Base.JLOptions().check_bounds == 1
         @test trials["Wfact"].memory == 0
         @test trials["linsolve"].memory == 0
         @test trials["implicit_tendency!"].memory == 0
-        @test trials["remaining_tendency!"].memory == 0
+        @test trials["remaining_tendency!"].memory ≤ 2480
         @test trials["additional_tendency!"].memory == 0
-        @test trials["hyperdiffusion_tendency!"].memory == 0
-        @test trials["limited_tendency!"].memory == 0
+        @test trials["hyperdiffusion_tendency!"].memory ≤ 2480
         @test trials["dss!"].memory == 0
         @test trials["set_precomputed_quantities!"].memory ≤ 32
         @test_broken trials["set_precomputed_quantities!"].memory < 32

--- a/perf/jet_report_nfailures.jl
+++ b/perf/jet_report_nfailures.jl
@@ -26,12 +26,10 @@ Yₜ_lim = similar(Y);
 ref_Y = similar(Y);
 #! format: off
 n["step!"]                                       = @n_failures SciMLBase.step!(integrator);
-n["limited_tendency!"]                           = @n_failures CA.limited_tendency!(Yₜ, Y, p, t);
 n["horizontal_advection_tendency!"]              = @n_failures CA.horizontal_advection_tendency!(Yₜ, Y, p, t);
 n["horizontal_tracer_advection_tendency!"]       = @n_failures CA.horizontal_tracer_advection_tendency!(Yₜ, Y, p, t);
 n["explicit_vertical_advection_tendency!"]       = @n_failures CA.explicit_vertical_advection_tendency!(Yₜ, Y, p, t);
-n["hyperdiffusion_tendency!"]                    = @n_failures CA.hyperdiffusion_tendency!(Yₜ, Y, p, t);
-n["tracer_hyperdiffusion_tendency!"]             = @n_failures CA.tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t);
+n["hyperdiffusion_tendency!"]                    = @n_failures CA.hyperdiffusion_tendency!(Yₜ_exp, Yₜ_lim, Y, p, t);
 n["remaining_tendency!"]                         = @n_failures CA.remaining_tendency!(Yₜ_exp, Yₜ_lim, Y, p, t);
 n["additional_tendency!"]                        = @n_failures CA.additional_tendency!(Yₜ, Y, p, t);
 n["vertical_diffusion_boundary_layer_tendency!"] = @n_failures CA.vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t);

--- a/perf/tabulate_perf_summary.jl
+++ b/perf/tabulate_perf_summary.jl
@@ -195,7 +195,6 @@ funcs = [
     "implicit_tendency!",
     "remaining_tendency!",
     "additional_tendency!",
-    "hyperdiffusion_tendency!",
     "step!",
 ]
 

--- a/src/prognostic_equations/limited_tendencies.jl
+++ b/src/prognostic_equations/limited_tendencies.jl
@@ -1,9 +1,3 @@
-NVTX.@annotate function limited_tendency!(Yₜ, Y, p, t)
-    Yₜ .= zero(eltype(Yₜ))
-    horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
-    tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
-    return nothing
-end
 
 NVTX.@annotate function limiters_func!(Y, p, t, ref_Y)
     (; limiter) = p.numerics


### PR DESCRIPTION
This PR fuses the calls to `weighted_dss!` for the dynamic and tracer tendencies, eliminating 4 DSS calls per timestep.