### PR TITLE
Disable default compression of NetCDF files

### DIFF
--- a/perf/benchmark_netcdf_io.jl
+++ b/perf/benchmark_netcdf_io.jl
@@ -104,7 +104,7 @@ for device in keys(timings)
     NCDatasets.defDim(nc, "x", NUM)
     NCDatasets.defDim(nc, "y", NUM)
     NCDatasets.defDim(nc, "z", NUM)
-    v = NCDatasets.defVar(nc, "rhoa", Float32, ("time", "x", "y", "z"))
+    v = NCDatasets.defVar(nc, "rhoa", Float64, ("time", "x", "y", "z"))
     outarray = Array(netcdf_writer.remappers["rhoa"]._interpolated_values)
     v[1, :, :, :] = outarray
 

--- a/src/diagnostics/netcdf_writer.jl
+++ b/src/diagnostics/netcdf_writer.jl
@@ -527,7 +527,7 @@ function NetCDFWriter(;
     cspace,
     num_points = (180, 90, 50),
     disable_vertical_interpolation = false,
-    compression_level = 9,
+    compression_level = 0,
 )
     space = cspace
     horizontal_space = Spaces.horizontal_space(space)


### PR DESCRIPTION
By default, NetCDF files were compressed on the fly. This had no measurable performance impact when the file was synced immediately (or maybe compression happened at sync?). Now that the sync is decoupled from output, disabling compression moves the io benchmark much closer to the theoretical limit set by NCDatasets. Coupling this with a reduced sync frequency, this should have very significant impact towards #2827

cc: @charleskawczynski 
