### PR TITLE
add FT wrapper for scalars

### DIFF
--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -404,3 +404,42 @@ function gaussian_smooth(arr::AbstractArray, sigma::Int = 1)
 
     return smoothed_arr
 end
+
+
+"""
+    macro convert_scalars(FT_expr, expr)
+
+The `convert_scalars` macro is used to convert scalar values in an expression to a specified type.
+
+## Arguments
+- `FT_expr`: A function or expression that specifies the type to which the scalar values should be converted.
+- `expr`: The expression in which scalar values need to be converted.
+
+## Returns
+The macro returns the modified expression with scalar values converted to the specified type.
+
+## Example
+```julia
+FT = Float32
+@convert_scalars FT 1 + 2.0 + 3.0f0 * π + sin(pi)
+# expands to: FT(1) + FT(2.0) + FT(3.0f0) * FT(π) + sin(FT(pi))
+```
+"""
+macro convert_scalars(FT_expr, expr)
+
+    # Helper function to process expressions
+    function process_expr(expr, FT_expr)
+        if isa(expr, Number) || expr in (:π, :pi)
+            return esc(:($FT_expr($expr)))
+        elseif expr isa Expr
+            return Expr(
+                expr.head,
+                map(e -> process_expr(e, FT_expr), expr.args)...,
+            )
+        else
+            return expr
+        end
+    end
+
+    return process_expr(expr, FT_expr)
+end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -251,3 +251,13 @@ end
     @test test_cent_space == cent_space
     @test test_face_space == face_space
 end
+
+@testset "macro expand FT" begin
+    # Test macro expansion of FT
+    @test typeof(CA.@convert_scalars Float64 1 + 2.0 + 3.0f0 * π + sin(pi)) ==
+          Float64
+    @test typeof(CA.@convert_scalars Float32 1 + 2.0 + 3.0f0 * π + sin(pi)) ==
+          Float32
+    FT = Float32
+    @test typeof(CA.@convert_scalars FT 3.0 + 1) == Float32
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Add macro `@convert_scalars` to conveniently wrap scalars (e.g. integers, floats) with the provided `FT`, e.g.:

```julia
FT = Float32
@convert_scalars FT 1 + 2.0 + 3.0f0 * π + sin(pi)
# expands to: FT(1) + FT(2.0) + FT(3.0f0) * FT(π) + sin(FT(pi))
```