### PR TITLE
Add function barrier to coriolis computation

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -131,30 +131,7 @@ function build_cache(
     ᶜΦ = grav .* ᶜcoord.z
     ᶠΦ = grav .* ᶠcoord.z
 
-    if eltype(ᶜcoord) <: Geometry.LatLongZPoint
-        Ω = CAP.Omega(params)
-        global_geom = Spaces.global_geometry(axes(ᶜcoord))
-        if global_geom isa Geometry.DeepSphericalGlobalGeometry
-            @info "using deep atmosphere"
-            coriolis_deep(coord::Geometry.LatLongZPoint) = Geometry.LocalVector(
-                Geometry.Cartesian123Vector(zero(Ω), zero(Ω), 2 * Ω),
-                global_geom,
-                coord,
-            )
-            ᶜf³ = @. CT3(CT123(coriolis_deep(ᶜcoord)))
-            ᶠf¹² = @. CT12(CT123(coriolis_deep(ᶠcoord)))
-        else
-            coriolis_shallow(coord::Geometry.LatLongZPoint) =
-                Geometry.WVector(2 * Ω * sind(coord.lat))
-            ᶜf³ = @. CT3(coriolis_shallow(ᶜcoord))
-            ᶠf¹² = nothing
-        end
-    else
-        f = CAP.f_plane_coriolis_frequency(params)
-        coriolis_f_plane(coord) = Geometry.WVector(f)
-        ᶜf³ = @. CT3(coriolis_f_plane(ᶜcoord))
-        ᶠf¹² = nothing
-    end
+    (; ᶜf³, ᶠf¹²) = compute_coriolis(ᶜcoord, ᶠcoord, params)
 
     quadrature_style =
         Spaces.quadrature_style(Spaces.horizontal_space(axes(Y.c)))
@@ -265,4 +242,33 @@ function build_cache(
     )
 
     return AtmosCache{map(typeof, args)...}(args...)
+end
+
+
+function compute_coriolis(ᶜcoord, ᶠcoord, params)
+    if eltype(ᶜcoord) <: Geometry.LatLongZPoint
+        Ω = CAP.Omega(params)
+        global_geom = Spaces.global_geometry(axes(ᶜcoord))
+        if global_geom isa Geometry.DeepSphericalGlobalGeometry
+            @info "using deep atmosphere"
+            coriolis_deep(coord::Geometry.LatLongZPoint) = Geometry.LocalVector(
+                Geometry.Cartesian123Vector(zero(Ω), zero(Ω), 2 * Ω),
+                global_geom,
+                coord,
+            )
+            ᶜf³ = @. CT3(CT123(coriolis_deep(ᶜcoord)))
+            ᶠf¹² = @. CT12(CT123(coriolis_deep(ᶠcoord)))
+        else
+            coriolis_shallow(coord::Geometry.LatLongZPoint) =
+                Geometry.WVector(2 * Ω * sind(coord.lat))
+            ᶜf³ = @. CT3(coriolis_shallow(ᶜcoord))
+            ᶠf¹² = nothing
+        end
+    else
+        f = CAP.f_plane_coriolis_frequency(params)
+        coriolis_f_plane(coord) = Geometry.WVector(f)
+        ᶜf³ = @. CT3(coriolis_f_plane(ᶜcoord))
+        ᶠf¹² = nothing
+    end
+    return (; ᶜf³, ᶠf¹²)
 end


### PR DESCRIPTION
This PR adds a function barrier to the computation of the coriolis force, which I noticed captures a variable (`f`):

```julia
        f = CAP.f_plane_coriolis_frequency(params)
        coriolis_f_plane(coord) = Geometry.WVector(f)
        ᶜf³ = @. CT3(coriolis_f_plane(ᶜcoord))
        ᶠf¹² = nothing
```
Due to this, users cannot copy-paste this into the REPL. I've also refactored that code to use `map` with an assertion so that it can be copy-pasted into the REPL. I did not yet apply these changes to the deep atmosphere, because we need to somehow avoid capturing `global_geom`.