### PR TITLE
Throw a more informative error for unsupported config dictionary entries

### DIFF
--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -18,7 +18,7 @@ function get_model_config(parsed_args)
     if !(config ∈ valid_configurations)
         error_message = string(
             "config = $config is not one of the ",
-            "valid configurations $valid_configurations"
+            "valid configurations $valid_configurations",
         )
         throw(ArgumentError(error_message))
     end

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -16,7 +16,7 @@ function get_model_config(parsed_args)
     valid_configurations = ("sphere", "column", "box", "plane")
 
     if !(config ∈ valid_configurations)
-        error_message = string("config = $config is not one of the",
+        error_message = string("config = $config is not one of the ",
                                "valid configurations $valid_configurations")
         throw(ArgumentError(error_message))
     end

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -12,7 +12,15 @@ end
 
 function get_model_config(parsed_args)
     config = parsed_args["config"]
-    @assert config in ("sphere", "column", "box", "plane")
+
+    valid_configurations = ("sphere", "column", "box", "plane")
+
+    if !(config ∈ valid_configurations)
+        error_message = string("config = $config is not one of the",
+                               "valid configurations $valid_configurations")
+        throw(ArgumentError(error_message))
+    end
+
     return if config == "sphere"
         SphericalModel()
     elseif config == "column"

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -16,8 +16,10 @@ function get_model_config(parsed_args)
     valid_configurations = ("sphere", "column", "box", "plane")
 
     if !(config ∈ valid_configurations)
-        error_message = string("config = $config is not one of the ",
-                               "valid configurations $valid_configurations")
+        error_message = string(
+            "config = $config is not one of the ",
+            "valid configurations $valid_configurations"
+        )
         throw(ArgumentError(error_message))
     end
 

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -72,7 +72,17 @@ function override_default_config(config_dict::AbstractDict;)
     for k in intersect(keys(config_dict), keys(default_config))
         default_type = typeof(default_config[k])
         v = config_dict[k]
-        config[k] = isnothing(default_config[k]) ? v : default_type(v)
+
+        # Attempt to convert user value `v` to the same type as
+        # the default. If that fails, throw an informative error.
+        config[k] = try
+            isnothing(default_config[k]) ? v : default_type(v)
+        catch err
+            user_entry_type = typeof(v)
+            msg = """Configuration entry "$(k)" = $v has type $(user_entry_type),
+                     but must have type $default_type."""
+            throw(ArgumentError(msg))
+        end
     end
 
     # The "diagnostics" entry is a more complex type that doesn't fit the schema described in


### PR DESCRIPTION
This PR helps users debug configuration dictionaries by throwing an error that indicates which entry is problematic and why.

After this PR,

```julia
using ClimaAtmos
configuration_dict = Dict("hyperdiff" => nothing)
configuration = ClimaAtmos.AtmosConfig(configuration_dict)
```

throw the error

```julia
ERROR: LoadError: ArgumentError: Configuration entry "hyperdiff" = nothing has type Nothing,
but must have type String.
Stacktrace:
 [1] override_default_config(config_dict::Dict{String, Nothing})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/yaml_helper.jl:84
 [2] ClimaAtmos.AtmosConfig(config::Dict{String, Nothing}; comms_ctx::Nothing)
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/types.jl:487
 [3] ClimaAtmos.AtmosConfig(config::Dict{String, Nothing})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/types.jl:486
 [4] top-level scope
   @ ~/Projects/ClimaEarth.jl/examples/atmos_single_column_model/test.jl:31
 [5] include(fname::String)
   @ Base.MainInclude ./client.jl:489
 [6] top-level scope
   @ REPL[1]:1
in expression starting at /Users/gregorywagner/Projects/ClimaEarth.jl/examples/atmos_single_column_model/test.jl:31

caused by: MethodError: no method matching String(::Nothing)

Closest candidates are:
  String(::Base.CodeUnits{UInt8, String})
   @ Base strings/string.jl:107
  String(::Vector{UInt8})
   @ Base strings/string.jl:67
  String(::LazyString)
   @ Base strings/lazy.jl:80
  ...

Stacktrace:
 [1] override_default_config(config_dict::Dict{String, Nothing})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/yaml_helper.jl:79
 [2] ClimaAtmos.AtmosConfig(config::Dict{String, Nothing}; comms_ctx::Nothing)
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/types.jl:487
 [3] ClimaAtmos.AtmosConfig(config::Dict{String, Nothing})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/types.jl:486
 [4] top-level scope
   @ ~/Projects/ClimaEarth.jl/examples/atmos_single_column_model/test.jl:31
 [5] include(fname::String)
   @ Base.MainInclude ./client.jl:489
 [6] top-level scope
   @ REPL[1]:1
```

whereas previously users were greeted with the more mysterious

```julia
MethodError: no method matching String(::Nothing)
```

(I'm also wondering how to turn hyperdiffusion off).

It also improves the error users get when their "config" is not valid (note that the term "config" is being used to mean multiple things --- either `AtmosConfig`, or the "config type", which can be sphere, column, etc. This should probably be improved because it is another source of bugs...)

For example if we try to use `config = "crazy configuration"` we get the error:

```julia
ERROR: LoadError: ArgumentError: config = crazy configuration is not one of the valid configurations ("sphere", "column", "box", "plane")
Stacktrace:
 [1] get_model_config(parsed_args::Dict{Any, Any})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/model_getters.jl:21
 [2] get_atmos(config::ClimaAtmos.AtmosConfig{…}, params::ClimaAtmos.Parameters.ClimaAtmosParameters{…})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/type_getters.jl:50
 [3] get_simulation(config::ClimaAtmos.AtmosConfig{Float32, ClimaParams.ParamDict{Float32}, Dict{Any, Any}, ClimaComms.SingletonCommsContext{ClimaComms.CPUSingleThreaded}})
   @ ClimaAtmos ~/Projects/ClimaAtmos.jl/src/solver/type_getters.jl:576
```