### PR TITLE
Add 1-moment microphysics to prognostic EDMF

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -573,7 +573,7 @@ steps:
         artifact_paths: "prognostic_edmfx_bomex_stretched_column/*"
         agents:
           slurm_mem: 20GB
-      
+
       - label: ":genie: Prognostic EDMFX Bomex in a column"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
@@ -590,7 +590,7 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":genie: Prognostic EDMFX Rico in a column"
+      - label: ":umbrella: Prognostic EDMFX Rico in a column"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_rico_column.yml
@@ -598,11 +598,19 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":genie: Prognostic EDMFX TRMM in a column"
+      - label: ":umbrella: Prognostic EDMFX TRMM in a column"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column.yml
         artifact_paths: "prognostic_edmfx_trmm_column/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":genie: Prognostic EDMFX TRMM in a column"
+        command: >
+          julia --color=yes --project=examples examples/hybrid/driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column_0M.yml
+        artifact_paths: "prognostic_edmfx_trmm_column_0M/*"
         agents:
           slurm_mem: 20GB
 

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -13,7 +13,7 @@ edmfx_nh_pressure: true
 edmfx_velocity_relaxation: true
 prognostic_tke: true
 moist: "equil"
-precip_model: "0M"
+precip_model: "1M"
 config: "column"
 z_max: 4e3
 x_elem: 2
@@ -33,4 +33,6 @@ diagnostics:
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
     period: 10mins
   - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
     period: 10mins

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -1,4 +1,4 @@
-job_id: prognostic_edmfx_trmm_column
+job_id: prognostic_edmfx_trmm_column_0M
 initial_condition: TRMM_LBA
 rad: TRMM_LBA
 surface_setup: TRMM_LBA
@@ -13,7 +13,7 @@ edmfx_velocity_relaxation: true
 prognostic_tke: true
 moist: equil
 apply_limiter: false
-precip_model: "1M"
+precip_model: "0M"
 config: column
 z_max: 16400
 x_elem: 2
@@ -30,9 +30,5 @@ netcdf_interpolation_num_points: [8, 8, 82]
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl]
     period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
     period: 10mins

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -183,6 +183,7 @@ if config.parsed_args["check_precipitation"]
             sol.t[end],
             colidx,
             sol.prob.p.atmos.precip_model,
+            sol.prob.p.atmos.turbconv_model,
         )
 
         @. Yₜ_ρqₚ[colidx] = -Yₜ.c.ρq_rai[colidx] - Yₜ.c.ρq_sno[colidx]

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -946,11 +946,16 @@ EDMFBoxPlots = Union{
     Val{:prognostic_edmfx_bomex_column},
     Val{:prognostic_edmfx_bomex_stretched_column},
     Val{:prognostic_edmfx_dycoms_rf01_column},
-    Val{:prognostic_edmfx_rico_column},
-    Val{:prognostic_edmfx_trmm_column},
+    Val{:prognostic_edmfx_trmm_column_0M},
     Val{:prognostic_edmfx_simpleplume_column},
     Val{:prognostic_edmfx_bomex_box},
 }
+
+EDMFBoxPlotsWithPrecip = Union{
+    Val{:prognostic_edmfx_rico_column},
+    Val{:prognostic_edmfx_trmm_column},
+}
+
 
 """
     plot_edmf_vert_profile!(grid_loc, var_group)
@@ -1025,8 +1030,13 @@ function pair_edmf_names(short_names)
     return grouped_vars
 end
 
-function make_plots(::EDMFBoxPlots, output_paths::Vector{<:AbstractString})
+function make_plots(
+    sim_type::Union{EDMFBoxPlots, EDMFBoxPlotsWithPrecip},
+    output_paths::Vector{<:AbstractString},
+)
     simdirs = SimDir.(output_paths)
+
+    precip_names = sim_type isa EDMFBoxPlotsWithPrecip ? ("husra", "hussn") : ()
 
     short_names = [
         "ua",
@@ -1050,6 +1060,7 @@ function make_plots(::EDMFBoxPlots, output_paths::Vector{<:AbstractString})
         "clwup",
         "cli",
         "cliup",
+        precip_names...,
     ]
     reduction = "inst"
     period = "30m"

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -3,6 +3,11 @@
 #####
 import CloudMicrophysics.Microphysics1M as CM1
 
+# helper function to safely get precipitation from state
+function qₚ(ρqₚ::FT, ρ::FT) where {FT}
+    return max(FT(0), ρqₚ / ρ)
+end
+
 """
     set_precipitation_precomputed_quantities!(Y, p, t)
 
@@ -12,9 +17,13 @@ for the 1-moment microphysics scheme
 function set_precipitation_precomputed_quantities!(Y, p, t)
     @assert (p.atmos.precip_model isa Microphysics1Moment)
 
-    (; ᶜwᵣ, ᶜwₛ) = p.precomputed
+    (; ᶜwᵣ, ᶜwₛ, ᶜqᵣ, ᶜqₛ) = p.precomputed
 
     cmp = CAP.microphysics_params(p.params)
+
+    # compute the precipitation specific humidities
+    @. ᶜqᵣ = qₚ(Y.c.ρq_rai, Y.c.ρ)
+    @. ᶜqₛ = qₚ(Y.c.ρq_sno, Y.c.ρ)
 
     # compute the precipitation terminal velocity [m/s]
     @. ᶜwᵣ = CM1.terminal_velocity(

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -13,11 +13,6 @@ const qᵥ = TD.vapor_specific_humidity
 qₗ(thp, ts) = TD.PhasePartition(thp, ts).liq
 qᵢ(thp, ts) = TD.PhasePartition(thp, ts).ice
 
-# helper function to safely get precipitation from state
-function qₚ(ρqₚ::FT, ρ::FT) where {FT}
-    return max(FT(0), ρqₚ / ρ)
-end
-
 # helper function to limit the tendency
 function limit(q::FT, dt::FT) where {FT}
     return q / dt / 5
@@ -78,12 +73,12 @@ function e_tot_0M_precipitation_sources_helper(
 end
 
 """
-    compute_precipitation_sources!(Sᵖ, Sᵖ_snow, Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ, ρ, ρqᵣ, ρqₛ, ts, Φ, dt, mp, thp)
+    compute_precipitation_sources!(Sᵖ, Sᵖ_snow, Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ, ρ, qᵣ, qₛ, ts, Φ, dt, mp, thp)
 
  - Sᵖ, Sᵖ_snow - temporary containters to help compute precipitation source terms
  - Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ - cached storage for precipitation source terms
  - ρ - air density
- - ρqᵣ, ρqₛ - precipitation (rain and snow) densities
+ - qᵣ, qₛ - precipitation (rain and snow) specific humidity
  - ts - thermodynamic state (see td package for details)
  - Φ - geopotential
  - dt - model time step
@@ -102,8 +97,8 @@ function compute_precipitation_sources!(
     Sqₛᵖ,
     Seₜᵖ,
     ρ,
-    ρqᵣ,
-    ρqₛ,
+    qᵣ,
+    qₛ,
     ts,
     Φ,
     dt,
@@ -111,6 +106,11 @@ function compute_precipitation_sources!(
     thp,
 )
     FT = eltype(Sqₜᵖ)
+    @. Sqₜᵖ = FT(0)
+    @. Sqᵣᵖ = FT(0)
+    @. Sqₛᵖ = FT(0)
+    @. Seₜᵖ = FT(0)
+
     #! format: off
     # rain autoconversion: q_liq -> q_rain
     @. Sᵖ = min(
@@ -133,7 +133,7 @@ function compute_precipitation_sources!(
     # accretion: q_liq + q_rain -> q_rain
     @. Sᵖ = min(
         limit(qₗ(thp, ts), dt),
-        CM1.accretion(mp.cl, mp.pr, mp.tv.rain, mp.ce, qₗ(thp, ts), qₚ(ρqᵣ, ρ), ρ),
+        CM1.accretion(mp.cl, mp.pr, mp.tv.rain, mp.ce, qₗ(thp, ts), qᵣ, ρ),
     )
     @. Sqₜᵖ -= Sᵖ
     @. Sqᵣᵖ += Sᵖ
@@ -142,7 +142,7 @@ function compute_precipitation_sources!(
     # accretion: q_ice + q_snow -> q_snow
     @. Sᵖ = min(
         limit(qᵢ(thp, ts), dt),
-        CM1.accretion(mp.ci, mp.ps, mp.tv.snow, mp.ce, qᵢ(thp, ts), qₚ(ρqₛ, ρ), ρ),
+        CM1.accretion(mp.ci, mp.ps, mp.tv.snow, mp.ce, qᵢ(thp, ts), qₛ, ρ),
     )
     @. Sqₜᵖ -= Sᵖ
     @. Sqₛᵖ += Sᵖ
@@ -152,7 +152,7 @@ function compute_precipitation_sources!(
     # sink of cloud water via accretion cloud water + snow
     @. Sᵖ = min(
         limit(qₗ(thp, ts), dt),
-        CM1.accretion(mp.cl, mp.ps, mp.tv.snow, mp.ce, qₗ(thp, ts), qₚ(ρqₛ, ρ), ρ),
+        CM1.accretion(mp.cl, mp.ps, mp.tv.snow, mp.ce, qₗ(thp, ts), qₛ, ρ),
     )
     # if T < T_freeze cloud droplets freeze to become snow
     # else the snow melts and both cloud water and snow become rain
@@ -160,7 +160,7 @@ function compute_precipitation_sources!(
     @. Sᵖ_snow = ifelse(
         Tₐ(thp, ts) < mp.ps.T_freeze,
         Sᵖ,
-        FT(-1) * min(Sᵖ * α(thp, ts), limit(qₚ(ρqₛ, ρ), dt)),
+        FT(-1) * min(Sᵖ * α(thp, ts), limit(qₛ, dt)),
     )
     @. Sqₛᵖ += Sᵖ_snow
     @. Sqₜᵖ -= Sᵖ
@@ -174,15 +174,15 @@ function compute_precipitation_sources!(
     # accretion: q_ice + q_rai -> q_sno
     @. Sᵖ = min(
         limit(qᵢ(thp, ts), dt),
-        CM1.accretion(mp.ci, mp.pr, mp.tv.rain, mp.ce, qᵢ(thp, ts), qₚ(ρqᵣ, ρ), ρ),
+        CM1.accretion(mp.ci, mp.pr, mp.tv.rain, mp.ce, qᵢ(thp, ts), qᵣ, ρ),
     )
     @. Sqₜᵖ -= Sᵖ
     @. Sqₛᵖ += Sᵖ
     @. Seₜᵖ -= Sᵖ * (Iᵢ(thp, ts) + Φ)
     # sink of rain via accretion cloud ice - rain
     @. Sᵖ = min(
-        limit(qₚ(ρqᵣ, ρ), dt),
-        CM1.accretion_rain_sink(mp.pr, mp.ci, mp.tv.rain, mp.ce, qᵢ(thp, ts), qₚ(ρqᵣ, ρ), ρ),
+        limit(qᵣ, dt),
+        CM1.accretion_rain_sink(mp.pr, mp.ci, mp.tv.rain, mp.ce, qᵢ(thp, ts), qᵣ, ρ),
     )
     @. Sqᵣᵖ -= Sᵖ
     @. Sqₛᵖ += Sᵖ
@@ -192,12 +192,12 @@ function compute_precipitation_sources!(
     @. Sᵖ = ifelse(
         Tₐ(thp, ts) < mp.ps.T_freeze,
         min(
-            limit(qₚ(ρqᵣ, ρ), dt),
-            CM1.accretion_snow_rain(mp.ps, mp.pr, mp.tv.rain, mp.tv.snow, mp.ce, qₚ(ρqₛ, ρ), qₚ(ρqᵣ, ρ), ρ),
+            limit(qᵣ, dt),
+            CM1.accretion_snow_rain(mp.ps, mp.pr, mp.tv.rain, mp.tv.snow, mp.ce, qₛ, qᵣ, ρ),
         ),
         -min(
-            limit(qₚ(ρqₛ, ρ), dt),
-            CM1.accretion_snow_rain(mp.pr, mp.ps, mp.tv.snow, mp.tv.rain, mp.ce, qₚ(ρqᵣ, ρ), qₚ(ρqₛ, ρ), ρ),
+            limit(qₛ, dt),
+            CM1.accretion_snow_rain(mp.pr, mp.ps, mp.tv.snow, mp.tv.rain, mp.ce, qᵣ, qₛ, ρ),
         ),
     )
     @. Sqₛᵖ += Sᵖ
@@ -207,12 +207,12 @@ function compute_precipitation_sources!(
 end
 
 """
-    compute_precipitation_sinks!(Sᵖ, Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ, ρ, ρqᵣ, ρqₛ, ts, Φ, dt, mp, thp)
+    compute_precipitation_sinks!(Sᵖ, Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ, ρ, qᵣ, qₛ, ts, Φ, dt, mp, thp)
 
  - Sᵖ - a temporary containter to help compute precipitation source terms
  - Sqₜᵖ, Sqᵣᵖ, Sqₛᵖ, Seₜᵖ - cached storage for precipitation source terms
  - ρ - air density
- - ρqᵣ, ρqₛ - precipitation (rain and snow) densities
+ - qᵣ, qₛ - precipitation (rain and snow) specific humidities
  - ts - thermodynamic state (see td package for details)
  - Φ - geopotential
  - dt - model time step
@@ -230,8 +230,8 @@ function compute_precipitation_sinks!(
     Sqₛᵖ,
     Seₜᵖ,
     ρ,
-    ρqᵣ,
-    ρqₛ,
+    qᵣ,
+    qₛ,
     ts,
     Φ,
     dt,
@@ -245,8 +245,8 @@ function compute_precipitation_sinks!(
     #! format: off
     # evaporation: q_rai -> q_vap
     @. Sᵖ = -min(
-        limit(qₚ(ρqᵣ, ρ), dt),
-        -CM1.evaporation_sublimation(rps..., PP(thp, ts), qₚ(ρqᵣ, ρ), ρ, Tₐ(thp, ts)),
+        limit(qᵣ, dt),
+        -CM1.evaporation_sublimation(rps..., PP(thp, ts), qᵣ, ρ, Tₐ(thp, ts)),
     )
     @. Sqₜᵖ -= Sᵖ
     @. Sqᵣᵖ += Sᵖ
@@ -254,19 +254,19 @@ function compute_precipitation_sinks!(
 
     # melting: q_sno -> q_rai
     @. Sᵖ = min(
-        limit(qₚ(ρqₛ, ρ), dt),
-        CM1.snow_melt(sps..., qₚ(ρqₛ, ρ), ρ, Tₐ(thp, ts)),
+        limit(qₛ, dt),
+        CM1.snow_melt(sps..., qₛ, ρ, Tₐ(thp, ts)),
     )
     @. Sqᵣᵖ += Sᵖ
     @. Sqₛᵖ -= Sᵖ
     @. Seₜᵖ -= Sᵖ * Lf(thp, ts)
 
     # deposition/sublimation: q_vap <-> q_sno
-    @. Sᵖ = CM1.evaporation_sublimation(sps..., PP(thp, ts), qₚ(ρqₛ, ρ), ρ, Tₐ(thp, ts))
+    @. Sᵖ = CM1.evaporation_sublimation(sps..., PP(thp, ts), qₛ, ρ, Tₐ(thp, ts))
     @. Sᵖ = ifelse(
         Sᵖ > FT(0),
         min(limit(qᵥ(thp, ts), dt), Sᵖ),
-        -min(limit(qₚ(ρqₛ, ρ), dt), FT(-1) * Sᵖ),
+        -min(limit(qₛ, dt), FT(-1) * Sᵖ),
     )
     @. Sqₜᵖ -= Sᵖ
     @. Sqₛᵖ += Sᵖ

--- a/src/prognostic_equations/edmfx_precipitation.jl
+++ b/src/prognostic_equations/edmfx_precipitation.jl
@@ -45,3 +45,33 @@ function edmfx_precipitation_tendency!(
     end
     return nothing
 end
+
+function edmfx_precipitation_tendency!(
+    Yₜ,
+    Y,
+    p,
+    t,
+    colidx,
+    turbconv_model::PrognosticEDMFX,
+    precip_model::Microphysics1Moment,
+)
+    n = n_mass_flux_subdomains(turbconv_model)
+    (; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜtsʲs) = p.precomputed
+    thp = CAP.thermodynamics_params(p.params)
+    (; ᶜΦ) = p.core
+
+    for j in 1:n
+
+        @. Yₜ.c.sgsʲs.:($$j).ρa[colidx] +=
+            Y.c.sgsʲs.:($$j).ρa[colidx] * ᶜSqₜᵖʲs.:($$j)[colidx]
+
+        @. Yₜ.c.sgsʲs.:($$j).mse[colidx] +=
+            ᶜSeₜᵖʲs.:($$j)[colidx] -
+            ᶜSqₜᵖʲs.:($$j)[colidx] *
+            TD.internal_energy(thp, ᶜtsʲs.:($$j)[colidx])
+
+        @. Yₜ.c.sgsʲs.:($$j).q_tot[colidx] +=
+            ᶜSqₜᵖʲs.:($$j)[colidx] * (1 - Y.c.sgsʲs.:($$j).q_tot[colidx])
+    end
+    return nothing
+end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -94,7 +94,15 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             p.atmos.turbconv_model,
             p.atmos.precip_model,
         )
-        precipitation_tendency!(Yₜ, Y, p, t, colidx, p.atmos.precip_model)
+        precipitation_tendency!(
+            Yₜ,
+            Y,
+            p,
+            t,
+            colidx,
+            p.atmos.precip_model,
+            p.atmos.turbconv_model,
+        )
 
         # NOTE: All ρa tendencies should be applied before calling this function
         pressure_work_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)


### PR DESCRIPTION
This PR adds 1-moment microphysics scheme to prognostic EDMF.

Precipitation (rain and snow) is only computed as a grid mean quantity (i.e. we don't have updraft and environment precipitation variables). The sources to precipitation are computed as a sum of contributions from updrafts and the environment. The precipitation sinks (evaporation, melting, deposition/sublimation) are only computed on the grid mean. 

My main priority was to only have one definition of `compute_precipitation_sources!` and `compute_precipitation_sinks!`. This is where I loop over all microphysics processes and I don't want to have multiple versions of it. That function returns 4 outputs (source terms to total water, rain, snow and energy) and I didn't know how to write it outside of a `colidx` loop.

Things I don't like about the code right now:
- the additional `colidx` loop
- all the additional variables I'm adding to the cache
- `compute_precipitation_sinks!` and `compute_precipitation_sources!` behave differently. The `sources` one zeroes out the cached `S` before adding to it. The `sinks` does not. This is because when used without EDMF, the `sinks` are done after the `sources` and add to the same cached values. This is clunky, but I didn't have a better idea and I did not want to add another 4 variables to the cache

Also, can I re-use my tmp scalar between different updraft j-s and the environment?

```
    tmp1 = p.scratch.ᶜtemp_scalar
    n = number of updrafts

    do colidx
        # Sources from the updrafts
        for j in 1:n
            foo!(
                tmp1[colidx],
               all_the_sgs_j_variables_and_dollars[colidx]
            )
        end
```