### PR TITLE
Wip on adding prescribed cloud droplet number concentration

### DIFF
--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -3,6 +3,7 @@
 import Thermodynamics as TD
 import CloudMicrophysics.Microphysics0M as CM0
 import CloudMicrophysics.Microphysics1M as CM1
+import CloudMicrophysics.Microphysics2M as CM2
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
 import CloudMicrophysics.Parameters as CMP
 
@@ -172,10 +173,12 @@ function compute_precipitation_sources!(
 
     #! format: off
     # rain autoconversion: q_liq -> q_rain
-    @. Sᵖ = min(
-        limit(qₗ(thp, ts), dt, 5),
+    @. Sᵖ = ifelse(
+        mp.Ndp <= 0,
         CM1.conv_q_liq_to_q_rai(mp.pr.acnv1M, qₗ(thp, ts), true),
+        CM2.conv_q_liq_to_q_rai(mp.var, qₗ(thp, ts), ρ, mp.Ndp),
     )
+    @. Sᵖ = min(limit(qₗ(thp, ts), dt, 5), Sᵖ)
     @. Sqₜᵖ -= Sᵖ
     @. Sqᵣᵖ += Sᵖ
     @. Seₜᵖ -= Sᵖ * (Iₗ(thp, ts) + Φ)

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -96,6 +96,12 @@ function create_parameter_set(config::AtmosConfig)
                 ce = CM.Parameters.CollisionEff(toml_dict),
                 tv = CM.Parameters.Blk1MVelType(toml_dict),
                 aps = CM.Parameters.AirProperties(toml_dict),
+                var = CM.Parameters.VarTimescaleAcnv(toml_dict),
+                Ndp = CP.get_parameter_values(
+                    toml_dict,
+                    "prescribed_cloud_droplet_number_concentration",
+                    "ClimaAtmos",
+                ).prescribed_cloud_droplet_number_concentration,
             )
         else
             error("Invalid precip_model $(precip_model)")

--- a/toml/single_column_precipitation_test.toml
+++ b/toml/single_column_precipitation_test.toml
@@ -1,2 +1,5 @@
 [C_H]
 value = 0.0
+
+[prescribed_cloud_droplet_number_concentration]
+value = 0.0


### PR DESCRIPTION
This PR changes the default rain autoconversion rate from [1 moment](https://clima.github.io/CloudMicrophysics.jl/dev/Microphysics1M/#Rain-autoconversion) to [prescribing cloud droplet number concentration](https://clima.github.io/CloudMicrophysics.jl/dev/Microphysics2M/#Auto-conversion-with-time-scale-depending-on-number-density).

The previous default option can still be used by specifying the `prescribed_cloud_droplet_number_concentration = 0`.  As usual, the parameter value can be overwritten via the toml files.

I kept one test with the old default and switched the rest to the new behavior. The changes in the results are small - you can see a slightly smoother precipitation profile in diagnostic edmf dycoms case. In some other cases there is a small decrease in precipitaton.

I want to switch to the new default because we have some good results calibrating it in KiD, and I want to experiment some more with it in Atmos with the help of our summer student.