### PR TITLE
Add support for saving checkpoints by calendar dates

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -155,7 +155,7 @@ test_dycore_consistency:
   help: "Test dycore consistency [`false` (default), `true`]"
   value: false
 dt_save_state_to_disk:
-  help: "Time between saving the state to disk. Examples: [`10secs`, `1hours`, `Inf` (do not save)]"
+  help: "Time between saving the state to disk. Examples: [`10secs`, `1hours`, `1months`, `Inf` (do not save)]"
   value: "Inf"
 dt_save_to_sol:
   help: "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"

--- a/config/model_configs/single_column_radiative_equilibrium_gray.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_gray.yml
@@ -1,4 +1,4 @@
-dt_save_state_to_disk: "100days"
+dt_save_state_to_disk: "3months"
 initial_condition: "IsothermalProfile"
 hyperdiff: false
 # It seems radiative equilibrium needs a larger dz near the top

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -669,7 +669,7 @@ function get_simulation(config::AtmosConfig)
     @info "ode_configuration: $s"
 
     s = @timed_str begin
-        callback = get_callbacks(config, sim_info, atmos, params, Y, p)
+        callback = get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
     end
     @info "get_callbacks: $s"
 


### PR DESCRIPTION
This commit adds support for providing a calendar frequency to the function that saves to the state to disk. This is required to ensure that diagnostics and states are synced and output at the same time. To enable this, I use the same infrastructure used by diagnostic module. Everything was already there, I just needed to add the YAML parsing.
