### PR TITLE
Try cuda always_inline

### DIFF
--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -305,7 +305,9 @@ version = "0.5.7"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "Static", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "bc6a0154e3bcc1657d3a75f697e216fb70121969"
+git-tree-sha1 = "7d64005f6855010abe9e12c2312f3b51d872825f"
+repo-rev = "ck/cuda_inline"
+repo-url = "https://github.com/CliMA/ClimaCore.jl.git"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 version = "0.13.2"
 weakdeps = ["Krylov"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -314,7 +314,9 @@ version = "0.5.7"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "Static", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "bc6a0154e3bcc1657d3a75f697e216fb70121969"
+git-tree-sha1 = "7d64005f6855010abe9e12c2312f3b51d872825f"
+repo-rev = "ck/cuda_inline"
+repo-url = "https://github.com/CliMA/ClimaCore.jl.git"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 version = "0.13.2"
 weakdeps = ["Krylov"]


### PR DESCRIPTION
This PR tries out always using `always_inline` for all CUDA kernel launches, since this can reduce function call overhead.