### PR TITLE
Use unrolled_dot_product to fix inference

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -64,7 +64,7 @@ function set_diagnostic_edmfx_env_quantities_level!(
 )
     @. u³⁰_halflevel = divide_by_ρa(
         ρ_level * u³_halflevel -
-        mapreduce_with_init(*, +, ρaʲs_level, u³ʲs_halflevel),
+        unrolled_dotproduct(ρaʲs_level, u³ʲs_halflevel),
         ρ_level,
         ρ_level * u³_halflevel,
         ρ_level,


### PR DESCRIPTION
This PR adds another use of `unrolled_dot_product`, needed on the gpu when using `always_inline`. This PR is a followup to #2814. This is needed for the upcoming ClimaCore release (build here: https://buildkite.com/clima/climaatmos-ci/builds/17748#018e63e5-e2d2-4d8e-9261-87363e82e186).