### PR TITLE
add single column prognostic edmf bomex

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -579,6 +579,14 @@ steps:
         artifact_paths: "prognostic_edmfx_bomex_stretched_box/*"
         agents:
           slurm_mem: 20GB
+      
+      - label: ":genie: Prognostic EDMFX Bomex in a column"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_bomex_column.yml
+        artifact_paths: "prognostic_edmfx_bomex_column/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":genie: Prognostic EDMFX Dycoms RF01 in a box"
         command: >

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -1,0 +1,37 @@
+job_id: "prognostic_edmfx_bomex_column"
+initial_condition: "Bomex"
+subsidence: "Bomex"
+edmf_coriolis: "Bomex"
+ls_adv: "Bomex"
+surface_setup: "Bomex"
+turbconv: "prognostic_edmfx"
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
+max_newton_iters_ode: 3
+edmfx_upwinding: first_order
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+edmfx_velocity_relaxation: true
+prognostic_tke: true
+moist: "equil"
+config: "column"
+z_max: 3e3
+z_elem: 60
+z_stretch: false
+perturb_initstate: false
+dt: "50secs"
+t_end: "6hours"
+dt_save_to_disk: "10mins"
+toml: [toml/prognostic_edmfx_bomex_box.toml]
+netcdf_output_at_levels: true
+netcdf_interpolation_num_points: [2, 2, 60]
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -943,6 +943,7 @@ EDMFBoxPlots = Union{
     Val{:prognostic_edmfx_gabls_box},
     Val{:prognostic_edmfx_bomex_fixtke_box},
     Val{:prognostic_edmfx_bomex_box},
+    Val{:prognostic_edmfx_bomex_column},
     Val{:prognostic_edmfx_bomex_stretched_box},
     Val{:prognostic_edmfx_dycoms_rf01_box},
     Val{:prognostic_edmfx_rico_column},


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a single column prognostic edmf bomex job. This will be helpful for debugging edmf and for building the calibration pipeline.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
