### PR TITLE
fix some allocation in prognostic edmf implicit solver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -804,7 +804,7 @@ steps:
           $PERF_CONFIG_PATH/flame_perf_target_prognostic_edmfx_aquaplanet.yml
         artifact_paths: "flame_perf_target_prognostic_edmfx_aquaplanet/*"
         agents:
-          slurm_mem: 32GB
+          slurm_mem: 48GB
 
       - label: ":fire: Flame graph: perf target (barowave jfnk)"
         command: >

--- a/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
+++ b/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
@@ -3,7 +3,6 @@ surface_setup: DefaultExchangeCoefficients
 rad: gray
 vert_diff: "false"
 turbconv: prognostic_edmfx 
-implicit_diffusion: false
 prognostic_tke: true
 edmfx_upwinding: first_order 
 edmfx_entr_model: "Generalized" 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -49,7 +49,7 @@ allocs_limit["flame_perf_target_frierson"] = 4_015_547_056
 allocs_limit["flame_perf_target_threaded"] = 1_276_864
 allocs_limit["flame_perf_target_callbacks"] = 172_032
 allocs_limit["flame_perf_gw"] = 3_268_961_856
-allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 73_608
+allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 2_770_296
 allocs_limit["flame_gpu_implicit_barowave_moist"] = 199_936
 # Ideally, we would like to track all the allocations, but this becomes too
 # expensive there is too many of them. Here, we set the default sample rate to

--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -55,11 +55,14 @@ function temporary_quantities(Y, atmos)
         ∂ᶜK_∂ᶜuₕ = similar(Y.c, DiagonalMatrixRow{Adjoint{FT, CTh{FT}}}),
         ∂ᶜK_∂ᶠu₃ = similar(Y.c, BidiagonalMatrixRow{Adjoint{FT, CT3{FT}}}),
         ᶠp_grad_matrix = similar(Y.f, BidiagonalMatrixRow{C3{FT}}),
+        ᶠbidiagonal_matrix_ct3 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
+        ᶠbidiagonal_matrix_ct3_2 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
         ᶜadvection_matrix = similar(
             Y.c,
             BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
         ),
         ᶜdiffusion_h_matrix = similar(Y.c, TridiagonalMatrixRow{FT}),
         ᶜdiffusion_u_matrix = similar(Y.c, TridiagonalMatrixRow{FT}),
+        ᶠtridiagonal_matrix_c3 = similar(Y.f, TridiagonalMatrixRow{C3{FT}}),
     )
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This brings down the difference in allocation between implicit and explicit prognostic edmf from several orders of magnitude to 10. I'm not sure where the factor 10 is, and we can look at it further. Turns back on `implicit_diffusion` in the performance job config. Part of #2818 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
