### PR TITLE
Add logic for reading/interpolating GCM forcings from file and storing in cache

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -232,6 +232,9 @@ ls_adv:
 external_forcing:
   help: "External forcing for single column experiments [`nothing` (default), `GCM`]"
   value: ~
+external_forcing_file:
+  help: "External forcing file containing large-scale forcings, initial conditions, and boundary conditions [`nothing` (default), `path/to/file`]"
+  value: ~
 fps:
   help: "Frames per second for animations"
   value: 5

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -1,6 +1,7 @@
 job_id: "prognostic_edmfx_gcmdriven_column"
 initial_condition: "Bomex"
 external_forcing: "GCM"
+external_forcing_file: "/groups/esm/zhaoyi/GCMForcedLES/cfsite/07/HadGEM2-A/amip/Output.cfsite23_HadGEM2-A_amip_2004-2008.07.4x/stats/Stats.cfsite23_HadGEM2-A_amip_2004-2008.07.nc"
 surface_setup: "Bomex"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -362,7 +362,7 @@ function get_external_forcing_model(parsed_args)
     return if isnothing(external_forcing)
         nothing
     elseif external_forcing == "GCM"
-        GCMForcing()
+        GCMForcing(parsed_args["external_forcing_file"])
     end
 end
 

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -115,7 +115,9 @@ struct LargeScaleAdvection{PT, PQ}
     prof_dqtdt::PQ # Set large-scale drying
 end
 # maybe need to <: AbstractForcing
-struct GCMForcing end
+struct GCMForcing{S}
+    external_forcing_file::S
+end
 
 struct EDMFCoriolis{U, V, FT}
     prof_ug::U


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add logic for reading GCM forcings from file,  interpolating to CA vertical grid, and storing in cache. Part of #2920



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
