### PR TITLE
use parameters for surface albedo

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -327,9 +327,9 @@ weakdeps = ["Krylov"]
 
 [[deps.ClimaParams]]
 deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "ec67949db856e01df4cbf7d6ddafefeda02f93ee"
+git-tree-sha1 = "1a3d2455fff201bcf130bbd5a71ac16fc3c21fd1"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "0.10.3"
+version = "0.10.4"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["ClimaComms", "Colors", "DataStructures", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -345,9 +345,9 @@ version = "0.7.5"
 
 [[deps.ClimaParams]]
 deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "ec67949db856e01df4cbf7d6ddafefeda02f93ee"
+git-tree-sha1 = "1a3d2455fff201bcf130bbd5a71ac16fc3c21fd1"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "0.10.3"
+version = "0.10.4"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["ClimaComms", "Colors", "DataStructures", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -354,9 +354,9 @@ version = "0.7.5"
 
 [[deps.ClimaParams]]
 deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "ec67949db856e01df4cbf7d6ddafefeda02f93ee"
+git-tree-sha1 = "1a3d2455fff201bcf130bbd5a71ac16fc3c21fd1"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "0.10.3"
+version = "0.10.4"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["ClimaComms", "Colors", "DataStructures", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]

--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -9,7 +9,7 @@ struct CouplerAlbedo <: SurfaceAlbedoModel end
 A constant surface albedo model. The default value is 0.38. It is used purely for idealized experiments.
 """
 Base.@kwdef struct ConstantAlbedo{FT} <: SurfaceAlbedoModel
-    α::FT = 0.38
+    α::FT
 end
 
 """

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -74,6 +74,9 @@ Base.@kwdef struct ClimaAtmosParameters{FT, TP, RP, IP, MPP, WP, SFP, TCP} <:
     zd_viscous::FT
     zd_rayleigh::FT
     kappa_2_sponge::FT
+    # Radiation
+    idealized_ocean_albedo::FT
+    water_refractive_index::FT
 end
 
 Base.eltype(::ClimaAtmosParameters{FT}) where {FT} = FT

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -111,6 +111,8 @@ function create_parameter_set(config::AtmosConfig)
         :drag_layer_vertical_extent => :σ_b,
         :kappa_2_sponge => :kappa_2_sponge,
         :held_suarez_minimum_temperature => :T_min_hs,
+        :ocean_surface_albedo => :idealized_ocean_albedo,
+        :water_refractive_index => :water_refractive_index,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
     return CAP.ClimaAtmosParameters{FT, TP, RP, IP, MPP, WP, SFP, TCP}(;

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -97,15 +97,15 @@ function get_surface_model(parsed_args)
     end
 end
 
-function get_surface_albedo_model(parsed_args, ::Type{FT}) where {FT}
+function get_surface_albedo_model(parsed_args, params, ::Type{FT}) where {FT}
     albedo_name = parsed_args["albedo_model"]
     return if albedo_name in ("ConstantAlbedo",)
-        ConstantAlbedo{FT}()
+        ConstantAlbedo{FT}(; α = params.idealized_ocean_albedo)
     elseif albedo_name in ("RegressionFunctionAlbedo",)
         isnothing(parsed_args["rad"]) && error(
             "Radiation model not specified, so cannot use RegressionFunctionAlbedo",
         )
-        RegressionFunctionAlbedo{FT}()
+        RegressionFunctionAlbedo{FT}(; n = params.water_refractive_index)
     elseif albedo_name in ("CouplerAlbedo",)
         CouplerAlbedo()
     else

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -86,7 +86,7 @@ function get_atmos(config::AtmosConfig, params)
         rayleigh_sponge = get_rayleigh_sponge_model(parsed_args, params, FT),
         sfc_temperature = get_sfc_temperature_form(parsed_args),
         surface_model = get_surface_model(parsed_args),
-        surface_albedo = get_surface_albedo_model(parsed_args, FT),
+        surface_albedo = get_surface_albedo_model(parsed_args, params, FT),
         numerics = get_numerics(parsed_args),
     )
     @assert !@any_reltype(atmos, (UnionAll, DataType))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Use clima parameters for ocean surface albedo and water refractive index. Closes #2757 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] update ClimaParams in all environments

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
