### PR TITLE
Remove error if config_dict value does not have default type

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -141,7 +141,7 @@ reference_job_id:
   value: ~
 vert_diff:
   help: "Vertical diffusion [`false` (default), `VerticalDiffusion`, `true` (defaults to `VerticalDiffusion`), `FriersonDiffusion`]"
-  value: "false"
+  value: false
 hyperdiff:
   help: "Hyperdiffusion [`ClimaHyperdiffusion` (or `true`; default), `none` (or `false`)]"
   value: "CAM_SE"
@@ -232,9 +232,6 @@ external_forcing:
 external_forcing_file:
   help: "External forcing file containing large-scale forcings, initial conditions, and boundary conditions [`nothing` (default), `path/to/file`]"
   value: ~
-fps:
-  help: "Frames per second for animations"
-  value: 5
 subsidence:
   help: "Subsidence [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `DYCOMS`]"
   value: ~
@@ -246,7 +243,7 @@ prognostic_tke:
   value: false
 prognostic_surface:
   help: "Determines if surface temperature is prognostic [`false` (default), , `true`, `PrognosticSurfaceTemperature`, `PrescribedSurfaceTemperature`]"
-  value: "false"
+  value: false
 albedo_model:
   help: "Variable surface albedo [`ConstantAlbedo` (default), `RegressionFunctionAlbedo`, `CouplerAlbedo`]"
   value: "ConstantAlbedo"

--- a/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -8,7 +8,7 @@ z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
 z_max: 55000.0
-vert_diff: "true"
+vert_diff: true
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true

--- a/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M_4process.yml
+++ b/config/gpu_configs/gpu_hs_rhoe_equil_55km_nz63_0M_4process.yml
@@ -8,7 +8,7 @@ z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
 z_max: 55000.0
-vert_diff: "true"
+vert_diff: true
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true

--- a/config/longrun_configs/longrun_moist_held_suarez.yml
+++ b/config/longrun_configs/longrun_moist_held_suarez.yml
@@ -7,7 +7,7 @@ dt: "100secs"
 t_end: "360days"
 moist: "equil"
 precip_model: "0M"
-vert_diff: "true"
+vert_diff: true
 rayleigh_sponge: true
 forcing: "held_suarez"
 dt_save_state_to_disk: "10days"

--- a/config/longrun_configs/longrun_moist_held_suarez_deepatmos.yml
+++ b/config/longrun_configs/longrun_moist_held_suarez_deepatmos.yml
@@ -8,7 +8,7 @@ t_end: "360days"
 deep_atmosphere: true
 moist: "equil"
 precip_model: "0M"
-vert_diff: "true"
+vert_diff: true
 rayleigh_sponge: true
 forcing: "held_suarez"
 dt_save_state_to_disk: "10days"

--- a/config/model_configs/box_hydrostatic_balance_rhoe.yml
+++ b/config/model_configs/box_hydrostatic_balance_rhoe.yml
@@ -1,6 +1,6 @@
 t_end: "1days"
 config: "box"
-hyperdiff: "false"
+hyperdiff: false
 dt: "20secs"
 perturb_initstate: false
 diagnostics:

--- a/config/model_configs/central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/model_configs/central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -8,7 +8,7 @@ z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
 z_max: 55000.0
-vert_diff: "true"
+vert_diff: true
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true

--- a/config/model_configs/central_gpu_hs_rhoe_equil_55km_nz63_0M.yml
+++ b/config/model_configs/central_gpu_hs_rhoe_equil_55km_nz63_0M.yml
@@ -8,7 +8,7 @@ z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
 z_max: 55000.0
-vert_diff: "true"
+vert_diff: true
 moist: "equil"
 precip_model: "0M"
 rayleigh_sponge: true

--- a/config/model_configs/gpu_prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/gpu_prognostic_edmfx_aquaplanet.yml
@@ -17,7 +17,7 @@ moist: equil
 precip_model: 1M
 dt: 10secs
 t_end: 1hours
-dt_save_to_disk: 600secs
+dt_save_state_to_disk: 600secs
 toml: [toml/prognostic_edmfx.toml]
 output_default_diagnostics: false
 diagnostics:

--- a/config/model_configs/plane_agnesi_mountain_test_stretched.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_stretched.yml
@@ -9,7 +9,7 @@ dz_top: 1000.0
 x_elem: 80
 dz_bottom: 200.0
 config: "plane"
-hyperdiff: "false"
+hyperdiff: false
 z_max: 25000.0
 topography: "Agnesi"
 toml: [toml/plane_agnesi_mountain_test_stretched.toml]

--- a/config/model_configs/plane_agnesi_mountain_test_uniform.yml
+++ b/config/model_configs/plane_agnesi_mountain_test_uniform.yml
@@ -8,7 +8,7 @@ t_end: "14400.0secs"
 z_stretch: false
 x_elem: 80
 config: "plane"
-hyperdiff: "false"
+hyperdiff: false
 z_max: 25000.0
 topography: "Agnesi"
 toml: [toml/plane_agnesi_mountain_test_uniform.toml]

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -24,7 +24,7 @@ z_stretch: false
 perturb_initstate: false
 dt: "10secs"
 t_end: "6hours"
-dt_save_to_disk: "10mins"
+dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
 diagnostics:

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -25,7 +25,7 @@ z_stretch: false
 perturb_initstate: false
 dt: "50secs"
 t_end: "6hours"
-dt_save_to_disk: "10mins"
+dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
 diagnostics:

--- a/config/model_configs/prognostic_edmfx_bomex_pigroup_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_pigroup_column.yml
@@ -22,7 +22,7 @@ z_stretch: false
 perturb_initstate: false
 dt: "5secs"
 t_end: "6hours"
-dt_save_to_disk: "10mins"
+dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex_pigroup.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
 diagnostics:

--- a/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
@@ -18,7 +18,7 @@ prognostic_tke: true
 moist: "equil"
 call_cloud_diagnostics_per_stage: true
 config: "column"
-hyperdiff: "false"
+hyperdiff: false
 z_max: 3e3
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -19,7 +19,7 @@ prognostic_tke: true
 moist: equil
 call_cloud_diagnostics_per_stage: true
 config: column
-hyperdiff: "false"
+hyperdiff: false
 z_max: 1500
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -15,7 +15,7 @@ edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
 config: "column"
-hyperdiff: "false"
+hyperdiff: false
 z_max: 400
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -23,7 +23,7 @@ z_stretch: false
 perturb_initstate: false
 dt: "10secs"
 t_end: "6hours"
-dt_save_to_disk: "10mins"
+dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -23,7 +23,7 @@ z_stretch: false
 perturb_initstate: false
 dt: 20secs"
 t_end: "12hours"
-dt_save_to_disk: "10mins"
+dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_simpleplume.toml]
 netcdf_interpolation_num_points: [2, 2, 80]
 diagnostics:

--- a/config/model_configs/single_column_hydrostatic_balance_ft64.yml
+++ b/config/model_configs/single_column_hydrostatic_balance_ft64.yml
@@ -2,7 +2,7 @@ dz_bottom: 30.0
 dt_save_state_to_disk: "5days"
 initial_condition: "IsothermalProfile"
 config: "column"
-hyperdiff: "false"
+hyperdiff: false
 z_elem: 45
 dt: "3hours"
 FLOAT_TYPE: "Float64"

--- a/config/model_configs/single_column_nonorographic_gravity_wave.yml
+++ b/config/model_configs/single_column_nonorographic_gravity_wave.yml
@@ -2,6 +2,6 @@ dt_save_state_to_disk: "400secs"
 initial_condition: "IsothermalProfile"
 t_end: "1500secs"
 config: "column"
-hyperdiff: "false"
+hyperdiff: false
 dt: "400secs"
 non_orographic_gravity_wave: true

--- a/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
@@ -1,6 +1,6 @@
 dt_save_state_to_disk: "100days"
 initial_condition: "IsothermalProfile"
-hyperdiff: "false"
+hyperdiff: false
 z_elem: 70
 dt: "3hours"
 idealized_h2o: true

--- a/config/model_configs/single_column_radiative_equilibrium_clearsky.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_clearsky.yml
@@ -1,6 +1,6 @@
 dt_save_state_to_disk: "100days"
 initial_condition: "IsothermalProfile"
-hyperdiff: "false"
+hyperdiff: false
 z_elem: 70
 dt: "3hours"
 idealized_h2o: true

--- a/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
@@ -1,7 +1,7 @@
 
 rad: "clearsky"
 idealized_h2o: true
-hyperdiff: "false"
+hyperdiff: false
 config: "column"
 initial_condition: "IsothermalProfile"
 z_max: 70000
@@ -12,6 +12,6 @@ t_end: "654days"
 dt: "3hours"
 dt_save_to_sol: "30hours"
 dt_save_state_to_disk: "100days"
-prognostic_surface: "true"
+prognostic_surface: true
 surface_setup: DefaultExchangeCoefficients
 toml: [toml/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.toml]

--- a/config/model_configs/single_column_radiative_equilibrium_gray.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_gray.yml
@@ -1,6 +1,6 @@
 dt_save_state_to_disk: "100days"
 initial_condition: "IsothermalProfile"
-hyperdiff: "false"
+hyperdiff: false
 z_elem: 70
 dt: "3hours"
 t_end: "654days"

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -8,7 +8,7 @@ surface_setup: "DefaultMoninObukhov"
 t_end: "15hours"
 non_orographic_gravity_wave: true
 dz_bottom: 300.0
-vert_diff: "true"
+vert_diff: true
 insolation: "timevarying"
 z_max: 55000.0
 precip_model: "0M"

--- a/config/model_configs/sphere_baroclinic_wave_conservation_source.yml
+++ b/config/model_configs/sphere_baroclinic_wave_conservation_source.yml
@@ -6,6 +6,6 @@ surface_setup: DefaultMoninObukhov
 prognostic_surface: "PrognosticSurfaceTemperature"
 rad: "clearsky"
 precip_model: "0M"
-vert_diff: "true"
+vert_diff: true
 dt_save_state_to_disk: "5days"
 check_conservation: true

--- a/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
+++ b/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
@@ -4,7 +4,7 @@ dt: "450secs"
 z_elem: 25
 t_end: "4days"
 dz_bottom: 300.0
-vert_diff: "true"
+vert_diff: true
 forcing: "held_suarez"
 z_max: 55000.0
 precip_model: "0M"

--- a/config/model_configs/sphere_held_suarez_rhoe_equilmoist_topography_dcmip.yml
+++ b/config/model_configs/sphere_held_suarez_rhoe_equilmoist_topography_dcmip.yml
@@ -3,7 +3,7 @@ rayleigh_sponge: true
 topo_smoothing: true
 dt: "200secs"
 t_end: "2days"
-vert_diff: "true"
+vert_diff: true
 forcing: "held_suarez"
 precip_model: "0M"
 topography: "DCMIP200"

--- a/config/model_configs/sphere_hydrostatic_balance_rhoe_ft64.yml
+++ b/config/model_configs/sphere_hydrostatic_balance_rhoe_ft64.yml
@@ -1,7 +1,7 @@
 dt_save_state_to_disk: "8days"
 t_end: "8days"
 discrete_hydrostatic_balance: true
-hyperdiff: "false"
+hyperdiff: false
 perturb_initstate: false
 FLOAT_TYPE: "Float64"
 dt_save_to_sol: "600secs"

--- a/config/model_configs/test_env.yml
+++ b/config/model_configs/test_env.yml
@@ -1,4 +1,4 @@
-vert_diff: "true"
+vert_diff: true
 surface_setup: "DefaultExchangeCoefficients"
 moist: "equil"
 rad: "allskywithclear"

--- a/config/mpi_configs/mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky.yml
+++ b/config/mpi_configs/mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky.yml
@@ -1,4 +1,4 @@
-vert_diff: "true"
+vert_diff: true
 surface_setup: "DefaultExchangeCoefficients"
 moist: "equil"
 rad: "clearsky"

--- a/config/perf_configs/bm_perf_target.yml
+++ b/config/perf_configs/bm_perf_target.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/bm_perf_target_threaded.yml
+++ b/config/perf_configs/bm_perf_target_threaded.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/checkbounds.yml
+++ b/config/perf_configs/checkbounds.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/cpu_implicit_barowave.yml
+++ b/config/perf_configs/cpu_implicit_barowave.yml
@@ -3,7 +3,7 @@ apply_limiter: true
 z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_gpu_implicit_barowave_moist.yml
+++ b/config/perf_configs/flame_gpu_implicit_barowave_moist.yml
@@ -3,7 +3,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_diagnostics.yml
+++ b/config/perf_configs/flame_perf_diagnostics.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_gw.yml
+++ b/config/perf_configs/flame_perf_gw.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_target.yml
+++ b/config/perf_configs/flame_perf_target.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_target_callbacks.yml
+++ b/config/perf_configs/flame_perf_target_callbacks.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_target_diagnostic_edmfx.yml
+++ b/config/perf_configs/flame_perf_target_diagnostic_edmfx.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12
@@ -14,11 +14,11 @@ dt_save_to_sol: "Inf"
 rad: "allskywithclear"
 log_progress: false
 dt_save_state_to_disk: "600secs"
-vert_diff: "false"
+vert_diff: false
 turbconv: "diagnostic_edmfx"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_upwinding: "first_order"
 prognostic_tke: true
-edmfx_sgs_flux: true
+

--- a/config/perf_configs/flame_perf_target_edmf.yml
+++ b/config/perf_configs/flame_perf_target_edmf.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/flame_perf_target_frierson.yml
+++ b/config/perf_configs/flame_perf_target_frierson.yml
@@ -8,7 +8,6 @@ dt_save_to_sol: "Inf"
 rad: "allskywithclear"
 log_progress: false
 vert_diff: "FriersonDiffusion"
-pproximate_linear_solve_iters: 2
 use_krylov_method: true
 use_dynamic_krylov_rtol: false
 krylov_rtol: 0.99

--- a/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
+++ b/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
@@ -7,7 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 surface_setup: DefaultExchangeCoefficients
 rad: gray
-vert_diff: "false"
+vert_diff: false
 turbconv: prognostic_edmfx 
 implicit_diffusion: true
 implicit_sgs_advection: true

--- a/config/perf_configs/flame_perf_target_threaded.yml
+++ b/config/perf_configs/flame_perf_target_threaded.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 approximate_linear_solve_iters: 2
 h_elem: 12
 forcing: "held_suarez"

--- a/config/perf_configs/flame_perf_target_tracers.yml
+++ b/config/perf_configs/flame_perf_target_tracers.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 approximate_linear_solve_iters: 2
 h_elem: 12
 forcing: "held_suarez"

--- a/config/perf_configs/flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
+++ b/config/perf_configs/flame_sphere_baroclinic_wave_rhoe_equilmoist_expvdiff.yml
@@ -11,7 +11,7 @@ use_krylov_method: true
 use_dynamic_krylov_rtol: false
 krylov_rtol: 0.99
 precip_model: "0M"
-vert_diff: "true"
+vert_diff: true
 z_elem: 20
 dz_bottom: 100
 dt_save_state_to_disk: "12hours"

--- a/config/perf_configs/gpu_implicit_barowave.yml
+++ b/config/perf_configs/gpu_implicit_barowave.yml
@@ -2,7 +2,7 @@ moist: "equil"
 apply_limiter: true
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 forcing: "held_suarez"

--- a/config/perf_configs/gpu_implicit_barowave_moist.yml
+++ b/config/perf_configs/gpu_implicit_barowave_moist.yml
@@ -1,5 +1,5 @@
 surface_setup: "DefaultExchangeCoefficients"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 forcing: "held_suarez"

--- a/config/perf_configs/gpu_implicit_barowave_wrt_h_elem.yml
+++ b/config/perf_configs/gpu_implicit_barowave_wrt_h_elem.yml
@@ -1,7 +1,7 @@
 moist: "equil"
 apply_limiter: true
 surface_setup: "DefaultExchangeCoefficients"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 forcing: "held_suarez"

--- a/config/perf_configs/invalidations.yml
+++ b/config/perf_configs/invalidations.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 h_elem: 12

--- a/config/perf_configs/jet_n_failures.yml
+++ b/config/perf_configs/jet_n_failures.yml
@@ -4,7 +4,7 @@ z_elem: 25
 dt: "1secs"
 surface_setup: "DefaultExchangeCoefficients"
 t_end: "10secs"
-vert_diff: "true"
+vert_diff: true
 approximate_linear_solve_iters: 2
 h_elem: 12
 forcing: "held_suarez"

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -28,7 +28,7 @@ edmfx_nh_pressure: true
 prognostic_tke: false
 moist: "equil"
 config: "box"
-hyperdiff: "true"
+hyperdiff: true
 x_max: 1e8
 y_max: 1e8
 z_max: 3e3

--- a/docs/src/radiative_equilibrium.md
+++ b/docs/src/radiative_equilibrium.md
@@ -13,7 +13,7 @@ The yaml file should look something like this:
 ```
 rad: "clearsky" 
 idealized_h2o: true 
-hyperdiff: "false" 
+hyperdiff: false 
 config: "column" 
 initial_condition: "IsothermalProfile" 
 z_max: 70000
@@ -24,7 +24,7 @@ t_end: "654days"
 dt: "3hours" 
 dt_save_to_sol: "30hours" 
 dt_save_state_to_disk: "100days" 
-prognostic_surface: "true" 
+prognostic_surface: true
 job_id: "single_column_radiative_equilibrium_clearsky_prognostic_surface_temp"
 ```
 

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -83,7 +83,11 @@ function override_default_config(config_dict::AbstractDict;)
         end
     end
 
-    unused_keys = filter(k -> !haskey(default_config, k), keys(config_dict))
+    excluded_keys = Set(["diagnostics"])
+    unused_keys = filter(
+        k -> !haskey(default_config, k) && !(k in excluded_keys),
+        keys(config_dict),
+    )
     if !isempty(unused_keys)
         @warn "The configuration passed to ClimaAtmos contains unused keys: $(join(unused_keys, ", "))"
     end

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -72,14 +72,14 @@ function override_default_config(config_dict::AbstractDict;)
         v = config_dict[k]
 
         # Attempt to convert user value `v` to the same type as
-        # the default. If that fails, throw an informative error.
+        # the default. If that fails, throw an informative warning.
         config[k] = try
-            isnothing(default_config[k]) ? v : default_type(v)
-        catch err
-            user_entry_type = typeof(v)
-            msg = """Configuration entry "$(k)" = $v has type $(user_entry_type),
-                     but must have type $default_type."""
-            throw(ArgumentError(msg))
+            isnothing(default_config[k]) ? v : convert(default_type, v)
+        catch e
+            # A failed conversion should result in a MethodError
+            e isa MethodError || rethrow(e)
+            @warn """Failed to convert `config_dict["$k"] = $v` to default type $default_type, keeping original value"""
+            v
         end
     end
 


### PR DESCRIPTION
This loosens the type restrictions for the YAML files - we can finally have `hyperdiff: false`!

If the AtmosConfig constructor is unable to convert an input value to the default type, just warn the user and use the given input value:
```
┌ Warning: Failed to convert `config_dict["hyperdiff"] = false` to default type String, keeping original value
```

This PR also follows up on #3203, fixing unused YAML keys and adding an exception for the `diagnostics` key, since it is not found in the default config file.

Example of undesired behavior:
```
┌ Warning: The configuration passed to ClimaAtmos contains unused keys: diagnostics
└ @ ClimaAtmos /central/scratch/esm/slurm-buildkite/climaatmos-ci/19847/climaatmos-ci/src/solver/yaml_helper.jl:88
```