### PR TITLE
Remove conditional in calibration model interface

### DIFF
--- a/calibration/experiments/sphere_held_suarez_rhoe_equilmoist/model_interface.jl
+++ b/calibration/experiments/sphere_held_suarez_rhoe_equilmoist/model_interface.jl
@@ -46,7 +46,6 @@ function run_forward_model(atmos_config::CA.AtmosConfig)
     simulation = CA.get_simulation(atmos_config)
     sol_res = CA.solve_atmos!(simulation)
     if sol_res.ret_code == :simulation_crashed
-        !isnothing(sol_res.sol) && sol_res.sol .= NaN
         error(
             "The ClimaAtmos simulation has crashed. See the stack trace for details.",
         )

--- a/calibration/model_interface.jl
+++ b/calibration/model_interface.jl
@@ -1,3 +1,10 @@
+# When Julia 1.10+ is used interactively, stacktraces contain reduced type information to make them shorter.
+# On the other hand, the full type information is printed when julia is not run interactively.
+# Given that ClimaCore objects are heavily parametrized, non-abbreviated stacktraces are hard to read,
+# so we force abbreviated stacktraces even in non-interactive runs.
+# (See also Base.type_limited_string_from_context())
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
+
 import ClimaAtmos as CA
 import YAML
 import ClimaComms
@@ -61,7 +68,6 @@ function run_forward_model(atmos_config::CA.AtmosConfig)
     simulation = CA.get_simulation(atmos_config)
     sol_res = CA.solve_atmos!(simulation)
     if sol_res.ret_code == :simulation_crashed
-        !isnothing(sol_res.sol) && sol_res.sol .= NaN
         error(
             "The ClimaAtmos simulation has crashed. See the stack trace for details.",
         )

--- a/calibration/test/e2e_test.jl
+++ b/calibration/test/e2e_test.jl
@@ -17,14 +17,15 @@ import Statistics: var, mean
 using Test
 
 # Paths and setup
-experiment_dir = joinpath(pkgdir(CA), "calibration", "test")
-model_interface = joinpath(pkgdir(CA), "calibration", "model_interface.jl")
+const experiment_dir = joinpath(pkgdir(CA), "calibration", "test")
+const model_interface =
+    joinpath(pkgdir(CA), "calibration", "model_interface.jl")
+const output_dir = joinpath("output", "calibration_end_to_end_test")
 include(model_interface)
 
 # Observation map
 function CAL.observation_map(iteration)
     ensemble_size = 10
-    output_dir = "calibration_end_to_end_test"
     single_member_dims = (1,)
     G_ensemble = Array{Float64}(undef, single_member_dims..., ensemble_size)
 
@@ -67,7 +68,6 @@ noise = 0.1 * I
 n_iterations = 3
 ensemble_size = 10
 prior = CAL.get_prior(joinpath(experiment_dir, "prior.toml"))
-output_dir = "calibration_end_to_end_test"
 experiment_config = CAL.ExperimentConfig(;
     n_iterations,
     ensemble_size,
@@ -94,7 +94,7 @@ if !(@isdefined backend)
 end
 @info "Running calibration E2E test" backend
 if backend <: CAL.SlurmBackend
-    slurm_kwargs = CAL.kwargs(time = 10)
+    slurm_kwargs = CAL.kwargs(time = 15)
     test_eki = CAL.calibrate(
         backend,
         experiment_config;

--- a/calibration/test/model_config.yml
+++ b/calibration/test/model_config.yml
@@ -4,7 +4,7 @@ config: column
 h_elem: 1
 insolation: timevarying
 job_id: calibration_end_to_end_test
-output_dir: calibration_end_to_end_test
+output_dir: output/calibration_end_to_end_test
 output_default_diagnostics: false
 dt_rad: 6hours
 rad: clearsky


### PR DESCRIPTION
This PR removes an overlooked conditional found in #3209 and adds a line to truncate stack traces to improve logging for calibration.

New stacktrace:
```
┌ Info: Progress
│   simulation_time = "1 week, 1 day"
│   n_steps_completed = 385
│   wall_time_per_step = "505 microseconds, 104 nanoseconds"
│   wall_time_total = "654 milliseconds, 614 microseconds"
│   wall_time_remaining = "460 milliseconds, 149 microseconds"
│   wall_time_spent = "194 milliseconds, 464 microseconds"
│   percent_complete = "29.7%"
│   sypd = 10848.173
│   date_now = 2024-07-19T11:57:13.285
└   estimated_finish_date = 2024-07-19T11:57:13.745
^C[ Info: Saving state to HDF5 file on day 10 second 28000
┌ Error: ClimaAtmos simulation crashed. Stacktrace for failed simulation
│   exception =
│    InterruptException:
│    Stacktrace:
│      [1] _log(x::Float32, base::Val{:ℯ}, func::Symbol)
│        @ Base.Math ./special/log.jl:305
│      [2] log
│        @ ./special/log.jl:264 [inlined]
│      [3] compute_interp_frac_press
│        @ ~/.julia/packages/RRTMGP/Hw5cF/src/optics/GasOptics.jl:105 [inlined]
│      [4] compute_gas_optics
│        @ ~/.julia/packages/RRTMGP/Hw5cF/src/optics/GasOptics.jl:174 [inlined]
│      [5] compute_optical_props!
│        @ ~/.julia/packages/RRTMGP/Hw5cF/src/optics/Optics.jl:285 [inlined]
│      [6] macro expansion
│        @ ~/.julia/packages/RRTMGP/Hw5cF/src/rte/longwave2stream.jl:57 [inlined]
│      [7] macro expansion
│        @ ~/.julia/packages/ClimaComms/Fy72Q/src/devices.jl:127 [inlined]
│      [8] rte_lw_2stream_solve!(device::ClimaComms.CPUSingleThreaded, flux::RRTMGP.Fluxes.FluxLW{…}, flux_lw::RRTMGP.Fluxes.FluxLW{…}, src_lw::RRTMGP.Sources.SourceLW2Str{…}, bcs_lw::RRTMGP.BCs.LwBCs{…}, op::RRTMGP.Optics.TwoStream{…}, as::RRTMGP.AtmosphericStates.AtmosphericState{…}, lookup_lw::RRTMGP.LookUpTables.LookUpLW{…}, lookup_lw_cld::Nothing, lookup_lw_aero::Nothing)
│        @ RRTMGP.RTESolver ~/.julia/packages/RRTMGP/Hw5cF/src/rte/longwave2stream.jl:50
│      [9] solve_lw!
│        @ ~/.julia/packages/RRTMGP/Hw5cF/src/rte/RTESolver.jl:81 [inlined]
│     [10] macro expansion
│        @ ~/clima/ClimaAtmos.jl/src/parameterized_tendencies/radiation/RRTMGPInterface.jl:1165 [inlined]
│     [11] update_lw_fluxes!(::ClimaAtmos.RRTMGPInterface.ClearSkyRadiation, model::ClimaAtmos.RRTMGPInterface.RRTMGPModel{…})
│        @ ClimaAtmos.RRTMGPInterface ~/.julia/packages/NVTX/pfSOQ/src/macro.jl:194
│     [12] macro expansion
│        @ ~/clima/ClimaAtmos.jl/src/parameterized_tendencies/radiation/RRTMGPInterface.jl:1019 [inlined]
│     [13] update_fluxes!(model::ClimaAtmos.RRTMGPInterface.RRTMGPModel{…})
│        @ ClimaAtmos.RRTMGPInterface ~/.julia/packages/NVTX/pfSOQ/src/macro.jl:194
│     [14] macro expansion
│        @ ~/clima/ClimaAtmos.jl/src/callbacks/callbacks.jl:179 [inlined]
│     [15] rrtmgp_model_callback!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…})
│        @ ClimaAtmos ~/.julia/packages/NVTX/pfSOQ/src/macro.jl:194
│     [16] AtmosCallback
│        @ ~/clima/ClimaAtmos.jl/src/solver/types.jl:460 [inlined]
│     [17] (::ClimaAtmos.var"#233#236"{…})(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…})
│        @ ClimaAtmos ~/clima/ClimaAtmos.jl/src/callbacks/callback_helpers.jl:36
│     [18] macro expansion
│        @ ~/.julia/packages/ClimaTimeSteppers/Wc2TE/src/integrators.jl:228 [inlined]
│     [19] macro expansion
│        @ ~/.julia/packages/NVTX/pfSOQ/src/macro.jl:145 [inlined]
│     [20] __step!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…})
│        @ ClimaTimeSteppers ~/.julia/packages/ClimaTimeSteppers/Wc2TE/src/integrators.jl:227
│     [21] macro expansion
│        @ ~/.julia/packages/ClimaTimeSteppers/Wc2TE/src/integrators.jl:169 [inlined]
│     [22] solve!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…})
│        @ ClimaTimeSteppers ~/.julia/packages/NVTX/pfSOQ/src/macro.jl:194
│     [23] #323
│        @ ~/clima/ClimaAtmos.jl/src/solver/solve.jl:27 [inlined]
│     [24] macro expansion
│        @ ~/.julia/packages/ClimaComms/Fy72Q/src/devices.jl:170 [inlined]
│     [25] macro expansion
│        @ ./timing.jl:395 [inlined]
│     [26] #elapsed#2
│        @ ~/.julia/packages/ClimaComms/Fy72Q/src/devices.jl:169 [inlined]
│     [27] elapsed
│        @ ~/.julia/packages/ClimaComms/Fy72Q/src/devices.jl:168 [inlined]
│     [28] macro expansion
│        @ ~/clima/ClimaAtmos.jl/src/solver/solve.jl:26 [inlined]
│     [29] macro expansion
│        @ ./timing.jl:279 [inlined]
│     [30] timed_solve!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…})
│        @ ClimaAtmos ~/clima/ClimaAtmos.jl/src/solver/solve.jl:25
│     [31] solve_atmos!(simulation::ClimaAtmos.AtmosSimulation{Float32, String, String, Tuple{…}, ClimaTimeSteppers.DistributedODEIntegrator{…}})
│        @ ClimaAtmos ~/clima/ClimaAtmos.jl/src/solver/solve.jl:87
│     [32] run_forward_model(atmos_config::ClimaAtmos.AtmosConfig{Float32, ClimaParams.ParamDict{Float32}, Dict{String, Any}, ClimaComms.SingletonCommsContext{ClimaComms.CPUSingleThreaded}, Vector{String}})
│        @ Main ~/clima/ClimaAtmos.jl/calibration/model_interface.jl:69
│     [33] calibrate(::Type{ClimaCalibrate.JuliaBackend}, config::ExperimentConfig; ekp_kwargs::@Kwargs{})
│        @ ClimaCalibrate ~/.julia/packages/ClimaCalibrate/IZzZx/src/backends.jl:93
│     [34] calibrate(::Type{ClimaCalibrate.JuliaBackend}, config::ExperimentConfig)
│        @ ClimaCalibrate ~/.julia/packages/ClimaCalibrate/IZzZx/src/backends.jl:82
│     [35] eval
│        @ ./boot.jl:385 [inlined]
│     [36] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
│        @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:150
│     [37] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
│        @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:246
│     [38] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
│        @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:231
│     [39] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
│        @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:389
│     [40] run_repl(repl::REPL.AbstractREPL, consumer::Any)
│        @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:375
│     [41] (::Base.var"#1013#1015"{Bool, Bool, Bool})(REPL::Module)
│        @ Base ./client.jl:432
│     [42] #invokelatest#2
│        @ ./essentials.jl:892 [inlined]
│     [43] invokelatest
│        @ ./essentials.jl:889 [inlined]
│     [44] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
│        @ Base ./client.jl:416
│     [45] exec_options(opts::Base.JLOptions)
│        @ Base ./client.jl:333
│     [46] _start()
│        @ Base ./client.jl:552
└ @ ClimaAtmos ~/clima/ClimaAtmos.jl/src/solver/solve.jl:97
[ Info: Memory currently used (after solve!) by the process (RSS): 3.72 GiB
ERROR: The ClimaAtmos simulation has crashed. See the stack trace for details.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] run_forward_model(atmos_config::ClimaAtmos.AtmosConfig{Float32, ClimaParams.ParamDict{Float32}, Dict{String, Any}, ClimaComms.SingletonCommsContext{ClimaComms.CPUSingleThreaded}, Vector{String}})
   @ Main ~/clima/ClimaAtmos.jl/calibration/model_interface.jl:71
 [3] calibrate(::Type{ClimaCalibrate.JuliaBackend}, config::ExperimentConfig; ekp_kwargs::@Kwargs{})
   @ ClimaCalibrate ~/.julia/packages/ClimaCalibrate/IZzZx/src/backends.jl:93
 [4] calibrate(::Type{ClimaCalibrate.JuliaBackend}, config::ExperimentConfig)
   @ ClimaCalibrate ~/.julia/packages/ClimaCalibrate/IZzZx/src/backends.jl:82
 [5] top-level scope
   @ REPL[27]:1
```