### PR TITLE
Set `dt = 100sec` for DYAMOND runs

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond.yml
@@ -14,7 +14,7 @@ dt_rad: "1hours"
 vert_diff: "true" 
 surface_setup: "DefaultMoninObukhov" 
 rayleigh_sponge: true
-dt: "50secs" 
+dt: "100secs" 
 t_end: "12hours"
 job_id: "gpu_aquaplanet_dyamond" 
 toml: [toml/longrun_aquaplanet_dyamond.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_2process.yml
@@ -14,7 +14,7 @@ dt_rad: "1hours"
 vert_diff: "true" 
 surface_setup: "DefaultMoninObukhov" 
 rayleigh_sponge: true
-dt: "50secs" 
+dt: "100secs" 
 t_end: "12hours"
 job_id: "gpu_aquaplanet_dyamond_2process" 
 toml: [toml/longrun_aquaplanet_dyamond.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_4process.yml
@@ -14,7 +14,7 @@ dt_rad: "1hours"
 vert_diff: "true" 
 surface_setup: "DefaultMoninObukhov" 
 rayleigh_sponge: true
-dt: "50secs" 
+dt: "100secs" 
 t_end: "12hours"
 job_id: "gpu_aquaplanet_dyamond_4process" 
 toml: [toml/longrun_aquaplanet_dyamond.toml]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Set `dt = 100sec` for DYAMOND runs to be consistent with `dt` for CHAP simulations.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
