### PR TITLE
Add check and informative error for empty YAML file

### DIFF
--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -525,7 +525,7 @@ function AtmosConfig(
 
     configs = map(all_config_files) do config_file
         @info "Loading yaml file $config_file"
-        strip_help_messages(YAML.load_file(config_file))
+        strip_help_messages(load_yaml_file(config_file))
     end
     return AtmosConfig(
         configs;

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -10,6 +10,11 @@ strip_help_message(v) = v
 strip_help_messages(d) =
     Dict(map(k -> Pair(k, strip_help_message(d[k])), collect(keys(d)))...)
 
+function load_yaml_file(f)
+    filesize(f) == 0 && error("File $f is empty or missing.")
+    return YAML.load_file(f)
+end
+
 """
     default_config_dict()
     default_config_dict(config_path)
@@ -17,7 +22,7 @@ strip_help_messages(d) =
 Loads the default configuration from files into a Dict for use in AtmosConfig().
 """
 function default_config_dict(config_file = default_config_file)
-    config = YAML.load_file(config_file)
+    config = load_yaml_file(config_file)
     return strip_help_messages(config)
 end
 
@@ -45,10 +50,10 @@ Takes in a Dict, vector of Dicts or filepaths and returns a Dict with the
 default configuration overridden by the given dicts or parsed YAML files.
 """
 override_default_config(config_files::AbstractString) =
-    override_default_config(YAML.load_file(config_files))
+    override_default_config(load_yaml_file(config_files))
 
 override_default_config(config_files::ContainerType(AbstractString)) =
-    override_default_config(YAML.load_file.(config_files))
+    override_default_config(load_yaml_file.(config_files))
 
 override_default_config(config_dicts::ContainerType(AbstractDict)) =
     override_default_config(merge(config_dicts...))
@@ -121,7 +126,7 @@ function configs_per_config_id(
             file = joinpath(root, f)
             !endswith(file, ".yml") && continue
             occursin("default_configs", file) && continue
-            config = YAML.load_file(file)
+            config = load_yaml_file(file)
             name = config_id_from_config_file(file)
             cmds[name] = (; config, config_file = file)
         end

--- a/test/config.jl
+++ b/test/config.jl
@@ -10,7 +10,7 @@ function extract_job_ids(folder_path)
     for (root, _, files) in walkdir(folder_path)
         for file in files
             filepath = joinpath(root, file)
-            data = YAML.load_file(filepath)
+            data = CA.load_yaml_file(filepath)
             if haskey(data, "job_id")
                 job_id_dict[filepath] = data["job_id"]
             end
@@ -33,3 +33,7 @@ end
 repeated_job_ids = filter(kv -> length(kv[2]) > 1, value_to_keys)
 
 @test isempty(repeated_job_ids)
+
+file, io = mktemp()
+config_err = ErrorException("File $(CA.normrelpath(file)) is empty or missing.")
+@test_throws config_err CA.AtmosConfig(file)


### PR DESCRIPTION
Closes #3151. It also looks like this will be fixed upstream with the next release https://github.com/JuliaData/YAML.jl/pull/219

New error is more informative: `File empty.yml is empty or missing.`