### PR TITLE
Add show for AtmosSolveResults

### DIFF
--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -42,6 +42,15 @@ struct AtmosSolveResults{S, RT, WT}
     walltime::WT
 end
 
+function Base.show(io::IO, sim::AtmosSolveResults)
+    return print(
+        io,
+        "Simulation completed\n",
+        "├── Return code: $(sim.ret_code)\n",
+        "└── Walltime: $(sim.walltime) seconds",
+    )
+end
+
 """
     solve_atmos!(integrator)
 


### PR DESCRIPTION
Looking like:
```
Simulation completed
├── Return code: success
└── Walltime: 2.7987e-5 seconds
```

Greatly improvers the user experience of calling `solve_atmos!` in the REPL.

Closes #2985 