### PR TITLE
Remove t_start from diagnostics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaAtmos.jl Release Notes
 Main
 -------
 
+### ![][badge-🐛bugfix] Bug fixes
+
+- Fixed incorrect time/date conversion in diagnostics when restarting a
+  simulation. PR [3287](https://github.com/CliMA/ClimaAtmos.jl/pull/3287)
+
 v0.27.5
 -------
 - Update RRTMGP and allow multiple aerosols for radiation.

--- a/config/model_configs/plane_density_current_test.yml
+++ b/config/model_configs/plane_density_current_test.yml
@@ -9,6 +9,7 @@ z_stretch: false
 x_elem: 80
 config: "plane"
 z_max: 6400.0
+output_default_diagnostics: false
 diagnostics:
   - short_name: thetaa
     period: 900secs

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -1,4 +1,4 @@
-function get_diagnostics(parsed_args, atmos_model, Y, p, t_start, dt)
+function get_diagnostics(parsed_args, atmos_model, Y, p, dt)
 
     FT = Spaces.undertype(axes(Y.c))
 
@@ -105,19 +105,15 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, t_start, dt)
                 output_schedule = CAD.EveryCalendarDtSchedule(
                     period_dates;
                     reference_date = p.start_date,
-                    t_start,
                 )
                 compute_schedule = CAD.EveryCalendarDtSchedule(
                     period_dates;
                     reference_date = p.start_date,
-                    t_start,
                 )
             else
                 period_seconds = FT(time_to_seconds(period_str))
-                output_schedule =
-                    CAD.EveryDtSchedule(period_seconds; t_start)
-                compute_schedule =
-                    CAD.EveryDtSchedule(period_seconds; t_start)
+                output_schedule = CAD.EveryDtSchedule(period_seconds)
+                compute_schedule = CAD.EveryDtSchedule(period_seconds)
             end
 
             if isnothing(output_name)
@@ -154,7 +150,6 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, t_start, dt)
         diagnostics = [
             CAD.default_diagnostics(
                 atmos_model,
-                t_start,
                 time_to_seconds(parsed_args["t_end"]),
                 p.start_date;
                 output_writer = netcdf_writer,
@@ -177,7 +172,7 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, t_start, dt)
     return diagnostics, writers
 end
 
-function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
+function get_callbacks(config, sim_info, atmos, params, Y, p)
     (; parsed_args, comms_ctx) = config
     FT = eltype(params)
     (; dt, output_dir) = sim_info

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -5,7 +5,7 @@
 # level interfaces, add them here. Feel free to include extra files.
 
 """
-    default_diagnostics(model, t_start, t_end, reference_date; output_writer)
+    default_diagnostics(model, t_end, reference_date; output_writer)
 
 Return a list of `ScheduledDiagnostic`s associated with the given `model` that use
 `output_write` to write to disk. `t_end` is the expected simulation end time and it is used
@@ -15,7 +15,7 @@ to choose the most reasonable output frequency.
 We convert time to date as
 
 ```julia
-current_date = reference_date + t_start + integrator.t
+current_date = reference_date + integrator.t
 ```
 
 The logic is as follows:
@@ -27,8 +27,7 @@ If `t_end >= 90 year` take monthly means.
 """
 function default_diagnostics(
     model::AtmosModel,
-    t_start::Real,
-    t_end::Real,
+    t_end,
     reference_date::DateTime;
     output_writer,
 )
@@ -39,7 +38,6 @@ function default_diagnostics(
         x ->
             default_diagnostics(
                 getfield(model, x),
-                t_start,
                 t_end,
                 reference_date;
                 output_writer,
@@ -50,11 +48,10 @@ function default_diagnostics(
     # We use a map because we want to ensure that diagnostics is a well defined type, not
     # Any. This reduces latency.
     return vcat(
-        core_default_diagnostics(output_writer, t_start, t_end, reference_date),
+        core_default_diagnostics(output_writer, t_end, reference_date),
         map(non_empty_fields) do field
             default_diagnostics(
                 getfield(model, field),
-                t_start,
                 t_end,
                 reference_date;
                 output_writer,
@@ -68,8 +65,7 @@ end
 # that all the default_diagnostics return the same type). This is used by
 # default_diagnostics(model::AtmosModel; output_writer), so that we can ignore defaults for
 # submodels that have no given defaults.
-default_diagnostics(submodel, t_start, t_end, reference_date; output_writer) =
-    []
+default_diagnostics(submodel, t_end, reference_date; output_writer) = []
 
 """
     produce_common_diagnostic_function(period, reduction)
@@ -80,7 +76,6 @@ function common_diagnostics(
     period,
     reduction,
     output_writer,
-    t_start,
     reference_date,
     short_names...;
     pre_output_hook! = nothing,
@@ -89,8 +84,8 @@ function common_diagnostics(
         map(short_names) do short_name
             output_schedule_func =
                 period isa Period ?
-                EveryCalendarDtSchedule(period; t_start, reference_date) :
-                EveryDtSchedule(period; t_start)
+                EveryCalendarDtSchedule(period; reference_date) :
+                EveryDtSchedule(period)
 
             return ScheduledDiagnostic(
                 variable = get_diagnostic_variable(short_name),
@@ -107,7 +102,7 @@ end
 include("standard_diagnostic_frequencies.jl")
 
 """
-    frequency_averages(t_start::Real, t_end::Real)
+    frequency_averages(t_end::Real)
 
 Return the correct averaging function depending on the total simulation time.
 
@@ -115,18 +110,17 @@ If `t_end < 1 day` take hourly means,
 if `t_end < 30 days` take daily means,
 if `t_end < 90 days` take means over ten days,
 If `t_end >= 90 year` take monthly means.
-
-One month is defined as 30 days.
 """
-function frequency_averages(t_start::Real, t_end::Real)
+function frequency_averages(t_end)
+    FT = eltype(t_end)
     if t_end >= 90 * 86400
-        return monthly_averages
+        return (args...; kwargs...) -> monthly_averages(FT, args...; kwargs...)
     elseif t_end >= 30 * 86400
-        return tendaily_averages
+        return (args...; kwargs...) -> tendaily_averages(FT, args...; kwargs...)
     elseif t_end >= 86400
-        return daily_averages
+        return (args...; kwargs...) -> daily_averages(FT, args...; kwargs...)
     else
-        return hourly_averages
+        return (args...; kwargs...) -> hourly_averages(FT, args...; kwargs...)
     end
 end
 
@@ -135,7 +129,7 @@ end
 ########
 # Core #
 ########
-function core_default_diagnostics(output_writer, t_start, t_end, reference_date)
+function core_default_diagnostics(output_writer, t_end, reference_date)
     core_diagnostics = [
         "ts",
         "ta",
@@ -152,20 +146,21 @@ function core_default_diagnostics(output_writer, t_start, t_end, reference_date)
         "hfes",
     ]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
+    FT = eltype(t_end)
 
     if t_end >= 90 * 86400
-        min_func = monthly_min
-        max_func = monthly_max
+        min_func = (args...; kwargs...) -> monthly_min(FT, args...; kwargs...)
+        max_func = (args...; kwargs...) -> monthly_max(FT, args...; kwargs...)
     elseif t_end >= 30 * 86400
-        min_func = tendaily_min
-        max_func = tendaily_max
+        min_func = (args...; kwargs...) -> tendaily_min(FT, args...; kwargs...)
+        max_func = (args...; kwargs...) -> tendaily_max(FT, args...; kwargs...)
     elseif t_end >= 86400
-        min_func = daily_min
-        max_func = daily_max
+        min_func = (args...; kwargs...) -> daily_min(FT, args...; kwargs...)
+        max_func = (args...; kwargs...) -> daily_max(FT, args...; kwargs...)
     else
-        min_func = hourly_min
-        max_func = hourly_max
+        min_func = (args...; kwargs...) -> hourly_min(FT, args...; kwargs...)
+        max_func = (args...; kwargs...) -> hourly_max(FT, args...; kwargs...)
     end
 
     return [
@@ -179,14 +174,9 @@ function core_default_diagnostics(output_writer, t_start, t_end, reference_date)
             output_writer,
             output_short_name = "orog_inst",
         ),
-        average_func(
-            core_diagnostics...;
-            output_writer,
-            t_start,
-            reference_date,
-        )...,
-        min_func("ts"; output_writer, t_start, reference_date),
-        max_func("ts"; output_writer, t_start, reference_date),
+        average_func(core_diagnostics...; output_writer, reference_date)...,
+        min_func("ts"; output_writer, reference_date),
+        max_func("ts"; output_writer, reference_date),
     ]
 end
 
@@ -195,7 +185,6 @@ end
 ##################
 function default_diagnostics(
     ::T,
-    t_start,
     t_end,
     reference_date;
     output_writer,
@@ -214,14 +203,9 @@ function default_diagnostics(
         "clwvi",
         "clivi",
     ]
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
     return [
-        average_func(
-            moist_diagnostics...;
-            output_writer,
-            t_start,
-            reference_date,
-        )...,
+        average_func(moist_diagnostics...; output_writer, reference_date)...,
     ]
 end
 
@@ -230,22 +214,16 @@ end
 #######################
 function default_diagnostics(
     ::Microphysics1Moment,
-    t_start,
     t_end,
     reference_date;
     output_writer,
 )
     precip_diagnostics = ["husra", "hussn"]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
 
     return [
-        average_func(
-            precip_diagnostics...;
-            output_writer,
-            t_start,
-            reference_date,
-        )...,
+        average_func(precip_diagnostics...; output_writer, reference_date)...,
     ]
 end
 
@@ -254,7 +232,6 @@ end
 ##################
 function default_diagnostics(
     ::RRTMGPI.AbstractRRTMGPMode,
-    t_start,
     t_end,
     reference_date;
     output_writer,
@@ -273,22 +250,14 @@ function default_diagnostics(
         "rlus",
     ]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
 
-    return [
-        average_func(
-            rad_diagnostics...;
-            output_writer,
-            t_start,
-            reference_date,
-        )...,
-    ]
+    return [average_func(rad_diagnostics...; output_writer, reference_date)...]
 end
 
 
 function default_diagnostics(
     ::RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-    t_start,
     t_end,
     reference_date;
     output_writer,
@@ -318,19 +287,13 @@ function default_diagnostics(
         "rlutcs",
     ]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
 
     return [
-        average_func(
-            rad_diagnostics...;
-            output_writer,
-            t_start,
-            reference_date,
-        )...,
+        average_func(rad_diagnostics...; output_writer, reference_date)...,
         average_func(
             rad_clearsky_diagnostics...;
             output_writer,
-            t_start,
             reference_date,
         )...,
     ]
@@ -341,7 +304,6 @@ end
 ##################
 function default_diagnostics(
     ::PrognosticEDMFX,
-    t_start,
     t_end,
     reference_date;
     output_writer,
@@ -373,19 +335,17 @@ function default_diagnostics(
         "lmix",
     ]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
 
     return [
         average_func(
             edmfx_draft_diagnostics...;
             output_writer,
-            t_start,
             reference_date,
         )...,
         average_func(
             edmfx_env_diagnostics...;
             output_writer,
-            t_start,
             reference_date,
         )...,
     ]
@@ -394,7 +354,6 @@ end
 
 function default_diagnostics(
     ::DiagnosticEDMFX,
-    t_start,
     t_end,
     reference_date;
     output_writer,
@@ -413,19 +372,17 @@ function default_diagnostics(
     ]
     diagnostic_edmfx_env_diagnostics = ["waen", "tke", "lmix"]
 
-    average_func = frequency_averages(t_start, t_end)
+    average_func = frequency_averages(t_end)
 
     return [
         average_func(
             diagnostic_edmfx_draft_diagnostics...;
             output_writer,
-            t_start,
             reference_date,
         )...,
         average_func(
             diagnostic_edmfx_env_diagnostics...;
             output_writer,
-            t_start,
             reference_date,
         )...,
     ]

--- a/src/diagnostics/standard_diagnostic_frequencies.jl
+++ b/src/diagnostics/standard_diagnostic_frequencies.jl
@@ -1,59 +1,56 @@
 """
-    monthly_maxs(short_names...; output_writer, t_start, reference_date)
+    monthly_maxs(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly max for the given variables.
 """
-monthly_maxs(short_names...; output_writer, t_start, reference_date) =
+monthly_maxs(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
         Month(1),
         max,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    monthly_max(short_names; output_writer, t_start, reference_date)
+    monthly_max(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly max for the given variable.
 """
-monthly_max(short_names; output_writer, t_start, reference_date) =
-    monthly_maxs(short_names; output_writer, t_start, reference_date)[1]
+monthly_max(FT, short_names; output_writer, reference_date) =
+    monthly_maxs(FT, short_names; output_writer, reference_date)[1]
 
 """
-    monthly_mins(short_names...; output_writer, t_start, reference_date)
+    monthly_mins(short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly min for the given variables.
 """
-monthly_mins(short_names...; output_writer, t_start, reference_date) =
+monthly_mins(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
         Month(1),
         min,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    monthly_min(short_names; output_writer, t_start, reference_date)
+    monthly_min(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly min for the given variable.
 """
-monthly_min(short_names; output_writer, t_start, reference_date) =
-    monthly_mins(short_names; output_writer, t_start, reference_date)[1]
+monthly_min(FT, short_names; output_writer, reference_date) =
+    monthly_mins(FT, short_names; output_writer, reference_date)[1]
 
 """
-    monthly_averages(short_names...; output_writer, t_start, reference_date)
+    monthly_averages(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly average for the given variables.
 """
 # An average is just a sum with a normalization before output
-monthly_averages(short_names...; output_writer, t_start, reference_date) =
+monthly_averages(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
         Month(1),
         (+),
         output_writer,
-        t_start,
         reference_date,
         short_names...,
         ;
@@ -61,220 +58,211 @@ monthly_averages(short_names...; output_writer, t_start, reference_date) =
     )
 
 """
-    monthly_average(short_names; output_writer, t_start, reference_date)
+    monthly_average(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the monthly average for the given variable.
 """
 # An average is just a sum with a normalization before output
-monthly_average(short_names; output_writer, t_start, reference_date) =
-    monthly_averages(short_names; output_writer, t_start, reference_date)[1]
+monthly_average(FT, short_names; output_writer, reference_date) =
+    monthly_averages(FT, short_names; output_writer, reference_date)[1]
 
 """
-    tendaily_maxs(short_names...; output_writer, t_start, reference_date)
+    tendaily_maxs(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the max over ten days for the given variables.
 """
-tendaily_maxs(short_names...; output_writer, t_start, reference_date) =
+tendaily_maxs(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        10 * 24 * 60 * 60 * one(t_start),
+        10 * 24 * 60 * 60 * one(FT),
         max,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    tendaily_max(short_names; output_writer, t_start, reference_date)
+    tendaily_max(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the max over ten days for the given variable.
 """
-tendaily_max(short_names; output_writer, t_start, reference_date) =
-    tendaily_maxs(short_names; output_writer, t_start, reference_date)[1]
+tendaily_max(FT, short_names; output_writer, reference_date) =
+    tendaily_maxs(FT, short_names; output_writer, reference_date)[1]
 
 """
-    tendaily_mins(short_names...; output_writer, t_start, reference_date)
+    tendaily_mins(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the min over ten days for the given variables.
 """
-tendaily_mins(short_names...; output_writer, t_start, reference_date) =
+tendaily_mins(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        10 * 24 * 60 * 60 * one(t_start),
+        10 * 24 * 60 * 60 * one(FT),
         min,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    tendaily_min(short_names; output_writer, t_start, reference_date)
+    tendaily_min(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the min over ten days for the given variable.
 """
-tendaily_min(short_names; output_writer, t_start, reference_date) =
-    tendaily_mins(short_names; output_writer, t_start, reference_date)[1]
+tendaily_min(FT, short_names; output_writer, reference_date) =
+    tendaily_mins(FT, short_names; output_writer, reference_date)[1]
 
 """
-    tendaily_averages(short_names...; output_writer, t_start, reference_date)
+    tendaily_averages(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the average over ten days for the given variables.
 """
 # An average is just a sum with a normalization before output
-tendaily_averages(short_names...; output_writer, t_start, reference_date) =
+tendaily_averages(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        10 * 24 * 60 * 60 * one(t_start),
+        10 * 24 * 60 * 60 * one(FT),
         (+),
         output_writer,
-        t_start,
         reference_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    tendaily_average(short_names; output_writer, t_start, reference_date)
+    tendaily_average(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the average over ten days for the given variable.
 """
 # An average is just a sum with a normalization before output
-tendaily_average(short_names; output_writer, t_start, reference_date) =
-    tendaily_averages(short_names; output_writer, t_start, reference_date)[1]
+tendaily_average(FT, short_names; output_writer, reference_date) =
+    tendaily_averages(FT, short_names; output_writer, reference_date)[1]
 
 """
-    daily_maxs(short_names...; output_writer, t_start, reference_date)
+    daily_maxs(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily max for the given variables.
 """
-daily_maxs(short_names...; output_writer, t_start, reference_date) =
+daily_maxs(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        24 * 60 * 60 * one(t_start),
+        24 * 60 * 60 * one(FT),
         max,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    daily_max(short_names; output_writer, t_start, reference_date)
+    daily_max(FT, short_names; output_writer, reference_date)
 
 
 Return a `ScheduledDiagnostics` that computes the daily max for the given variable.
 """
-daily_max(short_names; output_writer, t_start, reference_date) =
-    daily_maxs(short_names; output_writer, t_start, reference_date)[1]
+daily_max(FT, short_names; output_writer, reference_date) =
+    daily_maxs(FT, short_names; output_writer, reference_date)[1]
 
 """
-    daily_mins(short_names...; output_writer, t_start, reference_date)
+    daily_mins(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily min for the given variables.
 """
-daily_mins(short_names...; output_writer, t_start, reference_date) =
+daily_mins(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        24 * 60 * 60 * one(t_start),
+        24 * 60 * 60 * one(FT),
         min,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    daily_min(short_names; output_writer, t_start, reference_date)
+    daily_min(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the daily min for the given variable.
 """
-daily_min(short_names; output_writer, t_start, reference_date) =
-    daily_mins(short_names; output_writer, t_start, reference_date)[1]
+daily_min(FT, short_names; output_writer, reference_date) =
+    daily_mins(FT, short_names; output_writer, reference_date)[1]
 
 """
-    daily_averages(short_names...; output_writer, t_start, reference_date)
+    daily_averages(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily average for the given variables.
 """
 # An average is just a sum with a normalization before output
-daily_averages(short_names...; output_writer, t_start, reference_date) =
+daily_averages(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        24 * 60 * 60 * one(t_start),
+        24 * 60 * 60 * one(FT),
         (+),
         output_writer,
-        t_start,
         reference_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    daily_average(short_names; output_writer, t_start, reference_date)
+    daily_average(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that compute the daily average for the given variable.
 """
 # An average is just a sum with a normalization before output
-daily_average(short_names; output_writer, t_start, reference_date) =
-    daily_averages(short_names; output_writer, t_start, reference_date)[1]
+daily_average(FT, short_names; output_writer, reference_date) =
+    daily_averages(FT, short_names; output_writer, reference_date)[1]
 
 """
-    hourly_maxs(short_names...; output_writer, t_start, reference_date)
+    hourly_maxs(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly max for the given variables.
 """
-hourly_maxs(short_names...; output_writer, t_start, reference_date) =
+hourly_maxs(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        60 * 60 * one(t_start),
+        60 * 60 * one(FT),
         max,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 
 """
-    hourly_max(short_names; output_writer, t_start, reference_date)
+    hourly_max(FT, short_names; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly max for the given variable.
 """
-hourly_max(short_names; output_writer, t_start, reference_date) =
-    hourly_maxs(short_names; output_writer, t_start, reference_date)[1]
+hourly_max(FT, short_names; output_writer, reference_date) =
+    hourly_maxs(FT, short_names; output_writer, reference_date)[1]
 
 """
-    hourly_mins(short_names...; output_writer, t_start, reference_date)
+    hourly_mins(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly min for the given variables.
 """
-hourly_mins(short_names...; output_writer, t_start, reference_date) =
+hourly_mins(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        60 * 60 * one(t_start),
+        60 * 60 * one(FT),
         min,
         output_writer,
-        t_start,
         reference_date,
         short_names...,
     )
 """
-    hourly_mins(short_names...; output_writer, t_start, reference_date)
+    hourly_mins(FT, short_names...; output_writer, reference_date)
 
 
 Return a `ScheduledDiagnostics` that computes the hourly min for the given variable.
 """
-hourly_min(short_names; output_writer, t_start, reference_date) =
-    hourly_mins(short_names; output_writer, t_start, reference_date)[1]
+hourly_min(FT, short_names; output_writer, reference_date) =
+    hourly_mins(FT, short_names; output_writer, reference_date)[1]
 
 # An average is just a sum with a normalization before output
 """
-    hourly_averages(short_names...; output_writer, t_start, reference_date)
+    hourly_averages(FT, short_names...; output_writer, reference_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly average for the given variables.
 """
-hourly_averages(short_names...; output_writer, t_start, reference_date) =
+hourly_averages(FT, short_names...; output_writer, reference_date) =
     common_diagnostics(
-        60 * 60 * one(t_start),
+        60 * 60 * one(FT),
         (+),
         output_writer,
-        t_start,
         reference_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 
 """
-    hourly_average(short_names...; output_writer, t_start, reference_date)
+    hourly_average(FT, short_names...; output_writer, reference_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly average for the given variable.
 """
-hourly_average(short_names; output_writer, t_start, reference_date) =
-    hourly_averages(short_names; output_writer, t_start, reference_date)[1]
+hourly_average(FT, short_names; output_writer, reference_date) =
+    hourly_averages(FT, short_names; output_writer, reference_date)[1]

--- a/src/diagnostics/standard_diagnostic_frequencies.jl
+++ b/src/diagnostics/standard_diagnostic_frequencies.jl
@@ -1,268 +1,252 @@
 """
-    monthly_maxs(FT, short_names...; output_writer, reference_date)
+    monthly_maxs(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly max for the given variables.
 """
-monthly_maxs(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        Month(1),
-        max,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+monthly_maxs(FT, short_names...; output_writer, start_date) =
+    common_diagnostics(Month(1), max, output_writer, start_date, short_names...)
 """
-    monthly_max(FT, short_names; output_writer, reference_date)
+    monthly_max(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly max for the given variable.
 """
-monthly_max(FT, short_names; output_writer, reference_date) =
-    monthly_maxs(FT, short_names; output_writer, reference_date)[1]
+monthly_max(FT, short_names; output_writer, start_date) =
+    monthly_maxs(FT, short_names; output_writer, start_date)[1]
 
 """
-    monthly_mins(short_names...; output_writer, reference_date)
+    monthly_mins(short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly min for the given variables.
 """
-monthly_mins(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        Month(1),
-        min,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+monthly_mins(FT, short_names...; output_writer, start_date) =
+    common_diagnostics(Month(1), min, output_writer, start_date, short_names...)
 """
-    monthly_min(FT, short_names; output_writer, reference_date)
+    monthly_min(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the monthly min for the given variable.
 """
-monthly_min(FT, short_names; output_writer, reference_date) =
-    monthly_mins(FT, short_names; output_writer, reference_date)[1]
+monthly_min(FT, short_names; output_writer, start_date) =
+    monthly_mins(FT, short_names; output_writer, start_date)[1]
 
 """
-    monthly_averages(FT, short_names...; output_writer, reference_date)
+    monthly_averages(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly average for the given variables.
 """
 # An average is just a sum with a normalization before output
-monthly_averages(FT, short_names...; output_writer, reference_date) =
+monthly_averages(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         Month(1),
         (+),
         output_writer,
-        reference_date,
+        start_date,
         short_names...,
         ;
         pre_output_hook! = average_pre_output_hook!,
     )
 
 """
-    monthly_average(FT, short_names; output_writer, reference_date)
+    monthly_average(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that compute the monthly average for the given variable.
 """
 # An average is just a sum with a normalization before output
-monthly_average(FT, short_names; output_writer, reference_date) =
-    monthly_averages(FT, short_names; output_writer, reference_date)[1]
+monthly_average(FT, short_names; output_writer, start_date) =
+    monthly_averages(FT, short_names; output_writer, start_date)[1]
 
 """
-    tendaily_maxs(FT, short_names...; output_writer, reference_date)
+    tendaily_maxs(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the max over ten days for the given variables.
 """
-tendaily_maxs(FT, short_names...; output_writer, reference_date) =
+tendaily_maxs(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         10 * 24 * 60 * 60 * one(FT),
         max,
         output_writer,
-        reference_date,
+        start_date,
         short_names...,
     )
 """
-    tendaily_max(FT, short_names; output_writer, reference_date)
+    tendaily_max(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the max over ten days for the given variable.
 """
-tendaily_max(FT, short_names; output_writer, reference_date) =
-    tendaily_maxs(FT, short_names; output_writer, reference_date)[1]
+tendaily_max(FT, short_names; output_writer, start_date) =
+    tendaily_maxs(FT, short_names; output_writer, start_date)[1]
 
 """
-    tendaily_mins(FT, short_names...; output_writer, reference_date)
+    tendaily_mins(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the min over ten days for the given variables.
 """
-tendaily_mins(FT, short_names...; output_writer, reference_date) =
+tendaily_mins(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         10 * 24 * 60 * 60 * one(FT),
         min,
         output_writer,
-        reference_date,
+        start_date,
         short_names...,
     )
 """
-    tendaily_min(FT, short_names; output_writer, reference_date)
+    tendaily_min(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the min over ten days for the given variable.
 """
-tendaily_min(FT, short_names; output_writer, reference_date) =
-    tendaily_mins(FT, short_names; output_writer, reference_date)[1]
+tendaily_min(FT, short_names; output_writer, start_date) =
+    tendaily_mins(FT, short_names; output_writer, start_date)[1]
 
 """
-    tendaily_averages(FT, short_names...; output_writer, reference_date)
+    tendaily_averages(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the average over ten days for the given variables.
 """
 # An average is just a sum with a normalization before output
-tendaily_averages(FT, short_names...; output_writer, reference_date) =
+tendaily_averages(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         10 * 24 * 60 * 60 * one(FT),
         (+),
         output_writer,
-        reference_date,
+        start_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    tendaily_average(FT, short_names; output_writer, reference_date)
+    tendaily_average(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that compute the average over ten days for the given variable.
 """
 # An average is just a sum with a normalization before output
-tendaily_average(FT, short_names; output_writer, reference_date) =
-    tendaily_averages(FT, short_names; output_writer, reference_date)[1]
+tendaily_average(FT, short_names; output_writer, start_date) =
+    tendaily_averages(FT, short_names; output_writer, start_date)[1]
 
 """
-    daily_maxs(FT, short_names...; output_writer, reference_date)
+    daily_maxs(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily max for the given variables.
 """
-daily_maxs(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        24 * 60 * 60 * one(FT),
-        max,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+daily_maxs(FT, short_names...; output_writer, start_date) = common_diagnostics(
+    24 * 60 * 60 * one(FT),
+    max,
+    output_writer,
+    start_date,
+    short_names...,
+)
 """
-    daily_max(FT, short_names; output_writer, reference_date)
+    daily_max(FT, short_names; output_writer, start_date)
 
 
 Return a `ScheduledDiagnostics` that computes the daily max for the given variable.
 """
-daily_max(FT, short_names; output_writer, reference_date) =
-    daily_maxs(FT, short_names; output_writer, reference_date)[1]
+daily_max(FT, short_names; output_writer, start_date) =
+    daily_maxs(FT, short_names; output_writer, start_date)[1]
 
 """
-    daily_mins(FT, short_names...; output_writer, reference_date)
+    daily_mins(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily min for the given variables.
 """
-daily_mins(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        24 * 60 * 60 * one(FT),
-        min,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+daily_mins(FT, short_names...; output_writer, start_date) = common_diagnostics(
+    24 * 60 * 60 * one(FT),
+    min,
+    output_writer,
+    start_date,
+    short_names...,
+)
 """
-    daily_min(FT, short_names; output_writer, reference_date)
+    daily_min(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the daily min for the given variable.
 """
-daily_min(FT, short_names; output_writer, reference_date) =
-    daily_mins(FT, short_names; output_writer, reference_date)[1]
+daily_min(FT, short_names; output_writer, start_date) =
+    daily_mins(FT, short_names; output_writer, start_date)[1]
 
 """
-    daily_averages(FT, short_names...; output_writer, reference_date)
+    daily_averages(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the daily average for the given variables.
 """
 # An average is just a sum with a normalization before output
-daily_averages(FT, short_names...; output_writer, reference_date) =
+daily_averages(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         24 * 60 * 60 * one(FT),
         (+),
         output_writer,
-        reference_date,
+        start_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    daily_average(FT, short_names; output_writer, reference_date)
+    daily_average(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that compute the daily average for the given variable.
 """
 # An average is just a sum with a normalization before output
-daily_average(FT, short_names; output_writer, reference_date) =
-    daily_averages(FT, short_names; output_writer, reference_date)[1]
+daily_average(FT, short_names; output_writer, start_date) =
+    daily_averages(FT, short_names; output_writer, start_date)[1]
 
 """
-    hourly_maxs(FT, short_names...; output_writer, reference_date)
+    hourly_maxs(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly max for the given variables.
 """
-hourly_maxs(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        60 * 60 * one(FT),
-        max,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+hourly_maxs(FT, short_names...; output_writer, start_date) = common_diagnostics(
+    60 * 60 * one(FT),
+    max,
+    output_writer,
+    start_date,
+    short_names...,
+)
 
 """
-    hourly_max(FT, short_names; output_writer, reference_date)
+    hourly_max(FT, short_names; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly max for the given variable.
 """
-hourly_max(FT, short_names; output_writer, reference_date) =
-    hourly_maxs(FT, short_names; output_writer, reference_date)[1]
+hourly_max(FT, short_names; output_writer, start_date) =
+    hourly_maxs(FT, short_names; output_writer, start_date)[1]
 
 """
-    hourly_mins(FT, short_names...; output_writer, reference_date)
+    hourly_mins(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly min for the given variables.
 """
-hourly_mins(FT, short_names...; output_writer, reference_date) =
-    common_diagnostics(
-        60 * 60 * one(FT),
-        min,
-        output_writer,
-        reference_date,
-        short_names...,
-    )
+hourly_mins(FT, short_names...; output_writer, start_date) = common_diagnostics(
+    60 * 60 * one(FT),
+    min,
+    output_writer,
+    start_date,
+    short_names...,
+)
 """
-    hourly_mins(FT, short_names...; output_writer, reference_date)
+    hourly_mins(FT, short_names...; output_writer, start_date)
 
 
 Return a `ScheduledDiagnostics` that computes the hourly min for the given variable.
 """
-hourly_min(FT, short_names; output_writer, reference_date) =
-    hourly_mins(FT, short_names; output_writer, reference_date)[1]
+hourly_min(FT, short_names; output_writer, start_date) =
+    hourly_mins(FT, short_names; output_writer, start_date)[1]
 
 # An average is just a sum with a normalization before output
 """
-    hourly_averages(FT, short_names...; output_writer, reference_date)
+    hourly_averages(FT, short_names...; output_writer, start_date)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly average for the given variables.
 """
-hourly_averages(FT, short_names...; output_writer, reference_date) =
+hourly_averages(FT, short_names...; output_writer, start_date) =
     common_diagnostics(
         60 * 60 * one(FT),
         (+),
         output_writer,
-        reference_date,
+        start_date,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 
 """
-    hourly_average(FT, short_names...; output_writer, reference_date)
+    hourly_average(FT, short_names...; output_writer, start_date)
 
 Return a `ScheduledDiagnostics` that computes the hourly average for the given variable.
 """
-hourly_average(FT, short_names; output_writer, reference_date) =
-    hourly_averages(FT, short_names; output_writer, reference_date)[1]
+hourly_average(FT, short_names; output_writer, start_date) =
+    hourly_averages(FT, short_names; output_writer, start_date)[1]

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -681,7 +681,7 @@ function get_simulation(config::AtmosConfig)
     @info "ode_configuration: $s"
 
     s = @timed_str begin
-        callback = get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
+        callback = get_callbacks(config, sim_info, atmos, params, Y, p)
     end
     @info "get_callbacks: $s"
 
@@ -693,7 +693,6 @@ function get_simulation(config::AtmosConfig)
                 atmos,
                 Y,
                 p,
-                t_start,
                 sim_info.dt,
             )
         end


### PR DESCRIPTION
The diagnostic module was using `t_start`, but this was under the wrong assumption.

I was under the impression that integrator.t restarts from 0 upon restart, so that we needed to manually offset the time.

I think I got this (wrong) idea from ClimaLand, where t_start is used often.

Using t_start was (probably) leading to incorrect dates being written in NetCDF files when the simulation was restarted.
