### PR TITLE
Updates to gcm-driven single column calibrations

### DIFF
--- a/calibration/experiments/gcm_driven_scm/Manifest.toml
+++ b/calibration/experiments/gcm_driven_scm/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.3"
 manifest_format = "2.0"
-project_hash = "542f1a240809eb2aa29bf3360fa58dae93dd8526"
+project_hash = "61bbb6867bca3b8026963d6449c54dd91b1a85e4"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "99a6f5d0ce1c7c6afdb759daa30226f71c54f6b0"
@@ -37,24 +37,28 @@ uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 version = "0.4.5"
 
 [[deps.Accessors]]
-deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Markdown", "Test"]
-git-tree-sha1 = "f61b15be1d76846c0ce31d3fcfac5380ae53db6a"
+deps = ["CompositionsBase", "ConstructionBase", "InverseFunctions", "LinearAlgebra", "MacroTools", "Markdown"]
+git-tree-sha1 = "b392ede862e506d451fc1616e79aa6f4c673dab8"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
-version = "0.1.37"
+version = "0.1.38"
 
     [deps.Accessors.extensions]
     AccessorsAxisKeysExt = "AxisKeys"
+    AccessorsDatesExt = "Dates"
     AccessorsIntervalSetsExt = "IntervalSets"
     AccessorsStaticArraysExt = "StaticArrays"
     AccessorsStructArraysExt = "StructArrays"
+    AccessorsTestExt = "Test"
     AccessorsUnitfulExt = "Unitful"
 
     [deps.Accessors.weakdeps]
     AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
     IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
     Requires = "ae029012-a4dd-5104-9daa-d747884805df"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
     StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
     Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.Adapt]]
@@ -94,12 +98,6 @@ version = "1.2.0"
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
 
-[[deps.ArnoldiMethod]]
-deps = ["LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "d57bd3762d308bded22c3b82d033bff85f6195c6"
-uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
-version = "0.4.0"
-
 [[deps.Arpack]]
 deps = ["Arpack_jll", "Libdl", "LinearAlgebra", "Logging"]
 git-tree-sha1 = "9b9b347613394885fd1c8c7729bfc60528faa436"
@@ -114,9 +112,9 @@ version = "3.5.1+1"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra"]
-git-tree-sha1 = "f54c23a5d304fb87110de62bace7777d59088c34"
+git-tree-sha1 = "3640d077b6dafd64ceb8fd5c1ec76f7ca53bcf76"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.15.0"
+version = "7.16.0"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceBandedMatricesExt = "BandedMatrices"
@@ -144,9 +142,9 @@ version = "7.15.0"
 
 [[deps.ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "ce2ca959f932f5dad70697dd93133d1167cf1e4e"
+git-tree-sha1 = "0dd7edaff278e346eb0ca07a7e75c9438408a3ce"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "1.10.2"
+version = "1.10.3"
 weakdeps = ["SparseArrays"]
 
     [deps.ArrayLayouts.extensions]
@@ -193,9 +191,9 @@ version = "0.4.7"
 
 [[deps.BandedMatrices]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "PrecompileTools"]
-git-tree-sha1 = "71f605effb24081b09cae943ba39ef9ca90c04f4"
+git-tree-sha1 = "dce2e49fc53490efb39161267d74f27be0ae2cee"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.2"
+version = "1.7.4"
 weakdeps = ["SparseArrays"]
 
     [deps.BandedMatrices.extensions]
@@ -210,6 +208,17 @@ git-tree-sha1 = "f1dff6729bc61f4d49e140da1af55dcd1ac97b2f"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 version = "1.5.0"
 
+[[deps.BinaryProvider]]
+deps = ["Libdl", "Logging", "SHA"]
+git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.10"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.9"
+
 [[deps.BitTwiddlingConvenienceFunctions]]
 deps = ["Static"]
 git-tree-sha1 = "f21cfd4950cb9f0587d5067e69405ad2acd27b87"
@@ -218,9 +227,9 @@ version = "0.1.6"
 
 [[deps.BlockArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "5c0ffe1dff8cb7112de075f1b1cb32191675fcba"
+git-tree-sha1 = "d434647f798823bcae510aee0bc0401927f64391"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.1.0"
+version = "1.1.1"
 weakdeps = ["BandedMatrices"]
 
     [deps.BlockArrays.extensions]
@@ -270,6 +279,12 @@ git-tree-sha1 = "e329286945d0cfc04456972ea732551869af1cfc"
 uuid = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
 version = "1.0.1+0"
 
+[[deps.CSV]]
+deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
+git-tree-sha1 = "6c834533dc1fabd820c1db03c839bf97e45a3fab"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.10.14"
+
 [[deps.Cairo]]
 deps = ["Cairo_jll", "Colors", "Glib_jll", "Graphics", "Libdl", "Pango_jll"]
 git-tree-sha1 = "7b6ad8c35f4bc3bca8eb78127c8b99719506a5fb"
@@ -278,9 +293,9 @@ version = "1.1.0"
 
 [[deps.CairoMakie]]
 deps = ["CRC32c", "Cairo", "Cairo_jll", "Colors", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "PrecompileTools"]
-git-tree-sha1 = "3a6f8462053d199e6c81a83c7d22a9b8314c716a"
+git-tree-sha1 = "3443ecd9d38c1aeb2c6d0fa3a01598a59929da1d"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.12.6"
+version = "0.12.10"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -299,30 +314,30 @@ weakdeps = ["SparseArrays"]
     ChainRulesCoreSparseArraysExt = "SparseArrays"
 
 [[deps.ClimaAnalysis]]
-deps = ["NCDatasets", "OrderedCollections", "Reexport", "Statistics"]
-git-tree-sha1 = "8e11ef61b19226e8f3bd63004bed583bb1a4d107"
+deps = ["Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics"]
+git-tree-sha1 = "e13d742cd5a5ad287cf72ab22cb0927780cfe596"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.6"
+version = "0.5.7"
 
     [deps.ClimaAnalysis.extensions]
-    CairoMakieExt = "CairoMakie"
     GeoMakieExt = "GeoMakie"
+    MakieExt = "Makie"
 
     [deps.ClimaAnalysis.weakdeps]
-    CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
     GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [[deps.ClimaAtmos]]
-deps = ["Adapt", "ArgParse", "ArtifactWrappers", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "DiffEqBase", "DocStringExtensions", "FastGaussQuadrature", "Insolation", "Interpolations", "IntervalSets", "Krylov", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "Pkg", "Printf", "RRTMGP", "Random", "RootSolvers", "SciMLBase", "StaticArrays", "Statistics", "StatsBase", "SurfaceFluxes", "Thermodynamics", "YAML"]
-git-tree-sha1 = "f24cfc371c8e3b4ce431f21b272ca44ab75ef729"
-repo-rev = "14c944578663353dae5ee687935279ed121202e7"
-repo-url = "https://github.com/CliMA/ClimaAtmos.jl.git"
+deps = ["Adapt", "ArgParse", "ArtifactWrappers", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "DiffEqBase", "FastGaussQuadrature", "Insolation", "Interpolations", "LazyArtifacts", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "RRTMGP", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
+path = "../../.."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.27.2"
+version = "0.27.5"
 
 [[deps.ClimaCalibrate]]
 deps = ["Distributed", "Distributions", "EnsembleKalmanProcesses", "JLD2", "Random", "TOML", "YAML"]
-git-tree-sha1 = "73020ca323148eaab36a4d4234ff69dbb7171abc"
+git-tree-sha1 = "99fa21916c69ff86f4b7483730b9531b50bd83a1"
+repo-rev = "cc/bump_ekp_version"
+repo-url = "https://github.com/CliMA/ClimaCalibrate.jl.git"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 version = "0.0.3"
 
@@ -347,9 +362,9 @@ version = "0.6.4"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "3c05a897d67276ff8cfbdac4c92a5ad1da599c00"
+git-tree-sha1 = "806e8490ff1aa664ca579544d798f8addfa1b07d"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.14.11"
+version = "0.14.15"
 
     [deps.ClimaCore.extensions]
     ClimaCoreCUDAExt = "CUDA"
@@ -361,21 +376,21 @@ version = "0.14.11"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "Dates", "NCDatasets", "SciMLBase"]
-git-tree-sha1 = "4f8abbf3af5a78b36bc40a33ef7e3fa1d3e8f138"
+git-tree-sha1 = "0c60c2b40b0c5ae87690734e2aedea5a8c686e91"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-version = "0.2.4"
+version = "0.2.5"
 
 [[deps.ClimaParams]]
-deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "2c6841b4b71bb0a370616a2b7c7708bfb2ab8caf"
+deps = ["TOML"]
+git-tree-sha1 = "b43ca371c435056129295445122ea87fd843b505"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "0.10.12"
+version = "0.10.14"
 
 [[deps.ClimaTimeSteppers]]
-deps = ["ClimaComms", "Colors", "DataStructures", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]
-git-tree-sha1 = "56d5c0e5181281e86d4cc4b109b980882c30af3d"
+deps = ["ClimaComms", "Colors", "DataStructures", "DiffEqBase", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]
+git-tree-sha1 = "678b7f1dbaec5a7b486c29b5b98eeba1f916b9a8"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
-version = "0.7.33"
+version = "0.7.36"
 
     [deps.ClimaTimeSteppers.extensions]
     ClimaTimeSteppersBenchmarkToolsExt = ["CUDA", "BenchmarkTools", "OrderedCollections", "StatsBase", "PrettyTables"]
@@ -389,9 +404,9 @@ version = "0.7.33"
 
 [[deps.ClimaUtilities]]
 deps = ["Artifacts", "Dates"]
-git-tree-sha1 = "d572737e623699c37cdc8bb63d789fedc3dd3a95"
+git-tree-sha1 = "286cf36603ec68538dda4b0333af694fe70dd628"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.13"
+version = "0.1.14"
 
     [deps.ClimaUtilities.extensions]
     ClimaUtilitiesClimaCommsCUDAExt = ["ClimaComms", "CUDA"]
@@ -419,9 +434,9 @@ version = "0.1.13"
 
 [[deps.CloudMicrophysics]]
 deps = ["ClimaParams", "DocStringExtensions", "ForwardDiff", "HCubature", "LazyArtifacts", "QuadGK", "RootSolvers", "SpecialFunctions", "Thermodynamics"]
-git-tree-sha1 = "5d20d3452be63e6c6da766052ddce072e23b425e"
+git-tree-sha1 = "86c154ff7a7850b7a5cb2aa4b409933a865b1de8"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
-version = "0.22.1"
+version = "0.22.3"
 
     [deps.CloudMicrophysics.extensions]
     EmulatorModelsExt = ["DataFrames", "MLJ"]
@@ -493,15 +508,10 @@ uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 version = "0.2.4"
 
 [[deps.CommonSubexpressions]]
-deps = ["MacroTools", "Test"]
-git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
-version = "0.3.0"
-
-[[deps.CommonWorldInvalidations]]
-git-tree-sha1 = "ae52d1c52048455e85a387fbee9be553ec2b68d0"
-uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
-version = "1.0.0"
+version = "0.3.1"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -532,15 +542,21 @@ git-tree-sha1 = "f749037478283d372048690eb3b5f92a79432b34"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 version = "0.2.3"
 
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "ea32b83ca4fefa1768dc84e504cc0a94fb1ab8d1"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.4.2"
+
 [[deps.ConstructionBase]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "d8a9c0b6ac2d9081bf76324b39c78ca3ce4f0c98"
+git-tree-sha1 = "76219f1ed5771adbb096743bff43fb5fdd4c1157"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-version = "1.5.6"
-weakdeps = ["IntervalSets", "StaticArrays"]
+version = "1.5.8"
+weakdeps = ["IntervalSets", "LinearAlgebra", "StaticArrays"]
 
     [deps.ConstructionBase.extensions]
     ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
     ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [[deps.Contour]]
@@ -550,9 +566,9 @@ version = "0.6.3"
 
 [[deps.Convex]]
 deps = ["AbstractTrees", "BenchmarkTools", "LDLFactorizations", "LinearAlgebra", "MathOptInterface", "OrderedCollections", "SparseArrays", "Test"]
-git-tree-sha1 = "aee723f099f0bb8f7543573227fa90ee8cf4a25e"
+git-tree-sha1 = "dac1878b4996fa56292d2c3bd28f2498b980bb93"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.16.2"
+version = "0.16.3"
 
 [[deps.CpuId]]
 deps = ["Markdown"]
@@ -560,16 +576,27 @@ git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
 uuid = "adafc99b-e345-5852-983c-f28acb93d879"
 version = "0.3.1"
 
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
 [[deps.CubedSphere]]
-deps = ["Elliptic", "FFTW", "Printf", "ProgressBars", "SpecialFunctions", "TaylorSeries", "Test"]
-git-tree-sha1 = "10134667d7d3569b191a65801514271b8a93b292"
+deps = ["TaylorSeries"]
+git-tree-sha1 = "51bb25de518b4c62b7cdf26e5fbb84601bb27a60"
 uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
-version = "0.2.5"
+version = "0.3.0"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 version = "1.16.0"
+
+[[deps.DataFrames]]
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "REPL", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.6.1"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -586,11 +613,17 @@ version = "1.0.0"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[deps.Dbus_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "fc173b380865f70627d7dd1190dc2fce6cc105af"
+uuid = "ee1fde0b-3d02-5ea6-8484-8dfef6360eab"
+version = "1.14.10+0"
+
 [[deps.DelaunayTriangulation]]
 deps = ["AdaptivePredicates", "EnumX", "ExactPredicates", "Random"]
-git-tree-sha1 = "b5f1c6532d2ea71e99b74231b0a3d53fba846ced"
+git-tree-sha1 = "88c5695a8d7b23270afe1b6bef8232ac1f201862"
 uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
-version = "1.1.3"
+version = "1.3.1"
 
 [[deps.DelimitedFiles]]
 deps = ["Mmap"]
@@ -599,10 +632,10 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 version = "1.9.1"
 
 [[deps.DiffEqBase]]
-deps = ["ArrayInterface", "ConcreteStructs", "DataStructures", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "ForwardDiff", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "Parameters", "PreallocationTools", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "Static", "StaticArraysCore", "Statistics", "Tricks", "TruncatedStacktraces"]
-git-tree-sha1 = "2f3dfa7d150ca5401482777836d0e8f361087a80"
+deps = ["ArrayInterface", "ConcreteStructs", "DataStructures", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "ForwardDiff", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "Parameters", "PreallocationTools", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "SparseArrays", "Static", "StaticArraysCore", "Statistics", "Tricks", "TruncatedStacktraces"]
+git-tree-sha1 = "d1e8a4642e28b0945bde6e2e1ac569b9e0abd728"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.153.0"
+version = "6.151.5"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -614,7 +647,6 @@ version = "6.153.0"
     DiffEqBaseMeasurementsExt = "Measurements"
     DiffEqBaseMonteCarloMeasurementsExt = "MonteCarloMeasurements"
     DiffEqBaseReverseDiffExt = "ReverseDiff"
-    DiffEqBaseSparseArraysExt = "SparseArrays"
     DiffEqBaseTrackerExt = "Tracker"
     DiffEqBaseUnitfulExt = "Unitful"
 
@@ -628,19 +660,8 @@ version = "6.153.0"
     Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
     MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
     ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
     Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-
-[[deps.DiffEqCallbacks]]
-deps = ["DataStructures", "DiffEqBase", "ForwardDiff", "Functors", "LinearAlgebra", "Markdown", "NonlinearSolve", "Parameters", "RecipesBase", "RecursiveArrayTools", "SciMLBase", "StaticArraysCore"]
-git-tree-sha1 = "91e10deadcf1e33168bac3140eb0ea8cc4dfa5d7"
-uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "3.7.0"
-
-    [deps.DiffEqCallbacks.weakdeps]
-    OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-    Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
 [[deps.DiffResults]]
 deps = ["StaticArraysCore"]
@@ -654,42 +675,6 @@ git-tree-sha1 = "23163d55f885173722d1e4cf0f6110cdbaf7e272"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "1.15.1"
 
-[[deps.DifferentiationInterface]]
-deps = ["ADTypes", "Compat", "DocStringExtensions", "FillArrays", "LinearAlgebra", "PackageExtensionCompat", "SparseArrays", "SparseMatrixColorings"]
-git-tree-sha1 = "5f9a52dc40218e85daa695600733f5ccaa7eb80b"
-uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.5.13"
-
-    [deps.DifferentiationInterface.extensions]
-    DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
-    DifferentiationInterfaceDiffractorExt = "Diffractor"
-    DifferentiationInterfaceEnzymeExt = "Enzyme"
-    DifferentiationInterfaceFastDifferentiationExt = "FastDifferentiation"
-    DifferentiationInterfaceFiniteDiffExt = "FiniteDiff"
-    DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
-    DifferentiationInterfaceForwardDiffExt = "ForwardDiff"
-    DifferentiationInterfacePolyesterForwardDiffExt = "PolyesterForwardDiff"
-    DifferentiationInterfaceReverseDiffExt = "ReverseDiff"
-    DifferentiationInterfaceSymbolicsExt = "Symbolics"
-    DifferentiationInterfaceTapirExt = "Tapir"
-    DifferentiationInterfaceTrackerExt = "Tracker"
-    DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
-
-    [deps.DifferentiationInterface.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
-    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-    FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
-    FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-    FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
-    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-    Tapir = "07d77754-e150-4737-8c94-cd238a1fb45b"
-    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
 [[deps.DiskArrays]]
 deps = ["LRUCache", "OffsetArrays"]
 git-tree-sha1 = "ef25c513cad08d7ebbed158c91768ae32f308336"
@@ -702,9 +687,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "0e0a1264b0942f1f3abb2b30891f2a590cc652ac"
+git-tree-sha1 = "e6c693a0e4394f8fda0e51a5bdf5aef26f8235e9"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.110"
+version = "0.25.111"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -733,16 +718,11 @@ git-tree-sha1 = "e3290f2d49e661fbd94046d7e3726ffcb2d41053"
 uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
 version = "2.2.4+0"
 
-[[deps.Elliptic]]
-git-tree-sha1 = "71c79e77221ab3a29918aaf6db4f217b89138608"
-uuid = "b305315f-e792-5b7a-8f41-49f472929428"
-version = "1.0.1"
-
 [[deps.EnsembleKalmanProcesses]]
 deps = ["Convex", "Distributions", "DocStringExtensions", "GaussianRandomFields", "Interpolations", "LinearAlgebra", "MathOptInterface", "Optim", "QuadGK", "Random", "RecipesBase", "SCS", "SparseArrays", "Statistics", "StatsBase", "TOML"]
-git-tree-sha1 = "df6e9aeeae4b7d9129379d92e8884182a24caffe"
+git-tree-sha1 = "00bb94ff704d7aeed9c72d4a2a05d6abf6cb7946"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
-version = "1.1.7"
+version = "2.0.1"
 
 [[deps.EnumX]]
 git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
@@ -758,6 +738,12 @@ weakdeps = ["Adapt"]
     [deps.EnzymeCore.extensions]
     AdaptExt = "Adapt"
 
+[[deps.EpollShim_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8e9441ee83492030ace98f9789a654a6d0b1f643"
+uuid = "2702e6a9-849d-5ed8-8c21-79e8b8f9ee43"
+version = "0.0.20230411+0"
+
 [[deps.ErrorfreeArithmetic]]
 git-tree-sha1 = "d6863c556f1142a061532e79f611aa46be201686"
 uuid = "90fa49ef-747e-5e6f-a989-263ba693cf1a"
@@ -768,6 +754,12 @@ deps = ["IntervalArithmetic", "Random", "StaticArraysCore", "Test"]
 git-tree-sha1 = "276e83bc8b21589b79303b9985c321024ffdf59c"
 uuid = "429591f6-91af-11e9-00e2-59fbe8cec110"
 version = "2.2.5"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "dcb08a0d93ec0b1cdc4af184b26b591e9695423a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.10"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -787,15 +779,21 @@ uuid = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3636"
 version = "0.8.5"
 
 [[deps.Extents]]
-git-tree-sha1 = "94997910aca72897524d2237c41eb852153b0f65"
+git-tree-sha1 = "81023caa0021a41712685887db1fc03db26f41f5"
 uuid = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
-version = "0.1.3"
+version = "0.1.4"
+
+[[deps.FFMPEG]]
+deps = ["BinaryProvider", "Libdl"]
+git-tree-sha1 = "9143266ba77d3313a4cf61d8333a1970e8c5d8b6"
+uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
+version = "0.2.4"
 
 [[deps.FFMPEG_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "ab3f7e1819dba9434a3a5126510c8fda3a4e7000"
+git-tree-sha1 = "8cc47f299902e13f90405ddb5bf87e5d474c0d38"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "6.1.1+0"
+version = "6.1.2+0"
 
 [[deps.FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
@@ -822,15 +820,9 @@ version = "0.3.2"
 
 [[deps.FastGaussQuadrature]]
 deps = ["LinearAlgebra", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "0f478d8bad6f52573fb7658a263af61f3d96e43a"
+git-tree-sha1 = "fd923962364b645f3719855c88f7074413a6ad92"
 uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "0.5.1"
-
-[[deps.FastLapackInterface]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "cbf5edddb61a43669710cbc2241bc08b36d9e660"
-uuid = "29a986be-02c6-4525-aec4-84b980013641"
-version = "2.0.4"
+version = "1.0.2"
 
 [[deps.FastRounding]]
 deps = ["ErrorfreeArithmetic", "LinearAlgebra"]
@@ -851,19 +843,24 @@ uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
 version = "0.8.3"
 
 [[deps.FilePathsBase]]
-deps = ["Compat", "Dates", "Mmap", "Printf", "Test", "UUIDs"]
-git-tree-sha1 = "9f00e42f8d99fdde64d40c8ea5d14269a2e2c1aa"
+deps = ["Compat", "Dates"]
+git-tree-sha1 = "7878ff7172a8e6beedd1dea14bd27c3c6340d361"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
-version = "0.9.21"
+version = "0.9.22"
+weakdeps = ["Mmap", "Test"]
+
+    [deps.FilePathsBase.extensions]
+    FilePathsBaseMmapExt = "Mmap"
+    FilePathsBaseTestExt = "Test"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "0653c0a2396a6da5bc4766c43041ef5fd3efbe57"
+git-tree-sha1 = "6a70198746448456524cb442b8af316927ff3e1a"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.11.0"
+version = "1.13.0"
 weakdeps = ["PDMats", "SparseArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
@@ -949,15 +946,15 @@ git-tree-sha1 = "b104d487b34566608f8b4e1c39fb0b10aa279ff8"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 version = "0.1.3"
 
-[[deps.Functors]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "64d8e93700c7a3f28f717d265382d52fac9fa1c1"
-uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.4.12"
-
 [[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[deps.GLFW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "libdecor_jll", "xkbcommon_jll"]
+git-tree-sha1 = "532f9126ad901533af1d4f5c198867227a7bb077"
+uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+version = "3.4.0+1"
 
 [[deps.GMP_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -970,6 +967,18 @@ git-tree-sha1 = "ec632f177c0d990e64d955ccc1b8c04c485a0950"
 uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 version = "0.1.6"
 
+[[deps.GR]]
+deps = ["Artifacts", "Base64", "DelimitedFiles", "Downloads", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Preferences", "Printf", "Qt6Wayland_jll", "Random", "Serialization", "Sockets", "TOML", "Tar", "Test", "p7zip_jll"]
+git-tree-sha1 = "629693584cef594c3f6f99e76e7a7ad17e60e8d5"
+uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+version = "0.73.7"
+
+[[deps.GR_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "FreeType2_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Qt6Base_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "a8863b69c2a0859f2c2c87ebdc4c6712e88bdf0d"
+uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
+version = "0.73.7+0"
+
 [[deps.GaussQuadrature]]
 deps = ["SpecialFunctions"]
 git-tree-sha1 = "eb6f1f48aa994f3018cbd029a17863c6535a266d"
@@ -977,16 +986,21 @@ uuid = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
 version = "0.5.8"
 
 [[deps.GaussianRandomFields]]
-deps = ["Arpack", "FFTW", "FastGaussQuadrature", "LinearAlgebra", "Random", "RecipesBase", "SpecialFunctions", "Statistics", "StatsBase"]
-git-tree-sha1 = "055849d7a602c31eda477a0b0b86c9473a3e4fb9"
+deps = ["Arpack", "FFTW", "FastGaussQuadrature", "LinearAlgebra", "Plots", "Random", "RecipesBase", "SpecialFunctions", "Statistics", "StatsBase"]
+git-tree-sha1 = "aaf37fbddc7bca5391677fb5f5082dd29442ca8f"
 uuid = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
-version = "2.2.4"
+version = "2.2.5"
+
+[[deps.GeoFormatTypes]]
+git-tree-sha1 = "59107c179a586f0fe667024c5eb7033e81333271"
+uuid = "68eda718-8dee-11e9-39e7-89f7f65f511f"
+version = "0.4.2"
 
 [[deps.GeoInterface]]
-deps = ["Extents"]
-git-tree-sha1 = "9fff8990361d5127b770e3454488360443019bb3"
+deps = ["Extents", "GeoFormatTypes"]
+git-tree-sha1 = "5921fc0704e40c024571eca551800c699f86ceb4"
 uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
-version = "1.3.5"
+version = "1.3.6"
 
 [[deps.GeometryBasics]]
 deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
@@ -1034,12 +1048,6 @@ git-tree-sha1 = "344bf40dcab1073aca04aa0df4fb092f920e4011"
 uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
 version = "1.3.14+0"
 
-[[deps.Graphs]]
-deps = ["ArnoldiMethod", "Compat", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
-git-tree-sha1 = "ebd18c326fa6cee1efb7da9a3b45cf69da2ed4d9"
-uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.11.2"
-
 [[deps.GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
 git-tree-sha1 = "fc713f007cff99ff9e50accba6373624ddd33588"
@@ -1053,9 +1061,9 @@ version = "1.0.2"
 
 [[deps.HCubature]]
 deps = ["Combinatorics", "DataStructures", "LinearAlgebra", "QuadGK", "StaticArrays"]
-git-tree-sha1 = "10f37537bbd83e52c63abf6393f209dbd641fedc"
+git-tree-sha1 = "19ef9f0cb324eed957b7fe7257ac84e8ed8a48ec"
 uuid = "19dc6840-f33b-545b-b366-655c7e3ffd49"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.HDF5]]
 deps = ["Compat", "HDF5_jll", "Libdl", "MPIPreferences", "Mmap", "Preferences", "Printf", "Random", "Requires", "UUIDs"]
@@ -1073,17 +1081,17 @@ git-tree-sha1 = "82a471768b513dc39e471540fdadc84ff80ff997"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
 version = "1.14.3+3"
 
-[[deps.HarfBuzz_jll]]
-deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
-git-tree-sha1 = "129acf094d168394e80ee1dc4bc06ec835e510a3"
-uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "2.8.1+1"
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "d1d712be3164d61d1fb98e7ce9bcbc6cc06b45ed"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.10.8"
 
-[[deps.HostCPUFeatures]]
-deps = ["BitTwiddlingConvenienceFunctions", "IfElse", "Libdl", "Static"]
-git-tree-sha1 = "8e070b599339d622e9a081d17230d74a5c473293"
-uuid = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
-version = "0.1.17"
+[[deps.HarfBuzz_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "401e4f3f30f43af2c8478fc008da50096ea5240f"
+uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
+version = "8.3.1+0"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1148,21 +1156,34 @@ git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
 uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 version = "0.1.5"
 
+[[deps.InlineStrings]]
+git-tree-sha1 = "45521d31238e87ee9f9732561bfee12d4eebd52d"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.4.2"
+
+    [deps.InlineStrings.extensions]
+    ArrowTypesExt = "ArrowTypes"
+    ParsersExt = "Parsers"
+
+    [deps.InlineStrings.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+    Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
 [[deps.Insolation]]
 deps = ["Artifacts", "Dates", "DelimitedFiles", "Interpolations"]
-git-tree-sha1 = "16912df0f91cf8bb100a4fe0730b7befab55f0d0"
+git-tree-sha1 = "29e10cf6320739afe5a2b17e9c854a386fef7acc"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
-version = "0.9.3"
+version = "0.9.4"
 weakdeps = ["ClimaParams"]
 
     [deps.Insolation.extensions]
     CreateParametersExt = "ClimaParams"
 
 [[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "14eb2b542e748570b56446f4c50fbfb2306ebc45"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "10bd689145d2c3b2a9844005d01087cc1194e79e"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2024.2.0+0"
+version = "2024.2.1+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -1205,6 +1226,11 @@ weakdeps = ["Dates", "Test"]
     InverseFunctionsDatesExt = "Dates"
     InverseFunctionsTestExt = "Test"
 
+[[deps.InvertedIndices]]
+git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.3.0"
+
 [[deps.IrrationalConstants]]
 git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -1227,16 +1253,22 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[deps.JLD2]]
-deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Reexport", "Requires", "TranscodingStreams", "UUIDs", "Unicode"]
-git-tree-sha1 = "67d4690d32c22e28818a434b293a374cc78473d3"
+deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Requires", "TranscodingStreams"]
+git-tree-sha1 = "a0746c21bdc986d0dc293efa6b1faee112c37c28"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.51"
+version = "0.4.53"
+
+[[deps.JLFzf]]
+deps = ["Pipe", "REPL", "Random", "fzf_jll"]
+git-tree-sha1 = "39d64b09147620f5ffbf6b2d3255be3c901bec63"
+uuid = "1019f520-868f-41f5-a6de-eb00f4b6a39c"
+version = "0.1.8"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "f389674c99bfcde17dc57454011aa44d5a260a40"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -1262,21 +1294,17 @@ git-tree-sha1 = "af433a10f3942e882d3c671aacb203e006a5808f"
 uuid = "9c1d0b0a-7046-5b2e-a33f-ea22f176ac7e"
 version = "0.2.1+0"
 
-[[deps.KLU]]
-deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
-git-tree-sha1 = "07649c499349dad9f08dde4243a4c597064663e9"
-uuid = "ef3ab10e-7fda-4108-b977-705223b18434"
-version = "0.6.0"
-
 [[deps.KernelAbstractions]]
-deps = ["Adapt", "Atomix", "InteractiveUtils", "LinearAlgebra", "MacroTools", "PrecompileTools", "Requires", "SparseArrays", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
-git-tree-sha1 = "0fac59881e91c7233a9b0d47f4b7d9432e534f0f"
+deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
+git-tree-sha1 = "cb1cff88ef2f3a157cbad75bbe6b229e1975e498"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.23"
-weakdeps = ["EnzymeCore"]
+version = "0.9.25"
+weakdeps = ["EnzymeCore", "LinearAlgebra", "SparseArrays"]
 
     [deps.KernelAbstractions.extensions]
     EnzymeExt = "EnzymeCore"
+    LinearAlgebraExt = "LinearAlgebra"
+    SparseArraysExt = "SparseArrays"
 
 [[deps.KernelDensity]]
 deps = ["Distributions", "DocStringExtensions", "FFTW", "Interpolations", "StatsBase"]
@@ -1312,11 +1340,17 @@ git-tree-sha1 = "70f582b446a1c3ad82cf87e62b878668beef9d13"
 uuid = "40e66cde-538c-5869-a4ad-c39174c6795b"
 version = "0.10.1"
 
+[[deps.LERC_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "bf36f528eec6634efc60d7ec062008f171071434"
+uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
+version = "3.0.0+1"
+
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Preferences", "Printf", "Requires", "Unicode"]
-git-tree-sha1 = "2470e69781ddd70b8878491233cd09bc1bd7fc96"
+git-tree-sha1 = "4ad43cb0a4bb5e5b1506e1d1f48646d7e0c80363"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "8.1.0"
+version = "9.1.2"
 
     [deps.LLVM.extensions]
     BFloat16sExt = "BFloat16s"
@@ -1326,15 +1360,15 @@ version = "8.1.0"
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "597d1c758c9ae5d985ba4202386a607c675ee700"
+git-tree-sha1 = "05a8bd5a42309a9ec82f700876903abce1017dd3"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.31+0"
+version = "0.0.34+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e16271d212accd09d52ee0ae98956b8a05c4b626"
+git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
 uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
-version = "17.0.6+0"
+version = "18.1.7+0"
 
 [[deps.LRUCache]]
 git-tree-sha1 = "b3cc6698599b10e652832c2f23db3cab99d51b59"
@@ -1356,29 +1390,27 @@ git-tree-sha1 = "50901ebc375ed41dbf8058da26f9de442febbbec"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.3.1"
 
+[[deps.Latexify]]
+deps = ["Format", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
+git-tree-sha1 = "ce5f5621cac23a86011836badfedf664a612cee4"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.16.5"
+
+    [deps.Latexify.extensions]
+    DataFramesExt = "DataFrames"
+    SparseArraysExt = "SparseArrays"
+    SymEngineExt = "SymEngine"
+
+    [deps.Latexify.weakdeps]
+    DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
+
 [[deps.LayoutPointers]]
 deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static", "StaticArrayInterface"]
 git-tree-sha1 = "a9eaadb366f5493a5654e843864c13d8b107548c"
 uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
 version = "0.1.17"
-
-[[deps.LazyArrays]]
-deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "MacroTools", "SparseArrays"]
-git-tree-sha1 = "507b423197fdd9e77b74aa2532c0a05eb7eb4004"
-uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.2.0"
-
-    [deps.LazyArrays.extensions]
-    LazyArraysBandedMatricesExt = "BandedMatrices"
-    LazyArraysBlockArraysExt = "BlockArrays"
-    LazyArraysBlockBandedMatricesExt = "BlockBandedMatrices"
-    LazyArraysStaticArraysExt = "StaticArrays"
-
-    [deps.LazyArrays.weakdeps]
-    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-    BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
-    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -1428,6 +1460,12 @@ git-tree-sha1 = "9fd170c4bbfd8b935fdc5f8b7aa33532c991a673"
 uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
 version = "1.8.11+0"
 
+[[deps.Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "6f73d1dd803986947b2c750138528a999a6c7733"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.6.0+0"
+
 [[deps.Libgpg_error_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "fbb1f2bef882392312feb1ede3615ddc1e9b99ed"
@@ -1445,6 +1483,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "0c4f9c4f1a50d8f35048fa0532dabbadf702f81e"
 uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
 version = "2.40.1+0"
+
+[[deps.Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "2da088d113af58221c52828a80378e16be7d037a"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.5.1+1"
 
 [[deps.Libuuid_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1478,43 +1522,6 @@ version = "2.8.0"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 
-[[deps.LinearSolve]]
-deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "CpuId", "DocStringExtensions", "EnumX", "FastLapackInterface", "GPUArraysCore", "InteractiveUtils", "KLU", "Krylov", "LazyArrays", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "PrecompileTools", "Preferences", "RecursiveFactorization", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "SparseArrays", "Sparspak", "StaticArraysCore", "UnPack"]
-git-tree-sha1 = "ee625f4053362526950661ce3022c7a483c6f8e5"
-uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "2.32.0"
-
-    [deps.LinearSolve.extensions]
-    LinearSolveBandedMatricesExt = "BandedMatrices"
-    LinearSolveBlockDiagonalsExt = "BlockDiagonals"
-    LinearSolveCUDAExt = "CUDA"
-    LinearSolveCUDSSExt = "CUDSS"
-    LinearSolveEnzymeExt = ["Enzyme", "EnzymeCore"]
-    LinearSolveFastAlmostBandedMatricesExt = ["FastAlmostBandedMatrices"]
-    LinearSolveHYPREExt = "HYPRE"
-    LinearSolveIterativeSolversExt = "IterativeSolvers"
-    LinearSolveKernelAbstractionsExt = "KernelAbstractions"
-    LinearSolveKrylovKitExt = "KrylovKit"
-    LinearSolveMetalExt = "Metal"
-    LinearSolvePardisoExt = "Pardiso"
-    LinearSolveRecursiveArrayToolsExt = "RecursiveArrayTools"
-
-    [deps.LinearSolve.weakdeps]
-    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-    BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
-    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
-    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
-    FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
-    HYPRE = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
-    IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
-    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-    KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
-    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
-    Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
-    RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
-
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
 git-tree-sha1 = "a2d09619db4e765091ee5c6ffe8872849de0feea"
@@ -1534,16 +1541,11 @@ version = "0.3.28"
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[deps.LoopVectorization]]
-deps = ["ArrayInterface", "CPUSummary", "CloseOpenIntervals", "DocStringExtensions", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "PrecompileTools", "SIMDTypes", "SLEEFPirates", "Static", "StaticArrayInterface", "ThreadingUtilities", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "8084c25a250e00ae427a379a5b607e7aed96a2dd"
-uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.12.171"
-weakdeps = ["ChainRulesCore", "ForwardDiff", "SpecialFunctions"]
-
-    [deps.LoopVectorization.extensions]
-    ForwardDiffExt = ["ChainRulesCore", "ForwardDiff"]
-    SpecialFunctionsExt = "SpecialFunctions"
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "c1dd6d7978c12545b4179fb6153b9250c96b0075"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.0.3"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1564,9 +1566,9 @@ version = "0.4.17"
 
 [[deps.MPI]]
 deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "PkgVersion", "PrecompileTools", "Requires", "Serialization", "Sockets"]
-git-tree-sha1 = "14cef41baf5b675b192b02a22c710f725ab333a7"
+git-tree-sha1 = "5465632f9dd11aea0d912cb64a6f80640092a33e"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-version = "0.20.20"
+version = "0.20.21"
 
     [deps.MPI.extensions]
     AMDGPUExt = "AMDGPU"
@@ -1601,16 +1603,16 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.13"
 
 [[deps.Makie]]
-deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "InteractiveUtils", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
-git-tree-sha1 = "2fe1a9e0cfb8ffe846dc08b78a0cfd4746c99949"
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "768151abed75c6cf5be774456ae82bf9bb7274e9"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.21.6"
+version = "0.21.10"
 
 [[deps.MakieCore]]
 deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
-git-tree-sha1 = "1753d72dcf82beb1c582826d0a51a8253a719613"
+git-tree-sha1 = "4b7aa3b9c51d1d9db74e2401dd1d1eaec416ee55"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.8.5"
+version = "0.8.7"
 
 [[deps.ManualMemory]]
 git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
@@ -1628,9 +1630,9 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test", "Unicode"]
-git-tree-sha1 = "c0fe113e9c72aa0c9a185fd3c5ca1daa51de1486"
+git-tree-sha1 = "5b246fca5420ae176d65ed43a2d0ee5897775216"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.31.1"
+version = "1.31.2"
 
 [[deps.MathTeXEngine]]
 deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
@@ -1638,16 +1640,21 @@ git-tree-sha1 = "e1641f32ae592e415e3dbae7f4a188b5316d4b62"
 uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 version = "0.6.1"
 
-[[deps.MaybeInplace]]
-deps = ["ArrayInterface", "LinearAlgebra", "MacroTools", "SparseArrays"]
-git-tree-sha1 = "1b9e613f2ca3b6cdcbfe36381e17ca2b66d4b3a1"
-uuid = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
-version = "0.1.3"
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "c067a280ddc25f196b5e7df3877c6b226d390aaf"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.9"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+1"
+
+[[deps.Measures]]
+git-tree-sha1 = "c13304c81eec1ed3af7fc20e75fb6b26092a1102"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.2"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1699,9 +1706,9 @@ version = "1.4.6"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
-git-tree-sha1 = "a640912695952b074672edb5f9aaee2f7f9fd59a"
+git-tree-sha1 = "77df6d3708ec0eb3441551e1f20f7503b37c2393"
 uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-version = "0.14.4"
+version = "0.14.5"
 
 [[deps.NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
@@ -1727,6 +1734,12 @@ git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "1.0.2"
 
+[[deps.NaNStatistics]]
+deps = ["PrecompileTools", "Static", "StaticArrayInterface"]
+git-tree-sha1 = "643573fb1771d2ae140b775c18e4278578051c03"
+uuid = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
+version = "0.6.41"
+
 [[deps.NetCDF_jll]]
 deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
 git-tree-sha1 = "4686378c4ae1d1948cfbe46c002a11a4265dcb07"
@@ -1748,38 +1761,6 @@ version = "3.7.2+0"
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
-
-[[deps.NonlinearSolve]]
-deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "DiffEqBase", "FastBroadcast", "FastClosures", "FiniteDiff", "ForwardDiff", "LazyArrays", "LineSearches", "LinearAlgebra", "LinearSolve", "MaybeInplace", "PrecompileTools", "Preferences", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "SparseArrays", "SparseDiffTools", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
-git-tree-sha1 = "bcd8812e751326ff1d4b2dd50764b93df51f143b"
-uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "3.14.0"
-
-    [deps.NonlinearSolve.extensions]
-    NonlinearSolveBandedMatricesExt = "BandedMatrices"
-    NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
-    NonlinearSolveFixedPointAccelerationExt = "FixedPointAcceleration"
-    NonlinearSolveLeastSquaresOptimExt = "LeastSquaresOptim"
-    NonlinearSolveMINPACKExt = "MINPACK"
-    NonlinearSolveNLSolversExt = "NLSolvers"
-    NonlinearSolveNLsolveExt = "NLsolve"
-    NonlinearSolveSIAMFANLEquationsExt = "SIAMFANLEquations"
-    NonlinearSolveSpeedMappingExt = "SpeedMapping"
-    NonlinearSolveSymbolicsExt = "Symbolics"
-    NonlinearSolveZygoteExt = "Zygote"
-
-    [deps.NonlinearSolve.weakdeps]
-    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-    FastLevenbergMarquardt = "7a0df574-e128-4d35-8cbd-3d84502bf7ce"
-    FixedPointAcceleration = "817d07cb-a79a-5c30-9a31-890123675176"
-    LeastSquaresOptim = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
-    MINPACK = "4854310b-de5a-5eb6-a2a5-c1dee2bd17f9"
-    NLSolvers = "337daf1e-9722-11e9-073e-8b9effe078ba"
-    NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
-    SIAMFANLEquations = "084e46ad-d928-497d-ad5e-07fa361a48c4"
-    SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"
-    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [[deps.Observables]]
 git-tree-sha1 = "7438a59546cf62428fc9d1bc94729146d37a7225"
@@ -1835,11 +1816,17 @@ git-tree-sha1 = "e25c1778a98e34219a00455d6e4384e017ea9762"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
 version = "4.1.6+0"
 
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "38cb508d080d21dc1128f7fb04f20387ed4c0af4"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.4.3"
+
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
+git-tree-sha1 = "1b35263570443fdd9e76c76b7062116e2f374ab8"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.14+0"
+version = "3.0.15+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1858,10 +1845,10 @@ weakdeps = ["MathOptInterface"]
     OptimMOIExt = "MathOptInterface"
 
 [[deps.Opus_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "51a08fb14ec28da2ec7a927c4337e4332c2a4720"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6703a85cb3781bd5909d48730a67205f3f31a575"
 uuid = "91d4177d-7536-5919-b921-800302f37372"
-version = "1.3.2+0"
+version = "1.3.3+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
@@ -1911,9 +1898,9 @@ version = "0.5.12"
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "cb5a2ab6763464ae0f19c86c56c63d4a2b0f5bda"
+git-tree-sha1 = "e127b609fb9ecba6f201ba7ab753d5a605d53801"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.52.2+0"
+version = "1.54.1+0"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -1926,6 +1913,11 @@ deps = ["Dates", "PrecompileTools", "UUIDs"]
 git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.8.1"
+
+[[deps.Pipe]]
+git-tree-sha1 = "6842804e7867b115ca9de748a0cf6b364523c16d"
+uuid = "b98c9c47-44ae-5843-9183-064241ee97a0"
+version = "1.3.0"
 
 [[deps.Pixman_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
@@ -1944,11 +1936,37 @@ git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
 uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
 version = "0.3.3"
 
+[[deps.PlotThemes]]
+deps = ["PlotUtils", "Statistics"]
+git-tree-sha1 = "6e55c6841ce3411ccb3457ee52fc48cb698d6fb0"
+uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
+version = "3.2.0"
+
 [[deps.PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "PrecompileTools", "Printf", "Random", "Reexport", "Statistics"]
 git-tree-sha1 = "7b1a9df27f072ac4c9c7cbe5efb198489258d1f5"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.4.1"
+
+[[deps.Plots]]
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "UnitfulLatexify", "Unzip"]
+git-tree-sha1 = "c4fa93d7d66acad8f6f4ff439576da9d2e890ee0"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "1.40.1"
+
+    [deps.Plots.extensions]
+    FileIOExt = "FileIO"
+    GeometryBasicsExt = "GeometryBasics"
+    IJuliaExt = "IJulia"
+    ImageInTerminalExt = "ImageInTerminal"
+    UnitfulExt = "Unitful"
+
+    [deps.Plots.weakdeps]
+    FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+    GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+    IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+    ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.Polyester]]
 deps = ["ArrayInterface", "BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "ManualMemory", "PolyesterWeave", "Static", "StaticArrayInterface", "StrideArraysCore", "ThreadingUtilities"]
@@ -1966,6 +1984,12 @@ version = "0.2.2"
 git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
 uuid = "647866c9-e3ac-4575-94e7-e3d426903924"
 version = "0.1.2"
+
+[[deps.PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "36d8b4b899628fb92c2749eb488d884a926614d3"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.4.3"
 
 [[deps.PositiveFactorizations]]
 deps = ["LinearAlgebra"]
@@ -1997,6 +2021,12 @@ git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.4.3"
 
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "66b20dd35966a748321d3b2537c4584cf40387c7"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "2.3.2"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -2005,12 +2035,6 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 deps = ["Printf"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
-[[deps.ProgressBars]]
-deps = ["Printf"]
-git-tree-sha1 = "b437cdb0385ed38312d91d9c00c20f3798b30256"
-uuid = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
-version = "1.5.1"
-
 [[deps.ProgressMeter]]
 deps = ["Distributed", "Printf"]
 git-tree-sha1 = "8f6bc219586aef8baf0ff9a5fe16ee9c70cb65e4"
@@ -2018,9 +2042,9 @@ uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.10.2"
 
 [[deps.PtrArrays]]
-git-tree-sha1 = "f011fbb92c4d401059b2212c05c0601b70f8b759"
+git-tree-sha1 = "77a42d78b6a92df47ab37e177b2deac405e1c88f"
 uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.QOI]]
 deps = ["ColorTypes", "FileIO", "FixedPointNumbers"]
@@ -2028,11 +2052,41 @@ git-tree-sha1 = "18e8f4d1426e965c7b532ddd260599e1510d26ce"
 uuid = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
 version = "1.0.0"
 
+[[deps.Qt6Base_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Vulkan_Loader_jll", "Xorg_libSM_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_cursor_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "libinput_jll", "xkbcommon_jll"]
+git-tree-sha1 = "492601870742dcd38f233b23c3ec629628c1d724"
+uuid = "c0090381-4147-56d7-9ebc-da0b1113ec56"
+version = "6.7.1+1"
+
+[[deps.Qt6Declarative_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Qt6Base_jll", "Qt6ShaderTools_jll"]
+git-tree-sha1 = "e5dd466bf2569fe08c91a2cc29c1003f4797ac3b"
+uuid = "629bc702-f1f5-5709-abd5-49b8460ea067"
+version = "6.7.1+2"
+
+[[deps.Qt6ShaderTools_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Qt6Base_jll"]
+git-tree-sha1 = "1a180aeced866700d4bebc3120ea1451201f16bc"
+uuid = "ce943373-25bb-56aa-8eca-768745ed7b5a"
+version = "6.7.1+1"
+
+[[deps.Qt6Wayland_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Qt6Base_jll", "Qt6Declarative_jll"]
+git-tree-sha1 = "729927532d48cf79f49070341e1d918a65aba6b0"
+uuid = "e99dba38-086e-5de3-a5b1-6e4c66e897c3"
+version = "6.7.1+1"
+
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "e237232771fdafbae3db5c31275303e056afaa9f"
+git-tree-sha1 = "1d587203cf851a51bf1ea31ad7ff89eff8d625ea"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.10.1"
+version = "2.11.0"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -2040,9 +2094,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.RRTMGP]]
 deps = ["Adapt", "Artifacts", "ClimaComms", "DocStringExtensions", "Random"]
-git-tree-sha1 = "866d94b4cf46fe3a0ffd35d1414a3a4181c9db08"
+git-tree-sha1 = "d5be00bea8b5997ab318b2b9f0ca72e9bb9d2997"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
-version = "0.17.0"
+version = "0.19.0"
 
     [deps.RRTMGP.extensions]
     CreateParametersExt = "ClimaParams"
@@ -2077,6 +2131,12 @@ git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 version = "1.3.4"
 
+[[deps.RecipesPipeline]]
+deps = ["Dates", "NaNMath", "PlotUtils", "PrecompileTools", "RecipesBase"]
+git-tree-sha1 = "45cf9fd0ca5839d06ef333c8201714e888486342"
+uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
+version = "0.6.12"
+
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
 git-tree-sha1 = "b034171b93aebc81b3e1890a036d13a9c4a9e3e0"
@@ -2103,12 +2163,6 @@ version = "3.27.0"
     Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
     Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-[[deps.RecursiveFactorization]]
-deps = ["LinearAlgebra", "LoopVectorization", "Polyester", "PrecompileTools", "StrideArraysCore", "TriangularSolve"]
-git-tree-sha1 = "6db1a75507051bc18bfa131fbc7c3f169cc4b2f6"
-uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
-version = "0.2.23"
-
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -2128,15 +2182,15 @@ version = "1.3.0"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "f65dcb5fa46aee0cf9ed6274ccbd597adc49aa7b"
+git-tree-sha1 = "852bd0f55565a9e973fcfee83a84413270224dc4"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.1"
+version = "0.8.0"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e60724fd3beea548353984dc61c943ecddb0e29a"
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.4.3+0"
+version = "0.5.1+0"
 
 [[deps.RootSolvers]]
 deps = ["ForwardDiff"]
@@ -2190,17 +2244,11 @@ git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
 uuid = "94e857df-77ce-4151-89e5-788b33177be4"
 version = "0.1.0"
 
-[[deps.SLEEFPirates]]
-deps = ["IfElse", "Static", "VectorizationBase"]
-git-tree-sha1 = "456f610ca2fbd1c14f5fcf31c6bfadc55e7d66e0"
-uuid = "476501e8-09a2-5ece-8869-fb82de89a1fa"
-version = "0.6.43"
-
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "Expronicon", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "79564263adfdeb7a7110316c0bf0da55b95ab281"
+git-tree-sha1 = "c96f81c3e98d5e2f0848fb42aba4383d772c3bb7"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.49.0"
+version = "2.53.1"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2222,23 +2270,33 @@ version = "2.49.0"
     Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [[deps.SciMLOperators]]
-deps = ["ArrayInterface", "DocStringExtensions", "LinearAlgebra", "MacroTools", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "23b02c588ac9a17ecb276cc62ab37f3e4fe37b32"
+deps = ["Accessors", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "MacroTools"]
+git-tree-sha1 = "e39c5f217f9aca640c8e27ab21acf557a3967db5"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "0.3.9"
-weakdeps = ["SparseArrays"]
+version = "0.3.10"
+weakdeps = ["SparseArrays", "StaticArraysCore"]
+
+    [deps.SciMLOperators.extensions]
+    SciMLOperatorsSparseArraysExt = "SparseArrays"
+    SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface"]
-git-tree-sha1 = "20ad3e7c137156c50c93c888d0f2bc5b7883c729"
+git-tree-sha1 = "25514a6f200219cd1073e4ff23a6324e4a7efe64"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.4.2"
+version = "1.5.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]
 git-tree-sha1 = "3bac05bc7e74a75fd9cba4295cde4045d9fe2386"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
 version = "1.2.1"
+
+[[deps.SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "ff11acffdb082493657550959d4feb4b6149e73a"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.4.5"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -2276,23 +2334,10 @@ git-tree-sha1 = "d263a08ec505853a5ff1c1ebde2070419e3f28e9"
 uuid = "73760f76-fbc4-59ce-8f25-708e95d2df96"
 version = "0.4.0"
 
-[[deps.SimpleNonlinearSolve]]
-deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "DiffEqBase", "DiffResults", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "MaybeInplace", "PrecompileTools", "Reexport", "SciMLBase", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "4d7a7c177bcb4c6dc465f09db91bfdb28c578919"
-uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-version = "1.12.0"
-
-    [deps.SimpleNonlinearSolve.extensions]
-    SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
-    SimpleNonlinearSolveReverseDiffExt = "ReverseDiff"
-    SimpleNonlinearSolveTrackerExt = "Tracker"
-    SimpleNonlinearSolveZygoteExt = "Zygote"
-
-    [deps.SimpleNonlinearSolve.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.1.0"
 
 [[deps.SimpleTraits]]
 deps = ["InteractiveUtils", "MacroTools"]
@@ -2320,38 +2365,6 @@ deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 version = "1.10.0"
 
-[[deps.SparseDiffTools]]
-deps = ["ADTypes", "Adapt", "ArrayInterface", "Compat", "DataStructures", "FiniteDiff", "ForwardDiff", "Graphs", "LinearAlgebra", "PackageExtensionCompat", "Random", "Reexport", "SciMLOperators", "Setfield", "SparseArrays", "StaticArrayInterface", "StaticArrays", "Tricks", "UnPack", "VertexSafeGraphs"]
-git-tree-sha1 = "c9e5d7ee75cf6a1ca3a22c9a6a4ef451792cf62b"
-uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "2.20.0"
-
-    [deps.SparseDiffTools.extensions]
-    SparseDiffToolsEnzymeExt = "Enzyme"
-    SparseDiffToolsPolyesterExt = "Polyester"
-    SparseDiffToolsPolyesterForwardDiffExt = "PolyesterForwardDiff"
-    SparseDiffToolsSymbolicsExt = "Symbolics"
-    SparseDiffToolsZygoteExt = "Zygote"
-
-    [deps.SparseDiffTools.weakdeps]
-    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-    Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
-    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
-    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
-[[deps.SparseMatrixColorings]]
-deps = ["ADTypes", "Compat", "DataStructures", "DocStringExtensions", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "996dff77d814c45c3f2342fa0113e4ad31e712e8"
-uuid = "0a514795-09f3-496d-8182-132a7b665d35"
-version = "0.4.0"
-
-[[deps.Sparspak]]
-deps = ["Libdl", "LinearAlgebra", "Logging", "OffsetArrays", "Printf", "SparseArrays", "Test"]
-git-tree-sha1 = "342cf4b449c299d8d1ceaf00b7a49f4fbc7940e7"
-uuid = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
-version = "0.3.9"
-
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
 git-tree-sha1 = "2f5d4697f21388cbe1ff299430dd169ef97d7e14"
@@ -2369,10 +2382,10 @@ uuid = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 version = "0.1.1"
 
 [[deps.Static]]
-deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools"]
-git-tree-sha1 = "87d51a3ee9a4b0d2fe054bdd3fc2436258db2603"
+deps = ["IfElse"]
+git-tree-sha1 = "d2fdac9ff3906e27f7a618d47b676941baa6c80c"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.1.1"
+version = "0.8.10"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Static"]
@@ -2420,9 +2433,9 @@ version = "0.34.3"
 
 [[deps.StatsFuns]]
 deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "cef0472124fab0695b58ca35a77c6fb942fdab8a"
+git-tree-sha1 = "b423576adc27097764a90e163157bcfc9acf0f46"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "1.3.1"
+version = "1.3.2"
 weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
     [deps.StatsFuns.extensions]
@@ -2440,6 +2453,12 @@ deps = ["Libiconv_jll"]
 git-tree-sha1 = "b765e46ba27ecf6b44faf70df40c57aa3a547dcb"
 uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
 version = "0.3.7"
+
+[[deps.StringManipulation]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "a04cabe79c5f01f4d723cc6704070ada0b9d46d5"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.3.4"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2475,9 +2494,9 @@ weakdeps = ["ClimaParams"]
 
 [[deps.SymbolicIndexingInterface]]
 deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
-git-tree-sha1 = "c9fce29fb41a10677e24f74421ebe31220b81ad0"
+git-tree-sha1 = "988e04b34a4c3b824fb656f542473df99a4f610d"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.28"
+version = "0.3.30"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -2503,13 +2522,16 @@ version = "1.10.0"
 
 [[deps.TaylorSeries]]
 deps = ["LinearAlgebra", "Markdown", "Requires", "SparseArrays"]
-git-tree-sha1 = "1c7170668366821b0c4c4fe03ee78f8d6cf36e2c"
+git-tree-sha1 = "90c9bc500f4c5cdd235c81503ec91b2048f06423"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.16.0"
-weakdeps = ["IntervalArithmetic"]
+version = "0.17.8"
+weakdeps = ["IntervalArithmetic", "JLD2", "RecursiveArrayTools", "StaticArrays"]
 
     [deps.TaylorSeries.extensions]
     TaylorSeriesIAExt = "IntervalArithmetic"
+    TaylorSeriesJLD2Ext = "JLD2"
+    TaylorSeriesRATExt = "RecursiveArrayTools"
+    TaylorSeriesSAExt = "StaticArrays"
 
 [[deps.TensorCore]]
 deps = ["LinearAlgebra"]
@@ -2559,12 +2581,6 @@ git-tree-sha1 = "e84b3a11b9bece70d14cce63406bbc79ed3464d2"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.11.2"
 
-[[deps.TriangularSolve]]
-deps = ["CloseOpenIntervals", "IfElse", "LayoutPointers", "LinearAlgebra", "LoopVectorization", "Polyester", "Static", "VectorizationBase"]
-git-tree-sha1 = "be986ad9dac14888ba338c2554dcfec6939e1393"
-uuid = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
-version = "0.2.1"
-
 [[deps.Tricks]]
 git-tree-sha1 = "7822b97e99a1672bfb1b49b668a6d46d58d8cbcb"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
@@ -2580,6 +2596,11 @@ deps = ["InteractiveUtils", "MacroTools", "Preferences"]
 git-tree-sha1 = "ea3e54c2bdde39062abf5a9758a23735558705e1"
 uuid = "781d530d-4396-4725-bb49-402e4bee1e77"
 version = "1.4.0"
+
+[[deps.URIs]]
+git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.5.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -2610,11 +2631,26 @@ weakdeps = ["ConstructionBase", "InverseFunctions"]
     ConstructionBaseUnitfulExt = "ConstructionBase"
     InverseFunctionsUnitfulExt = "InverseFunctions"
 
+[[deps.UnitfulLatexify]]
+deps = ["LaTeXStrings", "Latexify", "Unitful"]
+git-tree-sha1 = "975c354fcd5f7e1ddcc1f1a23e6e091d99e99bc8"
+uuid = "45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+version = "1.6.4"
+
 [[deps.Unrolled]]
 deps = ["MacroTools"]
 git-tree-sha1 = "6cc9d682755680e0f0be87c56392b7651efc2c7b"
 uuid = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 version = "0.1.5"
+
+[[deps.UnrolledUtilities]]
+git-tree-sha1 = "1244bd810bfd53c539ef5463b01dd9b808c2e5da"
+uuid = "0fe1646c-419e-43be-ac14-22321958931b"
+version = "0.1.5"
+weakdeps = ["StaticArrays"]
+
+    [deps.UnrolledUtilities.extensions]
+    UnrolledUtilitiesStaticArraysExt = "StaticArrays"
 
 [[deps.UnsafeAtomics]]
 git-tree-sha1 = "6331ac3440856ea1988316b46045303bef658278"
@@ -2623,8 +2659,13 @@ version = "0.2.1"
 
 [[deps.UnsafeAtomicsLLVM]]
 deps = ["LLVM", "UnsafeAtomics"]
-git-tree-sha1 = "4073c836c2befcb041e5fe306cb6abf621eb3140"
+git-tree-sha1 = "2d17fabcd17e67d7625ce9c531fb9f40b7c42ce4"
 uuid = "d80eeb9a-aca5-4d75-85e5-170c8b632249"
+version = "0.2.1"
+
+[[deps.Unzip]]
+git-tree-sha1 = "ca0969166a028236229f63514992fc073799bb78"
+uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 version = "0.2.0"
 
 [[deps.VectorInterface]]
@@ -2633,17 +2674,29 @@ git-tree-sha1 = "7aff7d62bffad9bba9928eb6ab55226b32a351eb"
 uuid = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 version = "0.4.6"
 
-[[deps.VectorizationBase]]
-deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static", "StaticArrayInterface"]
-git-tree-sha1 = "e7f5b81c65eb858bed630fe006837b935518aca5"
-uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.70"
+[[deps.Vulkan_Loader_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Wayland_jll", "Xorg_libX11_jll", "Xorg_libXrandr_jll", "xkbcommon_jll"]
+git-tree-sha1 = "2f0486047a07670caad3a81a075d2e518acc5c59"
+uuid = "a44049a8-05dd-5a78-86c9-5fde0876e88c"
+version = "1.3.243+0"
 
-[[deps.VertexSafeGraphs]]
-deps = ["Graphs"]
-git-tree-sha1 = "8351f8d73d7e880bfc042a8b6922684ebeafb35c"
-uuid = "19fa3120-7c27-5ec5-8db8-b0b0aa330d6f"
-version = "0.2.0"
+[[deps.Wayland_jll]]
+deps = ["Artifacts", "EpollShim_jll", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "7558e29847e99bc3f04d6569e82d0f5c54460703"
+uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
+version = "1.21.0+1"
+
+[[deps.Wayland_protocols_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "93f43ab61b16ddfb2fd3bb13b3ce241cafb0e6c9"
+uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
+version = "1.31.0+0"
+
+[[deps.WeakRefStrings]]
+deps = ["DataAPI", "InlineStrings", "Parsers"]
+git-tree-sha1 = "b1be2855ed9ed8eac54e5caff2afcdb442d52c23"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "1.4.2"
 
 [[deps.WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -2651,11 +2704,16 @@ git-tree-sha1 = "c1a7aa6219628fcd757dede0ca95e245c5cd9511"
 uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 version = "1.0.0"
 
+[[deps.WorkerUtilities]]
+git-tree-sha1 = "cd1659ba0d57b71a464a29e64dbc67cfe83d54e7"
+uuid = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
+version = "1.6.1"
+
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "d9717ce3518dc68a99e6b96300813760d887a01d"
+git-tree-sha1 = "1165b0443d0eca63ac1e32b8c0eb69ed2f4f8127"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.1+0"
+version = "2.13.3+0"
 
 [[deps.XSLT_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "XML2_jll", "Zlib_jll"]
@@ -2669,6 +2727,18 @@ git-tree-sha1 = "ac88fb95ae6447c8dda6a5503f3bafd496ae8632"
 uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
 version = "5.4.6+0"
 
+[[deps.Xorg_libICE_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "326b4fea307b0b39892b3e85fa451692eda8d46c"
+uuid = "f67eecfb-183a-506d-b269-f58e52b52d7c"
+version = "1.1.1+0"
+
+[[deps.Xorg_libSM_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libICE_jll"]
+git-tree-sha1 = "3796722887072218eabafb494a13c963209754ce"
+uuid = "c834827a-8449-5923-a945-d239c165b7dd"
+version = "1.2.4+0"
+
 [[deps.Xorg_libX11_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
 git-tree-sha1 = "afead5aba5aa507ad5a3bf01f58f82c8d1403495"
@@ -2681,6 +2751,12 @@ git-tree-sha1 = "6035850dcc70518ca32f012e46015b9beeda49d8"
 uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
 version = "1.0.11+0"
 
+[[deps.Xorg_libXcursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "12e0eb3bc634fa2080c1c37fccf56f7c22989afd"
+uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
+version = "1.2.0+4"
+
 [[deps.Xorg_libXdmcp_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "34d526d318358a859d7de23da945578e8e8727b7"
@@ -2692,6 +2768,30 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
 git-tree-sha1 = "d2d1a5c49fae4ba39983f63de6afcbea47194e85"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
 version = "1.3.6+0"
+
+[[deps.Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "0e0dc7431e7a0587559f9294aeec269471c991a4"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "5.0.3+4"
+
+[[deps.Xorg_libXi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
+git-tree-sha1 = "89b52bc2160aadc84d707093930ef0bffa641246"
+uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
+version = "1.7.10+4"
+
+[[deps.Xorg_libXinerama_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll"]
+git-tree-sha1 = "26be8b1c342929259317d8b9f7b53bf2bb73b123"
+uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
+version = "1.1.4+4"
+
+[[deps.Xorg_libXrandr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "34cea83cb726fb58f325887bf0612c6b3fb17631"
+uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
+version = "1.5.2+4"
 
 [[deps.Xorg_libXrender_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
@@ -2710,6 +2810,60 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "XSLT_jll", "Xorg_libXau_jll", "Xor
 git-tree-sha1 = "bcd466676fef0878338c61e655629fa7bbc69d8e"
 uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
 version = "1.17.0+0"
+
+[[deps.Xorg_libxkbfile_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "730eeca102434283c50ccf7d1ecdadf521a765a4"
+uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
+version = "1.1.2+0"
+
+[[deps.Xorg_xcb_util_cursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_jll", "Xorg_xcb_util_renderutil_jll"]
+git-tree-sha1 = "04341cb870f29dcd5e39055f895c39d016e18ccd"
+uuid = "e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
+version = "0.1.4+0"
+
+[[deps.Xorg_xcb_util_image_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "0fab0a40349ba1cba2c1da699243396ff8e94b97"
+uuid = "12413925-8142-5f55-bb0e-6d7ca50bb09b"
+version = "0.4.0+1"
+
+[[deps.Xorg_xcb_util_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll"]
+git-tree-sha1 = "e7fd7b2881fa2eaa72717420894d3938177862d1"
+uuid = "2def613f-5ad1-5310-b15b-b15d46f528f5"
+version = "0.4.0+1"
+
+[[deps.Xorg_xcb_util_keysyms_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "d1151e2c45a544f32441a567d1690e701ec89b00"
+uuid = "975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+version = "0.4.0+1"
+
+[[deps.Xorg_xcb_util_renderutil_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "dfd7a8f38d4613b6a575253b3174dd991ca6183e"
+uuid = "0d47668e-0667-5a69-a72c-f761630bfb7e"
+version = "0.3.9+1"
+
+[[deps.Xorg_xcb_util_wm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "e78d10aab01a4a154142c5006ed44fd9e8e31b67"
+uuid = "c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+version = "0.4.1+1"
+
+[[deps.Xorg_xkbcomp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxkbfile_jll"]
+git-tree-sha1 = "330f955bc41bb8f5270a369c473fc4a5a4e4d3cb"
+uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
+version = "1.4.6+0"
+
+[[deps.Xorg_xkeyboard_config_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_xkbcomp_jll"]
+git-tree-sha1 = "691634e5453ad362044e2ad653e79f3ee3bb98c3"
+uuid = "33bec58e-1273-512f-9401-5d533626f822"
+version = "2.39.0+0"
 
 [[deps.Xorg_xtrans_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2734,6 +2888,24 @@ git-tree-sha1 = "e678132f07ddb5bfa46857f0d7620fb9be675d3b"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.6+0"
 
+[[deps.eudev_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "gperf_jll"]
+git-tree-sha1 = "431b678a28ebb559d224c0b6b6d01afce87c51ba"
+uuid = "35ca27e7-8b34-5b7f-bca9-bdc33f59eb06"
+version = "3.2.9+0"
+
+[[deps.fzf_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "936081b536ae4aa65415d869287d43ef3cb576b2"
+uuid = "214eeab7-80f7-51ab-84ad-2988db7cef09"
+version = "0.53.0+0"
+
+[[deps.gperf_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "3516a5630f741c9eecb3720b1ec9d8edc3ecc033"
+uuid = "1a1c6b14-54f6-533d-8383-74cd7377aa70"
+version = "3.1.1+0"
+
 [[deps.isoband_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "51b5eeb3f98367157a7a12a1fb0aa5328946c03c"
@@ -2753,21 +2925,39 @@ uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
 version = "3.9.0+0"
 
 [[deps.libass_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "5982a94fcba20f02f42ace44b9894ee2b140fe47"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "e17c115d55c5fbb7e52ebedb427a0dca79d4484e"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.15.1+0"
+version = "0.15.2+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.8.0+1"
 
-[[deps.libfdk_aac_jll]]
+[[deps.libdecor_jll]]
+deps = ["Artifacts", "Dbus_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pango_jll", "Wayland_jll", "xkbcommon_jll"]
+git-tree-sha1 = "9bf7903af251d2050b467f76bdbe57ce541f7f4f"
+uuid = "1183f4f0-6f2a-5f1a-908b-139f9cdfea6f"
+version = "0.2.2+0"
+
+[[deps.libevdev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "daacc84a041563f965be61859a36e17c4e4fcd55"
+git-tree-sha1 = "141fe65dc3efabb0b1d5ba74e91f6ad26f84cc22"
+uuid = "2db6ffa8-e38f-5e21-84af-90c45d0032cc"
+version = "1.11.0+0"
+
+[[deps.libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8a22cf860a7d27e4f3498a0fe0811a7957badb38"
 uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
-version = "2.0.2+0"
+version = "2.0.3+0"
+
+[[deps.libinput_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "eudev_jll", "libevdev_jll", "mtdev_jll"]
+git-tree-sha1 = "ad50e5b90f222cfe78aa3d5183a20a12de1322ce"
+uuid = "36db933b-70db-51c0-b978-0f229ee0e533"
+version = "1.18.0+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
@@ -2793,6 +2983,12 @@ git-tree-sha1 = "3282b7d16ae7ac3e57ec2f3fa8fafb564d8f9f7f"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
 version = "1.10.1+0"
 
+[[deps.mtdev_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "814e154bdb7be91d78b6802843f76b6ece642f11"
+uuid = "009596ad-96f7-51b1-9f1b-5ce2d5e8a71e"
+version = "1.1.6+0"
+
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
@@ -2810,13 +3006,19 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 version = "17.4.0+2"
 
 [[deps.x264_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4fea590b89e6ec504593146bf8b988b2c00922b2"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "35976a1216d6c066ea32cba2150c4fa682b276fc"
 uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-version = "2021.5.5+0"
+version = "10164.0.0+0"
 
 [[deps.x265_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ee567a171cce03570d77ad3a43e90218e38937a9"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dcc541bb19ed5b0ede95581fb2e41ecf179527d2"
 uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
-version = "3.5.0+0"
+version = "3.6.0+0"
+
+[[deps.xkbcommon_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
+git-tree-sha1 = "9c304562909ab2bab0262639bd4f444d7bc2be37"
+uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+version = "1.4.1+1"

--- a/calibration/experiments/gcm_driven_scm/Project.toml
+++ b/calibration/experiments/gcm_driven_scm/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 ClimaAtmos = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
@@ -6,6 +8,7 @@ ClimaCalibrate = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 ClimaUtilities = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
@@ -17,5 +20,4 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ClimaCalibrate = "=0.0.3"
-EnsembleKalmanProcesses = "=1.1.7"
-ClimaAtmos = "=0.27.2"
+EnsembleKalmanProcesses = "2"

--- a/calibration/experiments/gcm_driven_scm/README.md
+++ b/calibration/experiments/gcm_driven_scm/README.md
@@ -2,20 +2,24 @@
 
 This setup provide tools for calibrating both prognostic and diagnostic EDMF variants to LES profiles, given the same forcings and boundary conditions. The gcm-driven EDMF setup is employed in single-column mode, which uses both interactive radiation and surface fluxes. Forcing profiles include resolved eddy advection, horizontal advection, subsidence, and GCM state relaxation. The setup is run to the top of the atmosphere to compute radiation, but calibrations statistics are computed only on the lower 4km (`z_max`), where LES output is available.
 
-LES profiles are available for different geolocations ("cfsites"), spanning seasons, forcing host models, and climates (AMIP, AMIP4K). A given LES simulation is referred to as a "configuration". Calibrations employ batching by default and stack multiple configurations (a number equal to the `batch_size`) in a given iteration. The observation vector for a single configuration is formed by concatenating profiles across calibration variables, where each geophysical variable is normalized to have approximately unit variance and zero mean. These variable-by-variable normalization factors are precomputed (`norm_factors_dict`) and applied to all observations. Following this operation, the spatiotemporal calibration window is applied and temporal means are computed to form the observation vector `y`. Because variables are normalized, a constant, diagonal noise matrix is used (configurable as `const_noise`).
+LES profiles are available for different geolocations ("cfsites"), spanning seasons, forcing host models, and climates (AMIP, AMIP4K). A given LES simulation is referred to as a "configuration". Calibrations employ batching by default and stack multiple configurations (a number equal to the `batch_size`) in a given iteration. The observation vector for a single configuration is formed by concatenating profiles across calibration variables, where each geophysical variable is normalized to have approximately unit variance and zero mean. These variable-by-variable normalization factors are precomputed (`norm_factors_dict`) and applied to all observations. Following this operation, the spatiotemporal calibration window is applied and temporal means are computed to form the observation vector `y`. Because variables are normalized to have 0 mean and unit variance, a constant diagonal noise matrix is used (configurable as `const_noise`).
 
 
 ## Getting Started
 
 ### Define calibration and model configurations:
-- `experiment_config.yml` - Configuration of EKI hyperparameters and settings, spatiotemporal calibration window, required pipeline file paths
+- `experiment_config.yml` - Configuration of calibration settings, including spatiotemporal calibration window and required pipeline file paths.
+- `run_calibration.jl` - run script for calibration pipeline. EKI settings and hyperparameters can be modified where CAL.initialize is called.
 - `model_config_**.yml` - Config file for underlying ClimaAtmos single column model
-- `get_les_metadata.jl` - (Re)Define `get_les_calibration_library()` to specify which LES configurations to use
+- `get_les_metadata.jl` - (Re)Define `get_les_calibration_library()` to specify which LES configurations to use. Set `batch_size` in the `experiment_config.yml` accordingly (<= the number of cases).
 
 ### Run with:
-- `run_calibration.jl` - runs calibration end-to-end using HPC resources
+- `sbatch run_calibration.sbatch` -  schedules and runs calibration pipeline end-to-end using HPC resources
+- `julia --project run_calibration.jl` - interactively runs calibration end-to-end using HPC resources, streaming to a Julia REPL
 
 ### Analyze output with:
-- `plot_ensemble.jl` - plots vertical profiles of all ensemble members in a given iteration.
+- `julia --project plot_ensemble.jl` - plots vertical profiles of all ensemble members in a given iteration, given path to calibration output
+- `julia --project edmf_ensemble_stats.jl` - computes and plots metrics offline [i.e., root mean squared error (RMSE)] as a function of iteration, given path to calibration output.
+- `julia --project plot_eki.jl` - plot eki metrics [loss, var-weighted loss] and `y`, `g` vectors vs iteration, display best particles
 
 

--- a/calibration/experiments/gcm_driven_scm/edmf_ensemble_stats.jl
+++ b/calibration/experiments/gcm_driven_scm/edmf_ensemble_stats.jl
@@ -1,0 +1,326 @@
+#!/usr/bin/env julia
+
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+
+using ArgParse
+using Distributed
+addprocs()
+
+
+@everywhere begin
+    using EnsembleKalmanProcesses: TOMLInterface
+    import EnsembleKalmanProcesses as EKP
+    using EnsembleKalmanProcesses.ParameterDistributions
+    using ClimaCalibrate: observation_map, ExperimentConfig
+    using ClimaAnalysis
+    using Plots
+    using JLD2
+    using Statistics
+    using YAML
+    using DataFrames
+    using CSV
+
+    include("helper_funcs.jl")
+    include("observation_map.jl")
+    include("get_les_metadata.jl")
+end
+
+function parse_with_settings(s)
+    return ArgParse.parse_args(s)
+end
+
+function parse_args()
+    s = ArgParseSettings(description = "Process ensemble Kalman statistics")
+    @add_arg_table s begin
+        "--output_dir"
+        help = "Calibration output directory"
+        required = true
+        "--var_names"
+        help = "Variable names to process (comma-separated)"
+        default = "thetaa,hus,clw,arup,entr,detr,waup,tke"
+        "--reduction"
+        help = "Reduction method to use (default: inst)"
+        default = "inst"
+        "--iterations"
+        help = "Iterations to plot (e.g., 0:11), default is all iterations"
+        default = nothing
+        "--save_as_csv"
+        help = "Save results as CSV"
+        default = true
+        arg_type = Bool
+        "--load_from_csv"
+        help = "Load results from CSV"
+        default = false
+        arg_type = Bool
+        "--plot_dir"
+        help = "Directory to save plots (default: edmf_stats_plots)"
+        default = "edmf_stats_plots"
+    end
+    return parse_with_settings(s)
+end
+
+function main()
+    args = parse_args()
+
+    output_dir = args["output_dir"]
+    var_names = map(String, split(args["var_names"], ","))
+    reduction = args["reduction"]
+    save_as_csv = args["save_as_csv"]
+    load_from_csv = args["load_from_csv"]
+    plot_dir = args["plot_dir"]
+
+    if isnothing(args["iterations"])
+        iterations = nothing
+    else
+        iterations = eval(Meta.parse(args["iterations"]))
+    end
+
+    mkpath(joinpath(output_dir, "plots", plot_dir))
+
+    # Load configuration data
+    config_dict =
+        YAML.load_file(joinpath(output_dir, "configs", "experiment_config.yml"))
+    n_vert_levels = config_dict["dims_per_var"]
+    z_max = config_dict["z_max"]
+    ensemble_size = config_dict["ensemble_size"]
+    cal_vars = config_dict["y_var_names"]
+    const_noise_by_var = config_dict["const_noise_by_var"]
+    n_iterations = config_dict["n_iterations"]
+    model_config_dict =
+        YAML.load_file(joinpath(output_dir, "configs", "model_config.yml"))
+
+    if isnothing(iterations)
+        iterations = 0:(n_iterations - 1)
+    end
+
+    ref_paths, _ = get_les_calibration_library()
+    comms_ctx = ClimaComms.SingletonCommsContext()
+    atmos_config = CA.AtmosConfig(model_config_dict; comms_ctx)
+    zc_model = get_z_grid(atmos_config, z_max = z_max)
+
+    @everywhere function calculate_statistics(y_var)
+        non_nan_values = y_var[.!isnan.(y_var)]
+        if length(non_nan_values) == 0
+            return NaN, NaN, NaN
+        end
+        col_mean = mean(non_nan_values)
+        col_max = maximum(non_nan_values)
+        col_min = minimum(non_nan_values)
+        return col_mean, col_max, col_min
+    end
+
+    @everywhere function compute_ensemble_squared_error(ensemble_data, y_true)
+        return vec(sum((ensemble_data .- y_true) .^ 2, dims = 1))
+    end
+
+    @everywhere function process_iteration(
+        iteration,
+        output_dir,
+        var_names,
+        n_vert_levels,
+        config_dict,
+        z_max,
+        cal_vars,
+        const_noise_by_var,
+        ref_paths,
+        zc_model,
+        reduction,
+        ensemble_size,
+    )
+        println("Processing Iteration: $iteration")
+        stats_df = DataFrame(
+            iteration = Int[],
+            var_name = String[],
+            mean = Float64[],
+            max = Float64[],
+            min = Float64[],
+            rmse = Union{Missing, Float64}[],
+            rmse_min = Union{Missing, Float64}[],
+            rmse_max = Union{Missing, Float64}[],
+            rmse_std = Union{Missing, Float64}[],
+        )
+        config_indices = get_batch_indicies_in_iteration(iteration, output_dir)
+        for var_name in var_names
+            means = Float64[]
+            maxs = Float64[]
+            mins = Float64[]
+            sum_squared_errors = zeros(Float64, ensemble_size)
+            for config_i in config_indices
+                data = ensemble_data(
+                    process_profile_variable,
+                    iteration,
+                    config_i,
+                    config_dict;
+                    var_name = var_name,
+                    reduction = reduction,
+                    output_dir = output_dir,
+                    z_max = z_max,
+                    n_vert_levels = n_vert_levels,
+                )
+                for i in 1:size(data, 2)
+                    y_var = data[:, i]
+                    col_mean, col_max, col_min = calculate_statistics(y_var)
+                    push!(means, col_mean)
+                    push!(maxs, col_max)
+                    push!(mins, col_min)
+                end
+                if in(var_name, cal_vars)
+                    y_true, Σ_obs, norm_vec_obs = get_obs(
+                        ref_paths[config_i],
+                        [var_name],
+                        zc_model;
+                        ti = config_dict["y_t_start_sec"],
+                        tf = config_dict["y_t_end_sec"],
+                        Σ_const = const_noise_by_var,
+                        z_score_norm = false,
+                    )
+                    sum_squared_errors +=
+                        compute_ensemble_squared_error(data, y_true)
+                end
+            end
+            if in(var_name, cal_vars)
+                # Compute RMSE per ensemble member
+                rmse_per_member = sqrt.(sum_squared_errors / n_vert_levels)
+                # Filter out NaNs (failed simulations)
+                valid_rmse = rmse_per_member[.!isnan.(rmse_per_member)]
+                non_nan_simulation_count = length(valid_rmse)
+                mean_rmse = mean(valid_rmse)
+                min_rmse = minimum(valid_rmse)
+                max_rmse = maximum(valid_rmse)
+                rmse_std = std(valid_rmse)
+            else
+                mean_rmse = missing
+                min_rmse = missing
+                max_rmse = missing
+                rmse_std = missing
+            end
+            push!(
+                stats_df,
+                (
+                    iteration,
+                    var_name,
+                    mean(means[.!isnan.(means)]),
+                    maximum(maxs[.!isnan.(maxs)]),
+                    minimum(mins[.!isnan.(mins)]),
+                    mean_rmse,
+                    min_rmse,
+                    max_rmse,
+                    rmse_std,
+                ),
+            )
+        end
+        return stats_df
+    end
+
+    if !load_from_csv
+        iterations_list = collect(iterations)
+        stats_dfs = pmap(
+            iteration -> process_iteration(
+                iteration,
+                output_dir,
+                var_names,
+                n_vert_levels,
+                config_dict,
+                z_max,
+                cal_vars,
+                const_noise_by_var,
+                ref_paths,
+                zc_model,
+                reduction,
+                ensemble_size,
+            ),
+            iterations_list,
+        )
+
+        stats_df = vcat(stats_dfs...)
+        if save_as_csv
+            CSV.write(joinpath(output_dir, "stats_df.csv"), stats_df)
+        end
+
+    elseif load_from_csv
+        @info "Loading existing from CSV"
+        stats_df = CSV.read(joinpath(output_dir, "stats_df.csv"), DataFrame)
+    end
+
+    stats_df = CSV.read(joinpath(output_dir, "stats_df.csv"), DataFrame)
+    rmse_df = dropmissing(stats_df, [:rmse, :rmse_min, :rmse_max, :rmse_std])
+    unique_vars = unique(rmse_df.var_name)
+    n_vars = length(unique_vars)
+
+    p = plot(layout = (n_vars, 1), size = (600, 400 * n_vars))
+
+    for (i, var_name) in enumerate(unique_vars)
+        df_var = rmse_df[rmse_df.var_name .== var_name, :]
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.rmse,
+            label = "Mean RMSE",
+            lw = 2,
+            marker = :o,
+            color = :blue,
+            ribbon = 1 .* df_var.rmse_std,
+            fillalpha = 0.3,
+            fillcolor = :blue,
+        )
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.rmse_min,
+            linestyle = :dash,
+            color = :black,
+            label = "",
+        )
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.rmse_max,
+            linestyle = :dash,
+            color = :black,
+            label = "",
+        )
+        Plots.xlabel!("Iteration")
+        Plots.ylabel!("RMSE")
+        Plots.title!(p[i], var_name)
+    end
+    savefig(joinpath(output_dir, "plots", plot_dir, "rmse_vs_iteration.pdf"))
+
+    n_vars = length(var_names)
+    p = plot(layout = (n_vars, 1), size = (800, 400 * n_vars))
+
+    for (i, var_name) in enumerate(var_names)
+        df_var = stats_df[stats_df.var_name .== var_name, :]
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.mean,
+            label = "Mean RMSE",
+            lw = 2,
+            marker = :o,
+            color = :blue,
+        )
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.min,
+            linestyle = :dash,
+            color = :black,
+            label = "",
+        )
+        Plots.plot!(
+            p[i],
+            df_var.iteration,
+            df_var.max,
+            linestyle = :dash,
+            color = :black,
+            label = "",
+        )
+        Plots.xlabel!("Iteration")
+        Plots.ylabel!("Ranges")
+        Plots.title!(p[i], var_name)
+    end
+    savefig(joinpath(output_dir, "plots", plot_dir, "stats_vs_iteration.pdf"))
+end
+
+main()

--- a/calibration/experiments/gcm_driven_scm/experiment_config.yml
+++ b/calibration/experiments/gcm_driven_scm/experiment_config.yml
@@ -1,15 +1,25 @@
-prior: prior_prognostic.toml
-ensemble_size: 50
-n_iterations: 5
-batch_size: 1
-model_config : model_config_prognostic.yml
-output_dir : output/gcm_driven_scm
-y_var_names: [thetaa, hus, clw] # calibration variables
-z_max : 4000 # [m]
-dims : 90  # num vertical levels below z_max x num variables x batch size
-eki_timestep: 0.001 # timestep of eki
-const_noise: 0.05 # constant noise (diagonal elements of noise cov matrix Γ)
+prior_path: prior_prognostic_pi_entr.toml
+ensemble_size: 100
+n_iterations: 12
+batch_size: 2 # number of cases per iteration
+model_config : model_config_prognostic.yml # options {model_config_prognostic.yml, model_config_diagnostic.yml}
+output_dir : output/exp_1 # output dir
+y_var_names: [thetaa, hus, clw] # calibration variables clw
+log_vars: ["clw"] # take log(var) when forming y, g
+z_max : 4000 # spatial subsetting: use statistics from [0, z_max] (in [m]) for calibration
+dims_per_var : 29 # num dimensions per variable (num cells in vertical profile below z_max)
+# eki_timestep: 0.1 # timestep of eki, if using default
 y_t_start_sec : 475200.0 # start time of LES averaging window [s] : 5.5 days
 y_t_end_sec : 518400.0 # end time of LES averaging window [s] : 6 days (LES length = 6 days)
 g_t_start_sec : 216000.0 # start time of SCM averaging window [s] : 2.5 days
 g_t_end_sec : 259200.0 # end time of SCM averaging window [s] : 3 days (SCM length = 3 days)
+
+norm_factors_by_var:
+  thetaa: [298.828, 8.617]
+  hus: [0.00676, 0.00423]
+  clw: [-9.808, 3.116] # log norm factors
+
+const_noise_by_var:
+  thetaa: 0.00005
+  hus: 0.00005
+  clw: 0.00005

--- a/calibration/experiments/gcm_driven_scm/get_les_metadata.jl
+++ b/calibration/experiments/gcm_driven_scm/get_les_metadata.jl
@@ -15,7 +15,6 @@ function get_les_calibration_library()
     return (ref_paths, cfsite_numbers)
 end
 
-
 """
     get_LES_library
 

--- a/calibration/experiments/gcm_driven_scm/helper_funcs.jl
+++ b/calibration/experiments/gcm_driven_scm/helper_funcs.jl
@@ -4,6 +4,7 @@ using Interpolations
 using Statistics
 using LinearAlgebra
 import ClimaAtmos as CA
+import ClimaCalibrate as CAL
 
 "Optional vector"
 const OptVec{T} = Union{Nothing, Vector{T}}
@@ -320,21 +321,29 @@ function normalize_profile(
     prof_indices::OptVec{Bool} = nothing;
     norm_factors_dict = nothing,
     z_score_norm::Bool = true,
+    log_vars = [],
+    Σ_const::Dict = nothing,
+    Σ_scaling::String = nothing,
 ) where {FT <: Real, IT <: Integer}
     y_ = deepcopy(y)
     n_vars = length(y_names)
+    noise = zeros(0)
     prof_indices =
         isnothing(prof_indices) ? repeat([true], n_vars) : prof_indices
     norm_vec = Array{Float64}(undef, n_vars, 2)
     loc_start = 1
     for i in 1:n_vars
+        var_name = y_names[i]
         loc_end = prof_indices[i] ? loc_start + prof_dof - 1 : loc_start
 
         if z_score_norm
             y_i = y_[loc_start:loc_end]
+            if var_name in log_vars
+                y_i = log10.(y_i .+ 1e-12)
+            end
 
             if !isnothing(norm_factors_dict)
-                norm_i = norm_factors_dict[y_names[i]]
+                norm_i = norm_factors_dict[var_name]
                 y_μ, y_σ = norm_i
             else
                 y_μ, y_σ = mean(y_i), std(y_i)
@@ -344,9 +353,20 @@ function normalize_profile(
         else
             y_[loc_start:loc_end] = y_[loc_start:loc_end]
         end
+
+
+        if Σ_scaling == "prop"
+            append!(noise, Σ_const[var_name] * abs.(y_[loc_start:loc_end]))
+        elseif Σ_scaling == "const"
+            append!(
+                noise,
+                Σ_const[var_name] * ones(length(y_[loc_start:loc_end])),
+            )
+        end
+
         loc_start = loc_end + 1
     end
-    return y_, norm_vec
+    return y_, norm_vec, Diagonal(noise)
 end
 
 """
@@ -510,6 +530,7 @@ If `z_scm` is given, interpolate observations to the given levels.
  - `norm_factors_dict` :: Dict of precomputed normalization factors Dict(var_name => (μ, σ)) for each variable.
  - `z_score_norm` :: z-score normalization
  - `Σ_const` :: If given, sets constant diagonal σ^2 to use for noise cov Σ
+ -  `Σ_scaling` ::String = {"const", "prop"}
 
 # Returns
  - `y::Vector`           :: Mean of observations `y`, possibly interpolated to `z_scm` levels.
@@ -525,11 +546,18 @@ function get_obs(
     model_error::OptVec{FT} = nothing,
     norm_factors_dict = nothing,
     z_score_norm = true,
-    Σ_const::FT = nothing,
+    log_vars = [],
+    Σ_const::Dict = nothing,
+    Σ_scaling::String = "const",
 ) where {FT <: Real}
 
     # map to CA names to LES names 
     y_names = [CLIMADIAGNOSTICS_LES_NAME_MAP[var_i] for var_i in y_names]
+    if !isnothing(log_vars)
+        log_vars =
+            [CLIMADIAGNOSTICS_LES_NAME_MAP[log_var_i] for log_var_i in log_vars]
+    end
+
     if !isnothing(norm_factors_dict)
         norm_factors_dict = Dict(
             CLIMADIAGNOSTICS_LES_NAME_MAP[var_i] => value for
@@ -537,29 +565,36 @@ function get_obs(
         )
     end
 
+    if !isnothing(Σ_const)
+        Σ_const = Dict(
+            CLIMADIAGNOSTICS_LES_NAME_MAP[var_i] => value for
+            (var_i, value) in Σ_const
+        )
+    end
+
     # Get true observables
     y, prof_indices = get_profile(
         filename,
-        y_names,
+        y_names;
         z_scm = z_scm,
         ti = ti,
         tf = tf,
         prof_ind = true,
     )
     # normalize
-    y, norm_vec = normalize_profile(
+    y, norm_vec, Σ = normalize_profile(
         y,
         y_names,
         length(z_scm),
-        prof_indices,
+        prof_indices;
         norm_factors_dict = norm_factors_dict,
         z_score_norm = z_score_norm,
+        log_vars = log_vars,
+        Σ_const,
+        Σ_scaling,
     )
 
-
-    if !isnothing(Σ_const)
-        Σ = collect(Diagonal(Σ_const * ones(length(y))))
-    else
+    if isnothing(Σ_const) & isnothing(Σ_scaling)
         # time covariance
         Σ, pool_var = get_time_covariance(
             filename,
@@ -704,13 +739,18 @@ function get_iters_with_config(config_i::Int, config_dict::Dict)
 
         end
     end
+    if length(iters_with_config) == 0
+        @info "No iterations found for config $config_i"
+    end
     return iters_with_config
 end
 
 """
     ensemble_data(
+        process_profile_func,
         iteration,
-        config_i::Int;
+        config_i::Int,
+        config_dict;
         var_name = "hus",
         reduction = "inst",
         output_dir = nothing,
@@ -722,8 +762,10 @@ Fetch output vectors `y` for a specific variable across ensemble members.
     Fills missing data from crash simulations with NaN.
 
 # Arguments
+ - `process_profile_func` :: Function to process profile data (typically the observation map)
  - `iteration`   :: Iteration number for the ensemble data
  - `config_i`    :: Configuration id
+ - `config_dict` :: Configuration dictionary
 
 # Keywords
  - `var_name`    :: Name of the variable to extract data for
@@ -736,9 +778,10 @@ Fetch output vectors `y` for a specific variable across ensemble members.
  - `G_ensemble::Array{Float64}` :: Array containing the data for the specified variable across all ensemble members, with shape (n_vert_levels, ensemble_size).
 """
 function ensemble_data(
+    process_profile_func,
     iteration,
     config_i::Int,
-    ;
+    config_dict;
     var_name = "hus",
     reduction = "inst",
     output_dir = nothing,
@@ -756,9 +799,11 @@ function ensemble_data(
                 TOMLInterface.path_to_ensemble_member(output_dir, iteration, m)
             simdir =
                 SimDir(joinpath(member_path, "config_$config_i", "output_0000"))
-            G_ensemble[:, m] .= get_var_data(
+
+            G_ensemble[:, m] .= process_profile_func(
                 simdir,
                 var_name;
+                reduction = reduction,
                 t_start = config_dict["g_t_start_sec"],
                 t_end = config_dict["g_t_end_sec"],
                 z_max = z_max,
@@ -771,52 +816,52 @@ function ensemble_data(
     return G_ensemble
 end
 
-"""
-    get_var_data(simdir, var_name; t_start, t_end, reduction = "inst", z_max = nothing)
+"""Get minimum loss (RMSE) from EKI obj for a given iteration."""
+function get_loss_min(output_dir, iteration; n_lowest = 10, return_rmse = true)
+    iter_path = CAL.path_to_iteration(output_dir, iteration)
+    eki = JLD2.load_object(joinpath(iter_path, "eki_file.jld2"))
 
-Extract variable data from simulation directory, applying spatiotemporal filtering.
+    iter_path_p1 = CAL.path_to_iteration(output_dir, iteration + 1)
+    eki_p1 = JLD2.load_object(joinpath(iter_path_p1, "eki_file.jld2"))
 
-# Arguments
- - `simdir`     :: Simulation directory containing the output data
- - `var_name`   :: Name of the variable to extract data for
+    y = EKP.get_obs(eki)
+    g = EKP.get_g_final(eki_p1)
 
-# Keywords
- - `t_start`    :: Start time for the averaging window [s]
- - `t_end`      :: End time for the averaging window [s]
- - `reduction`  :: Type of data reduction to apply. Default is "inst"
- - `z_max`      :: Maximum vertical level to include in the data. Default is `nothing`
+    # Find successful simulations
+    non_nan_columns_indices = findall(x -> !x, vec(any(isnan, g, dims = 1)))
+    g = g[:, non_nan_columns_indices]
 
-# Returns
- - `y_var_i :: Array containing the averaged variable data
-"""
+    return lowest_loss_rmse(y, g; n_lowest, return_rmse)
+end
 
-function get_var_data(
-    simdir,
-    var_name;
-    t_start,
-    t_end,
-    reduction = "inst",
-    z_max = nothing,
+function lowest_loss_rmse(
+    y::Vector,
+    g::Matrix;
+    n_lowest::Int = 1,
+    return_rmse = true,
 )
+    @assert length(y) == size(g, 1)
+    y_diff = y .- g
+    rmse = sqrt.(sum(y_diff .^ 2, dims = 1) ./ size(y_diff, 1))
+    sorted_indices = sortperm(vec(rmse); rev = false)
 
-    var_i = get(simdir; short_name = var_name, reduction = reduction)
-
-    if !isnothing(z_max)
-        z_window = filter(x -> x <= z_max, var_i.dims["z"])
-        var_i = window(var_i, "z", right = maximum(z_window))
+    if return_rmse
+        return sorted_indices[1:n_lowest], rmse[sorted_indices[1:n_lowest]]
+    else
+        return sorted_indices[1:n_lowest]
     end
+end
 
-    sim_t_end = var_i.dims["time"][end]
+function get_forcing_file(i, ref_paths)
+    return "/central/groups/esm/zhaoyi/GCMForcedLES/forcing/corrected/HadGEM2-A_amip.2004-2008.07.nc"
+end
 
-    if sim_t_end < 0.95 * t_end
-        throw(ErrorException("Simulation failed."))
-    end
-    # take time-mean of last N hours
-    var_i_ave =
-        average_time(window(var_i, "time", left = t_start, right = sim_t_end))
+function get_cfsite_id(i, cfsite_numbers)
+    return string("site", cfsite_numbers[i])
+end
 
-    y_var_i = slice(var_i_ave, x = 1, y = 1).data
-
-    return y_var_i
-
+function get_batch_indicies_in_iteration(iteration, output_dir::AbstractString)
+    iter_path = CAL.path_to_iteration(output_dir, iteration)
+    eki = JLD2.load_object(joinpath(iter_path, "eki_file.jld2"))
+    return EKP.get_current_minibatch(eki)
 end

--- a/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
@@ -8,8 +8,9 @@ approximate_linear_solve_iters: 2
 prognostic_tke: true
 edmfx_upwinding: "first_order"
 rayleigh_sponge: true
-edmfx_entr_model: "Generalized"
-edmfx_detr_model: "Generalized"
+edmfx_entr_model: "PiGroups"
+edmfx_detr_model: "PiGroups"
+# precip_model: 1M
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
@@ -17,13 +18,12 @@ edmfx_nh_pressure: true
 moist: "equil"
 call_cloud_diagnostics_per_stage: true
 config: "column"
-cloud_model: "diagnostic_edmfx"
+cloud_model: "quadrature_sgs"
 hyperdiff: "false"
-max: 40e3
+z_max: 40e3
 z_elem: 60
 z_stretch: true
 dz_bottom: 30
-dz_top: 3000
 rad: allskywithclear
 insolation: "gcmdriven"
 dt: "100secs"
@@ -32,7 +32,6 @@ dt_save_state_to_disk: "10mins"
 toml: [scm_tomls/diagnostic_edmfx.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
 netcdf_output_at_levels: true
-output_dir: output/gcm_driven_scm
 diagnostics:
   - short_name: [hus, thetaa, clw, arup, tke, entr, detr, waup]
     period: 10mins

--- a/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
@@ -9,34 +9,34 @@ approximate_linear_solve_iters: 2
 max_newton_iters_ode: 1
 edmfx_upwinding: "first_order"
 rayleigh_sponge: true
-edmfx_entr_model: "Generalized"
-edmfx_detr_model: "Generalized"
+edmfx_entr_model: "PiGroups"
+edmfx_detr_model: "PiGroups"
 # precip_model: 1M
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_filter: true
+edmfx_filter: false
 prognostic_tke: true
 moist: "equil"
 config: "column"
 hyperdiff: "false"
-max: 40e3
+z_max: 40e3
 z_elem: 60
 z_stretch: true
 dz_bottom: 30
-dz_top: 3000
 rad: allskywithclear
 insolation: "gcmdriven"
 perturb_initstate: false
 dt: "10secs"
+dt_rad: "30mins"
 t_end: "72hours"
 dt_save_to_disk: "10mins"
+cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage : true
 ode_algo: "ARS343"
-output_dir: output/gcm_driven_scm
 toml: [scm_tomls/prognostic_edmfx.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
 diagnostics:
-  - short_name: [hus, thetaa, clw, arup, tke, entr, detr, waup]
+  - short_name: [hus, thetaa, clw, arup, tke, entr, detr, waup, turbentr]
     period: 10mins

--- a/calibration/experiments/gcm_driven_scm/observation_map.jl
+++ b/calibration/experiments/gcm_driven_scm/observation_map.jl
@@ -3,22 +3,18 @@ import ClimaCalibrate:
     observation_map, ExperimentConfig, path_to_ensemble_member
 using ClimaAnalysis
 using JLD2
+using Statistics
 
-const config_dict = YAML.load_file(joinpath(@__DIR__, "experiment_config.yml"))
-const output_dir = config_dict["output_dir"]
 
-function observation_map(iteration)
+function observation_map(iteration; config_dict::Dict)
 
-    G_ensemble = Array{Float64}(
-        undef,
-        config_dict["dims"]...,
-        config_dict["ensemble_size"],
-    )
+    full_dim =
+        config_dict["dims_per_var"] *
+        length(config_dict["y_var_names"]) *
+        config_dict["batch_size"]
 
-    f_diagnostics = JLD2.jldopen(
-        joinpath(config_dict["output_dir"], "norm_factors.jld2"),
-        "r+",
-    )
+    G_ensemble =
+        Array{Float64}(undef, full_dim..., config_dict["ensemble_size"])
 
     iter_path = CAL.path_to_iteration(output_dir, iteration)
     eki = JLD2.load_object(joinpath(iter_path, "eki_file.jld2"))
@@ -33,7 +29,8 @@ function observation_map(iteration)
                 t_start = config_dict["g_t_start_sec"],
                 t_end = config_dict["g_t_end_sec"],
                 z_max = config_dict["z_max"],
-                norm_factors_dict = f_diagnostics["norm_factors_dict"],
+                norm_factors_dict = config_dict["norm_factors_by_var"],
+                log_vars = config_dict["log_vars"],
             )
         catch err
             @info "Error during observation map for ensemble member $m" err
@@ -52,38 +49,70 @@ function process_member_data(
     t_end,
     z_max = nothing,
     norm_factors_dict = nothing,
+    log_vars = [],
 )
     forcing_file_indices = EKP.get_current_minibatch(eki)
     g = Float64[]
     for i in forcing_file_indices
         simdir = SimDir(joinpath(member_path, "config_$i", "output_0000"))
         for (i, y_name) in enumerate(y_names)
-            var_i = get(simdir; short_name = y_name, reduction)
-
-            # subset vertical coordinate
-            if !isnothing(z_max)
-                z_window = filter(x -> x <= z_max, var_i.dims["z"])
-                var_i = window(var_i, "z", right = maximum(z_window))
-            end
-            sim_t_end = var_i.dims["time"][end]
-
-            if sim_t_end < 0.95 * t_end
-                throw(ErrorException("Simulation failed."))
-            end
-            # take time-mean
-            var_i_ave = average_time(
-                window(var_i, "time", left = t_start, right = sim_t_end),
+            y_var_i = process_profile_variable(
+                simdir,
+                y_name;
+                reduction,
+                t_start,
+                t_end,
+                z_max,
+                norm_factors_dict,
+                log_vars,
             )
-
-            y_var_i = slice(var_i_ave, x = 1, y = 1).data
-            if !isnothing(norm_factors_dict)
-                y_μ, y_σ = norm_factors_dict[y_name]
-                y_var_i = (y_var_i .- y_μ) ./ y_σ
-            end
-
             append!(g, y_var_i)
         end
     end
 
     return g
+end
+
+
+function process_profile_variable(
+    simdir,
+    y_name;
+    reduction,
+    t_start,
+    t_end,
+    z_max = nothing,
+    norm_factors_dict = nothing,
+    log_vars = [],
+)
+
+    var_i = get(simdir; short_name = y_name, reduction)
+
+    # subset vertical coordinate
+    if !isnothing(z_max)
+        z_window = filter(x -> x <= z_max, var_i.dims["z"])
+        var_i = window(var_i, "z", right = maximum(z_window))
+    end
+    sim_t_end = var_i.dims["time"][end]
+
+    if sim_t_end < 0.95 * t_end
+        throw(ErrorException("Simulation failed."))
+    end
+
+    # take time-mean
+    var_i_ave =
+        average_time(window(var_i, "time", left = t_start, right = sim_t_end))
+    y_var_i = slice(var_i_ave, x = 1, y = 1).data
+
+    if y_name in log_vars
+        y_var_i = log10.(y_var_i .+ 1e-12)
+    end
+
+    # normalize
+    if !isnothing(norm_factors_dict)
+        y_μ, y_σ = norm_factors_dict[y_name]
+        y_var_i = (y_var_i .- y_μ) ./ y_σ
+    end
+
+    return y_var_i
+
 end

--- a/calibration/experiments/gcm_driven_scm/plot_eki.jl
+++ b/calibration/experiments/gcm_driven_scm/plot_eki.jl
@@ -1,0 +1,265 @@
+import TOML, YAML
+import JLD2
+using Distributions
+import EnsembleKalmanProcesses as EKP
+using EnsembleKalmanProcesses.ParameterDistributions
+using EnsembleKalmanProcesses.TOMLInterface
+import ClimaCalibrate as CAL
+using Plots
+using LinearAlgebra
+using DataFrames
+
+output_dir = "output/exp_1"
+iterations = nothing
+
+include("helper_funcs.jl")
+
+const config_dict =
+    YAML.load_file(joinpath(output_dir, "configs", "experiment_config.yml"))
+const n_iterations = config_dict["n_iterations"]
+
+# plotting output dirs
+plot_dir = joinpath(output_dir, "plots", "param_plots")
+mkpath(plot_dir)
+plot_dir_y_vec = joinpath(output_dir, "plots", "y_vec_plots")
+mkpath(plot_dir_y_vec)
+
+
+if isnothing(iterations)
+    iterations = collect(0:(n_iterations - 1))
+end
+
+const prior = CAL.get_prior(joinpath(output_dir, "configs", "prior.toml"))
+
+function inv_variance_weighted_loss(
+    y_diff::Matrix{Float64},
+    gamma_i::Matrix{Float64},
+)
+    var_vec = diag(gamma_i)
+    inv_var_vec = 1.0 ./ var_vec
+    losses = [mean(y_diff[:, j] .^ 2 .* inv_var_vec) for j in 1:size(y_diff, 2)]
+    return mean(losses), std(losses), minimum(losses)
+end
+
+
+function mean_loss(y_diff::Matrix{Float64})
+    losses = [mean(y_diff[:, j] .^ 2) for j in 1:size(y_diff, 2)]
+    return mean(losses), std(losses), minimum(losses)
+end
+
+loss_results = Dict(
+    :mean_loss_avg => Float64[],
+    :mean_loss_std => Float64[],
+    :var_weighted_loss_avg => Float64[],
+    :var_weighted_loss_std => Float64[],
+    :min_loss_avg => Float64[],
+    :var_weighted_min_loss_avg => Float64[],
+)
+
+
+for iteration in iterations
+
+    @info iteration
+
+    iter_path = CAL.path_to_iteration(output_dir, iteration)
+    eki = JLD2.load_object(joinpath(iter_path, "eki_file.jld2"))
+
+    iter_path_p1 = CAL.path_to_iteration(output_dir, iteration + 1)
+    eki_p1 = JLD2.load_object(joinpath(iter_path_p1, "eki_file.jld2"))
+
+    Δt = EKP.get_Δt(eki)
+    y_i = EKP.get_obs(eki)
+    gamma_i = EKP.get_obs_noise_cov(eki)
+
+    g = EKP.get_g_final(eki_p1)
+
+    nan_columns_count = sum(any(isnan, g, dims = 1))
+
+    # Find successful simulations
+    non_nan_columns_indices = findall(x -> !x, vec(any(isnan, g, dims = 1)))
+    g_non_nan = g[:, non_nan_columns_indices]
+
+    y_diff = y_i .- g_non_nan
+
+    u = EKP.get_u_final(eki)
+    N_obs = size(g, 1)
+    cov_init = cov(u, dims = 2)
+
+    avg_loss, std_loss, min_loss = mean_loss(y_diff)
+    push!(loss_results[:mean_loss_avg], avg_loss)
+    push!(loss_results[:mean_loss_std], std_loss)
+    push!(loss_results[:min_loss_avg], min_loss)
+    avg_var_loss, std_var_loss, var_min_loss =
+        inv_variance_weighted_loss(y_diff, gamma_i)
+    push!(loss_results[:var_weighted_loss_avg], avg_var_loss)
+    push!(loss_results[:var_weighted_loss_std], std_var_loss)
+    push!(loss_results[:var_weighted_min_loss_avg], var_min_loss)
+
+    plt = plot()
+    for i in 1:size(g_non_nan, 2)
+        plot!(plt, 1:size(g_non_nan, 1), g_non_nan[:, i], label = false)
+    end
+    plot!(plt, 1:size(y_i, 1), y_i, label = "Observations", color = :black)
+
+    noise_std = sqrt.(diag(gamma_i))
+    x_range = 1:size(g_non_nan, 1)
+    plot!(
+        plt,
+        x_range,
+        y_i .+ 2 * noise_std,
+        fillrange = y_i .- 2 * noise_std,
+        fillalpha = 0.2,
+        label = "Noise range",
+        color = :gray,
+    )
+
+    ylims!(plt, -3.0, 3.0)
+    savefig(plt, joinpath(plot_dir_y_vec, "eki_y_vs_g_iter_$(iteration).png"))
+
+end
+
+
+### print best particles and loss
+loss_min_inds, loss_min_vals = get_loss_min(output_dir, iterations[end])
+df = DataFrame(ParticleNumber = loss_min_inds, Loss = loss_min_vals)
+display(df)
+
+### Plot EKI loss evolution
+function plot_loss(
+    iter_range,
+    avg_loss,
+    std_loss,
+    min_loss,
+    title_str,
+    file_name,
+)
+    plt = plot(
+        iter_range,
+        avg_loss,
+        label = "$(title_str) Avg",
+        lw = 2,
+        xlabel = "Iteration",
+        ylabel = "Loss",
+        title = title_str,
+        marker = :o,
+        color = :black,
+    )
+    upper_2std = avg_loss .+ 2 .* std_loss
+    lower_2std = avg_loss .- 2 .* std_loss
+    plot!(
+        plt,
+        iter_range,
+        upper_2std,
+        fillrange = lower_2std,
+        label = "±2 STD Shading",
+        fillalpha = 0.3,
+        lw = 0,
+        color = :blue,
+    )
+    plot!(
+        plt,
+        iter_range,
+        min_loss,
+        linestyle = :dash,
+        color = :black,
+        label = "Min $(title_str)",
+    )
+    savefig(plt, joinpath(plot_dir_y_vec, file_name))
+end
+
+iterations_range = 1:length(iterations)
+
+plot_loss(
+    iterations_range,
+    loss_results[:mean_loss_avg],
+    loss_results[:mean_loss_std],
+    loss_results[:min_loss_avg],
+    "Mean Loss",
+    "mean_loss_vs_iteration.png",
+)
+plot_loss(
+    iterations_range,
+    loss_results[:var_weighted_loss_avg],
+    loss_results[:var_weighted_loss_std],
+    loss_results[:var_weighted_min_loss_avg],
+    "Variance-Weighted Loss",
+    "var_weighted_loss_vs_iteration.png",
+)
+
+
+### Plot parameter evolution
+iter_path = CAL.path_to_iteration(output_dir, iterations[end])
+eki = JLD2.load_object(joinpath(iter_path, "eki_file.jld2"))
+u_all = EKP.get_u(eki)
+
+phi_all = EKP.transform_unconstrained_to_constrained(prior, u_all)
+phi_all_stacked = cat(phi_all...; dims = 3)
+
+
+names = []
+for i in 1:length(prior.name)
+    if isa(prior.distribution[i], EKP.Parameterized)
+        push!(names, prior.name[i])
+    elseif isa(prior.distribution[i], EKP.VectorOfParameterized)
+        for j in 1:length(prior.distribution[i].distribution)
+            push!(names, prior.name[i] * "_$j")
+        end
+    end
+end
+
+
+
+for param_i in 1:size(phi_all_stacked, 1)
+    param_name = names[param_i]
+    data = phi_all_stacked[param_i, :, :]
+
+    mean_vals = mean(data, dims = 1)
+    max_vals = maximum(data, dims = 1)
+    min_vals = minimum(data, dims = 1)
+    std_vals = std(data, dims = 1)
+
+    mean_vals = vec(mean_vals)
+    max_vals = vec(max_vals)
+    min_vals = vec(min_vals)
+    std_vals = vec(std_vals)
+
+    upper_2std = mean_vals .+ 2 .* std_vals
+    lower_2std = mean_vals .- 2 .* std_vals
+
+    iterations = 1:size(phi_all_stacked, 3)
+    plot(iterations, mean_vals, label = "Mean", lw = 2, color = :black)
+    plot!(
+        iterations,
+        max_vals,
+        label = "Max",
+        lw = 1,
+        linestyle = :dash,
+        color = :black,
+    )
+    plot!(
+        iterations,
+        min_vals,
+        label = "Min",
+        lw = 1,
+        linestyle = :dash,
+        color = :black,
+    )
+
+    plot!(
+        iterations,
+        upper_2std,
+        fillrange = lower_2std,
+        label = "±2 STD Shading",
+        fillalpha = 0.3,
+        lw = 0,
+        color = :blue,
+    )
+
+    xlabel!("Iteration")
+    ylabel!("$param_name")
+    title!("Parameter evol: $param_name")
+
+
+    savefig(joinpath(plot_dir, "param_$(param_name)_stats.png"))
+
+end

--- a/calibration/experiments/gcm_driven_scm/plot_ensemble.jl
+++ b/calibration/experiments/gcm_driven_scm/plot_ensemble.jl
@@ -14,18 +14,22 @@ include("observation_map.jl")
 include("get_les_metadata.jl")
 
 
+output_dir = "output/exp_1" # output directory
 config_i = 1 # config to plot
-N_VERT_LEVELS = 30 # variables to plot
-var_names = ("thetaa", "hus", "clw", "arup", "entr", "detr", "waup", "tke")
+ylims = (0, 4000) # y limits for plotting (`z` coord)
+iterations = nothing # iterations to plot (i.e., 0:2). default is all iterations
+var_names =
+    ("thetaa", "hus", "clw", "arup", "entr", "detr", "waup", "tke", "turbentr")
 reduction = "inst"
 
-
-config_dict = YAML.load_file("experiment_config.yml")
-const model_config = config_dict["model_config"]
+config_dict =
+    YAML.load_file(joinpath(output_dir, "configs", "experiment_config.yml"))
 const z_max = config_dict["z_max"]
 const cal_var_names = config_dict["y_var_names"]
-const output_dir = config_dict["output_dir"]
-model_config_dict = YAML.load_file(model_config)
+const const_noise_by_var = config_dict["const_noise_by_var"]
+const n_vert_levels = config_dict["dims_per_var"]
+model_config_dict =
+    YAML.load_file(joinpath(output_dir, "configs", "model_config.yml"))
 
 ref_paths, _ = get_les_calibration_library()
 atmos_config = CA.AtmosConfig(model_config_dict)
@@ -33,24 +37,43 @@ atmos_config = CA.AtmosConfig(model_config_dict)
 # get/store LES obs and norm factors 
 zc_model = get_z_grid(atmos_config, z_max = z_max)
 
-iterations = get_iters_with_config(config_i, config_dict)
+if isnothing(iterations)
+    iterations = get_iters_with_config(config_i, config_dict)
+end
 
-xlims_dict = Dict("arup" => (-0.1, 1.2))
+xlims_dict = Dict("arup" => (-0.1, 0.4), "clw" => "auto")
+
+
+function compute_plot_limits(data; margin_ratio = 0.5, fixed_margin = 1.0)
+
+    min_val = minimum(data)
+    max_val = maximum(data)
+
+    data_range = max_val - min_val
+    margin = data_range == 0 ? fixed_margin : margin_ratio * data_range
+    limits = (min_val - margin, max_val + margin)
+
+    return limits
+end
+
 
 for iteration in iterations
     @show "Iter: $iteration"
     for var_name in var_names
 
         data = ensemble_data(
+            process_profile_variable,
             iteration,
-            config_i;
+            config_i,
+            config_dict;
             var_name = var_name,
             reduction = reduction,
             output_dir = output_dir,
             z_max = z_max,
-            n_vert_levels = N_VERT_LEVELS,
+            n_vert_levels = n_vert_levels,
         )
-        # size(data)= [num vertical levels x ensemble size]
+
+        # size(data) = [num vertical levels x ensemble size]
         eki_filepath = joinpath(
             ClimaCalibrate.path_to_iteration(output_dir, iteration),
             "eki_file.jld2",
@@ -70,7 +93,7 @@ for iteration in iterations
                 zc_model;
                 ti = config_dict["y_t_start_sec"],
                 tf = config_dict["y_t_end_sec"],
-                Σ_const = 0.05,
+                Σ_const = const_noise_by_var,
                 z_score_norm = false,
             )
             Plots.plot!(y_truth, zc_model, color = :black, label = "LES")
@@ -79,11 +102,16 @@ for iteration in iterations
 
         xlims = get(xlims_dict, var_name, nothing)
 
+        if xlims == "auto"
+            xlims = compute_plot_limits(y_truth)
+        end
+
         Plots.plot!(
             xlabel = var_name,
             ylabel = "Height (z)",
-            title = "Matrix Columns vs. Height",
+            title = var_name,
             xlims = xlims,
+            ylims = ylims,
         )
 
         plot_rel_dir = joinpath(

--- a/calibration/experiments/gcm_driven_scm/prior_prognostic.toml
+++ b/calibration/experiments/gcm_driven_scm/prior_prognostic.toml
@@ -1,5 +1,6 @@
-[EDMF_surface_area]
-prior = "constrained_gaussian(EDMF_surface_area, 0.1, 0.03, 0, Inf)"
+[turb_entr_param_vec]
+prior = "VectorOfParameterized([Normal(-3.149, 0.554), Normal(8.228, 0.362)])"
+constraint = "repeat([bounded_below(0.0)], 2)"
 type = "float"
 
 [entr_inv_tau]
@@ -7,19 +8,19 @@ prior = "constrained_gaussian(entr_inv_tau, 0.0001, 1e-5, 0, Inf)"
 type = "float"
 
 [entr_coeff]
-prior = "constrained_gaussian(entr_coeff, 0.3, 0.1, 0, Inf)"
+prior = "constrained_gaussian(entr_coeff, 0.4, 0.3, 0, Inf)"
 type = "float"
 
 [detr_massflux_vertdiv_coeff]
-prior = "constrained_gaussian(detr_massflux_vertdiv_coeff, 1.0, 0.5, 0, Inf)"
+prior = "constrained_gaussian(detr_massflux_vertdiv_coeff, 1.0, 0.7, 0, Inf)"
 type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
-prior = "constrained_gaussian(mixing_length_eddy_viscosity_coefficient, 0.14, 0.07, 0, Inf)"
+prior = "constrained_gaussian(mixing_length_eddy_viscosity_coefficient, 0.14, 0.09, 0, Inf)"
 type = "float"
 
 [mixing_length_diss_coeff]
-prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.1, 0, Inf)"
+prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.15, 0, Inf)"
 type = "float"
 
 [mixing_length_tke_surf_scale]
@@ -31,7 +32,7 @@ prior = "constrained_gaussian(mixing_length_static_stab_coeff, 0.4, 0.15, 0, Inf
 type = "float"
 
 [mixing_length_Prandtl_number_0]
-prior = "constrained_gaussian(mixing_length_Prandtl_number_0, 0.74, 0.2, 0, Inf)"
+prior = "constrained_gaussian(mixing_length_Prandtl_number_0, 0.74, 0.3, 0, Inf)"
 type = "float"
 
 [pressure_normalmode_buoy_coeff1]
@@ -41,3 +42,13 @@ type = "float"
 [pressure_normalmode_drag_coeff]
 prior = "constrained_gaussian(pressure_normalmode_drag_coeff, 40.0, 10.0, 0, Inf)"
 type = "float"
+
+[diagnostic_covariance_coeff]
+prior = "constrained_gaussian(diagnostic_covariance_coeff, 2.1, 1.0, 0, Inf)"
+type = "float"
+
+[EDMF_surface_area]
+prior = "constrained_gaussian(EDMF_surface_area, 0.1, 0.03, 0, Inf)"
+type = "float"
+
+

--- a/calibration/experiments/gcm_driven_scm/prior_prognostic_pi_entr.toml
+++ b/calibration/experiments/gcm_driven_scm/prior_prognostic_pi_entr.toml
@@ -1,22 +1,15 @@
-[turb_entr_param_vec]
-prior = "VectorOfParameterized([Normal(-3.149, 0.554), Normal(8.228, 0.362)])"
-constraint = "repeat([bounded_below(0.0)], 2)"
+[entr_param_vec]
+prior = "VectorOfParameterized([Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.25, 0.15), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.0, 1.0), Normal(0.6, 0.3)])"
+constraint = "repeat([no_constraint()], 12)"
 type = "float"
 
 [entr_inv_tau]
-prior = "constrained_gaussian(entr_inv_tau, 0.0001, 0.0001, 0, Inf)"
+prior = "constrained_gaussian(entr_inv_tau, 1e-4, 6e-5, 0, Inf)"
 type = "float"
 
-[entr_coeff]
-prior = "constrained_gaussian(entr_coeff, 0.3, 0.2, 0, Inf)"
-type = "float"
-
-[detr_buoy_coeff]
-prior = "constrained_gaussian(detr_buoy_coeff, 0.12, 0.1, 0, Inf)"
-type = "float"
-
-[detr_vertdiv_coeff]
-prior = "constrained_gaussian(detr_vertdiv_coeff, 0.6, 0.4, 0, Inf)"
+[turb_entr_param_vec]
+prior = "VectorOfParameterized([Normal(-3.149, 0.554), Normal(8.228, 0.362)])"
+constraint = "repeat([bounded_below(0.0)], 2)"
 type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
@@ -28,11 +21,11 @@ prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.15, 0, Inf)"
 type = "float"
 
 [mixing_length_tke_surf_scale]
-prior = "constrained_gaussian(mixing_length_tke_surf_scale, 3.75, 1.5, 0, Inf)"
+prior = "constrained_gaussian(mixing_length_tke_surf_scale, 2.5, 2.0, 0, Inf)"
 type = "float"
 
 [mixing_length_static_stab_coeff]
-prior = "constrained_gaussian(mixing_length_static_stab_coeff, 0.4, 0.15, 0, Inf)"
+prior = "constrained_gaussian(mixing_length_static_stab_coeff, 0.4, 0.2, 0, Inf)"
 type = "float"
 
 [mixing_length_Prandtl_number_0]
@@ -40,11 +33,11 @@ prior = "constrained_gaussian(mixing_length_Prandtl_number_0, 0.74, 0.2, 0, Inf)
 type = "float"
 
 [pressure_normalmode_buoy_coeff1]
-prior = "constrained_gaussian(pressure_normalmode_buoy_coeff1, 0.12, 0.06, 0, Inf)"
+prior = "constrained_gaussian(pressure_normalmode_buoy_coeff1, 0.12, 0.08, 0, Inf)"
 type = "float"
 
 [pressure_normalmode_drag_coeff]
-prior = "constrained_gaussian(pressure_normalmode_drag_coeff, 10.0, 7.0, 0, Inf)"
+prior = "constrained_gaussian(pressure_normalmode_drag_coeff, 40.0, 10.0, 0, Inf)"
 type = "float"
 
 [diagnostic_covariance_coeff]

--- a/calibration/experiments/gcm_driven_scm/run_calibration.sbatch
+++ b/calibration/experiments/gcm_driven_scm/run_calibration.sbatch
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#SBATCH --time=06:00:00   # walltime
+#SBATCH --nodes=1   # number of nodes
+#SBATCH --ntasks=1  # number of processor cores (i.e. tasks)
+#SBATCH --mem=5G   # memory per CPU core
+#SBATCH -J "scm_calibration"   # job name
+#SBATCH --output=scm_calibration.out
+
+module purge
+export MODULEPATH="/groups/esm/modules:$MODULEPATH"
+module load climacommon/2024_05_27
+
+julia --project run_calibration.jl
+
+echo finished

--- a/calibration/experiments/gcm_driven_scm/scm_tomls/diagnostic_edmfx.toml
+++ b/calibration/experiments/gcm_driven_scm/scm_tomls/diagnostic_edmfx.toml
@@ -1,9 +1,3 @@
-[EDMF_surface_area]
-value = 0.1
-
-[entr_coeff]
-value = 0
-
 [detr_inv_tau]
 value = 0
 


### PR DESCRIPTION
Improve gcm-driven single column calibrations:

1.  modify priors
2. add entrainment pi group calibration
3.  improve plotting scripts
4.  add rmse metrics and plotting
5.  add eki metrics and plotting
6.  parallelize CA single column runs (cases) over cpu cores
7.  easier specification of normalization for LES/EDMF profiles (mean, std to transform vars -> N(0, 1)); option for taking log


A summary of the 

The observation vector for a single configuration is formed by concatenating profiles across calibration variables, where each geophysical variable is normalized to have approximately unit variance and zero mean. These variable-by-variable normalization factors are precomputed (`norm_factors_dict`) and applied to all observations. Following this operation, the spatiotemporal calibration window is applied and temporal means are computed to form the observation vector `y`. Because variables are normalized to have 0 mean and unit variance, a constant diagonal noise matrix is used (configurable as `const_noise`).


### Observation Map
1. **Time-mean**: Time-mean of profiles taken between [`y_t_start_sec`, `y_t_end_sec`] for `y` and [`g_t_start_sec`, `g_t_end_sec`] for `G`.
2. **Interpolation**: Case-specific (i.e., "shallow", "deep") interpolation to the calibration grid, defined with stretch-grid parameters in `z_cal_grid`.
3. **Normalization**: Variable-specific normalization using the mean and standard deviation defined in `norm_factors_by_var`. Optionally, take log of variables using `log_vars` before normalization.
4. **Concatenation**: Stack across cases in a batch, forming `y`, `G`.


## Prognostic EDMF results after 11 iterations with default calibration configurations (defined in `experiment_config.yml`)

#### cfSite 23
![ensemble_plot_clw_i_11_cu](https://github.com/user-attachments/assets/9fc1ba80-9a97-42c0-b99d-f9f0cd3c6541)


#### cfSite 17
![ensemble_plot_clw_i_11](https://github.com/user-attachments/assets/2ff21b49-b705-4abc-8a99-1dbdff0347bc)


#### RMSE Plot
![rmse_vs_iteration.pdf](https://github.com/user-attachments/files/17124199/rmse_vs_iteration.pdf)




