### PR TITLE
Fix an inference failure in gpu prognostic edmf

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -50,7 +50,7 @@ allocs_limit["flame_perf_target_threaded"] = 1_276_864
 allocs_limit["flame_perf_target_callbacks"] = 398_984
 allocs_limit["flame_perf_gw"] = 3_268_961_856
 allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 299_616
-allocs_limit["flame_gpu_implicit_barowave_moist"] = 381_968
+allocs_limit["flame_gpu_implicit_barowave_moist"] = 658_664
 # Ideally, we would like to track all the allocations, but this becomes too
 # expensive there is too many of them. Here, we set the default sample rate to
 # 1, but lower it to a smaller value when we expect the job to produce lots of

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -63,7 +63,8 @@ function set_diagnostic_edmfx_env_quantities_level!(
     turbconv_model,
 )
     @. u³⁰_halflevel = divide_by_ρa(
-        ρ_level * u³_halflevel - mapreduce(*, +, ρaʲs_level, u³ʲs_halflevel),
+        ρ_level * u³_halflevel -
+        mapreduce_with_init(*, +, ρaʲs_level, u³ʲs_halflevel),
         ρ_level,
         ρ_level * u³_halflevel,
         ρ_level,


### PR DESCRIPTION
This PR fixes an inference failure when calling `mapreduce` inside broadcast expressions. Generally speaking, we need to provide `init` so that `mapreduce` can infer the result (due to the edge case of an empty collection). In one other case, however, we're hitting a compiler heuristic, and we need to define a custom `unrolled_dot_product`, so that the compiler can unroll / infer the result. 

relevant issue: #2365.

I'm going to merge this, and I'll followup on the next issue when I have a chance. Thanks again @szy21 for adding that job!