### PR TITLE
minor fix for some longruns

### DIFF
--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
@@ -1,5 +1,5 @@
 dt_save_state_to_disk: "10days"
-dt: "150secs"
+dt: "120secs"
 rad: "clearsky"
 dt_rad: "6hours"
 t_end: "500days"

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -676,6 +676,7 @@ MoistHeldSuarezPlots = Union{
     Val{:sphere_baroclinic_wave_rhoe_equilmoist_impvdiff},
     Val{:sphere_held_suarez_rhoe_equilmoist_hightop_sponge},
     Val{:longrun_hs_rhoe_equil_55km_nz63_0M},
+    Val{:longrun_hs_rhoe_equil_55km_nz63_0M_deepatmos},
 }
 
 function make_plots(
@@ -830,7 +831,6 @@ AquaplanetPlots = Union{
     Val{:longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M},
     Val{:longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth},
     Val{:longrun_aquaplanet_rhoe_equil_highres_allsky_ft32},
-    Val{:longrun_hs_rhoe_equil_55km_nz63_0M_deepatmos},
     Val{:longrun_aquaplanet_dyamond},
 }
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fixes plotting for `longrun_hs_rhoe_equil_55km_nz63_0M_deepatmos`. Reduces dt in `longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth`. See the errors in the most recent [build](https://buildkite.com/clima/climaatmos-gpulongruns/builds/100#_).

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
