### PR TITLE
Fix benchmark timing for netcdf_io

### DIFF
--- a/perf/benchmark_netcdf_io.jl
+++ b/perf/benchmark_netcdf_io.jl
@@ -85,15 +85,16 @@ for device in keys(timings)
     @info "Flame saved in $flame_path"
 
     @info "Benchmarking our NetCDF writer (only IO) ($device_name)"
-    timings[device] = @benchmark CAD.save_diagnostic_to_disk!(
-        $netcdf_writer,
-        $field,
-        $rhoa_diag,
-        $(integrator.u),
-        $(integrator.p),
-        $(integrator.t),
-        $(simulation.output_dir),
-    )
+    timings[device] =
+        @benchmark ClimaComms.@cuda_sync $device CAD.save_diagnostic_to_disk!(
+            $netcdf_writer,
+            $field,
+            $rhoa_diag,
+            $(integrator.u),
+            $(integrator.p),
+            $(integrator.t),
+            $(simulation.output_dir),
+        )
 
     @info "Benchmarking NCDatasets ($device_name)"
 


### PR DESCRIPTION
The existing io benchmark is not using `CUDA.@sync` inside `@benchmark`, which means that the timings do not include kernel execution time (see the CUDA docs [here](https://cuda.juliagpu.org/dev/development/profiling/#Time-measurements)).

We could alternatively use https://github.com/CliMA/ClimaComms.jl/pull/73 once it lands to avoid some code duplication.