### PR TITLE
use default numerics config and parameters

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss_1process.yml
@@ -19,4 +19,4 @@ surface_setup: DefaultMoninObukhov
 rayleigh_sponge: true
 dt: 100secs
 t_end: 12hours
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss_2process.yml
@@ -19,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "100secs"
 t_end: "12hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss_4process.yml
@@ -19,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "100secs"
 t_end: "12hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -19,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "100secs"
 t_end: "12hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -19,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "100secs"
 t_end: "12hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -19,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "100secs"
 t_end: "12hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -13,4 +13,4 @@ moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M_4process.yml
+++ b/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M_4process.yml
@@ -13,4 +13,4 @@ moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_clearsky_1M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_clearsky_1M.yml
@@ -14,4 +14,4 @@ implicit_diffusion: true
 approximate_linear_solve_iters: 2
 rad: "clearsky"
 dt_rad: "6hours"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_dyamond.yml
+++ b/config/longrun_configs/longrun_aquaplanet_dyamond.yml
@@ -9,10 +9,10 @@ cloud_model: "grid_scale"
 rad: "allskywithclear" 
 insolation: "timevarying"
 dt_rad: "1hours"
-vert_diff: "true" 
+vert_diff: "FriersonDiffusion" 
 surface_setup: "DefaultMoninObukhov" 
 rayleigh_sponge: true
 dt_save_state_to_disk: "10days"
 dt: "50secs" 
 t_end: "10days"
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
@@ -25,4 +25,4 @@ rayleigh_sponge: true
 dt_save_state_to_disk: "10days"
 dt: "100secs"
 t_end: "120days"
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
@@ -15,4 +15,4 @@ implicit_diffusion: true
 approximate_linear_solve_iters: 2
 rad: "clearsky"
 dt_rad: "6hours"
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
@@ -11,9 +11,6 @@ z_max: 55000.0
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true
-vorticity_hyperdiffusion_coefficient: 1.0
-divergence_damping_factor: 4.0
-scalar_hyperdiffusion_coefficient: 4.0
 smoothing_order: 2
 topo_smoothing: true
 topography: "Earth"
@@ -21,4 +18,4 @@ surface_setup: "DefaultMoninObukhov"
 vert_diff: "FriersonDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth_sleve.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth_sleve.yml
@@ -11,9 +11,6 @@ z_max: 55000.0
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true
-vorticity_hyperdiffusion_coefficient: 3.0
-divergence_damping_factor: 1.0
-scalar_hyperdiffusion_coefficient: 3.0
 smoothing_order: 2
 topo_smoothing: true
 mesh_warp_type: "SLEVE"
@@ -22,4 +19,4 @@ surface_setup: "DefaultMoninObukhov"
 vert_diff: "FriersonDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth_sleve.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_tvinsol_0M_slabocean.yml
@@ -20,4 +20,4 @@ albedo_model: "RegressionFunctionAlbedo"
 prognostic_surface: "PrognosticSurfaceTemperature"
 check_conservation: true
 bubble: false
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.yml
@@ -14,4 +14,4 @@ surface_setup: "DefaultExchangeCoefficients"
 moist: "equil"
 rad: "gray"
 precip_model: "0M"
-toml: [toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_hs_rhoe_dry_55km_nz63.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_dry_55km_nz63.yml
@@ -8,4 +8,4 @@ t_end: "300days"
 forcing: "held_suarez"
 rayleigh_sponge: true
 dt_save_state_to_disk: "10days"
-toml: [toml/longrun_hs_rhoe_dry_55km_nz63.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M.yml
@@ -11,4 +11,4 @@ vert_diff: "true"
 rayleigh_sponge: true
 forcing: "held_suarez"
 dt_save_state_to_disk: "10days"
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M_deepatmos.yml
+++ b/config/longrun_configs/longrun_hs_rhoe_equil_55km_nz63_0M_deepatmos.yml
@@ -12,4 +12,4 @@ vert_diff: "true"
 rayleigh_sponge: true
 forcing: "held_suarez"
 dt_save_state_to_disk: "10days"
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_sphere_hydrostatic_balance_rhoe.yml
+++ b/config/longrun_configs/longrun_sphere_hydrostatic_balance_rhoe.yml
@@ -8,3 +8,4 @@ dz_top: 3000.0
 z_max: 55000.0
 perturb_initstate: false
 discrete_hydrostatic_balance: true
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/model_configs/box_density_current_test.yml
+++ b/config/model_configs/box_density_current_test.yml
@@ -11,8 +11,6 @@ z_stretch: false
 x_elem: 45
 ode_algo: "SSP33ShuOsher"
 config: "box"
-vorticity_hyperdiffusion_coefficient: 0.6
-scalar_hyperdiffusion_coefficient: 0.6
 z_max: 6400.0
 diagnostics:
   - short_name: thetaa

--- a/config/model_configs/central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/model_configs/central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -14,4 +14,4 @@ precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
 call_cloud_diagnostics_per_stage: true
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/model_configs/central_gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/model_configs/central_gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -13,4 +13,4 @@ moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true
 forcing: "held_suarez"
-toml: [toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/model_configs/gpu_aquaplanet_dyamond.yml
+++ b/config/model_configs/gpu_aquaplanet_dyamond.yml
@@ -20,4 +20,4 @@ dt: "100secs"
 t_end: "8hours"
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "OC1", "OC2", "SO4", "SOA", "SSLT01", "SSLT02", "SSLT03", "SSLT04"]
-toml: [toml/longrun_aquaplanet_dyamond.toml]
+toml: [toml/longrun_aquaplanet.toml]

--- a/config/model_configs/plane_density_current_test.yml
+++ b/config/model_configs/plane_density_current_test.yml
@@ -8,8 +8,6 @@ discrete_hydrostatic_balance: true
 z_stretch: false
 x_elem: 80
 config: "plane"
-vorticity_hyperdiffusion_coefficient: 0.6
-scalar_hyperdiffusion_coefficient: 0.6
 z_max: 6400.0
 diagnostics:
   - short_name: thetaa

--- a/config/model_configs/plane_schar_mountain_test_stretched.yml
+++ b/config/model_configs/plane_schar_mountain_test_stretched.yml
@@ -10,8 +10,6 @@ x_elem: 100
 dz_bottom: 200.0
 ode_algo: "SSP33ShuOsher"
 config: "plane"
-vorticity_hyperdiffusion_coefficient: 0.5
-scalar_hyperdiffusion_coefficient: 0.5
 z_max: 25000.0
 topography: "Schar"
 toml: [toml/plane_schar_mountain_test_stretched.toml]

--- a/config/model_configs/plane_schar_mountain_test_uniform.yml
+++ b/config/model_configs/plane_schar_mountain_test_uniform.yml
@@ -9,8 +9,6 @@ z_stretch: false
 x_elem: 100
 ode_algo: "SSP33ShuOsher"
 config: "plane"
-vorticity_hyperdiffusion_coefficient: 0.5
-scalar_hyperdiffusion_coefficient: 0.5
 z_max: 25000.0
 topography: "Schar"
 toml: [toml/plane_schar_mountain_test_uniform.toml]

--- a/toml/longrun_aquaplanet.toml
+++ b/toml/longrun_aquaplanet.toml
@@ -1,0 +1,2 @@
+[zd_rayleigh]
+value = 35000.0

--- a/toml/longrun_aquaplanet_dyamond.toml
+++ b/toml/longrun_aquaplanet_dyamond.toml
@@ -1,5 +1,0 @@
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.toml
@@ -1,8 +1,0 @@
-[alpha_rayleigh_w]
-value = 3.0
-
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth_sleve.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth_sleve.toml
@@ -1,8 +1,0 @@
-[alpha_rayleigh_w]
-value = 10.0
-
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_diagedmf_0M.toml
@@ -1,9 +1,6 @@
 [zd_rayleigh]
 value = 35000.0
 
-[alpha_rayleigh_uh]
-value = 0.0
-
 [precipitation_timescale]
 value = 600
 

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_progedmf_0M.toml
@@ -1,9 +1,6 @@
 [zd_rayleigh]
 value = 35000.0
 
-[alpha_rayleigh_uh]
-value = 0.0
-
 [precipitation_timescale]
 value = 600
 

--- a/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
+++ b/toml/longrun_aquaplanet_rhoe_equil_55km_nz63_gray_0M.toml
@@ -1,5 +1,0 @@
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0

--- a/toml/longrun_hs_rhoe_dry_55km_nz63.toml
+++ b/toml/longrun_hs_rhoe_dry_55km_nz63.toml
@@ -1,5 +1,0 @@
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0

--- a/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
+++ b/toml/longrun_hs_rhoe_equil_55km_nz63_0M.toml
@@ -1,5 +1,0 @@
-[zd_rayleigh]
-value = 35000.0
-
-[alpha_rayleigh_uh]
-value = 0.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
There is a requirement that all the global runs should use the same parameters for numerics (hyperdiffusion, sponge, etc.) This PR changes that. Note that the stability of the simulations after the change has not been tested.

cc @akshaysridhar 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
