### PR TITLE
move surface tendency after precipitation tendency

### DIFF
--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -24,7 +24,6 @@ end
 
 NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     viscous_sponge_tendency!(Yₜ, Y, p, t, p.atmos.viscous_sponge)
-    surface_temp_tendency!(Yₜ, Y, p, t, p.atmos.surface_model)
 
     # Vertical tendencies
     rayleigh_sponge_tendency!(Yₜ, Y, p, t, p.atmos.rayleigh_sponge)
@@ -79,6 +78,10 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
         p.atmos.precip_model,
         p.atmos.turbconv_model,
     )
+
+    # NOTE: Precipitation tendencies should be applied before calling this function,
+    # because precipitation cache is used in this function
+    surface_temp_tendency!(Yₜ, Y, p, t, p.atmos.surface_model)
 
     # NOTE: All ρa tendencies should be applied before calling this function
     pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)

--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -218,14 +218,14 @@ Return:
 """
 function check_conservation(sol)
     # energy
-    energy_total = sum(sol.u[end].c.ρe_tot)
+    energy_total = sum(sol.u[1].c.ρe_tot)
     energy_atmos_change = sum(sol.u[end].c.ρe_tot) - sum(sol.u[1].c.ρe_tot)
     p = sol.prob.p
     sfc = p.atmos.surface_model
     if sfc isa PrognosticSurfaceTemperature
         sfc_cρh = sfc.ρ_ocean * sfc.cp_ocean * sfc.depth_ocean
         energy_total +=
-            horizontal_integral_at_boundary(sol.u[end].sfc.T .* sfc_cρh)
+            horizontal_integral_at_boundary(sol.u[1].sfc.T .* sfc_cρh)
         energy_surface_change =
             horizontal_integral_at_boundary(
                 sol.u[end].sfc.T .- sol.u[1].sfc.T,
@@ -253,6 +253,10 @@ function check_conservation(sol)
         water_surface_change = horizontal_integral_at_boundary(
             sol.u[end].sfc.water .- sol.u[1].sfc.water,
         )
+
+        mass_conservation =
+            (sum(sol.u[end].c.ρ) - sum(sol.u[1].c.ρ) + water_surface_change) /
+            sum(sol.u[1].c.ρ)
 
         water_conservation =
             abs(water_atmos_change + water_surface_change) / water_total


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Move surface tendency after precipitation tendency so that precipitation used in atmos and surface tendencies are in sync. Fixes water conservation issue with SSP. After this change, SSP conserves water but ARS doesn't (2% error in 100 days): https://buildkite.com/clima/climaatmos-gpulongruns/builds/264#_. We should look into ARS if we want to use it.

I don't like that we need to have a specific order of tendencies for the test to work, but this is a quick fix and refactoring precipitation needs more work. cc @trontrytel . We should check what the coupler is doing.

Also changes energy conservation to use the initial condition as the reference. Only water conservation uses the final state as the reference, because the initial condition can be zero.

Closes #3113 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
