### PR TITLE
Group NCDatasets.sync calls

### DIFF
--- a/perf/benchmark_netcdf_io.jl
+++ b/perf/benchmark_netcdf_io.jl
@@ -66,6 +66,8 @@ for device in keys(timings)
         integrator.t,
         simulation.output_dir,
     )
+    output_path = CAD.outpath_name(simulation.output_dir, rhoa_diag)
+    NCDatasets.sync(netcdf_writer.open_files[output_path])
     # Now, profile
     @info "Profiling ($device_name)"
     prof = Profile.@profile CAD.save_diagnostic_to_disk!(

--- a/src/diagnostics/netcdf_writer.jl
+++ b/src/diagnostics/netcdf_writer.jl
@@ -664,6 +664,10 @@ function interpolate_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
     return nothing
 end
 
+function outpath_name(output_dir, diagnostic)
+    joinpath(output_dir, "$(diagnostic.output_short_name).nc")
+end
+
 function save_diagnostic_to_disk!(
     writer::NetCDFWriter,
     field,
@@ -681,7 +685,7 @@ function save_diagnostic_to_disk!(
     space = axes(field)
     FT = Spaces.undertype(space)
 
-    output_path = joinpath(output_dir, "$(diagnostic.output_short_name).nc")
+    output_path = outpath_name(output_dir, diagnostic)
 
     if !haskey(writer.open_files, output_path)
         # Append or write a new file
@@ -738,9 +742,6 @@ function save_diagnostic_to_disk!(
     elseif length(dim_names) == 1
         v[time_index, :] = interpolated_field
     end
-
-    # Write data to disk
-    NCDatasets.sync(writer.open_files[output_path])
     return nothing
 end
 

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -870,8 +870,9 @@ function get_simulation(config::AtmosConfig)
                 diagnostic_counters[diag] = 1
                 # If it is not a reduction, call the output writer as well
                 if isnothing(diag.reduction_time_func)
+                    writer = diag.output_writer
                     CAD.write_field!(
-                        diag.output_writer,
+                        writer,
                         diagnostic_storage[diag],
                         diag,
                         Y,
@@ -879,6 +880,11 @@ function get_simulation(config::AtmosConfig)
                         t_start,
                         output_dir,
                     )
+                    if writer isa CAD.NetCDFWriter &&
+                       ClimaComms.iamroot(ClimaComms.context(Y.c))
+                        output_path = CAD.outpath_name(output_dir, diag)
+                        NCDatasets.sync(writer.open_files[output_path])
+                    end
                 else
                     # Add to the accumulator
 


### PR DESCRIPTION
In light of #2827, this PR hoists the `NCDatasets.sync` to a separate callback so that we can (eventually) and use `Threads.@spawn` to leverage threads (if we have them).

I've also named/annotated `compute_callback` and `output_callback`, so that they show up in the NVTX reports.