### PR TITLE
Encapsulate surface conditions setting functionality so it can be reused

### DIFF
--- a/regression_tests/ref_counter.jl
+++ b/regression_tests/ref_counter.jl
@@ -1,13 +1,16 @@
-161
+162
 
-# 161: 
+# 162:
+# - Changed the order of operations in surface conditions calculation.
+
+# 161:
 # - Change domain top to 55 km in simulations with high top
 
-# 160: 
+# 160:
 # - Introduces initial conditions for the baroclinic-wave
 #   test case in a deep-atmosphere configuration. Modifies
-#   existing config to use `deep_atmosphere` mode. 
-#
+#   existing config to use `deep_atmosphere` mode.
+
 # 159:
 # - Changed the boundary condition of edmf updraft properties
 #   to be dependent on the surface area


### PR DESCRIPTION
This small PR encapsulates some of the functionality of `atmos_surface_conditions` so that it can be used elsewhere. It also tries to introduce a bit of notation hopefully to make the code a little clearer.

With @LenkaNovak and @akshaysridhar 