### PR TITLE
add different aerosol types to radiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaAtmos.jl Release Notes
 
 Main
 -------
+- Allow different aerosol types for radiation.
+  PR [#3180](https://github.com/CliMA/ClimaAtmos.jl/pull/3180)
 
 v0.27.0
 -------

--- a/src/cache/tracer_cache.jl
+++ b/src/cache/tracer_cache.jl
@@ -2,8 +2,9 @@ using ClimaUtilities.ClimaArtifacts
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
 
 function tracer_cache(Y, atmos, prescribed_aerosol_names, start_date)
-    prescribed_aerosol_timevaryinginputs = (;)
-    prescribed_aerosol_fields = (;)
+    if isempty(prescribed_aerosol_names)
+        return (;)
+    end
 
     # Take the aerosol2005/aero_2005.nc file, read the keys with names matching
     # the ones passed in the prescribed_aerosol_names option, and create a
@@ -13,30 +14,30 @@ function tracer_cache(Y, atmos, prescribed_aerosol_names, start_date)
     # The keys in the aero_2005.nc file have to match the ones passed with the
     # configuration. The file also has to be defined on the globe and provide
     # time series of lon-lat-z data.
-    if !isempty(prescribed_aerosol_names)
-        prescribed_aerosol_names_as_symbols = Symbol.(prescribed_aerosol_names)
-        target_space = axes(Y.c)
-        timevaryinginputs = [
-            TimeVaryingInput(
-                joinpath(
-                    @clima_artifact("aerosol2005", ClimaComms.context(Y.c)),
-                    "aero_2005.nc",
-                ),
-                name,
-                target_space;
-                reference_date = start_date,
-                regridder_type = :InterpolationsRegridder,
-            ) for name in prescribed_aerosol_names
-        ]
-        empty_fields =
-            [zero(Y.c.ρ) for _ in prescribed_aerosol_names_as_symbols]
+    prescribed_aerosol_names_as_symbols = Symbol.(prescribed_aerosol_names)
+    target_space = axes(Y.c)
+    timevaryinginputs = [
+        TimeVaryingInput(
+            joinpath(
+                @clima_artifact("aerosol2005", ClimaComms.context(Y.c)),
+                "aero_2005.nc",
+            ),
+            name,
+            target_space;
+            reference_date = start_date,
+            regridder_type = :InterpolationsRegridder,
+        ) for name in prescribed_aerosol_names
+    ]
 
-        prescribed_aerosol_timevaryinginputs =
-            (; zip(prescribed_aerosol_names_as_symbols, timevaryinginputs)...)
-
-        # We add empty Fields here. Fields are updated in the radiation callback
-        prescribed_aerosol_fields =
-            (; zip(prescribed_aerosol_names_as_symbols, empty_fields)...)
-    end
-    return (; prescribed_aerosol_fields, prescribed_aerosol_timevaryinginputs)
+    # Field is updated in the radiation callback
+    prescribed_aerosols_field = similar(
+        Y.c,
+        NamedTuple{
+            prescribed_aerosol_names_as_symbols,
+            NTuple{length(prescribed_aerosol_names_as_symbols), eltype(Y.c.ρ)},
+        },
+    )
+    prescribed_aerosol_timevaryinginputs =
+        (; zip(prescribed_aerosol_names_as_symbols, timevaryinginputs)...)
+    return (; prescribed_aerosols_field, prescribed_aerosol_timevaryinginputs)
 end

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -43,8 +43,13 @@ function radiation_model_cache(
     (; idealized_h2o, idealized_clouds) = radiation_mode
     if !(radiation_mode isa RRTMGPI.GrayRadiation)
         (; aerosol_radiation) = radiation_mode
-        if aerosol_radiation && !("SO4" in aerosol_names)
-            error("Aerosol radiation is turned on but SO4 is not provided")
+        if aerosol_radiation && !(any(
+            x -> x in aerosol_names,
+            ["DST01", "SSLT01", "SO4", "CB1", "CB2", "OC1", "OC2"],
+        ))
+            error(
+                "Need at least one aerosol type when aerosol radiation is turned on",
+            )
         end
     end
     FT = Spaces.undertype(axes(Y.c))
@@ -191,7 +196,7 @@ function radiation_model_cache(
             if aerosol_radiation
                 kwargs = (;
                     kwargs...,
-                    center_aerosol_type = 3, # assuming only sulfate
+                    center_aerosol_type = 0, # initialized in callback
                     center_aerosol_radius = 0.2, # assuming fixed aerosol radius
                     center_aerosol_column_mass_density = NaN, # initialized in callback
                 )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
co-authored-by: @charleskawczynski. Finds the maximum aerosol concentration in each grid box and assign the corresponding aerosol type in radiation. Also changes prescribed aerosols from named tuple of fields to field of named tuples.

Closes #3170 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
