### PR TITLE
Remove ᶜT from cache

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -166,7 +166,6 @@ function build_cache(
         ᶜΦ,
         ᶠgradᵥ_ᶜΦ = ᶠgradᵥ.(ᶜΦ),
         ᶜgradᵥ_ᶠΦ = ᶜgradᵥ.(ᶠΦ),
-        ᶜT = similar(Y.c, FT),
         ᶜf³,
         ᶠf¹²,
         # Used by diagnostics such as hfres, evspblw

--- a/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
@@ -150,7 +150,7 @@ function non_orographic_gravity_wave_tendency!(
     ::NonOrographyGravityWave,
 )
     #unpack
-    (; ᶜT,) = p.core
+    ᶜT = p.scratch.ᶜtemp_scalar
     (; ᶜts) = p.precomputed
     (; params) = p
     (;

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -78,7 +78,7 @@ function orographic_gravity_wave_cache(Y, ogw::OrographicGravityWave)
 end
 
 function orographic_gravity_wave_tendency!(Yₜ, Y, p, t, ::OrographicGravityWave)
-    (; ᶜT) = p.core
+    ᶜT = p.scratch.ᶜtemp_scalar
     (; params) = p
     (; ᶜts, ᶜp) = p.precomputed
     (; ᶜdTdz) = p.orographic_gravity_wave

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -133,7 +133,7 @@ function compute_precipitation_surface_fluxes!(
     p,
     precip_model::Microphysics0Moment,
 )
-    (; ᶜT) = p.core
+    ᶜT = p.scratch.ᶜtemp_scalar
     (; ᶜts) = p.precomputed  # assume ᶜts has been updated
     (; ᶜ3d_rain, ᶜ3d_snow, ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
     (; surface_rain_flux, surface_snow_flux) = p.precipitation
@@ -147,7 +147,6 @@ function compute_precipitation_surface_fluxes!(
     # update surface precipitation fluxes in cache for coupler's use
     thermo_params = CAP.thermodynamics_params(p.params)
     T_freeze = TD.Parameters.T_freeze(thermo_params)
-    @. ᶜT = TD.air_temperature(thermo_params, ᶜts)
     @. ᶜ3d_rain = ifelse(ᶜT >= T_freeze, ᶜS_ρq_tot, 0)
     @. ᶜ3d_snow = ifelse(ᶜT < T_freeze, ᶜS_ρq_tot, 0)
     Operators.column_integral_definite!(surface_rain_flux, ᶜ3d_rain)


### PR DESCRIPTION
`ᶜT` was never used. It was calculated in place every time it was used.
