### PR TITLE
reduce t_end in diagnostic edmf diffusion on only longrun

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M.yml
@@ -20,6 +20,6 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 dt_save_state_to_disk: "30days"
 dt: "100secs"
-t_end: "100days"
+t_end: "60days"
 job_id: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M"
 toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]


### PR DESCRIPTION
Reduces t_end to 60 days in `longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_diffonly_0M`, as this job times out in recent builds.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
