### PR TITLE
change the tolerance for conservation without source or sink

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -139,10 +139,14 @@ if config.parsed_args["check_conservation"]
             energy_radiation_input,
         ) / energy_total
     @info "    Net energy change: $energy_net"
-    @test (energy_net / energy_total) ≈ 0 atol = sqrt(eps(FT))
+    if CA.has_no_source_or_sink(config.parsed_args)
+        @test (energy_net / energy_total) ≈ 0 atol = 50 * eps(FT)
+    else
+        @test (energy_net / energy_total) ≈ 0 atol = sqrt(eps(FT))
+    end
 
-    if p.atmos.moisture_model isa CA.DryModel
-        # density
+    if CA.has_no_source_or_sink(config.parsed_args)
+        # mass
         @test sum(sol.u[1].c.ρ) ≈ sum(sol.u[end].c.ρ) rtol = 50 * eps(FT)
     else
         if sfc isa CA.PrognosticSurfaceTemperature

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -16,6 +16,13 @@ is_tracer_var(symbol) = !(
     is_turbconv_var(symbol)
 )
 
+has_no_source_or_sink(parsed_args) = all((
+    isnothing(parsed_args["forcing"]),
+    parsed_args["vert_diff"] == "false",
+    isnothing(parsed_args["turbconv"]),
+    isnothing(parsed_args["precip_model"]),
+))
+
 # we may be hitting a slow path:
 # https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
 fast_pow(x::FT, y::FT) where {FT <: AbstractFloat} = exp(y * log(x))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds back the more strict conservation test for simulations without source and sink (except for radiation). We can refactor the test in the future to have more hierarchy.

Closes #2556 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
