### PR TITLE
Update to pipelines

### DIFF
--- a/.buildkite/comparison/pipeline.sh
+++ b/.buildkite/comparison/pipeline.sh
@@ -13,7 +13,7 @@ profiling=disable
 # set up environment and agents
 cat << EOM
 env:
-  JULIA_VERSION: "1.8.5"
+  JULIA_VERSION: "1.10.5"
   MPICH_VERSION: "4.0.0"
   OPENMPI_VERSION: "4.1.1"
   CUDA_VERSION: "11.3"
@@ -82,7 +82,7 @@ cat << EOM
     - label: ":computer: MPI Held-Suarez $res resolution test(ρe_tot) - ($nprocs) process"
       key: $job_id
       command:
-        - module load cuda/11.3 nsight-systems/2023.3.1
+        - module load cuda/11.3 nsight-systems/2024.6.1
         - mpiexec $command
       artifact_paths:
         - "$job_id/scaling_data_${nprocs}_processes.jld2"

--- a/.buildkite/gpu_pipeline/pipeline.yml
+++ b/.buildkite/gpu_pipeline/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_mem: 8G
-  modules: julia/1.10.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.4.1
+  modules: julia/1.10.5 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.6.1
 
 env:
   JULIA_MPI_HAS_CUDA: "true"

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_mem: 8G
-  modules: julia/1.10.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.2.1
+  modules: julia/1.10.5 cuda/julia-pref openmpi/4.1.5-mpitrampoline nsight-systems/2024.6.1
 
 env:
   JULIA_MPI_HAS_CUDA: "true"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_08
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/.buildkite/scaling/pipeline.sh
+++ b/.buildkite/scaling/pipeline.sh
@@ -66,7 +66,7 @@ done
 cat << 'EOM'
 agents:
   queue: new-central
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_08
   # This constraint is set for consistent architectures across nodes
   slurm_constraint: icelake
 

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '1'
+        version: '1.10'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/perf/jet_test_nfailures.jl
+++ b/perf/jet_test_nfailures.jl
@@ -38,7 +38,7 @@ using Test
     # inference. By increasing this counter, we acknowledge that
     # we have introduced an inference failure. We hope to drive
     # this number down to 0.
-    n_allowed_failures = 253
+    n_allowed_failures = 254
     @show n
     @test n ≤ n_allowed_failures
     if n < n_allowed_failures


### PR DESCRIPTION
This PR updates us to use climacommon `2024_10_08`, which should (hopefully) fix the nsight issues. Looks like this closes #2911.

I'm going to update a few things in the pipelines.