### PR TITLE
Fix GPU sharing on GPU-longruns

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -4,14 +4,13 @@ agents:
   modules: julia/1.10.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.2.1
 
 env:
-  JULIA_CUDA_MEMORY_POOL: none
   JULIA_MPI_HAS_CUDA: "true"
   JULIA_NVTX_CALLBACKS: gc
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100
   OPENBLAS_NUM_THREADS: 1
   OMPI_MCA_opal_warn_on_missing_libcuda: 0
   SLURM_KILL_BAD_EXIT: 1
-  SLURM_GPU_BIND: none # https://github.com/open-mpi/ompi/issues/11949#issuecomment-1737712291
+  SLURM_GRES_FLAGS: "allow-task-sharing"
   CONFIG_PATH: "config/longrun_configs"
   CLIMAATMOS_GC_NSTEPS: 10
 


### PR DESCRIPTION
This was fixed a few months ago updating to the most recent version of slurm.