### PR TITLE
Update `.gitignore` ignoring of Manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,9 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-/Manifest.toml
-test/Manifest.toml
-calibration/test/Manifest.toml
+/Manifest*.toml
+test/Manifest*.toml
+calibration/test/Manifest*.toml
 
 # ignore vscode artifacts
 *.vscode


### PR DESCRIPTION
`Manifest.toml` -> `Manifest*.toml`
Add wildcard to match e.g. Manifest-v1.11.toml as is now possible in Julia v1.11.