### PR TITLE
Add support for monthly calendar diagnostics

### DIFF
--- a/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
@@ -13,3 +13,7 @@ insolation: "timevarying"
 z_max: 70000.0
 dt_save_to_sol: "30hours"
 rad: "allskywithclear"
+diagnostics:
+  - short_name: rhoa
+    reduction_time: average
+    period: 1months

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -379,9 +379,9 @@ version = "0.7.6"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "Dates", "NCDatasets", "SciMLBase"]
-git-tree-sha1 = "228ff3bc4dbd7329ef054f9bfbbe34075234ca25"
+git-tree-sha1 = "4f8abbf3af5a78b36bc40a33ef7e3fa1d3e8f138"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-version = "0.2.3"
+version = "0.2.4"
 
 [[deps.ClimaParams]]
 deps = ["DocStringExtensions", "TOML", "Test"]

--- a/perf/Manifest.toml
+++ b/perf/Manifest.toml
@@ -390,9 +390,9 @@ version = "0.7.6"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "Dates", "NCDatasets", "SciMLBase"]
-git-tree-sha1 = "228ff3bc4dbd7329ef054f9bfbbe34075234ca25"
+git-tree-sha1 = "4f8abbf3af5a78b36bc40a33ef7e3fa1d3e8f138"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-version = "0.2.3"
+version = "0.2.4"
 
 [[deps.ClimaParams]]
 deps = ["DocStringExtensions", "TOML", "Test"]

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -845,7 +845,9 @@ function make_plots(
         short_name = short_names_3D[1],
         reduction,
     )
-    if "30d" in available_periods
+    if "1M" in available_periods
+        period = "1M"
+    elseif "30d" in available_periods
         period = "30d"
     elseif "10d" in available_periods
         period = "10d"
@@ -893,7 +895,9 @@ function make_plots(
         short_name = short_names_3D[1],
         reduction,
     )
-    if "30d" in available_periods
+    if "1M" in available_periods
+        period = "1M"
+    elseif "30d" in available_periods
         period = "30d"
     elseif "10d" in available_periods
         period = "10d"
@@ -969,7 +973,9 @@ function make_plots(::AquaplanetPlots, output_paths::Vector{<:AbstractString})
         short_name = short_names_3D[1],
         reduction,
     )
-    if "30d" in available_periods
+    if "1M" in available_periods
+        period = "1M"
+    elseif "30d" in available_periods
         period = "30d"
     elseif "10d" in available_periods
         period = "10d"
@@ -1027,7 +1033,9 @@ function make_plots(::Aquaplanet1MPlots, output_paths::Vector{<:AbstractString})
         short_name = short_names_3D[1],
         reduction,
     )
-    if "30d" in available_periods
+    if "1M" in available_periods
+        period = "1M"
+    elseif "30d" in available_periods
         period = "30d"
     elseif "10d" in available_periods
         period = "10d"

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -1,5 +1,7 @@
 module Diagnostics
 
+import Dates: Month, DateTime, Period
+
 import ClimaComms
 
 import LinearAlgebra: dot
@@ -50,7 +52,8 @@ import ClimaDiagnostics:
 
 import ClimaDiagnostics.DiagnosticVariables: descriptive_short_name
 
-import ClimaDiagnostics.Schedules: EveryStepSchedule, EveryDtSchedule
+import ClimaDiagnostics.Schedules:
+    EveryStepSchedule, EveryDtSchedule, EveryCalendarDtSchedule
 
 import ClimaDiagnostics.Writers:
     HDF5Writer,

--- a/src/diagnostics/standard_diagnostic_frequencies.jl
+++ b/src/diagnostics/standard_diagnostic_frequencies.jl
@@ -1,264 +1,280 @@
 """
-    monthly_maxs(short_names...; output_writer, t_start)
+    monthly_maxs(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly max for the given variables.
-
-A month is defined as 30 days.
 """
-monthly_maxs(short_names...; output_writer, t_start) = common_diagnostics(
-    30 * 24 * 60 * 60 * one(t_start),
-    max,
-    output_writer,
-    t_start,
-    short_names...,
-)
+monthly_maxs(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        Month(1),
+        max,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    monthly_max(short_names; output_writer, t_start)
+    monthly_max(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly max for the given variable.
-
-A month is defined as 30 days.
 """
-monthly_max(short_names; output_writer, t_start) =
-    monthly_maxs(short_names; output_writer, t_start)[1]
+monthly_max(short_names; output_writer, t_start, reference_date) =
+    monthly_maxs(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    monthly_mins(short_names...; output_writer, t_start)
+    monthly_mins(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly min for the given variables.
 """
-monthly_mins(short_names...; output_writer, t_start) = common_diagnostics(
-    30 * 24 * 60 * 60 * one(t_start),
-    min,
-    output_writer,
-    t_start,
-    short_names...,
-)
+monthly_mins(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        Month(1),
+        min,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    monthly_min(short_names; output_writer, t_start)
+    monthly_min(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly min for the given variable.
-
-A month is defined as 30 days.
 """
-monthly_min(short_names; output_writer, t_start) =
-    monthly_mins(short_names; output_writer, t_start)[1]
+monthly_min(short_names; output_writer, t_start, reference_date) =
+    monthly_mins(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    monthly_averages(short_names...; output_writer, t_start)
+    monthly_averages(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly average for the given variables.
-
-A month is defined as 30 days.
 """
 # An average is just a sum with a normalization before output
-monthly_averages(short_names...; output_writer, t_start) = common_diagnostics(
-    30 * 24 * 60 * 60 * one(t_start),
-    (+),
-    output_writer,
-    t_start,
-    short_names...;
-    pre_output_hook! = average_pre_output_hook!,
-)
+monthly_averages(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        Month(1),
+        (+),
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+        ;
+        pre_output_hook! = average_pre_output_hook!,
+    )
+
 """
-    monthly_average(short_names; output_writer, t_start)
+    monthly_average(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the monthly average for the given variable.
-
-A month is defined as 30 days.
 """
 # An average is just a sum with a normalization before output
-monthly_average(short_names; output_writer, t_start) =
-    monthly_averages(short_names; output_writer, t_start)[1]
+monthly_average(short_names; output_writer, t_start, reference_date) =
+    monthly_averages(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    tendaily_maxs(short_names...; output_writer, t_start)
+    tendaily_maxs(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the max over ten days for the given variables.
 """
-tendaily_maxs(short_names...; output_writer, t_start) = common_diagnostics(
-    10 * 24 * 60 * 60 * one(t_start),
-    max,
-    output_writer,
-    t_start,
-    short_names...,
-)
+tendaily_maxs(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        10 * 24 * 60 * 60 * one(t_start),
+        max,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    tendaily_max(short_names; output_writer, t_start)
+    tendaily_max(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the max over ten days for the given variable.
 """
-tendaily_max(short_names; output_writer, t_start) =
-    tendaily_maxs(short_names; output_writer, t_start)[1]
+tendaily_max(short_names; output_writer, t_start, reference_date) =
+    tendaily_maxs(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    tendaily_mins(short_names...; output_writer, t_start)
+    tendaily_mins(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the min over ten days for the given variables.
 """
-tendaily_mins(short_names...; output_writer, t_start) = common_diagnostics(
-    10 * 24 * 60 * 60 * one(t_start),
-    min,
-    output_writer,
-    t_start,
-    short_names...,
-)
+tendaily_mins(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        10 * 24 * 60 * 60 * one(t_start),
+        min,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    tendaily_min(short_names; output_writer, t_start)
+    tendaily_min(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the min over ten days for the given variable.
 """
-tendaily_min(short_names; output_writer, t_start) =
-    tendaily_mins(short_names; output_writer, t_start)[1]
+tendaily_min(short_names; output_writer, t_start, reference_date) =
+    tendaily_mins(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    tendaily_averages(short_names...; output_writer, t_start)
+    tendaily_averages(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the average over ten days for the given variables.
 """
 # An average is just a sum with a normalization before output
-tendaily_averages(short_names...; output_writer, t_start) = common_diagnostics(
-    10 * 24 * 60 * 60 * one(t_start),
-    (+),
-    output_writer,
-    t_start,
-    short_names...;
-    pre_output_hook! = average_pre_output_hook!,
-)
+tendaily_averages(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        10 * 24 * 60 * 60 * one(t_start),
+        (+),
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...;
+        pre_output_hook! = average_pre_output_hook!,
+    )
 """
-    tendaily_average(short_names; output_writer, t_start)
+    tendaily_average(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the average over ten days for the given variable.
 """
 # An average is just a sum with a normalization before output
-tendaily_average(short_names; output_writer, t_start) =
-    tendaily_averages(short_names; output_writer, t_start)[1]
+tendaily_average(short_names; output_writer, t_start, reference_date) =
+    tendaily_averages(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    daily_maxs(short_names...; output_writer, t_start)
+    daily_maxs(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily max for the given variables.
 """
-daily_maxs(short_names...; output_writer, t_start) = common_diagnostics(
-    24 * 60 * 60 * one(t_start),
-    max,
-    output_writer,
-    t_start,
-    short_names...,
-)
+daily_maxs(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        24 * 60 * 60 * one(t_start),
+        max,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    daily_max(short_names; output_writer, t_start)
+    daily_max(short_names; output_writer, t_start, reference_date)
 
 
 Return a `ScheduledDiagnostics` that computes the daily max for the given variable.
 """
-daily_max(short_names; output_writer, t_start) =
-    daily_maxs(short_names; output_writer, t_start)[1]
+daily_max(short_names; output_writer, t_start, reference_date) =
+    daily_maxs(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    daily_mins(short_names...; output_writer, t_start)
+    daily_mins(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily min for the given variables.
 """
-daily_mins(short_names...; output_writer, t_start) = common_diagnostics(
-    24 * 60 * 60 * one(t_start),
-    min,
-    output_writer,
-    t_start,
-    short_names...,
-)
+daily_mins(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        24 * 60 * 60 * one(t_start),
+        min,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    daily_min(short_names; output_writer, t_start)
+    daily_min(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the daily min for the given variable.
 """
-daily_min(short_names; output_writer, t_start) =
-    daily_mins(short_names; output_writer, t_start)[1]
+daily_min(short_names; output_writer, t_start, reference_date) =
+    daily_mins(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    daily_averages(short_names...; output_writer, t_start)
+    daily_averages(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily average for the given variables.
 """
 # An average is just a sum with a normalization before output
-daily_averages(short_names...; output_writer, t_start) = common_diagnostics(
-    24 * 60 * 60 * one(t_start),
-    (+),
-    output_writer,
-    t_start,
-    short_names...;
-    pre_output_hook! = average_pre_output_hook!,
-)
+daily_averages(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        24 * 60 * 60 * one(t_start),
+        (+),
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...;
+        pre_output_hook! = average_pre_output_hook!,
+    )
 """
-    daily_average(short_names; output_writer, t_start)
+    daily_average(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the daily average for the given variable.
 """
 # An average is just a sum with a normalization before output
-daily_average(short_names; output_writer, t_start) =
-    daily_averages(short_names; output_writer, t_start)[1]
+daily_average(short_names; output_writer, t_start, reference_date) =
+    daily_averages(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    hourly_maxs(short_names...; output_writer, t_start)
+    hourly_maxs(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly max for the given variables.
 """
-hourly_maxs(short_names...; output_writer, t_start) = common_diagnostics(
-    60 * 60 * one(t_start),
-    max,
-    output_writer,
-    t_start,
-    short_names...,
-)
+hourly_maxs(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        60 * 60 * one(t_start),
+        max,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 
 """
-    hourly_max(short_names; output_writer, t_start)
+    hourly_max(short_names; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly max for the given variable.
 """
-hourly_max(short_names; output_writer, t_start) =
-    hourly_maxs(short_names; output_writer, t_start)[1]
+hourly_max(short_names; output_writer, t_start, reference_date) =
+    hourly_maxs(short_names; output_writer, t_start, reference_date)[1]
 
 """
-    hourly_mins(short_names...; output_writer, t_start)
+    hourly_mins(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly min for the given variables.
 """
-hourly_mins(short_names...; output_writer, t_start) = common_diagnostics(
-    60 * 60 * one(t_start),
-    min,
-    output_writer,
-    t_start,
-    short_names...,
-)
+hourly_mins(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        60 * 60 * one(t_start),
+        min,
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...,
+    )
 """
-    hourly_mins(short_names...; output_writer, t_start)
+    hourly_mins(short_names...; output_writer, t_start, reference_date)
 
 
 Return a `ScheduledDiagnostics` that computes the hourly min for the given variable.
 """
-hourly_min(short_names; output_writer, t_start) =
-    hourly_mins(short_names; output_writer, t_start)[1]
+hourly_min(short_names; output_writer, t_start, reference_date) =
+    hourly_mins(short_names; output_writer, t_start, reference_date)[1]
 
 # An average is just a sum with a normalization before output
 """
-    hourly_averages(short_names...; output_writer, t_start)
+    hourly_averages(short_names...; output_writer, t_start, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly average for the given variables.
 """
-hourly_averages(short_names...; output_writer, t_start) = common_diagnostics(
-    60 * 60 * one(t_start),
-    (+),
-    output_writer,
-    t_start,
-    short_names...;
-    pre_output_hook! = average_pre_output_hook!,
-)
+hourly_averages(short_names...; output_writer, t_start, reference_date) =
+    common_diagnostics(
+        60 * 60 * one(t_start),
+        (+),
+        output_writer,
+        t_start,
+        reference_date,
+        short_names...;
+        pre_output_hook! = average_pre_output_hook!,
+    )
 
 """
-    hourly_average(short_names...; output_writer, t_start)
+    hourly_average(short_names...; output_writer, t_start, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly average for the given variable.
 """
-hourly_average(short_names; output_writer, t_start) =
-    hourly_averages(short_names; output_writer, t_start)[1]
+hourly_average(short_names; output_writer, t_start, reference_date) =
+    hourly_averages(short_names; output_writer, t_start, reference_date)[1]


### PR DESCRIPTION
Using the new schedules defined in https://github.com/CliMA/ClimaDiagnostics.jl/pull/67

Floating point errors can lead to some accumulated variables having one additional timestep.

Use in the yaml with `1months`