### PR TITLE
Decrease JET failure limit

### DIFF
--- a/perf/jet_test_nfailures.jl
+++ b/perf/jet_test_nfailures.jl
@@ -38,7 +38,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 1089
+    n_allowed_failures = 253
     @show n
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures


### PR DESCRIPTION
This PR lowers the JET failure limit, now that we've fixed a handful of inference failures.