### PR TITLE
Add `restart_file` configuration variable, remove ENV variable, enable restarted progress logging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -370,7 +370,6 @@ steps:
         artifact_paths: "restart_mpi_baroclinic_wave_rhoe/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
-          RESTART_FILE: "mpi_make_restart/day5.0.hdf5"
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -274,3 +274,6 @@ log_progress:
 deep_atmosphere:
   help: "Do not assume that the atmosphere is shallow, where the vertical columns are cylindrical"
   value: false
+restart_file:
+  help: "Path to HDF5 file to use as simulation starting point"
+  value: ~

--- a/config/mpi_configs/restart_mpi_baroclinic_wave_rhoe.yml
+++ b/config/mpi_configs/restart_mpi_baroclinic_wave_rhoe.yml
@@ -1,3 +1,4 @@
 job_id: "restart_mpi_baroclinic_wave_rhoe"
 t_end: "20days"
 initial_condition: "DryBaroclinicWave"
+restart_file: "mpi_make_restart/day5.0.hdf5"

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -231,6 +231,7 @@ end
 import Dates
 function print_walltime_estimate(integrator)
     (; walltime_estimate, dt, t_end) = integrator.p
+    t_start = integrator.sol.prob.tspan[1]
     wte = walltime_estimate
 
     # Notes on `ready_to_report`
@@ -258,11 +259,11 @@ function print_walltime_estimate(integrator)
 
     if wte.n_calls == wte.n_next && ready_to_report
         t = integrator.t
-        n_steps_total = ceil(Int, t_end / dt)
-        n_steps = ceil(Int, t / dt)
+        n_steps_total = ceil(Int, (t_end - t_start) / dt)
+        n_steps = ceil(Int, (t - t_start) / dt)
         wall_time_ave_per_step = wte.∑Δt_wall / n_steps
         wall_time_ave_per_step_str = time_and_units_str(wall_time_ave_per_step)
-        percent_complete = round(t / t_end * 100; digits = 1)
+        percent_complete = round((t - t_start) / t_end * 100; digits = 1)
         n_steps_remaining = n_steps_total - n_steps
         wall_time_remaining = wall_time_ave_per_step * n_steps_remaining
         wall_time_remaining_str = time_and_units_str(wall_time_remaining)
@@ -272,7 +273,7 @@ function print_walltime_estimate(integrator)
         simulation_time = time_and_units_str(Float64(t))
         sypd = round(
             simulated_years_per_day(
-                EfficiencyStats((zero(t), t), wte.∑Δt_wall),
+                EfficiencyStats((t_start, t), wte.∑Δt_wall),
             );
             digits = 3,
         )

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -4,7 +4,7 @@ function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
     (; dt, output_dir) = sim_info
 
     callbacks = ()
-    if parsed_args["log_progress"] && !sim_info.restart
+    if parsed_args["log_progress"]
         @info "Progress logging enabled."
         callbacks = (
             callbacks...,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -727,7 +727,6 @@ function get_simulation(config::AtmosConfig)
         s = @timed_str begin
             (Y, t_start) = get_state_restart(config)
             spaces = get_spaces_restart(Y)
-            @warn "Progress estimates do not support restarted simulations"
         end
         @info "Allocating Y: $s"
     else

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -296,9 +296,11 @@ function get_spaces_restart(Y)
     return (; center_space, face_space)
 end
 
-function get_state_restart(comms_ctx)
-    @assert haskey(ENV, "RESTART_FILE")
-    reader = InputOutput.HDF5Reader(ENV["RESTART_FILE"], comms_ctx)
+function get_state_restart(config::AtmosConfig)
+    (; parsed_args, comms_ctx) = config
+    restart_file = parsed_args["restart_file"]
+    @assert !isnothing(restart_file)
+    reader = InputOutput.HDF5Reader(restart_file, comms_ctx)
     Y = InputOutput.read_field(reader, "Y")
     t_start = InputOutput.HDF5.read_attribute(reader.file, "time")
     return (Y, t_start)
@@ -472,7 +474,7 @@ function get_sim_info(config::AtmosConfig)
 
     sim = (;
         output_dir,
-        restart = haskey(ENV, "RESTART_FILE"),
+        restart = !isnothing(parsed_args["restart_file"]),
         job_id,
         dt = FT(time_to_seconds(parsed_args["dt"])),
         start_date = DateTime(parsed_args["start_date"], dateformat"yyyymmdd"),
@@ -723,7 +725,7 @@ function get_simulation(config::AtmosConfig)
 
     if sim_info.restart
         s = @timed_str begin
-            (Y, t_start) = get_state_restart(config.comms_ctx)
+            (Y, t_start) = get_state_restart(config)
             spaces = get_spaces_restart(Y)
             @warn "Progress estimates do not support restarted simulations"
         end


### PR DESCRIPTION
This PR improves restarted simulations:

Content
- Move the restart file from `ENV["RESTART_FILE"]` to `parsed_args["restart_file"]`. This will make it simpler to set the restart file for calibration experiments.
- Enable progress logging in restarted simulations. The progress callback now takes the start time into account instead of assuming that a sim starts from 0.0