### PR TITLE
Use lowres SST/SIC in downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -28,14 +28,6 @@ jobs:
           version: '1.10'
       - uses: julia-actions/cache@v2
 
-        # Hash/links found in ClimaArtifacts
-      - name: Create SST/SIC artifact folder
-        run: mkdir -p ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5
-      - name: Download SST/SIC files
-        run: |
-          wget -q -O ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5/MODEL.ICE.HAD187001-198110.OI198111-202206.nc https://gdex.ucar.edu/dataset/158_asphilli/file/MODEL.ICE.HAD187001-198110.OI198111-202206.nc
-          wget -q -O ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5/MODEL.SST.HAD187001-198110.OI198111-202206.nc https://gdex.ucar.edu/dataset/158_asphilli/file/MODEL.SST.HAD187001-198110.OI198111-202206.nc
-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
ClimaCoupler can now automatically use low resolution versions of these files