### PR TITLE
Add face_sw_direct_flux_dn only for AllSkyRadiationWithClearSkyDiagnostics

### DIFF
--- a/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
+++ b/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
@@ -622,7 +622,6 @@ function RRTMGPModel(
             RRTMGP.Fluxes.FluxSW(ncol, nlay, FT, DA)
         set_and_save!(flux_sw.flux_up, "face_sw_flux_up", t...)
         set_and_save!(flux_sw.flux_dn, "face_sw_flux_dn", t...)
-        set_and_save!(flux_sw.flux_dn_dir, "face_sw_direct_flux_dn", t...)
         set_and_save!(flux_sw.flux_net, "face_sw_flux", t...)
         if radiation_mode isa AllSkyRadiationWithClearSkyDiagnostics
             flux_sw2 = RRTMGP.Fluxes.FluxSW(ncol, nlay, FT, DA)
@@ -634,6 +633,7 @@ function RRTMGPModel(
                 t...,
             )
             set_and_save!(flux_sw2.flux_net, "face_clear_sw_flux", t...)
+            set_and_save!(flux_sw.flux_dn_dir, "face_sw_direct_flux_dn", t...)
         end
 
         cos_zenith = DA{FT}(undef, ncol)


### PR DESCRIPTION
`face_sw_direct_flux_dn` is used only in
`AllSkyRadiationWithClearSkyDiagnostics` in this block:

```julia
NVTX.@annotate function update_sw_fluxes!(
    ::AllSkyRadiationWithClearSkyDiagnostics,
    model,
)
    RRTMGP.RTESolver.solve_sw!(
        model.sw_solver,
        model.as,
        model.lookups.lookup_sw,
        nothing,
        model.lookups.lookup_sw_aero,
    )
    parent(model.face_clear_sw_flux_up) .= parent(model.face_sw_flux_up)
    parent(model.face_clear_sw_flux_dn) .= parent(model.face_sw_flux_dn)
    parent(model.face_clear_sw_direct_flux_dn) .=
        parent(model.face_sw_direct_flux_dn)
    parent(model.face_clear_sw_flux) .= parent(model.face_sw_flux)
    RRTMGP.RTESolver.solve_sw!(
        model.sw_solver,
        model.as,
        model.lookups.lookup_sw,
        model.lookups.lookup_sw_cld,
        model.lookups.lookup_sw_aero,
    )
end
```

It is not used by other modes, so I don't add it
