### PR TITLE
Do not fail when reading old checkpoints

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -454,6 +454,7 @@ steps:
         timeout_in_minutes: 20
         soft_fail:
           - exit_status: -1
+          - exit_status: 255
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G
@@ -469,6 +470,7 @@ steps:
         timeout_in_minutes: 20
         soft_fail:
           - exit_status: -1
+          - exit_status: 255
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 2

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@ Main
   incorrect results when the more diagnostics were output at the same time. PR
   [3365](https://github.com/CliMA/ClimaAtmos.jl/pull/3365)
 
+- ClimaAtmos no longer fails when reading restart files generated with versions
+  of ClimaAtmos prior to `0.27.6`. PR
+  [3388](https://github.com/CliMA/ClimaAtmos.jl/pull/3388)
+
 v0.27.6
 -------
 

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -304,13 +304,16 @@ function get_state_restart(config::AtmosConfig, restart_file, atmos_model_hash)
     @assert !isnothing(restart_file)
     reader = InputOutput.HDF5Reader(restart_file, comms_ctx)
     Y = InputOutput.read_field(reader, "Y")
+    # TODO: Do not use InputOutput.HDF5 directly
     t_start = InputOutput.HDF5.read_attribute(reader.file, "time")
-    atmos_model_hash_in_restart =
-        InputOutput.HDF5.read_attribute(reader.file, "atmos_model_hash")
-    if atmos_model_hash_in_restart != atmos_model_hash
-        error(
-            "Restart file $(restart_file) was constructed with a different AtmosModel",
-        )
+    if "atmos_model_hash" in keys(InputOutput.HDF5.attrs(reader.file))
+        atmos_model_hash_in_restart =
+            InputOutput.HDF5.read_attribute(reader.file, "atmos_model_hash")
+        if atmos_model_hash_in_restart != atmos_model_hash
+            error(
+                "Restart file $(restart_file) was constructed with a different AtmosModel",
+            )
+        end
     end
     return (Y, t_start)
 end


### PR DESCRIPTION
Old checkpoints to do not contain the model hash attribute, so we don't check it if it is not there.

Closes #3387 