### PR TITLE
move buoyancy gradient and strain rate norm to grid-mean cache

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -53,6 +53,8 @@ function precomputed_quantities(Y, atmos)
         ᶜp = similar(Y.c, FT),
         ᶜh_tot = similar(Y.c, FT),
         ᶜmixing_length = similar(Y.c, FT),
+        ᶜlinear_buoygrad = similar(Y.c, FT),
+        ᶜstrain_rate_norm = similar(Y.c, FT),
         sfc_conditions = Fields.Field(SCT, Spaces.level(axes(Y.f), half)),
     )
     cloud_diagnostics = (; ᶜcloud_fraction = similar(Y.c, FT),)
@@ -83,8 +85,6 @@ function precomputed_quantities(Y, atmos)
             ᶜq_tot⁰ = similar(Y.c, FT),
             ᶜts⁰ = similar(Y.c, TST),
             ᶜρ⁰ = similar(Y.c, FT),
-            ᶜlinear_buoygrad = similar(Y.c, FT),
-            ᶜstrain_rate_norm = similar(Y.c, FT),
             ᶜK_u = similar(Y.c, FT),
             ᶜK_h = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
@@ -123,8 +123,6 @@ function precomputed_quantities(Y, atmos)
             ᶜu⁰ = similar(Y.c, C123{FT}),
             ᶜK⁰ = similar(Y.c, FT),
             ᶜtke⁰ = similar(Y.c, FT),
-            ᶜlinear_buoygrad = similar(Y.c, FT),
-            ᶜstrain_rate_norm = similar(Y.c, FT),
             ᶜK_u = similar(Y.c, FT),
             ᶜK_h = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -247,6 +247,38 @@ add_diagnostic_variable!(
 )
 
 ###
+# Buoyancy gradient (3d)
+###
+add_diagnostic_variable!(
+    short_name = "bgrad",
+    long_name = "Linearized Buoyancy Gradient",
+    units = "s^-2",
+    compute! = (out, state, cache, time) -> begin
+        if isnothing(out)
+            return copy(cache.precomputed.ᶜlinear_buoygrad)
+        else
+            out .= cache.precomputed.ᶜlinear_buoygrad
+        end
+    end,
+)
+
+###
+# Strain rate magnitude (3d)
+###
+add_diagnostic_variable!(
+    short_name = "strain",
+    long_name = "String Rate Magnitude",
+    units = "s^-2",
+    compute! = (out, state, cache, time) -> begin
+        if isnothing(out)
+            return copy(cache.precomputed.ᶜstrain_rate_norm)
+        else
+            out .= cache.precomputed.ᶜstrain_rate_norm
+        end
+    end,
+)
+
+###
 # Relative humidity (3d)
 ###
 compute_hur!(out, state, cache, time) =

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -883,64 +883,6 @@ add_diagnostic_variable!(
 )
 
 ###
-# Buoyancy gradient (3d)
-###
-compute_bgrad!(out, state, cache, time) =
-    compute_bgrad!(out, state, cache, time, cache.atmos.turbconv_model)
-compute_bgrad!(_, _, _, _, turbconv_model::T) where {T} =
-    error_diagnostic_variable("bgrad", turbconv_model)
-
-function compute_bgrad!(
-    out,
-    state,
-    cache,
-    time,
-    turbconv_model::Union{PrognosticEDMFX, DiagnosticEDMFX},
-)
-    if isnothing(out)
-        return copy(cache.precomputed.ᶜlinear_buoygrad)
-    else
-        out .= cache.precomputed.ᶜlinear_buoygrad
-    end
-end
-
-add_diagnostic_variable!(
-    short_name = "bgrad",
-    long_name = "Linearized Buoyancy Gradient",
-    units = "s^-2",
-    compute! = compute_bgrad!,
-)
-
-###
-# Strain rate magnitude (3d)
-###
-compute_strain!(out, state, cache, time) =
-    compute_strain!(out, state, cache, time, cache.atmos.turbconv_model)
-compute_strain!(_, _, _, _, turbconv_model::T) where {T} =
-    error_diagnostic_variable("strain", turbconv_model)
-
-function compute_strain!(
-    out,
-    state,
-    cache,
-    time,
-    turbconv_model::Union{PrognosticEDMFX, DiagnosticEDMFX},
-)
-    if isnothing(out)
-        return copy(cache.precomputed.ᶜstrain_rate_norm)
-    else
-        out .= cache.precomputed.ᶜstrain_rate_norm
-    end
-end
-
-add_diagnostic_variable!(
-    short_name = "strain",
-    long_name = "String Rate Magnitude",
-    units = "s^-2",
-    compute! = compute_strain!,
-)
-
-###
 # Diffusivity of heat (3d)
 ###
 compute_edt!(out, state, cache, time) = compute_edt!(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
We are already calculating buoyancy gradient and strain rate norm in the get_cloud_fraction callback. This PR moves them to the grid-mean precomputed quantities and core diagnostics, so we can compare the values with and without edmf.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
