### PR TITLE
Ensure that the CI plots are in the CI folder

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -257,7 +257,7 @@ if ClimaComms.iamroot(config.comms_ctx)
         paths = if isempty(readdir(nc_dir))
             simulation.output_dir
         else
-            [nc_dir, simulation.output_dir]
+            [simulation.output_dir, nc_dir]
         end
         make_plots(Val(Symbol(reference_job_id)), paths)
     end

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -36,9 +36,6 @@ using Test
 import Tar
 import Base.Filesystem: rm
 import OrderedCollections
-using ClimaCoreTempestRemap
-using ClimaCorePlots
-using ClimaCoreMakie, CairoMakie
 include(joinpath(pkgdir(CA), "post_processing", "ci_plots.jl"))
 
 ref_job_id = config.parsed_args["reference_job_id"]


### PR DESCRIPTION
`ci_plots` writes the files in the first folder, so it is currently writing to the our reference folder as opposed to the ci one. This swaps the order, ensuring that we write the correct artifact path.

I also did some import cleaning in the meantime.
