### PR TITLE
add ClimaCoupler downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,38 @@
+name: Downstream
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+# Needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: downstream ClimaCoupler.jl
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: actions/checkout@v4
+        with:
+          repository: 'CliMA/ClimaCoupler.jl'
+          path: ClimaCoupler.jl
+      - run: |
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/run_amip.jl --config_file ClimaCoupler.jl/config/ci_configs/target_amip_albedo_function.yml --job_id target_amip_albedo_function


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
It would be useful to have a driver that runs a simple coupled ClimaAtmos/ClimaLand setup for one or two timesteps. This could be used by these packages to test the effects of changes downstream in ClimaCoupler. It wouldn't test physical stability, but it would test interface changes

see https://github.com/CliMA/ClimaCoupler.jl/issues/877


## To-do
It would be good to have a more streamlined test that doesn't require instantiating the entire `ClimaEarth` environment, but for now this is fine

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
