### PR TITLE
Add function barrier to orchestrate diagnostics

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -38,19 +38,19 @@ ProfileCanvas.html_file(joinpath(output_dir, "flame.html"), results)
 #####
 
 allocs_limit = Dict()
-allocs_limit["flame_perf_target"] = 278_360
-allocs_limit["flame_perf_target_tracers"] = 308_336
-allocs_limit["flame_perf_target_edmfx"] = 7_005_552
+allocs_limit["flame_perf_target"] = 51_600
+allocs_limit["flame_perf_target_tracers"] = 81_576
+allocs_limit["flame_perf_target_edmfx"] = 86_608
 allocs_limit["flame_perf_diagnostics"] = 10_876_900
-allocs_limit["flame_perf_target_diagnostic_edmfx"] = 412_056
+allocs_limit["flame_perf_target_diagnostic_edmfx"] = 86_608
 allocs_limit["flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff"] =
     4_018_252_656
 allocs_limit["flame_perf_target_frierson"] = 4_015_547_056
 allocs_limit["flame_perf_target_threaded"] = 1_276_864
-allocs_limit["flame_perf_target_callbacks"] = 398_984
+allocs_limit["flame_perf_target_callbacks"] = 172_032
 allocs_limit["flame_perf_gw"] = 3_268_961_856
-allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 299_616
-allocs_limit["flame_gpu_implicit_barowave_moist"] = 252_300
+allocs_limit["flame_perf_target_prognostic_edmfx_aquaplanet"] = 73_608
+allocs_limit["flame_gpu_implicit_barowave_moist"] = 199_936
 # Ideally, we would like to track all the allocations, but this becomes too
 # expensive there is too many of them. Here, we set the default sample rate to
 # 1, but lower it to a smaller value when we expect the job to produce lots of

--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -717,6 +717,15 @@ NVTX.@annotate function output_callback!(
     return nothing
 end
 
+function orchestrate_diagnostics(integrator, diagnostics_functions)
+    for d in diagnostics_functions
+        if d.cbf.n > 0 && integrator.step % d.cbf.n == 0
+            d.f!(integrator)
+        end
+    end
+end
+
+
 """
     get_callbacks_from_diagnostics(diagnostics, storage, counters)
 

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -814,13 +814,8 @@ function get_simulation(config::AtmosConfig)
     # reason, we only add one callback to the integrator, and this function takes care of
     # executing the other callbacks. This single function is orchestrate_diagnostics
 
-    function orchestrate_diagnostics(integrator)
-        for d in diagnostics_functions
-            if d.cbf.n > 0 && integrator.step % d.cbf.n == 0
-                d.f!(integrator)
-            end
-        end
-    end
+    orchestrate_diagnostics(integrator) =
+        CAD.orchestrate_diagnostics(integrator, diagnostics_functions)
 
     diagnostic_callbacks =
         call_every_n_steps(orchestrate_diagnostics, skip_first = true)


### PR DESCRIPTION
This PR adds a function barrier to orchestrate diagnostics, in hopes to fix some of the diagnostics allocations (#2831.)

I actually kind of like this better anyway, since it's more clear what variables we're using in closures.