### PR TITLE
rename radiation_model to rrtmgp_model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaAtmos.jl Release Notes
 
 Main
 -------
+- ![][badge-💥breaking] Change "radiation_model" in the radiation cache to "rrtmgp_model".
+  PR [#3167](https://github.com/CliMA/ClimaAtmos.jl/pull/3167)
 - ![][badge-💥breaking] Change the "idealized_insolation" argument to "insolation", 
   and add RCEMIP insolation. PR [#3150](https://github.com/CliMA/ClimaAtmos.jl/pull/3150)
 

--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -56,7 +56,7 @@ Set the surface albedo to a constant value.
 function set_surface_albedo!(Y, p, t, α_model::ConstantAlbedo{FT}) where {FT}
 
     (; direct_sw_surface_albedo, diffuse_sw_surface_albedo) =
-        p.radiation.radiation_model
+        p.radiation.rrtmgp_model
 
     @. direct_sw_surface_albedo = α_model.α
     @. diffuse_sw_surface_albedo = α_model.α
@@ -75,7 +75,7 @@ function set_surface_albedo!(
 ) where {FT}
 
     (; direct_sw_surface_albedo, diffuse_sw_surface_albedo, cos_zenith) =
-        p.radiation.radiation_model
+        p.radiation.rrtmgp_model
 
     λ = FT(0) # spectral wavelength (not used for now)
     μ = cos_zenith

--- a/src/diagnostics/radiation_diagnostics.jl
+++ b/src/diagnostics/radiation_diagnostics.jl
@@ -19,12 +19,12 @@ function compute_rsd!(
 ) where {T <: RRTMGPI.AbstractRRTMGPMode}
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_sw_flux_dn,
+            cache.radiation.rrtmgp_model.face_sw_flux_dn,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_sw_flux_dn,
+            cache.radiation.rrtmgp_model.face_sw_flux_dn,
             axes(state.f),
         )
     end
@@ -58,7 +58,7 @@ function compute_rsdt!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_sw_flux_dn,
                 axes(state.f),
             ),
             nlevels + half,
@@ -66,7 +66,7 @@ function compute_rsdt!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_sw_flux_dn,
                 axes(state.f),
             ),
             nlevels + half,
@@ -101,7 +101,7 @@ function compute_rsds!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_sw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -109,7 +109,7 @@ function compute_rsds!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_sw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -143,12 +143,12 @@ function compute_rsu!(
 ) where {T <: RRTMGPI.AbstractRRTMGPMode}
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_sw_flux_up,
+            cache.radiation.rrtmgp_model.face_sw_flux_up,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_sw_flux_up,
+            cache.radiation.rrtmgp_model.face_sw_flux_up,
             axes(state.f),
         )
     end
@@ -182,7 +182,7 @@ function compute_rsut!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_sw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -190,7 +190,7 @@ function compute_rsut!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_sw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -225,7 +225,7 @@ function compute_rsus!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_sw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -233,7 +233,7 @@ function compute_rsus!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_sw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -267,12 +267,12 @@ function compute_rld!(
 ) where {T <: RRTMGPI.AbstractRRTMGPMode}
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_lw_flux_dn,
+            cache.radiation.rrtmgp_model.face_lw_flux_dn,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_lw_flux_dn,
+            cache.radiation.rrtmgp_model.face_lw_flux_dn,
             axes(state.f),
         )
     end
@@ -305,7 +305,7 @@ function compute_rlds!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_dn,
+                cache.radiation.rrtmgp_model.face_lw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -313,7 +313,7 @@ function compute_rlds!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_dn,
+                cache.radiation.rrtmgp_model.face_lw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -347,12 +347,12 @@ function compute_rlu!(
 ) where {T <: RRTMGPI.AbstractRRTMGPMode}
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_lw_flux_up,
+            cache.radiation.rrtmgp_model.face_lw_flux_up,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_lw_flux_up,
+            cache.radiation.rrtmgp_model.face_lw_flux_up,
             axes(state.f),
         )
     end
@@ -386,7 +386,7 @@ function compute_rlut!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_lw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -394,7 +394,7 @@ function compute_rlut!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_lw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -429,7 +429,7 @@ function compute_rlus!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_lw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -437,7 +437,7 @@ function compute_rlus!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_lw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -471,12 +471,12 @@ function compute_rsdcs!(
 )
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_clear_sw_flux_dn,
+            cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_clear_sw_flux_dn,
+            cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
             axes(state.f),
         )
     end
@@ -509,7 +509,7 @@ function compute_rsdscs!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -517,7 +517,7 @@ function compute_rsdscs!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_dn,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -551,12 +551,12 @@ function compute_rsucs!(
 )
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_clear_sw_flux_up,
+            cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_clear_sw_flux_up,
+            cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
             axes(state.f),
         )
     end
@@ -590,7 +590,7 @@ function compute_rsutcs!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -598,7 +598,7 @@ function compute_rsutcs!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -633,7 +633,7 @@ function compute_rsuscs!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -641,7 +641,7 @@ function compute_rsuscs!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_sw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
                 axes(state.f),
             ),
             half,
@@ -676,12 +676,12 @@ function compute_rldcs!(
 )
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_clear_lw_flux_dn,
+            cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_clear_lw_flux_dn,
+            cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
             axes(state.f),
         )
     end
@@ -714,7 +714,7 @@ function compute_rldscs!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_lw_flux_dn,
+                cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -722,7 +722,7 @@ function compute_rldscs!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_lw_flux_dn,
+                cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
                 axes(state.f),
             ),
             half,
@@ -756,12 +756,12 @@ function compute_rlucs!(
 )
     if isnothing(out)
         return Fields.array2field(
-            cache.radiation.radiation_model.face_clear_lw_flux_up,
+            cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
             axes(state.f),
         )
     else
         out .= Fields.array2field(
-            cache.radiation.radiation_model.face_clear_lw_flux_up,
+            cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
             axes(state.f),
         )
     end
@@ -795,7 +795,7 @@ function compute_rlutcs!(
     if isnothing(out)
         return Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,
@@ -803,7 +803,7 @@ function compute_rlutcs!(
     else
         out .= Fields.level(
             Fields.array2field(
-                cache.radiation.radiation_model.face_clear_lw_flux_up,
+                cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
                 axes(state.f),
             ),
             nlevels + half,

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -66,7 +66,7 @@ function radiation_model_cache(
     else
         latitude = Fields.field2array(zero(bottom_coords.z)) # flat space is on Equator
     end
-    local radiation_model
+    local rrtmgp_model
     orbital_data = Insolation.OrbitalData()
     file_name = joinpath(
         "examples",
@@ -209,7 +209,7 @@ function radiation_model_cache(
 
         cos_zenith = weighted_irradiance = NaN # initialized in callback
 
-        radiation_model = RRTMGPI.RRTMGPModel(
+        rrtmgp_model = RRTMGPI.RRTMGPModel(
             rrtmgp_params,
             data_loader,
             context;
@@ -233,7 +233,7 @@ function radiation_model_cache(
         orbital_data,
         idealized_h2o,
         idealized_clouds,
-        radiation_model,
+        rrtmgp_model,
         insolation_tuple = similar(Spaces.level(Y.c, 1), Tuple{FT, FT, FT}),
         ᶠradiation_flux = similar(Y.f, Geometry.WVector{FT}),
     )

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -18,10 +18,8 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     (; u, p, t) = simulation.integrator
     ClimaAtmos.set_surface_albedo!(u, p, t, p.atmos.surface_albedo)
 
-    @test all(p.radiation.radiation_model.direct_sw_surface_albedo .== FT(0.38))
-    @test all(
-        p.radiation.radiation_model.diffuse_sw_surface_albedo .== FT(0.38),
-    )
+    @test all(p.radiation.rrtmgp_model.direct_sw_surface_albedo .== FT(0.38))
+    @test all(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .== FT(0.38))
 
     # test set_surface_albedo!(Y, p, t, α_type::RegressionFunctionAlbedo)
     config.parsed_args["rad"] = "clearsky"
@@ -32,8 +30,8 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     ClimaAtmos.set_surface_albedo!(u, p, t, p.atmos.surface_albedo)
 
     # test that the albedo is initiated (not NaN) - precise values are checked in the testset below
-    @test !isnan(sum(p.radiation.radiation_model.direct_sw_surface_albedo))
-    @test !isnan(sum(p.radiation.radiation_model.diffuse_sw_surface_albedo))
+    @test !isnan(sum(p.radiation.rrtmgp_model.direct_sw_surface_albedo))
+    @test !isnan(sum(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo))
 
     # test set_surface_albedo!(Y, p, t, α_type::CouplerAlbedo)
     config.parsed_args["rad"] = "clearsky"
@@ -44,8 +42,8 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     ClimaAtmos.set_surface_albedo!(u, p, t, p.atmos.surface_albedo)
 
     # test that the albedo is not initiated by atmos (includes NaNs)
-    @test isnan(sum(p.radiation.radiation_model.direct_sw_surface_albedo))
-    @test isnan(sum(p.radiation.radiation_model.diffuse_sw_surface_albedo))
+    @test isnan(sum(p.radiation.rrtmgp_model.direct_sw_surface_albedo))
+    @test isnan(sum(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo))
 
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Removes radiation_mode from radiation_model as it is the same as radiation_mode in atmos. This does require an additional radiation_mode argument in some functions, but I still think it is better not to have redundant information. @Sbozzolo @dennisYatunin What do you think?

Edit: From an offline discussion we are renaming radiation_model to rrtmgp_model.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
