### PR TITLE
Refactor surface

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -75,8 +75,8 @@ are_boundschecks_forced = Base.JLOptions().check_bounds == 1
         @test trials["additional_tendency!"].memory == 0
         @test trials["hyperdiffusion_tendency!"].memory ≤ 2480
         @test trials["dss!"].memory == 0
-        @test trials["set_precomputed_quantities!"].memory ≤ 32
-        @test_broken trials["set_precomputed_quantities!"].memory < 32
+        @test trials["set_precomputed_quantities!"].memory ≤ 40
+        @test_broken trials["set_precomputed_quantities!"].memory < 40
 
         # It's difficult to guarantee zero allocations,
         # so let's just leave this as broken for now.


### PR DESCRIPTION
This PR refactors the surface `surface_state_to_conditions` by:

 - Making `surface_state_to_conditions` take the wrapped surface setup, and a local `surface_state` is then made inside.
 - Made `sfc_prognostic_temp` a non-optional argument and removed the splatting (sometimes this is difficult for the compiler to infer).

There's several benefits to the first bullet:
 - Expressions directly inside broadcast expressions are treated differently than if they were called inside, and sometimes this will result in allocations / runtime calls (https://github.com/CliMA/ClimaCore.jl/issues/1649).
 - The compiler may be able to better optimize this because it is explicitly clear that `surface_state`'s can be locally defined, and a full field of `surface_state`'s is not necessary.
 - We also explicitly pass the local geometry and interior z fewer times to the function

According to my local tests, this PR allows us to use `always_inline` for this kernel.