### PR TITLE
Add aerosols to job with regression test

### DIFF
--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -17,4 +17,6 @@ surface_temperature: "ZonallyAsymmetric"
 moist: "equil"
 albedo_model: "RegressionFunctionAlbedo"
 regression_test: true
+aerosol_radiation: true
+prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "OC1", "OC2", "SO4"]
 toml: [toml/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.toml]

--- a/regression_tests/ref_counter.jl
+++ b/regression_tests/ref_counter.jl
@@ -1,6 +1,9 @@
-177
+178
 
 #=
+178:
+- Added aerosol to one of the regression tests
+
 177:
 - change numerics of non-orographic gravity waves
 


### PR DESCRIPTION
RRTMGP 0.19 probably changed behavior, but we didn't catch this because we don't test for aerosols.