### PR TITLE
Restore OutputPathGenerator

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -123,6 +123,9 @@ t_end:
 output_dir:
   help: "Output directory"
   value: ~
+output_dir_style:
+  help: "What to do when `output_dir` already exists. With `RemovePreexisting`, `output_dir` is overwritten with a new one. With `ActiveLink`, `output_dir` is treated as a base folder and numbered subfolders are created inside. A new subfolder is created every time a simulation is run, with `output_dir/output_active` pointing to the most recent results. Check out ClimaUtilities.OutputPathGenerator for more information. [`ActiveLink` (default), `RemovePreexisting`]"
+  value: "ActiveLink"
 device:
   help: "Device type to use [`auto` (default) `CPUSingleThreaded`, `CPUMultiThreaded`, `CUDADevice`]"
   value: "auto"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -173,9 +173,9 @@ version = "0.5.0"
 
 [[deps.BandedMatrices]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "PrecompileTools"]
-git-tree-sha1 = "30b7ea34abc4fe816eb1a5f434a43da804836163"
+git-tree-sha1 = "4ec0289155eac14c057229395fa7a6a54ffea343"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.0"
+version = "1.7.1"
 weakdeps = ["SparseArrays"]
 
     [deps.BandedMatrices.extensions]
@@ -313,9 +313,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
+git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.23.0"
+version = "1.24.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -374,9 +374,9 @@ version = "0.7.30"
 
 [[deps.ClimaUtilities]]
 deps = ["Artifacts", "Dates"]
-git-tree-sha1 = "7974f09027c65595250532188309642eb6b821bb"
+git-tree-sha1 = "af4af7e14e02861c1a13c9ee0efade4c863fab9a"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.7"
+version = "0.1.8"
 
     [deps.ClimaUtilities.extensions]
     CUDAUtilsExt = ["ClimaCore", "CUDA"]
@@ -1439,9 +1439,9 @@ version = "2.8.0"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
+git-tree-sha1 = "a2d09619db4e765091ee5c6ffe8872849de0feea"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.27"
+version = "0.3.28"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -1818,9 +1818,9 @@ version = "1.4.3"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "ForwardDiff"]
-git-tree-sha1 = "a660e9daab5db07adf3dedfe09b435cc530d855e"
+git-tree-sha1 = "406c29a7f46706d379a3bce45671b4e3a39ddfbc"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.21"
+version = "0.4.22"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsReverseDiffExt = "ReverseDiff"

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -168,9 +168,9 @@ version = "0.5.0"
 
 [[deps.BandedMatrices]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "PrecompileTools"]
-git-tree-sha1 = "30b7ea34abc4fe816eb1a5f434a43da804836163"
+git-tree-sha1 = "4ec0289155eac14c057229395fa7a6a54ffea343"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.0"
+version = "1.7.1"
 weakdeps = ["SparseArrays"]
 
     [deps.BandedMatrices.extensions]
@@ -291,9 +291,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
+git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.23.0"
+version = "1.24.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -396,9 +396,9 @@ version = "0.7.30"
 
 [[deps.ClimaUtilities]]
 deps = ["Artifacts", "Dates"]
-git-tree-sha1 = "7974f09027c65595250532188309642eb6b821bb"
+git-tree-sha1 = "af4af7e14e02861c1a13c9ee0efade4c863fab9a"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.7"
+version = "0.1.8"
 weakdeps = ["Adapt", "CUDA", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "Interpolations", "NCDatasets"]
 
     [deps.ClimaUtilities.extensions]
@@ -1455,9 +1455,9 @@ version = "2.16.0+0"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
+git-tree-sha1 = "a2d09619db4e765091ee5c6ffe8872849de0feea"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.27"
+version = "0.3.28"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -1864,9 +1864,9 @@ version = "24.5.0+0"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "ForwardDiff"]
-git-tree-sha1 = "a660e9daab5db07adf3dedfe09b435cc530d855e"
+git-tree-sha1 = "406c29a7f46706d379a3bce45671b4e3a39ddfbc"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.21"
+version = "0.4.22"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsReverseDiffExt = "ReverseDiff"

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -205,12 +205,11 @@ if ClimaComms.iamroot(config.comms_ctx)
     end
     @info "Plotting done"
 
-    # TODO: Use readlink again once
-    # https://github.com/CliMA/ClimaUtilities.jl/issues/56 is fixed.
-    symlink_to_fullpath(path) = path
-    # function symlink_to_fullpath(path)
-    #     return joinpath(dirname(path), readlink(path))
-    # end
+    if islink(simulation.output_dir)
+        symlink_to_fullpath(path) = joinpath(dirname(path), readlink(path))
+    else
+        symlink_to_fullpath(path) = path
+    end
 
     @info "Creating tarballs"
     # These NC files are used by our reproducibility tests,

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -168,9 +168,9 @@ version = "0.5.0"
 
 [[deps.BandedMatrices]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "PrecompileTools"]
-git-tree-sha1 = "30b7ea34abc4fe816eb1a5f434a43da804836163"
+git-tree-sha1 = "4ec0289155eac14c057229395fa7a6a54ffea343"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.0"
+version = "1.7.1"
 weakdeps = ["SparseArrays"]
 
     [deps.BandedMatrices.extensions]
@@ -302,9 +302,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
+git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.23.0"
+version = "1.24.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -401,9 +401,9 @@ weakdeps = ["BenchmarkTools", "CUDA", "OrderedCollections", "PrettyTables", "Sta
 
 [[deps.ClimaUtilities]]
 deps = ["Artifacts", "Dates"]
-git-tree-sha1 = "7974f09027c65595250532188309642eb6b821bb"
+git-tree-sha1 = "af4af7e14e02861c1a13c9ee0efade4c863fab9a"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.7"
+version = "0.1.8"
 weakdeps = ["Adapt", "CUDA", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "Interpolations", "NCDatasets"]
 
     [deps.ClimaUtilities.extensions]
@@ -1507,9 +1507,9 @@ version = "2.16.0+0"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
+git-tree-sha1 = "a2d09619db4e765091ee5c6ffe8872849de0feea"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.27"
+version = "0.3.28"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -1934,9 +1934,9 @@ version = "0.2.4"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "ForwardDiff"]
-git-tree-sha1 = "a660e9daab5db07adf3dedfe09b435cc530d855e"
+git-tree-sha1 = "406c29a7f46706d379a3bce45671b4e3a39ddfbc"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.21"
+version = "0.4.22"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsReverseDiffExt = "ReverseDiff"

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -483,14 +483,21 @@ function get_sim_info(config::AtmosConfig)
     out_dir = parsed_args["output_dir"]
     base_output_dir = isnothing(out_dir) ? default_output : out_dir
 
-    output_dir = joinpath(base_output_dir, "output_active")
-    mkpath(output_dir)
-    # TODO: Put this back in once
-    # https://github.com/CliMA/ClimaUtilities.jl/issues/56 is fixed.
-    # output_dir = OutputPathGenerator.generate_output_path(
-    #     base_output_dir;
-    #     context = config.comms_ctx,
-    # )
+    allowed_dir_styles = Dict(
+        "activelink" => OutputPathGenerator.ActiveLinkStyle(),
+        "removepreexisting" => OutputPathGenerator.RemovePreexistingStyle(),
+    )
+
+    requested_style = parsed_args["output_dir_style"]
+
+    haskey(allowed_dir_styles, lowercase(requested_style)) ||
+        error("output_dir_style $(requested_style) not available")
+
+    output_dir = OutputPathGenerator.generate_output_path(
+        base_output_dir;
+        context = config.comms_ctx,
+        style = allowed_dir_styles[lowercase(requested_style)],
+    )
 
     sim = (;
         output_dir,

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -35,7 +35,13 @@ const T2 = 290
 @testset "Coupler Compatibility (Hacky Version)" begin
     # Initialize a model. The value of surface_setup is irrelevant, since it
     # will get overwritten.
-    config = CA.AtmosConfig(Dict("initial_condition" => "DryBaroclinicWave"))
+    config = CA.AtmosConfig(
+        Dict(
+            "initial_condition" => "DryBaroclinicWave",
+            "output_dir_style" => "RemovePreexisting",
+        );
+        job_id = "coupler_compatibility1",
+    )
     simulation = CA.get_simulation(config)
     (; integrator) = simulation
     (; p, t) = integrator
@@ -111,7 +117,8 @@ end
         Dict(
             "initial_condition" => "DryBaroclinicWave",
             "surface_setup" => "PrescribedSurface",
-        ),
+        );
+        job_id = "coupler_compatibility2",
     )
     simulation = CA.get_simulation(config)
     (; integrator) = simulation
@@ -220,7 +227,8 @@ end
             # remove the following line and check that the test runs in less than a few
             # minutes on GitHub
             "output_default_diagnostics" => false,
-        ),
+        );
+        job_id = "coupler_compatibility3",
     )
     simulation = CA.get_simulation(config)
 end

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -20,6 +20,7 @@ include("../../test_helpers.jl")
             "config" => "column",
             "output_default_diagnostics" => false,
         ),
+        job_id = "precipitation1",
     )
     (; Y, p, params) = generate_test_simulation(config)
 
@@ -63,6 +64,7 @@ include("../../test_helpers.jl")
             "config" => "column",
             "output_default_diagnostics" => false,
         ),
+        job_id = "precipitation2",
     )
     (; Y, p, params) = generate_test_simulation(config)
     precip_model = CA.Microphysics1Moment()

--- a/test/parameterized_tendencies/sponge/rayleigh_sponge.jl
+++ b/test/parameterized_tendencies/sponge/rayleigh_sponge.jl
@@ -9,7 +9,10 @@ include("../../test_helpers.jl")
 @testset begin
     "Rayleigh-sponge functions"
     ### Boilerplate default integrator objects
-    config = CA.AtmosConfig(Dict("initial_condition" => "DryBaroclinicWave"))
+    config = CA.AtmosConfig(
+        Dict("initial_condition" => "DryBaroclinicWave");
+        job_id = "sponge1",
+    )
     (; Y) = generate_test_simulation(config)
     zmax = maximum(CC.Fields.coordinate_field(Y.f).z)
     z = CC.Fields.coordinate_field(Y.c).z

--- a/test/parameters/parameter_tests.jl
+++ b/test/parameters/parameter_tests.jl
@@ -16,7 +16,8 @@ default_args = CA.cli_defaults(CA.argparse_settings())
         "dt_save_state_to_disk" => "str",
         "bubble" => true,
     )
-    parsed_args = CA.AtmosConfig(config_dict).parsed_args
+    parsed_args =
+        CA.AtmosConfig(config_dict, job_id = "paremter_tests1").parsed_args
     @test parsed_args["krylov_rtol"] isa FT
     @test parsed_args["newton_rtol"] isa FT
     @test parsed_args["max_newton_iters_ode"] isa Int
@@ -27,9 +28,10 @@ end
 
 @testset "Test all parameter tomls in toml/" begin
     toml_path = joinpath(pkgdir(CA), "toml")
-    for toml in readdir(toml_path)
+    for (index, toml) in enumerate(readdir(toml_path))
         config_dict = Dict("toml" => [joinpath(toml_path, toml)])
-        config = CA.AtmosConfig(config_dict)
+        config =
+            CA.AtmosConfig(config_dict, job_id = "paremter_tests$(index + 1)")
         # Ensure that there are no errors
         @test CA.create_parameter_set(config) isa
               CA.Parameters.ClimaAtmosParameters

--- a/test/solver/model_getters.jl
+++ b/test/solver/model_getters.jl
@@ -1,11 +1,11 @@
 import ClimaAtmos as CA
 
 @testset "Model config" begin
-    config = CA.AtmosConfig(Dict("config" => "box"))
+    config = CA.AtmosConfig(Dict("config" => "box"), job_id = "model1")
     parsed_args = config.parsed_args
     @test CA.get_model_config(parsed_args) isa CA.BoxModel
 
-    config = CA.AtmosConfig(Dict("config" => "plane"))
+    config = CA.AtmosConfig(Dict("config" => "plane"), job_id = "model2")
     parsed_args = config.parsed_args
     @test CA.get_model_config(parsed_args) isa CA.PlaneModel
 end
@@ -19,6 +19,7 @@ end
             "scalar_hyperdiffusion_coefficient" => 99.0,
             "divergence_damping_factor" => 99.0,
         ),
+        job_id = "model3",
     )
     parsed_args = config.parsed_args
     FT = eltype(config)
@@ -36,7 +37,10 @@ end
     @test hyperdiff_model.divergence_damping_factor == cam_se_ν₄_dd
 
     @info "Test unrecognized Hyperdiffusion scheme"
-    config = CA.AtmosConfig(Dict("hyperdiff" => "UnknownHyperdiffusion"))
+    config = CA.AtmosConfig(
+        Dict("hyperdiff" => "UnknownHyperdiffusion"),
+        job_id = "model4",
+    )
     parsed_args = config.parsed_args
     FT = eltype(config)
     @test_throws ErrorException CA.get_hyperdiffusion_model(parsed_args, FT)

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -7,7 +7,7 @@ Random.seed!(1234)
 redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 
 @testset "set_surface_albedo!" begin
-    config = ClimaAtmos.AtmosConfig()
+    config = ClimaAtmos.AtmosConfig(; job_id = "surface_albedo1")
     FT = Float32
 
     # test set_surface_albedo!(Y, p, t, α_type::ConstantAlbedo)


### PR DESCRIPTION
This commit restores OutputPathGenerator for directory managment and adds a new option, `output_dir_style` to control its behavior.

By default OutputPathGenerator uses the ActiveLinkStyle, meaning that new subfolders are created within `output_dir` every time a Simulation object is created. The most recent output can always be found in `output_dir/output_active`. This style preserves existing data, and running multiple times on the same `output_dir` will lead to a list of `output_dir/output_0123` folders with the data for each separate run.

The other style currently implemented is `RemovePreexisting`. With this style, if `output_dir` already exists, it will be overwritten with the new one.

Closes #3048 