### PR TITLE
Do not move output outside of buildkite climaatmos-ci

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -238,7 +238,6 @@ if ClimaComms.iamroot(config.comms_ctx)
     if path == :self_reference
         make_plots(Val(Symbol(reference_job_id)), simulation.output_dir)
     else
-
         main_job_path = joinpath(path, reference_job_id)
         nc_dir = joinpath(main_job_path, "nc_files")
         if ispath(nc_dir)

--- a/regression_tests/move_output.jl
+++ b/regression_tests/move_output.jl
@@ -9,7 +9,7 @@ job_ids = getindex.(split.(lines, "\""), 2)
 @assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
 @assert length(job_ids) ≠ 0 # safety net
 
-if haskey(ENV, "BUILDKITE_COMMIT") && haskey(ENV, "BUILDKITE_BRANCH")
+if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaatmos-ci"
     commit = ENV["BUILDKITE_COMMIT"]
     branch = ENV["BUILDKITE_BRANCH"]
     # Note: cluster_data_prefix is also defined in compute_mse.jl

--- a/regression_tests/self_reference_or_path.jl
+++ b/regression_tests/self_reference_or_path.jl
@@ -14,6 +14,9 @@ function sorted_dataset_folder(; dir = pwd())
 end
 
 function self_reference_or_path()
+    if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) != "climaatmos-ci"
+        return :self_reference
+    end
 
     # Note: cluster_data_prefix is also defined in move_output.jl
     cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
@@ -86,7 +89,7 @@ function get_main_branch_buildkite_path()
     # TODO: Combine this method with `self_reference_or_path`, above.
     cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
     if !ispath(cluster_data_prefix)
-        if haskey(ENV, "BUILDKITE_COMMIT") || haskey(ENV, "BUILDKITE_BRANCH")
+        if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaatmos-ci"
             error("No path found for comparison against main")
         else
             @warn "Buildkite reference data is not available locally; skipping \


### PR DESCRIPTION
We only want to move things around on the main climaatmos-ci pipeline.