### PR TITLE
Fix format errors in gpu longrun pipeline

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -234,7 +234,6 @@ steps:
           JOB_NAME: "longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean"
 
   - group: "DYAMOND"
-
     steps:
 
       - label: ":computer: aquaplanet dyamond"
@@ -249,7 +248,6 @@ steps:
           JOB_NAME: "longrun_aquaplanet_dyamond"
 
   - group: "atmos-only coupler runs"
-
     steps:
 
       - label: ":computer: amip target diagnostic edmf"


### PR DESCRIPTION
https://buildkite.com/clima/climaatmos-gpulongruns/builds/262 failed due to yaml format issues. This PR fixes the pipeline file; the resulting buildkite pipeline upload is shown here: https://buildkite.com/clima/climaatmos-gpulongruns/builds/265#01906f3a-a92e-4f74-9c3e-b2f2cac27f10
