### PR TITLE
Fix updraft_top computation on the gpu

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -699,7 +699,7 @@ steps:
         agents:
           slurm_gpus: 1
           slurm_mem: 20G
-      
+
       - label: "GPU: Prognostic EDMFX aquaplanet"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
@@ -708,7 +708,6 @@ steps:
         agents:
           slurm_gpus: 1
           slurm_mem: 20G
-        soft_fail: true
 
   - group: "GPU Performance"
     steps:

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -74,6 +74,7 @@ function precomputed_quantities(Y, atmos)
             ᶜK_u = similar(Y.c, FT),
             ᶜK_h = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
+            ᶜupdraft_top = similar(Fields.level(Y.c, 1), FT),
             ᶜuʲs = similar(Y.c, NTuple{n, C123{FT}}),
             ᶠu³ʲs = similar(Y.f, NTuple{n, CT3{FT}}),
             ᶜKʲs = similar(Y.c, NTuple{n, FT}),


### PR DESCRIPTION
This PR attempts to fix the inference failure in:

```julia
        updraft_top = FT(0)
        for level in 1:Spaces.nlevels(axes(ᶜz))
            if draft_area(
                Spaces.level(Y.c.sgsʲs.:($j).ρa[colidx], level)[],
                Spaces.level(ᶜρʲs.:($j)[colidx], level)[],
            ) > a_min
                updraft_top = Spaces.level(ᶜz[colidx], level)[]
            end
        end
        updraft_top = updraft_top - z_sfc[colidx][]
```

I know that we probably want to get rid of this segment of the code altogether but, updating this only took a few minutes, and this might allow me to see the next failure (if any, hopefully not!).

This PR needs rebased once #2814 lands, to see the impact.