### PR TITLE
Cleanup in 0M diagnostic EDMF

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -58,10 +58,7 @@ function precomputed_quantities(Y, atmos)
     cloud_diagnostics = (; ᶜcloud_fraction = similar(Y.c, FT),)
     precipitation_sgs_quantities =
         atmos.precip_model isa Microphysics0Moment ?
-        (;
-            ᶜS_q_totʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜS_q_tot⁰ = similar(Y.c, FT),
-        ) :
+        (; ᶜSqₜᵖʲs = similar(Y.c, NTuple{n, FT}), ᶜSqₜᵖ⁰ = similar(Y.c, FT)) :
         atmos.precip_model isa Microphysics1Moment ?
         (;
             ᶜSeₜᵖʲs = similar(Y.c, NTuple{n, FT}),
@@ -122,9 +119,6 @@ function precomputed_quantities(Y, atmos)
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
             ᶠnh_pressure³ʲs = similar(Y.f, NTuple{n, CT3{FT}}),
-            ᶜS_q_totʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜS_q_tot⁰ = similar(Y.c, FT),
-            ᶜS_e_totʲs_helper = similar(Y.c, NTuple{n, FT}),
             ᶠu³⁰ = similar(Y.f, CT3{FT}),
             ᶜu⁰ = similar(Y.c, C123{FT}),
             ᶜK⁰ = similar(Y.c, FT),
@@ -134,6 +128,7 @@ function precomputed_quantities(Y, atmos)
             ᶜK_u = similar(Y.c, FT),
             ᶜK_h = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
+            precipitation_sgs_quantities...,
         ) : (;)
     vert_diff_quantities = if atmos.vert_diff isa VerticalDiffusion
         ᶜK_h = similar(Y.c, FT)
@@ -518,6 +513,12 @@ NVTX.@annotate function set_precomputed_quantities!(Y, p, t)
         set_diagnostic_edmf_precomputed_quantities_do_integral!(Y, p, t)
         set_diagnostic_edmf_precomputed_quantities_top_bc!(Y, p, t)
         set_diagnostic_edmf_precomputed_quantities_env_closures!(Y, p, t)
+        set_diagnostic_edmf_precomputed_quantities_env_precipitation!(
+            Y,
+            p,
+            t,
+            p.atmos.precip_model,
+        )
     end
 
     if vert_diff isa VerticalDiffusion

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -364,12 +364,12 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     (; params, dt) = p
     thp = CAP.thermodynamics_params(params)
     cmp = CAP.microphysics_params(params)
-    (; ᶜts⁰, ᶜq_tot⁰, ᶜtsʲs, ᶜS_q_totʲs, ᶜS_q_tot⁰) = p.precomputed
+    (; ᶜts⁰, ᶜq_tot⁰, ᶜtsʲs, ᶜSqₜᵖʲs, ᶜSqₜᵖ⁰) = p.precomputed
 
     # Sources from the updrafts
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
     for j in 1:n
-        @. ᶜS_q_totʲs.:($$j) = q_tot_precipitation_sources(
+        @. ᶜSqₜᵖʲs.:($$j) = q_tot_precipitation_sources(
             Microphysics0Moment(),
             thp,
             cmp,
@@ -379,7 +379,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
         )
     end
     # sources from the environment
-    @. ᶜS_q_tot⁰ = q_tot_precipitation_sources(
+    @. ᶜSqₜᵖ⁰ = q_tot_precipitation_sources(
         Microphysics0Moment(),
         thp,
         cmp,

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -28,6 +28,7 @@ function precipitation_cache(Y, precip_model::Microphysics0Moment)
     FT = Spaces.undertype(axes(Y.c))
     return (;
         ᶜS_ρq_tot = similar(Y.c, FT),
+        ᶜS_ρe_tot = similar(Y.c, FT),
         ᶜ3d_rain = similar(Y.c, FT),
         ᶜ3d_snow = similar(Y.c, FT),
         col_integrated_rain = zeros(
@@ -42,7 +43,8 @@ end
 function compute_precipitation_cache!(Y, p, colidx, ::Microphysics0Moment, _)
     (; params, dt) = p
     (; ᶜts) = p.precomputed
-    (; ᶜS_ρq_tot) = p.precipitation
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
+    (; ᶜΦ) = p.core
     cm_params = CAP.microphysics_params(params)
     thermo_params = CAP.thermodynamics_params(params)
     @. ᶜS_ρq_tot[colidx] =
@@ -54,6 +56,12 @@ function compute_precipitation_cache!(Y, p, colidx, ::Microphysics0Moment, _)
             Y.c.ρq_tot[colidx] / Y.c.ρ[colidx],
             ᶜts[colidx],
         )
+    @. ᶜS_ρe_tot[colidx] =
+        ᶜS_ρq_tot[colidx] * e_tot_0M_precipitation_sources_helper(
+            thermo_params,
+            ᶜts[colidx],
+            ᶜΦ[colidx],
+        )
 end
 
 function compute_precipitation_cache!(
@@ -64,16 +72,35 @@ function compute_precipitation_cache!(
     ::DiagnosticEDMFX,
 )
     # For environment we multiply by grid mean ρ and not byᶜρa⁰
-    # I.e. assuming a⁰=1
+    # assuming a⁰=1
+    (; ᶜΦ) = p.core
+    (; ᶜSqₜᵖ⁰, ᶜSqₜᵖʲs, ᶜρaʲs) = p.precomputed
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
+    (; ᶜts, ᶜtsʲs) = p.precomputed
+    thermo_params = CAP.thermodynamics_params(p.params)
 
-    (; ᶜS_q_tot⁰, ᶜS_q_totʲs, ᶜρaʲs) = p.precomputed
-    (; ᶜS_ρq_tot) = p.precipitation
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
     ρ = Y.c.ρ
 
-    @. ᶜS_ρq_tot[colidx] = ᶜS_q_tot⁰[colidx] * ρ[colidx]
+    @. ᶜS_ρq_tot[colidx] = ᶜSqₜᵖ⁰[colidx] * ρ[colidx]
+    @. ᶜS_ρe_tot[colidx] =
+        ᶜSqₜᵖ⁰[colidx] *
+        ρ[colidx] *
+        e_tot_0M_precipitation_sources_helper(
+            thermo_params,
+            ᶜts[colidx],
+            ᶜΦ[colidx],
+        )
     for j in 1:n
-        @. ᶜS_ρq_tot[colidx] += ᶜS_q_totʲs.:($$j)[colidx] * ᶜρaʲs.:($$j)[colidx]
+        @. ᶜS_ρq_tot[colidx] += ᶜSqₜᵖʲs.:($$j)[colidx] * ᶜρaʲs.:($$j)[colidx]
+        @. ᶜS_ρe_tot[colidx] +=
+            ᶜSqₜᵖʲs.:($$j)[colidx] *
+            ᶜρaʲs.:($$j)[colidx] *
+            e_tot_0M_precipitation_sources_helper(
+                thermo_params,
+                ᶜtsʲs.:($$j)[colidx],
+                ᶜΦ[colidx],
+            )
     end
 end
 
@@ -84,14 +111,34 @@ function compute_precipitation_cache!(
     ::Microphysics0Moment,
     ::PrognosticEDMFX,
 )
-    (; ᶜS_q_tot⁰, ᶜS_q_totʲs, ᶜρa⁰) = p.precomputed
-    (; ᶜS_ρq_tot) = p.precipitation
+    (; ᶜΦ) = p.core
+    (; ᶜSqₜᵖ⁰, ᶜSqₜᵖʲs, ᶜρa⁰) = p.precomputed
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
+    (; ᶜts⁰, ᶜtsʲs) = p.precomputed
+    thermo_params = CAP.thermodynamics_params(p.params)
+
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
 
-    @. ᶜS_ρq_tot[colidx] = ᶜS_q_tot⁰[colidx] * ᶜρa⁰[colidx]
+    @. ᶜS_ρq_tot[colidx] = ᶜSqₜᵖ⁰[colidx] * ᶜρa⁰[colidx]
+    @. ᶜS_ρe_tot[colidx] =
+        ᶜSqₜᵖ⁰[colidx] *
+        ᶜρa⁰[colidx] *
+        e_tot_0M_precipitation_sources_helper(
+            thermo_params,
+            ᶜts⁰[colidx],
+            ᶜΦ[colidx],
+        )
     for j in 1:n
         @. ᶜS_ρq_tot[colidx] +=
-            ᶜS_q_totʲs.:($$j)[colidx] * Y.c.sgsʲs.:($$j).ρa[colidx]
+            ᶜSqₜᵖʲs.:($$j)[colidx] * Y.c.sgsʲs.:($$j).ρa[colidx]
+        @. ᶜS_ρe_tot[colidx] +=
+            ᶜSqₜᵖʲs.:($$j)[colidx] *
+            Y.c.sgsʲs.:($$j).ρa[colidx] *
+            e_tot_0M_precipitation_sources_helper(
+                thermo_params,
+                ᶜtsʲs.:($$j)[colidx],
+                ᶜΦ[colidx],
+            )
     end
 end
 
@@ -105,28 +152,30 @@ function precipitation_tendency!(
     _,
 )
     (; ᶜT, ᶜΦ) = p.core
-    (; ᶜts,) = p.precomputed  # assume ᶜts has been updated
+    (; ᶜts) = p.precomputed  # assume ᶜts has been updated
     (; params) = p
     (; turbconv_model) = p.atmos
-    (;
-        ᶜ3d_rain,
-        ᶜ3d_snow,
-        ᶜS_ρq_tot,
-        col_integrated_rain,
-        col_integrated_snow,
-    ) = p.precipitation
+    (; ᶜ3d_rain, ᶜ3d_snow, ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
+    (; col_integrated_rain, col_integrated_snow) = p.precipitation
     (; col_integrated_precip_energy_tendency,) = p.conservation_check
-
     thermo_params = CAP.thermodynamics_params(params)
-    compute_precipitation_cache!(Y, p, colidx, precip_model, turbconv_model)
-    if !isnothing(Yₜ)
-        @. Yₜ.c.ρq_tot[colidx] += ᶜS_ρq_tot[colidx]
-        @. Yₜ.c.ρ[colidx] += ᶜS_ρq_tot[colidx]
-    end
-    T_freeze = TD.Parameters.T_freeze(thermo_params)
 
+    # Compute the ρq_tot and ρe_tot precipitation source terms
+    compute_precipitation_cache!(Y, p, colidx, precip_model, turbconv_model)
+
+    # Add the source terms to the tendencies
+    @. Yₜ.c.ρq_tot[colidx] += ᶜS_ρq_tot[colidx]
+    @. Yₜ.c.ρ[colidx] += ᶜS_ρq_tot[colidx]
+    @. Yₜ.c.ρe_tot[colidx] += ᶜS_ρe_tot[colidx]
+
+    # update total column energy source for surface energy balance
+    Operators.column_integral_definite!(
+        col_integrated_precip_energy_tendency[colidx],
+        ᶜS_ρe_tot[colidx],
+    )
     # update precip in cache for coupler's use
     # 3d rain and snow
+    T_freeze = TD.Parameters.T_freeze(thermo_params)
     @. ᶜT[colidx] = TD.air_temperature(thermo_params, ᶜts[colidx])
     @. ᶜ3d_rain[colidx] = ifelse(ᶜT[colidx] >= T_freeze, ᶜS_ρq_tot[colidx], 0)
     @. ᶜ3d_snow[colidx] = ifelse(ᶜT[colidx] < T_freeze, ᶜS_ρq_tot[colidx], 0)
@@ -138,40 +187,6 @@ function precipitation_tendency!(
         col_integrated_snow[colidx],
         ᶜ3d_snow[colidx],
     )
-
-    if :ρe_tot in propertynames(Y.c)
-        #TODO - this is a hack right now. But it will be easier to clean up
-        # once we drop the support for the old EDMF code
-        if turbconv_model isa DiagnosticEDMFX && !isnothing(Yₜ)
-            @. Yₜ.c.ρe_tot[colidx] +=
-                sum(
-                    p.precomputed.ᶜS_q_totʲs[colidx] *
-                    p.precomputed.ᶜρaʲs[colidx] *
-                    p.precomputed.ᶜS_e_totʲs_helper[colidx],
-                ) +
-                p.precomputed.ᶜS_q_tot⁰[colidx] *
-                Y.c.ρ[colidx] *
-                e_tot_0M_precipitation_sources_helper(
-                    thermo_params,
-                    ᶜts[colidx],
-                    ᶜΦ[colidx],
-                )
-        elseif !isnothing(Yₜ)
-            ρe_tot_tend_colidx = p.scratch.ᶜtemp_scalar_3[colidx]
-            @. ρe_tot_tend_colidx =
-                ᶜS_ρq_tot[colidx] * e_tot_0M_precipitation_sources_helper(
-                    thermo_params,
-                    ᶜts[colidx],
-                    ᶜΦ[colidx],
-                )
-
-            @. Yₜ.c.ρe_tot[colidx] += ρe_tot_tend_colidx
-            Operators.column_integral_definite!(
-                col_integrated_precip_energy_tendency[colidx],
-                ρe_tot_tend_colidx,
-            )
-        end
-    end
     return nothing
 end
 

--- a/src/prognostic_equations/edmfx_precipitation.jl
+++ b/src/prognostic_equations/edmfx_precipitation.jl
@@ -22,17 +22,17 @@ function edmfx_precipitation_tendency!(
     precip_model::Microphysics0Moment,
 )
     n = n_mass_flux_subdomains(turbconv_model)
-    (; ᶜS_q_totʲs, ᶜtsʲs) = p.precomputed
+    (; ᶜSqₜᵖʲs, ᶜtsʲs) = p.precomputed
     thermo_params = CAP.thermodynamics_params(p.params)
     (; ᶜΦ) = p.core
 
     for j in 1:n
 
         @. Yₜ.c.sgsʲs.:($$j).ρa[colidx] +=
-            Y.c.sgsʲs.:($$j).ρa[colidx] * ᶜS_q_totʲs.:($$j)[colidx]
+            Y.c.sgsʲs.:($$j).ρa[colidx] * ᶜSqₜᵖʲs.:($$j)[colidx]
 
         @. Yₜ.c.sgsʲs.:($$j).mse[colidx] +=
-            ᶜS_q_totʲs.:($$j)[colidx] * (
+            ᶜSqₜᵖʲs.:($$j)[colidx] * (
                 e_tot_0M_precipitation_sources_helper(
                     thermo_params,
                     ᶜtsʲs.:($$j)[colidx],
@@ -41,7 +41,7 @@ function edmfx_precipitation_tendency!(
             )
 
         @. Yₜ.c.sgsʲs.:($$j).q_tot[colidx] +=
-            ᶜS_q_totʲs.:($$j)[colidx] * (1 - Y.c.sgsʲs.:($$j).q_tot[colidx])
+            ᶜSqₜᵖʲs.:($$j)[colidx] * (1 - Y.c.sgsʲs.:($$j).q_tot[colidx])
     end
     return nothing
 end


### PR DESCRIPTION
This PR:
-  gets rid of the `ᶜS_e_totʲs_helper` from the 0-moment diagnostic edmf. I think with that I can have the same cache structure for the prognostic and diagnostic edmf for both 0M and 1M options
- adds `ᶜS_ρe_tot` to the 0-moment precipitation cache to simplify the tendency evaluations
- makes diagnostic 0M environmental precip a dispatch choice
- what I do in the diagnostic 0M updraft precipitation is a little hacky, but it avoids allocating for when we are not running with 0M scheme 
