### PR TITLE
Use sgs quadrature fields for cloud diagnostics

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -194,7 +194,7 @@ precip_model:
   help: "Precipitation model [`nothing` (default), `0M`]"
   value: ~
 cloud_model:
-  help: "Cloud model [`grid_scale`, `quadrature` (default), `diagnostic_edmfx`]"
+  help: "Cloud model [`grid_scale`, `quadrature` (default), `quadrature_sgs`]"
   value: "quadrature"
 perf_summary:
   help: "Flag for collecting performance summary information"

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -6,7 +6,7 @@ z_elem: 63
 dz_bottom: 30.0
 dz_top: 3000.0
 moist: "equil"
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 precip_model: "0M"
 override_τ_precip: false
 rad: "allskywithclear"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -11,7 +11,7 @@ dt: "120secs"
 t_end: "240days"
 dt_save_state_to_disk: "30days"
 moist: "equil"
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/model_configs/aquaplanet_diagedmf.yml
+++ b/config/model_configs/aquaplanet_diagedmf.yml
@@ -22,7 +22,7 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true 
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 precip_model: 0M
 dt: 90secs
 t_end: 1days

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -11,7 +11,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 precip_model: 0M
 override_τ_precip: false
 dt: 100secs

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -14,7 +14,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: "equil"
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "box"
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
@@ -14,7 +14,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: "equil"
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "box"
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -14,7 +14,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
@@ -12,7 +12,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -14,7 +14,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -12,7 +12,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -13,7 +13,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -12,7 +12,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 apply_limiter: false
 precip_model: "1M"

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -12,7 +12,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
 override_τ_precip: false

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -13,7 +13,7 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: diagnostic_edmfx
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
 override_τ_precip: false

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -10,6 +10,7 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
+cloud_model: "quadrature_sgs"
 precip_model: 0M
 dt: 10secs
 t_end: 1hours

--- a/config/model_configs/prognostic_edmfx_bomex_box.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_box.yml
@@ -17,6 +17,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "box"
 x_max: 1e8

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -16,6 +16,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 3e3

--- a/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
@@ -13,6 +13,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 3e3

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -17,6 +17,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 3e3

--- a/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
@@ -16,6 +16,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 hyperdiff: false

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -17,6 +17,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: equil
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: column
 hyperdiff: false

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -27,6 +27,7 @@ perturb_initstate: false
 dt: "10secs"
 t_end: "6hours"
 dt_save_state_to_disk: "6hours"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage : true
 toml: [toml/prognostic_edmfx_gcmdriven.toml]
 netcdf_output_at_levels: true

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -15,6 +15,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -15,6 +15,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 4e3

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -14,6 +14,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: equil
+cloud_model: "quadrature_sgs"
 apply_limiter: false
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -14,6 +14,7 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 prognostic_tke: true
 moist: equil
+cloud_model: "quadrature_sgs"
 apply_limiter: false
 precip_model: "0M"
 call_cloud_diagnostics_per_stage: true

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -286,8 +286,8 @@ function get_cloud_model(parsed_args)
         GridScaleCloud()
     elseif cloud_model == "quadrature"
         QuadratureCloud()
-    elseif cloud_model == "diagnostic_edmfx"
-        DiagnosticEDMFCloud()
+    elseif cloud_model == "quadrature_sgs"
+        SGSQuadratureCloud()
     else
         error("Invalid cloud_model $(cloud_model)")
     end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -15,7 +15,7 @@ struct Microphysics1Moment <: AbstractPrecipitationModel end
 abstract type AbstractCloudModel end
 struct GridScaleCloud <: AbstractCloudModel end
 struct QuadratureCloud <: AbstractCloudModel end
-struct DiagnosticEDMFCloud <: AbstractCloudModel end
+struct SGSQuadratureCloud <: AbstractCloudModel end
 
 abstract type AbstractModelConfig end
 struct SingleColumnModel <: AbstractModelConfig end


### PR DESCRIPTION
Use subdomain values (with quadratures in the environment) to compute cloud properties for prognostic EDMF.  