### PR TITLE
Fix ClimaCalibrate compat

### DIFF
--- a/calibration/experiments/sphere_held_suarez_rhoe_equilmoist/Project.toml
+++ b/calibration/experiments/sphere_held_suarez_rhoe_equilmoist/Project.toml
@@ -12,3 +12,4 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ClimaAtmos = "=0.24.0"
+ClimaCalibrate = "=0.0.1"

--- a/calibration/test/Project.toml
+++ b/calibration/test/Project.toml
@@ -10,3 +10,6 @@ EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+
+[compat]
+ClimaCalibrate = "0.0.2"

--- a/calibration/test/e2e_test.jl
+++ b/calibration/test/e2e_test.jl
@@ -93,15 +93,15 @@ if !(@isdefined backend)
     backend = CAL.get_backend()
 end
 @info "Running calibration E2E test" backend
-if backend <: CAL.SlurmBackend
-    slurm_kwargs = CAL.kwargs(time = 15)
-    test_eki = CAL.calibrate(
-        backend,
-        experiment_config;
-        slurm_kwargs,
-        model_interface,
-        verbose = true,
-    )
+if backend <: CAL.HPCBackend
+    hpc_kwargs =
+        test_eki = CAL.calibrate(
+            backend,
+            experiment_config;
+            hpc_kwargs = CAL.kwargs(time = 15),
+            model_interface,
+            verbose = true,
+        )
 else
     test_eki = CAL.calibrate(backend, experiment_config)
 end

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -83,7 +83,7 @@ function override_default_config(config_dict::AbstractDict;)
         end
     end
 
-    excluded_keys = Set(["diagnostics"])
+    excluded_keys = ("diagnostics", "job_id")
     unused_keys = filter(
         k -> !haskey(default_config, k) && !(k in excluded_keys),
         keys(config_dict),


### PR DESCRIPTION
I released a new patch version of ClimaCalibrate, and the calibration tests need a compat to ensure they get the correct verison.

I also added `job_id` as an exception for unused keys in the AtmosConfig.