### PR TITLE
Add insolation_tuple only when needed

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -190,7 +190,13 @@ function build_cache(
 
     radiation_args =
         atmos.radiation_mode isa RRTMGPI.AbstractRRTMGPMode ?
-        (params, precomputed.ᶜp, prescribe_ozone, aerosol_names) : ()
+        (
+            params,
+            precomputed.ᶜp,
+            prescribe_ozone,
+            aerosol_names,
+            atmos.insolation,
+        ) : ()
 
     hyperdiff = hyperdiffusion_cache(Y, atmos)
     rayleigh_sponge = rayleigh_sponge_cache(Y, atmos)

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -34,7 +34,8 @@ function radiation_model_cache(
     params,
     ᶜp, # Used for ozone
     prescribe_ozone,
-    aerosol_names;
+    aerosol_names,
+    insolation_mode;
     interpolation = RRTMGPI.BestFit(),
     bottom_extrapolation = RRTMGPI.SameAsInterpolation(),
     data_loader = rrtmgp_data_loader,
@@ -253,11 +254,21 @@ function radiation_model_cache(
             kwargs...,
         )
     end
+    return merge(
+        (;
+            orbital_data,
+            rrtmgp_model,
+            ᶠradiation_flux = similar(Y.f, Geometry.WVector{FT}),
+        ),
+        insolation_cache(insolation_mode, Y),
+    )
+end
+
+insolation_cache(_, _) = (;)
+function insolation_cache(::TimeVaryingInsolation, Y)
+    FT = Spaces.undertype(axes(Y.c))
     return (;
-        orbital_data,
-        rrtmgp_model,
-        insolation_tuple = similar(Spaces.level(Y.c, 1), Tuple{FT, FT, FT}),
-        ᶠradiation_flux = similar(Y.f, Geometry.WVector{FT}),
+        insolation_tuple = similar(Spaces.level(Y.c, 1), Tuple{FT, FT, FT})
     )
 end
 


### PR DESCRIPTION
`insolation_tuple` was unconditionally added to the cache, even it is used only by a specific type of insolation. This change ensures that the value is not added when it not going to be used.

Closes #3312 