### PR TITLE
Add spectrum of total kinetic energy in baroclinc wave

### DIFF
--- a/config/longrun_configs/longrun_bw_rhoe_equil_highres.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_equil_highres.yml
@@ -9,5 +9,5 @@ precip_model: "0M"
 job_id: "longrun_bw_rhoe_equil_highres"
 moist: "equil"
 diagnostics:
-  - short_name: [pfull, wa, va, rv, hus]
+  - short_name: [pfull, wa, va, rv, hus, ke]
     period: 1days

--- a/config/longrun_configs/longrun_bw_rhoe_highres.yml
+++ b/config/longrun_configs/longrun_bw_rhoe_highres.yml
@@ -7,5 +7,5 @@ z_elem: 45
 dt: "400secs"
 job_id: "longrun_bw_rhoe_highres"
 diagnostics:
-  - short_name: [pfull, wa, va, rv]
+  - short_name: [pfull, wa, va, rv, ke]
     period: 1days

--- a/config/model_configs/sphere_baroclinic_wave_rhoe.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe.yml
@@ -4,7 +4,7 @@ dt: "400secs"
 t_end: "10days"
 job_id: "sphere_baroclinic_wave_rhoe"
 diagnostics:
-  - short_name: [pfull, wa, va, rv]
+  - short_name: [pfull, wa, va, rv, ke]
     period: 1days
   - short_name: [pfull, wa, va, rv]
     period: 1days

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -227,6 +227,24 @@ add_diagnostic_variable!(
 )
 
 ###
+# Total kinetic energy
+###
+add_diagnostic_variable!(
+    short_name = "ke",
+    long_name = "Total Kinetic Energy",
+    standard_name = "total_kinetic_energy",
+    units = "m^2 s^-2",
+    comments = "The kinetic energy on cell centers",
+    compute! = (out, state, cache, time) -> begin
+        if isnothing(out)
+            return copy(cache.precomputed.ᶜK)
+        else
+            out .= cache.precomputed.ᶜK
+        end
+    end,
+)
+
+###
 # Mixing length (3d)
 ###
 add_diagnostic_variable!(


### PR DESCRIPTION
Add total kinetic energy to the diagnostics and adds a function to compute its spectrum in the `ci_plots`. The function uses `ClimaCoreSpectra.power_spectrum_2d`, which returns the power spectrum along the two wave numbers, and integrates over the azimuthal wave number ($m$).