### PR TITLE
Add nsys profile to gpu_aquaplanet_diagedmf

### DIFF
--- a/.buildkite/gpu_pipeline/pipeline.yml
+++ b/.buildkite/gpu_pipeline/pipeline.yml
@@ -240,6 +240,7 @@ steps:
         command:
           - mkdir -p gpu_aquaplanet_diagedmf
           - >
+            nsys profile --trace=nvtx,mpi,cuda,osrt --output=gpu_aquaplanet_diagedmf/report
             julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}gpu_aquaplanet_diagedmf.yml
         artifact_paths: "gpu_aquaplanet_diagedmf/*"


### PR DESCRIPTION
This PR adds nsight profiling to the gpu aquaplanet diagnostic edmf job, so that we can understand the performance issues.