### PR TITLE
Warn when dt_rad and dt_checkpoints are not compatible

### DIFF
--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -403,3 +403,54 @@ function gaussian_smooth(arr::AbstractArray, sigma::Int = 1)
 
     return smoothed_arr
 end
+
+"""
+    isdivisible(dt_large::Dates.Period, dt_small::Dates.Period)
+
+Check if two periods are evenly divisible, i.e., if the larger period can be
+expressed as an integer multiple of the smaller period.
+
+In this, take into account the case when periods do not have fixed size, e.g.,
+one month is a variable number of days.
+
+# Examples
+```
+julia> isdivisible(Dates.Year(1), Dates.Month(1))
+true
+
+julia> isdivisible(Dates.Month(1), Dates.Day(1))
+true
+
+julia> isdivisible(Dates.Month(1), Dates.Week(1))
+false
+```
+
+## Notes
+
+Not all the combinations are fully implemented. If something is missing, please
+consider adding it.
+"""
+function isdivisible(dt_large::Dates.Period, dt_small::Dates.Period)
+    @warn "The combination $(typeof(dt_large)) and $(dt_small) was not covered. Please add a method to handle this case."
+    return false
+end
+
+# For FixedPeriod and OtherPeriod, it is easy, we can directly divide the two
+# (as long as they are both the same)
+function isdivisible(dt_large::Dates.FixedPeriod, dt_small::Dates.FixedPeriod)
+    return isinteger(dt_large / dt_small)
+end
+
+function isdivisible(dt_large::Dates.OtherPeriod, dt_small::Dates.OtherPeriod)
+    return isinteger(dt_large / dt_small)
+end
+
+function isdivisible(
+    dt_large::Union{Dates.Month, Dates.Year},
+    dt_small::Dates.FixedPeriod,
+)
+    # The only case where periods are commensurate for Month/Year is when we
+    # have a Day or an integer divisor of a day. (Note that 365 and 366 don't
+    # have any common divisor)
+    return isinteger(Dates.Day(1) / dt_small)
+end

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -241,7 +241,7 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
 
     simulation_restarted = CA.get_simulation(config_should_be_same)
 
-    if pkgversion(RRTMGP) <= v"0.19"
+    if pkgversion(RRTMGP) < v"0.20"
         # Versions of RRTMGP older than 0.20 have a bug and do not set the
         # flux_dn_dir, so that face_clear_sw_direct_flux_dn and
         # face_sw_direct_flux_dn is uninitialized and not deterministic

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,6 +1,7 @@
 using Test
 using ClimaComms
 ClimaComms.@import_required_backends
+import Dates
 using Random
 Random.seed!(1234)
 import ClimaAtmos as CA
@@ -28,6 +29,18 @@ end
     @test extrema(randy)[1] <= smoothed[1]
     # max
     @test extrema(randy)[2] >= smoothed[2]
+end
+
+@testset "isdivisible" begin
+    @test CA.isdivisible(Dates.Month(1), Dates.Day(1))
+    @test !CA.isdivisible(Dates.Month(1), Dates.Day(25))
+    @test CA.isdivisible(Dates.Week(1), Dates.Day(1))
+    @test CA.isdivisible(Dates.Day(1), Dates.Hour(1))
+    @test CA.isdivisible(Dates.Hour(1), Dates.Second(1))
+    @test CA.isdivisible(Dates.Minute(1), Dates.Second(30))
+    @test !CA.isdivisible(Dates.Minute(1), Dates.Second(13))
+    @test !CA.isdivisible(Dates.Day(1), Dates.Second(1e6))
+    @test CA.isdivisible(Dates.Month(1), Dates.Hour(1))
 end
 
 @testset "kinetic_energy (c.f. analytical function)" begin


### PR DESCRIPTION
If we want our restarts to be reproducible, we have to worry about callbacks. Callbacks contain information about when they were last called, information that is not saved to checkpoint. This is particularly relevant for radiation. For example, if we save checkpoints every day, but call radiation every 15 h, we will have that restarting a simulation leads to a different evolution compared to not doing that. This is because radiation is called at different times:

Non-restarted simulation
t = 15h: radiation
t = 24h: checkpoint
t = 30h: radiation

Restarted simulation:
t = 15h: radiation
t = 24h: checkpoint
t = 39h: radiation

This commit adds a warning that a given simulation will not be reproducible when radiation and checkpoints frequencies are not commensurate.

To accomplish this, I added `periods_are_commensurate`, a functon that to check whether two `Dates.Periods` are compatible, meaning one is an integer multiple of the other. This is a little tricky to accomplish because some periods don't have a fixed length: for example, one Month can be 28, 29, 30, and 31 days.

In `periods_are_commensurate`, I handle all the cases that can be handled directly (e.g., periods with fixed length), and hardcoded some special, but relevant cases. The most important of these cases is when we have a Month.

Not all the cases are covered, but we can add them when/if they become relavant.

