### PR TITLE
Add MPI tests for restarts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -444,21 +444,31 @@ steps:
           slurm_gpus: 1
           slurm_mem: 16G
 
+      # This job occasionally times out. We add a soft file when the agent is
+      # lost because of timeout
       - label: ":computer: test restart MPI"
         command: >
           srun julia --color=yes --project=examples test/restart.jl
         env:
           CLIMACOMMS_CONTEXT: "MPI"
+        timeout_in_minutes: 20
+        soft_fail:
+          - exit_status: -1
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G
 
+      # This job occasionally times out. We add a soft file when the agent is
+      # lost because of timeout
       - label: ":computer: test restart GPU MPI"
         command: >
           srun julia --color=yes --project=examples test/restart.jl
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
+        timeout_in_minutes: 20
+        soft_fail:
+          - exit_status: -1
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -444,26 +444,25 @@ steps:
           slurm_gpus: 1
           slurm_mem: 16G
 
+      - label: ":computer: test restart MPI"
+        command: >
+          srun julia --color=yes --project=examples test/restart.jl
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+        agents:
+          slurm_ntasks: 2
+          slurm_mem: 16G
 
-      # - label: ":computer: test restart MPI"
-      #   command: >
-      #     srun julia --color=yes --project=examples test/restart.jl
-      #   env:
-      #     CLIMACOMMS_CONTEXT: "MPI"
-      #   agents:
-      #     slurm_ntasks: 2
-      #     slurm_mem: 16G
-
-      # - label: ":computer: test restart GPU MPI"
-      #   command: >
-      #     srun julia --color=yes --project=examples test/restart.jl
-      #   env:
-      #     CLIMACOMMS_CONTEXT: "MPI"
-      #     CLIMACOMMS_DEVICE: "CUDA"
-      #   agents:
-      #     slurm_gpus_per_task: 1
-      #     slurm_ntasks: 2
-      #     slurm_mem: 16G
+      - label: ":computer: test restart GPU MPI"
+        command: >
+          srun julia --color=yes --project=examples test/restart.jl
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus_per_task: 1
+          slurm_ntasks: 2
+          slurm_mem: 20G
 
   - group: "MPI Examples"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -939,6 +939,7 @@ steps:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
+          slurm_mem: 16G
 
       - label: "GPU: Diagnostic EDMFX aquaplanet"
         key: "diagnostic_edmfx_aquaplanet_gpu"

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -216,7 +216,7 @@ Test if the restarts are consistent for a simulation defined by the `test_dict` 
 have to be ignored when reading a simulation.
 """
 function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
-    println("job_id = $(job_id)")
+    ClimaComms.iamroot(comms_ctx) && println("job_id = $(job_id)")
 
     local_success = true
 

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -218,7 +218,7 @@ have to be ignored when reading a simulation.
 function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
     println("job_id = $(job_id)")
 
-    local_success = Ref(true)
+    local_success = true
 
     config = CA.AtmosConfig(test_dict; job_id, comms_ctx)
 
@@ -251,17 +251,17 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
         rrtmgp_clear_fix = ()
     end
 
-    local_success[] &= compare(
+    local_success &= compare(
         simulation.integrator.u,
         simulation_restarted.integrator.u;
         name = "integrator.u",
     )
-    local_success[] &= compare(
+    local_success &= compare(
         axes(simulation.integrator.u.c),
         axes(simulation_restarted.integrator.u.c);
         name = "space",
     )
-    local_success[] &= compare(
+    local_success &= compare(
         simulation.integrator.p,
         simulation_restarted.integrator.p;
         name = "integrator.p",
@@ -302,12 +302,12 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
     CA.fill_with_nans!(simulation_restarted2.integrator.p)
 
     CA.solve_atmos!(simulation_restarted2)
-    local_success[] &= compare(
+    local_success &= compare(
         simulation.integrator.u,
         simulation_restarted2.integrator.u;
         name = "integrator.u",
     )
-    local_success[] &= compare(
+    local_success &= compare(
         simulation.integrator.p,
         simulation_restarted2.integrator.p;
         name = "integrator.p",
@@ -323,7 +323,7 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
     )
 
     return (
-        local_success[],
+        local_success,
         simulation,
         simulation_restarted,
         simulation_restarted2,


### PR DESCRIPTION
For reasons that I don't understand, MPI tests occasionally hang. I could not find why. I also tried creating new MPI contexts (using MPI.Comm_split) and freeing them, one for each simulation. That didn't work.

I suspect there's something, somewhere, in our codes that doesn't like being when multiple simulations are run in the same MPI context. Luckily, this doesn't seem to be an extremely common use case, so I think we can move on.

What I did was marking the test as soft fail when the exist status is -1, which is the exist status associated to lost agent. If the test fails for the intended purpose, it will return error code 1 and that will marked as a real failure.
