### PR TITLE
remove filter for radiative fluxes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ ClimaAtmos.jl Release Notes
 
 Main
 -------
-
+- ![][badge-🔥behavioralΔ] Removed the filter for shortwave radiative fluxes. 
+  PR [#3099](https://github.com/CliMA/ClimaAtmos.jl/pull/3099).
 
 v0.26.0
 -------
@@ -14,7 +15,7 @@ v0.26.0
 v0.25.0
 -------
 - ![][badge-💥breaking] Remove reference state from the dycore and the
-relevant config. PR [#3074](https://github.com/CliMA/ClimaAtmos.jl/pull/3074).
+  relevant config. PR [#3074](https://github.com/CliMA/ClimaAtmos.jl/pull/3074).
 - Make prognostic and diagnostic EDMF work with 1-moment microphysics on GPU
   PR [#3070](https://github.com/CliMA/ClimaAtmos.jl/pull/3070)
 - Add precipitation heating terms for 1-moment microphysics

--- a/regression_tests/ref_counter.jl
+++ b/regression_tests/ref_counter.jl
@@ -1,4 +1,7 @@
-166
+167
+
+# 167:
+# - Removed the filter for radiative fluxes when zenith angle is close to 90 degrees
 
 # 166:
 # - Move to SSPKnoth

--- a/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
+++ b/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
@@ -1157,28 +1157,14 @@ end
 
 function update_net_fluxes!(_, model)
     FT = eltype(model.face_flux)
-    model.face_flux .=
-        ifelse.(
-            model.cos_zenith' .<= sqrt(eps(FT)),
-            model.face_lw_flux,
-            model.face_lw_flux .+ model.face_sw_flux,
-        )
+    model.face_flux .= model.face_lw_flux .+ model.face_sw_flux
 
 end
 function update_net_fluxes!(::AllSkyRadiationWithClearSkyDiagnostics, model)
     FT = eltype(model.face_flux)
     model.face_clear_flux .=
-        ifelse.(
-            model.cos_zenith' .<= sqrt(eps(FT)),
-            model.face_clear_lw_flux,
-            model.face_clear_lw_flux .+ model.face_clear_sw_flux,
-        )
-    model.face_flux .=
-        ifelse.(
-            model.cos_zenith' .<= sqrt(eps(FT)),
-            model.face_lw_flux,
-            model.face_lw_flux .+ model.face_sw_flux,
-        )
+        model.face_clear_lw_flux .+ model.face_clear_sw_flux
+    model.face_flux .= model.face_lw_flux .+ model.face_sw_flux
 end
 
 end # end module


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I think it's not ideal to have different values in the diagnostics and in the variables that are used by the model, so I decided to remove this filter. Alternatively, I can add a filter to set the SW fluxes to zero, but I think it would be good to reveal the problem and see if modifying rrtmgp can fix it. If this continues to be a problem, I can use my own branch with the filter for the vesri run.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
