### PR TITLE
use fixed height scale in nonhydrostatic pressure drag

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -74,7 +74,6 @@ function precomputed_quantities(Y, atmos)
             ᶜK_u = similar(Y.c, FT),
             ᶜK_h = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
-            ᶜupdraft_top = similar(Fields.level(Y.c, 1), FT),
             ᶜuʲs = similar(Y.c, NTuple{n, C123{FT}}),
             ᶠu³ʲs = similar(Y.f, NTuple{n, CT3{FT}}),
             ᶜKʲs = similar(Y.c, NTuple{n, FT}),

--- a/toml/prognostic_edmfx_bomex_box.toml
+++ b/toml/prognostic_edmfx_bomex_box.toml
@@ -36,3 +36,6 @@ value = 1
 
 [max_area_limiter_scale]
 value = 0
+
+[pressure_normalmode_drag_coeff]
+value = 40.0

--- a/toml/prognostic_edmfx_box.toml
+++ b/toml/prognostic_edmfx_box.toml
@@ -33,3 +33,6 @@ value = 1
 
 [max_area_limiter_scale]
 value = 0
+
+[pressure_normalmode_drag_coeff]
+value = 40.0

--- a/toml/prognostic_edmfx_dycoms_rf01_box.toml
+++ b/toml/prognostic_edmfx_dycoms_rf01_box.toml
@@ -36,3 +36,6 @@ value = 1
 
 [max_area_limiter_scale]
 value = 0.01
+
+[pressure_normalmode_drag_coeff]
+value = 40.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Uses scale height for the plume height scale in the nonhydrostatic pressure drag. To keep the shallow convection result similar to before, I increase the drag coefficient by a factor of 4.

Closes #2807 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
