### PR TITLE
Bump to 0.24.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.24.1"
+version = "0.24.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
ClimaCoupler tests are failing for a field2array error (https://buildkite.com/clima/climacoupler-ci/builds/3901). It could be a mismatch between the ClimaAtmos and ClimaCoupler versions, so I'd like to make a new release of Atmos.

```
ERROR: LoadError: DimensionMismatch: array size 15360 must be divisible by the product of the new dimensions (10, 10, 10, 1, Colon())
Stacktrace:
  [1] (::Base.var"#throw2#330")(A::SubArray{…}, dims::Tuple{…})
    @ Base ./reshapedarray.jl:123
  [2] _reshape_uncolon
    @ ./reshapedarray.jl:129 [inlined]
  [3] reshape(parent::SubArray{Float64, 2, Matrix{…}, Tuple{…}, false}, dims::Tuple{Int64, Int64, Int64, Int64, Colon})
    @ Base ./reshapedarray.jl:119
  [4] reshape
    @ ./reshapedarray.jl:118 [inlined]
  [5] array2data(array::SubArray{…}, ::ClimaCore.DataLayouts.VIJFH{…})
    @ ClimaAtmos.RRTMGPInterface /central/scratch/esm/slurm-buildkite/climacoupler-ci/depot/cpu/packages/ClimaAtmos/OGwjS/src/parameterized_tendencies/radiation/RRTMGPInterface.jl:86
  [6] array2field(array::SubArray{…}, space::ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace{…})
    @ ClimaAtmos.RRTMGPInterface /central/scratch/esm/slurm-buildkite/climacoupler-ci/depot/cpu/packages/ClimaAtmos/OGwjS/src/parameterized_tendencies/radiation/RRTMGPInterface.jl:61
```