### PR TITLE
Always use ClimaCommon modules

### DIFF
--- a/.buildkite/gpu_pipeline/pipeline.yml
+++ b/.buildkite/gpu_pipeline/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_mem: 8G
-  modules: julia/1.10.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.4.1
+  modules: climacommon/2024_05_27
 
 env:
   JULIA_MPI_HAS_CUDA: "true"

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_mem: 8G
-  modules: julia/1.10.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.2.1
+  modules: climacommon/2024_05_27
 
 env:
   JULIA_MPI_HAS_CUDA: "true"


### PR DESCRIPTION
Perhaps this is why we've been getting inconsistent timings on buildkite (and why some of our target gpu runs have been broken).