### PR TITLE
fix dividing by 0 in percentile_bounds_mean_norm

### DIFF
--- a/src/prognostic_equations/edmfx_boundary_condition.jl
+++ b/src/prognostic_equations/edmfx_boundary_condition.jl
@@ -56,8 +56,9 @@ function percentile_bounds_mean_norm(
     gauss_int(x) = -exp(-x * x / 2) / sqrt(2 * pi)
     xp_low = Distributions.quantile(Distributions.Normal(), low_percentile)
     xp_high = Distributions.quantile(Distributions.Normal(), high_percentile)
-    return (gauss_int(xp_high) - gauss_int(xp_low)) / (
+    return (gauss_int(xp_high) - gauss_int(xp_low)) / max(
         Distributions.cdf(Distributions.Normal(), xp_high) -
-        Distributions.cdf(Distributions.Normal(), xp_low)
+        Distributions.cdf(Distributions.Normal(), xp_low),
+        eps(FT),
     )
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
