### PR TITLE
Use Rayleigh sponge and interactive surface fluxes for gcm-driven EDMF setup

### DIFF
--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -8,6 +8,7 @@ implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_upwinding: first_order
+rayleigh_sponge: true
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true
@@ -27,7 +28,7 @@ dt: "10secs"
 t_end: "6hours"
 dt_save_state_to_disk: "6hours"
 call_cloud_diagnostics_per_stage : true
-toml: [toml/prognostic_edmfx_bomex.toml]
+toml: [toml/prognostic_edmfx_gcmdriven.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
 output_default_diagnostics: false

--- a/src/surface_conditions/surface_setups.jl
+++ b/src/surface_conditions/surface_setups.jl
@@ -258,19 +258,14 @@ end
 function (surface_setup::GCMDriven)(params)
     FT = eltype(params)
     (; external_forcing_file, cfsite_number) = surface_setup
-    T, lhf, shf =
-        FT.(gcm_surface_conditions(external_forcing_file, cfsite_number))
+    T = FT.(gcm_surface_conditions(external_forcing_file, cfsite_number))
     z0 = FT(1e-4)  # zrough
-    parameterization = MoninObukhov(; z0, fluxes = HeatFluxes(; lhf, shf))
+    parameterization = MoninObukhov(; z0)
     return SurfaceState(; parameterization, T)
 end
 
 function gcm_surface_conditions(external_forcing_file, cfsite_number)
     NC.NCDataset(external_forcing_file) do ds
-        (
-            mean(gcm_driven_timeseries(ds.group[cfsite_number], "ts")),
-            mean(gcm_driven_timeseries(ds.group[cfsite_number], "hfls")),
-            mean(gcm_driven_timeseries(ds.group[cfsite_number], "hfss")),
-        )
+        mean(gcm_driven_timeseries(ds.group[cfsite_number], "ts"))
     end
 end

--- a/toml/prognostic_edmfx_gcmdriven.toml
+++ b/toml/prognostic_edmfx_gcmdriven.toml
@@ -1,0 +1,41 @@
+[EDMF_surface_area]
+value = 0.1
+
+[EDMF_min_area]
+value = 1.0e-5
+
+[EDMF_max_area]
+value = 0.7
+
+[entr_inv_tau]
+value = 0.0001
+
+[entr_coeff]
+value = 0.3
+
+[min_area_limiter_scale]
+value = 0
+
+[detr_inv_tau]
+value = 0
+
+[detr_coeff]
+value = 0
+
+[detr_buoy_coeff]
+value = 0
+
+[detr_vertdiv_coeff]
+value = 0
+
+[detr_massflux_vertdiv_coeff]
+value = 1
+
+[max_area_limiter_scale]
+value = 0
+
+[pressure_normalmode_drag_coeff]
+value = 40.0
+
+[zd_rayleigh]
+value = 20000.0


### PR DESCRIPTION
Modify default gcm-driven EDMF setup to use Rayleigh sponge and interactive surface fluxes.