### PR TITLE
fix zero_tendency on gpu

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -67,15 +67,3 @@ steps:
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           JOB_NAME: "longrun_ssp_bw_rhoe_equil_highres"
-
-      - label: ":computer: aquaplanet equilmoist clearsky radiation + prognostic edmf diffusion only + 0M microphysics"
-        command:
-          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml --job_id $$JOB_NAME
-        artifact_paths: "$$JOB_NAME/output_active/*"
-        agents:
-          slurm_ntasks: 64
-          slurm_nodes: 4
-          slurm_time: 24:00:00
-        env:
-          CLIMACOMMS_CONTEXT: "MPI"
-          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_diffonly_0M"

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -156,6 +156,17 @@ steps:
         env:
           CLIMACOMMS_DEVICE: "CUDA"
           JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M"
+      
+      - label: ":computer: aquaplanet equilmoist clearsky radiation + prognostic edmf diffusion only + 0M microphysics"
+        command:
+          - srun julia --project=examples examples/hybrid/driver.jl --config_file $CONFIG_PATH/$$JOB_NAME.yml --job_id $$JOB_NAME
+        artifact_paths: "$$JOB_NAME/output_active/*"
+        agents:
+          slurm_gpus: 1
+          slurm_time: 12:00:00
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+          JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_diffonly_0M"
 
       - label: ":computer: aquaplanet equilmoist clearsky radiation + 0M microphysics + earth topography"
         command:

--- a/src/prognostic_equations/zero_tendency.jl
+++ b/src/prognostic_equations/zero_tendency.jl
@@ -6,12 +6,12 @@ zero_tendency!(Yₜ, Y, p, t, _, _) = nothing
 
 function zero_tendency!(Yₜ, Y, p, t, ::NoGridScaleTendency, _)
     # turn off all grid-scale tendencies
-    @. Yₜ.c.ρ = 0
-    @. Yₜ.c.uₕ = C12(0, 0)
-    @. Yₜ.f.u₃ = C3(0)
-    @. Yₜ.c.ρe_tot = 0
+    @. Yₜ.c.ρ *= 0
+    @. Yₜ.c.uₕ *= 0
+    @. Yₜ.f.u₃ *= 0
+    @. Yₜ.c.ρe_tot *= 0
     for ρχ_name in filter(is_tracer_var, propertynames(Y.c))
-        @. Yₜ.c.:($$ρχ_name) = 0
+        @. Yₜ.c.:($$ρχ_name) *= 0
     end
     return nothing
 end
@@ -27,10 +27,10 @@ function zero_tendency!(
     # turn off all subgrid-scale tendencies
     n = n_prognostic_mass_flux_subdomains(p.atmos.turbconv_model)
     for j in 1:n
-        @. Yₜ.c.sgsʲs.:($$j).ρa = 0
-        @. Yₜ.f.sgsʲs.:($$j).u₃ = C3(0)
-        @. Yₜ.c.sgsʲs.:($$j).mse = 0
-        @. Yₜ.c.sgsʲs.:($$j).q_tot = 0
+        @. Yₜ.c.sgsʲs.:($$j).ρa *= 0
+        @. Yₜ.f.sgsʲs.:($$j).u₃ *= 0
+        @. Yₜ.c.sgsʲs.:($$j).mse *= 0
+        @. Yₜ.c.sgsʲs.:($$j).q_tot *= 0
     end
     return nothing
 end

--- a/src/prognostic_equations/zero_velocity.jl
+++ b/src/prognostic_equations/zero_velocity.jl
@@ -8,11 +8,11 @@ function zero_velocity_tendency!(Yₜ, Y, p, t)
         FT = eltype(Y)
         n = n_mass_flux_subdomains(p.atmos.turbconv_model)
 
-        @. Yₜ.c.uₕ = C12(FT(0), FT(0))
-        @. Yₜ.f.u₃ = Geometry.Covariant3Vector(FT(0))
+        @. Yₜ.c.uₕ *= 0
+        @. Yₜ.f.u₃ *= 0
         if p.atmos.turbconv_model isa PrognosticEDMFX
             for j in 1:n
-                @. Yₜ.f.sgsʲs.:($$j).u₃ = Geometry.Covariant3Vector(FT(0))
+                @. Yₜ.f.sgsʲs.:($$j).u₃ *= 0
             end
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Also moves prognostic edmf diffusion only longrun to GPU. Closes #3053.

I was following the pattern [here](https://github.com/CliMA/ClimaAtmos.jl/blob/b437ba4a0e801fbebaa02be2e746ed4da2eae601/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl#L168) and didn't try the `fill!` option. I can try it if that's preferred.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
