### PR TITLE
remove redundant pressure clipping in rrtmgp

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -89,12 +89,7 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
 
     ᶜp = Fields.array2field(rrtmgp_model.center_pressure, axes(Y.c))
     ᶜT = Fields.array2field(rrtmgp_model.center_temperature, axes(Y.c))
-    # When add_isothermal_boundary_layer is true, we add a layer in rrtmgp and set the
-    # pressure to half of the sum of top level pressure and rrtmgp minimum pressure. 
-    # Here we limit the pressure to p_min multiplied by a small number to prevent 
-    # pressure from decreasing or being constant with height.
-    p_min = RRTMGPI.get_p_min(rrtmgp_model)
-    @. ᶜp = max(TD.air_pressure(thermo_params, ᶜts), p_min * FT(1.01))
+    @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
     # TODO: move this to RRTMGP
     @. ᶜT =
         min(max(TD.air_temperature(thermo_params, ᶜts), FT(T_min)), FT(T_max))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I just realized we already clip pressure in rrtmgp [here](https://github.com/CliMA/ClimaAtmos.jl/blob/c81411ad36c02bfb51653968261883d628430660/src/parameterized_tendencies/radiation/RRTMGPInterface.jl#L1174), so we don't need to add another clipping. Also this doesn't seem to be the actual problem why the simulation fails.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] Check nightly amip with this branch: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/121


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
