### PR TITLE
Fix isdac radiation broadcast

### DIFF
--- a/config/model_configs/les_isdac_box.yml
+++ b/config/model_configs/les_isdac_box.yml
@@ -1,30 +1,39 @@
-job_id: "les_isdac_box"
+# ISDAC config
 initial_condition: "ISDAC" 
 subsidence: "ISDAC" 
 surface_setup: "ISDAC"
 external_forcing: "ISDAC"
 rad: "ISDAC"
+config: "box"
+# microphysics
 moist: "equil"
-config: "box" 
-hyperdiff: "false" 
-implicit_diffusion: false
-ode_algo: "SSP33ShuOsher"
 precip_model: "1M"
+# diffusion
+implicit_diffusion: false
+approximate_linear_solve_iters: 2
+hyperdiff: "false" 
+apply_limiter: false
 smagorinsky_lilly: true
 c_smag: 0.20
+# time- and spatial discretization
+x_elem: 10
 x_max: 3.2e3
+y_elem: 10
 y_max: 3.2e3 
-z_max: 2e3
-x_elem: 4
-y_elem: 4
-z_elem: 10
+z_elem: 15
+z_max: 2.5e3
 z_stretch: false
+rayleigh_sponge: true
+toml: [toml/isdac_box.toml]  # sponge height
+ode_algo: "SSPKnoth"
 dt: "0.05secs" 
-t_end: "10mins" 
+t_end: "2mins" 
+dt_cloud_fraction: "10mins"
 dt_save_state_to_disk: "1mins"
-# restart_file: "restart/isdac/day0.0.hdf5"
-netcdf_interpolation_num_points: [10, 10, 20]
+netcdf_interpolation_num_points: [30, 30, 150]
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl]
-    reduction: average
-    period: 1mins
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, husra, cl, clw, cli, hussfc, evspsbl, hfes, pr]
+    period: 10mins
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, husra, cl, clw, cli, hussfc, evspsbl, hfes, pr]
+    reduction_time: average
+    period: 60mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1095,7 +1095,6 @@ EDMFBoxPlotsWithPrecip = Union{
     Val{:diagnostic_edmfx_rico_box},
     Val{:diagnostic_edmfx_trmm_box},
     Val{:diagnostic_edmfx_trmm_stretched_box},
-    Val{:les_isdac_box},
 }
 
 

--- a/toml/isdac_box.toml
+++ b/toml/isdac_box.toml
@@ -1,0 +1,2 @@
+[zd_rayleigh]
+value = 2000.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
 Need to compute radiation flux before applying `ᶜdivᵥ` until we resolve this PR: https://github.com/CliMA/ClimaCore.jl/issues/1989.

Update config file so simulation runs successfully once #3059 is merged. 

Note: can merge this now, since the isdac test case from #3025 is set to soft fail.

Note2: Once #3059 is merged, add `Val{:les_isdac_box},` to `LESBoxPlots` (which is defined there)

<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
