### PR TITLE
add some prognostic edmf filters

### DIFF
--- a/config/default_configs/default_edmf_config.yml
+++ b/config/default_configs/default_edmf_config.yml
@@ -14,7 +14,7 @@ implicit_sgs_advection:
 edmf_coriolis:
   help: "EDMF coriolis [`nothing` (default), `Bomex`,`LifeCycleTan2018`,`Rico`,`ARM_SGP`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
   value: ~
-edmfx_velocity_relaxation:
+edmfx_filter:
   help: "If set to true, it switches on the relaxation of negative velocity in EDMFX.  [`true`, `false` (default)]"
   value: false
 edmfx_nh_pressure:

--- a/config/gpu_configs/gpu_aquaplanet_progedmf.yml
+++ b/config/gpu_configs/gpu_aquaplanet_progedmf.yml
@@ -23,7 +23,7 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized" 
 edmfx_detr_model: "Generalized" 
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 precip_model: 0M

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_diffonly_0M.yml
@@ -19,7 +19,7 @@ edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: false
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true

--- a/config/model_configs/gpu_prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/gpu_prognostic_edmfx_aquaplanet.yml
@@ -11,7 +11,7 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized" 
 edmfx_detr_model: "Generalized" 
 edmfx_nh_pressure: true 
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil 

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -7,7 +7,7 @@ edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized" 
 edmfx_detr_model: "Generalized" 
 edmfx_nh_pressure: true 
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil 

--- a/config/model_configs/prognostic_edmfx_bomex_box.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_box.yml
@@ -15,7 +15,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "box"

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -15,7 +15,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_bomex_explicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_explicit_column.yml
@@ -15,7 +15,7 @@ edmfx_detr_model: "PiGroups"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 cloud_model: "grid_scale"
 moist: "equil"

--- a/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
@@ -11,7 +11,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
@@ -15,7 +15,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -16,7 +16,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: equil
 config: column

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -13,7 +13,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -14,7 +14,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -14,7 +14,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 precip_model: "1M"

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -13,7 +13,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: false
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -13,7 +13,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: equil
 apply_limiter: false

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -13,7 +13,7 @@ edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_velocity_relaxation: true
+edmfx_filter: true
 prognostic_tke: true
 moist: equil
 apply_limiter: false

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -14,12 +14,15 @@ function edmfx_sgs_mass_flux_tendency!(
 )
 
     n = n_mass_flux_subdomains(turbconv_model)
+    turbconv_params = CAP.turbconv_params(p.params)
+    a_max = CAP.max_area(turbconv_params)
     (; edmfx_sgsflux_upwinding) = p.atmos.numerics
     (; ᶠu³, ᶜh_tot, ᶜspecific) = p.precomputed
     (; ᶠu³ʲs, ᶜKʲs, ᶜρʲs) = p.precomputed
     (; ᶜρa⁰, ᶜρ⁰, ᶠu³⁰, ᶜK⁰, ᶜmse⁰, ᶜq_tot⁰) = p.precomputed
     (; dt) = p
     ᶜJ = Fields.local_geometry_field(Y.c).J
+    FT = eltype(Y)
 
     if p.atmos.edmfx_sgs_mass_flux
         # energy
@@ -27,11 +30,31 @@ function edmfx_sgs_mass_flux_tendency!(
         ᶜa_scalar_colidx = p.scratch.ᶜtemp_scalar[colidx]
         for j in 1:n
             @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
+            # @. ᶜa_scalar_colidx =
+            #     (
+            #         Y.c.sgsʲs.:($$j).mse[colidx] + ᶜKʲs.:($$j)[colidx] -
+            #         ᶜh_tot[colidx]
+            #     ) * draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
+            # TODO: remove this filter when mass flux is treated implicitly
             @. ᶜa_scalar_colidx =
                 (
                     Y.c.sgsʲs.:($$j).mse[colidx] + ᶜKʲs.:($$j)[colidx] -
                     ᶜh_tot[colidx]
-                ) * draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
+                ) * min(
+                    min(
+                        draft_area(
+                            Y.c.sgsʲs.:($$j).ρa[colidx],
+                            ᶜρʲs.:($$j)[colidx],
+                        ),
+                        a_max,
+                    ),
+                    FT(0.02) / max(
+                        Geometry.WVector(
+                            ᶜinterp(ᶠu³_diff_colidx),
+                        ).components.data.:1,
+                        eps(FT),
+                    ),
+                )
             vertical_transport!(
                 Yₜ.c.ρe_tot[colidx],
                 ᶜJ[colidx],
@@ -60,9 +83,27 @@ function edmfx_sgs_mass_flux_tendency!(
             # specific humidity
             for j in 1:n
                 @. ᶠu³_diff_colidx = ᶠu³ʲs.:($$j)[colidx] - ᶠu³[colidx]
+                # @. ᶜa_scalar_colidx =
+                #     (Y.c.sgsʲs.:($$j).q_tot[colidx] - ᶜspecific.q_tot[colidx]) *
+                #     draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
+                # TODO: remove this filter when mass flux is treated implicitly
                 @. ᶜa_scalar_colidx =
                     (Y.c.sgsʲs.:($$j).q_tot[colidx] - ᶜspecific.q_tot[colidx]) *
-                    draft_area(Y.c.sgsʲs.:($$j).ρa[colidx], ᶜρʲs.:($$j)[colidx])
+                    min(
+                        min(
+                            draft_area(
+                                Y.c.sgsʲs.:($$j).ρa[colidx],
+                                ᶜρʲs.:($$j)[colidx],
+                            ),
+                            a_max,
+                        ),
+                        FT(0.02) / max(
+                            Geometry.WVector(
+                                ᶜinterp(ᶠu³_diff_colidx),
+                            ).components.data.:1,
+                            eps(FT),
+                        ),
+                    )
                 vertical_transport!(
                     Yₜ.c.ρq_tot[colidx],
                     ᶜJ[colidx],

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -83,14 +83,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             p.atmos.turbconv_model,
         )
         edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
-        edmfx_velocity_relaxation_tendency!(
-            Yₜ,
-            Y,
-            p,
-            t,
-            colidx,
-            p.atmos.turbconv_model,
-        )
+        edmfx_filter_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
         edmfx_tke_tendency!(Yₜ, Y, p, t, colidx, p.atmos.turbconv_model)
         # Non-equilibrium cloud formation
         cloud_condensate_tendency!(Yₜ, p, colidx, p.atmos.moisture_model)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -42,8 +42,8 @@ function get_atmos(config::AtmosConfig, params)
     edmfx_nh_pressure = parsed_args["edmfx_nh_pressure"]
     @assert edmfx_nh_pressure in (false, true)
 
-    edmfx_velocity_relaxation = parsed_args["edmfx_velocity_relaxation"]
-    @assert edmfx_velocity_relaxation in (false, true)
+    edmfx_filter = parsed_args["edmfx_filter"]
+    @assert edmfx_filter in (false, true)
 
     implicit_diffusion = parsed_args["implicit_diffusion"]
     @assert implicit_diffusion in (true, false)
@@ -70,7 +70,7 @@ function get_atmos(config::AtmosConfig, params)
         edmfx_sgs_mass_flux,
         edmfx_sgs_diffusive_flux,
         edmfx_nh_pressure,
-        edmfx_velocity_relaxation,
+        edmfx_filter,
         precip_model,
         cloud_model,
         forcing_type,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -385,7 +385,7 @@ Base.@kwdef struct AtmosModel{
     edmfx_sgs_mass_flux::ESMF = nothing
     edmfx_sgs_diffusive_flux::ESDF = nothing
     edmfx_nh_pressure::ENP = nothing
-    edmfx_velocity_relaxation::EVR = nothing
+    edmfx_filter::EVR = nothing
     turbconv_model::TCM = nothing
     non_orographic_gravity_wave::NOGW = nothing
     orographic_gravity_wave::OGW = nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Part of #2974. Adds a filter to \rhoa and renames `edmfx_velocity_relaxation` to `edmfx_filter` for clarity. I didn't add the TKE filter as I was hoping we could stabilize the simulation without it:)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
