### PR TITLE
Try using purely vertical spaces for column configurations

### DIFF
--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -353,9 +353,11 @@ weakdeps = ["CUDA", "MPI"]
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "7209c2ed595f535db446709b9d19e22f8b000736"
+git-tree-sha1 = "d7cdfd5268ff76345dfce642a46f2854b2be1bb5"
+repo-rev = "main"
+repo-url = "https://github.com/CliMA/ClimaCore.jl"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.14.22"
+version = "0.14.23"
 weakdeps = ["CUDA", "Krylov"]
 
     [deps.ClimaCore.extensions]
@@ -394,7 +396,9 @@ version = "0.7.6"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "Dates", "NCDatasets", "OrderedCollections", "SciMLBase"]
-git-tree-sha1 = "e9ac94af815dcae2a2ab24e54b53e76cca6258b7"
+git-tree-sha1 = "d2323b7b6a203fd1d364e543c30b5e1caeffb265"
+repo-rev = "tr/point-space-support"
+repo-url = "https://github.com/CliMA/ClimaDiagnostics.jl"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 version = "0.2.11"
 

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -353,8 +353,8 @@ weakdeps = ["CUDA", "MPI"]
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "CubedSphere", "DataStructures", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "d7cdfd5268ff76345dfce642a46f2854b2be1bb5"
-repo-rev = "main"
+git-tree-sha1 = "137644370352036c05dd51d507df7921d680d34a"
+repo-rev = "tr/support-atmos-single-column"
 repo-url = "https://github.com/CliMA/ClimaCore.jl"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
 version = "0.14.23"

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -396,7 +396,7 @@ version = "0.7.6"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "Dates", "NCDatasets", "OrderedCollections", "SciMLBase"]
-git-tree-sha1 = "d2323b7b6a203fd1d364e543c30b5e1caeffb265"
+git-tree-sha1 = "80456efa7642466e6bd967c6fd03f303df63d8b1"
 repo-rev = "tr/point-space-support"
 repo-url = "https://github.com/CliMA/ClimaDiagnostics.jl"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -328,7 +328,9 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     @. ᶠΦ = CAP.grav(params) * ᶠz
     ᶜ∇Φ³ = p.scratch.ᶜtemp_CT3
     @. ᶜ∇Φ³ = CT3(ᶜgradᵥ(ᶠΦ))
-    @. ᶜ∇Φ³ += CT3(gradₕ(ᶜΦ))
+    if !iscolumn(axes(Y.c))
+        @. ᶜ∇Φ³ += CT3(gradₕ(ᶜΦ))
+    end
     ᶜ∇Φ₃ = p.scratch.ᶜtemp_C3
     @. ᶜ∇Φ₃ = ᶜgradᵥ(ᶠΦ)
 

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -175,6 +175,23 @@ function get_diagnostics(
             )...,
             diagnostics...,
         ]
+        if !iscolumn(axes(Y.c))
+            # The topography is only defined when there is a horizontal grid.
+            # We need to compute the topography at the beginning of the simulation (and only at
+            # the beginning), so we set output/compute_schedule_func to false. It is still
+            # computed at the very beginning
+            diagnostics = [
+                CAD.ScheduledDiagnostic(;
+                    variable = CAD.get_diagnostic_variable("orog"),
+                    output_schedule_func = (integrator) -> false,
+                    compute_schedule_func = (integrator) -> false,
+                    output_writer = netcdf_writer,
+                    output_short_name = "orog_inst",
+                ),
+                diagnostics...,
+            ]
+
+        end
     end
     diagnostics = collect(diagnostics)
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -167,16 +167,6 @@ function core_default_diagnostics(output_writer, duration, start_date)
     end
 
     return [
-        # We need to compute the topography at the beginning of the simulation (and only at
-        # the beginning), so we set output/compute_schedule_func to false. It is still
-        # computed at the very beginning
-        ScheduledDiagnostic(;
-            variable = get_diagnostic_variable("orog"),
-            output_schedule_func = (integrator) -> false,
-            compute_schedule_func = (integrator) -> false,
-            output_writer,
-            output_short_name = "orog_inst",
-        ),
         average_func(core_diagnostics...; output_writer, start_date)...,
         min_func("ts"; output_writer, start_date),
         max_func("ts"; output_writer, start_date),

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -278,7 +278,9 @@ function compute_precipitation_heating!(
 
     # compute full temperature gradient
     @. ᶜ∇T = CT123(ᶜgradᵥ(ᶠinterp(Tₐ(thp, ᶜts))))
-    @. ᶜ∇T += CT123(gradₕ(Tₐ(thp, ᶜts)))
+    if !iscolumn(axes(ᶜSeₜᵖ))
+        @. ᶜ∇T += CT123(gradₕ(Tₐ(thp, ᶜts)))
+    end
     # dot product with effective velocity of precipitation
     # (times q and specific heat)
     @. ᶜSeₜᵖ -= dot(ᶜ∇T, (ᶜu - C123(Geometry.WVector(ᶜwᵣ)))) * cᵥₗ(thp) * ᶜqᵣ

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -259,7 +259,8 @@ function radiation_model_cache(
             rrtmgp_params,
             data_loader,
             context;
-            ncol = length(Spaces.all_nodes(axes(Spaces.level(Y.c, 1)))),
+            ncol = iscolumn(axes(Y.c)) ? 1 :
+                   length(Spaces.all_nodes(axes(Spaces.level(Y.c, 1)))),
             domain_nlay = Spaces.nlevels(axes(Y.c)),
             radiation_mode,
             interpolation,

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -100,9 +100,11 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     for j in 1:n
         @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
     end
-    @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
-    for j in 1:n
-        @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
+    if !iscolumn(axes(Y.c))
+        @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
+        for j in 1:n
+            @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
+        end
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -91,7 +91,8 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
 
     if point_type <: Geometry.Abstract3DPoint
         @. ᶜω³ = curlₕ(Y.c.uₕ)
-    elseif point_type <: Geometry.Abstract2DPoint
+    elseif point_type <: Geometry.Abstract2DPoint ||
+           point_type <: Geometry.Abstract1DPoint
         @. ᶜω³ = zero(ᶜω³)
     end
 

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -103,9 +103,7 @@ function external_forcing_cache(Y, external_forcing::GCMForcing, params)
             parent(cc_field) .= ds.group[cfsite_number]["coszen"][1]
         end
 
-        zc_forcing = gcm_height(ds.group[cfsite_number])
-        Fields.bycolumn(axes(Y.c)) do colidx
-
+        function set_column_data(colidx)
             zc_gcm = Fields.coordinate_field(Y.c).z[colidx]
 
             setvar!(ᶜdTdt_hadv, "tntha", colidx, zc_gcm, zc_forcing)
@@ -138,6 +136,15 @@ function external_forcing_cache(Y, external_forcing::GCMForcing, params)
 
             @. ᶜinv_τ_wind[colidx] = 1 / (6 * 3600)
             @. ᶜinv_τ_scalar[colidx] = compute_gcm_driven_scalar_inv_τ(zc_gcm)
+        end
+
+        zc_forcing = gcm_height(ds.group[cfsite_number])
+        if iscolumn(axes(Y.c))
+            set_column_data(:)
+        else
+            Fields.bycolumn(axes(Y.c)) do colidx
+                set_column_data(colidx)
+            end
         end
     end
 

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -13,8 +13,6 @@ hyperdiffusion_cache(Y, atmos) =
 hyperdiffusion_cache(Y, hyperdiff::Nothing, _) = (;)
 
 function hyperdiffusion_cache(Y, hyperdiff::ClimaHyperdiffusion, turbconv_model)
-    quadrature_style =
-        Spaces.quadrature_style(Spaces.horizontal_space(axes(Y.c)))
     FT = eltype(Y)
     n = n_mass_flux_subdomains(turbconv_model)
 

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -43,6 +43,10 @@ end
 function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
     hyperdiff_name = parsed_args["hyperdiff"]
     if hyperdiff_name in ("ClimaHyperdiffusion", "true", true)
+        if parsed_args["config"] == "column"
+            @warn "Hyperdiffusion should not be used with column configuration\
+            The `hyperdiffusion_tendency!` function will not be called."
+        end
         ν₄_vorticity_coeff =
             FT(parsed_args["vorticity_hyperdiffusion_coefficient"])
         ν₄_scalar_coeff = FT(parsed_args["scalar_hyperdiffusion_coefficient"])
@@ -60,6 +64,10 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
         @info "Using CAM_SE hyperdiffusion. vorticity_hyperdiffusion_coefficient, \
                scalar_hyperdiffusion_coefficient and divergence_damping_factor in the config \
                will be ignored."
+        if parsed_args["config"] == "column"
+            @warn "Hyperdiffusion should not be used with column configuration. \
+            The `hyperdiffusion_tendency!` function will not be called."
+        end
         ν₄_vorticity_coeff = FT(0.150 * 1.238)
         ν₄_scalar_coeff = FT(0.751 * 1.238)
         divergence_damping_factor = FT(5)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -163,26 +163,17 @@ function get_spaces(parsed_args, params, comms_ctx)
     elseif parsed_args["config"] == "column" # single column
         @warn "perturb_initstate flag is ignored for single column configuration"
         FT = eltype(params)
-        Δx = FT(1) # Note: This value shouldn't matter, since we only have 1 column.
-        quad = Quadratures.GL{1}()
-        horizontal_mesh = periodic_rectangle_mesh(;
-            x_max = Δx,
-            y_max = Δx,
-            x_elem = 1,
-            y_elem = 1,
-        )
-        if bubble
+        quad = nothing
+        horizontal_mesh = nothing
+        bubble &&
             @warn "Bubble correction not compatible with single column configuration. It will be switched off."
-            bubble = false
-        end
-        h_space =
-            make_horizontal_space(horizontal_mesh, quad, comms_ctx, bubble)
         z_stretch = if parsed_args["z_stretch"]
             Meshes.HyperbolicTangentStretching(dz_bottom)
         else
             Meshes.Uniform()
         end
-        make_hybrid_spaces(h_space, z_max, z_elem, z_stretch; parsed_args)
+        # make_hybrid_spaces(h_space, z_max, z_elem, z_stretch; parsed_args)
+        make_column_spaces(z_max, z_elem, z_stretch, comms_ctx)
     elseif parsed_args["config"] == "box"
         FT = eltype(params)
         nh_poly = parsed_args["nh_poly"]
@@ -222,13 +213,18 @@ function get_spaces(parsed_args, params, comms_ctx)
         end
         make_hybrid_spaces(h_space, z_max, z_elem, z_stretch; parsed_args, deep)
     end
-    ncols = Fields.ncolumns(center_space)
-    ndofs_total = ncols * z_elem
-    hspace = Spaces.horizontal_space(center_space)
-    quad_style = Spaces.quadrature_style(hspace)
-    Nq = Quadratures.degrees_of_freedom(quad_style)
-
-    @info "Resolution stats: " Nq h_elem z_elem ncols ndofs_total
+    if center_space isa Spaces.FiniteDifferenceSpace
+        ncols = 1
+        ndofs_total = ncols * z_elem
+        @info "Resolution stats: " z_elem ncols ndofs_total
+    else
+        ncols = Fields.ncolumns(center_space)
+        ndofs_total = ncols * z_elem
+        hspace = Spaces.horizontal_space(center_space)
+        quad_style = Spaces.quadrature_style(hspace)
+        Nq = Quadratures.degrees_of_freedom(quad_style)
+        @info "Resolution stats: " Nq h_elem z_elem ncols ndofs_total
+    end
     return (;
         center_space,
         face_space,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -3,7 +3,7 @@ import Interpolations
 import NCDatasets
 import ClimaCore
 import ClimaUtilities.OutputPathGenerator
-import ClimaCore: InputOutput, Meshes, Spaces, Quadratures
+import ClimaCore: InputOutput, Meshes, Spaces, Quadratures, CommonSpaces
 import ClimaAtmos.RRTMGPInterface as RRTMGPI
 import ClimaAtmos as CA
 import LinearAlgebra
@@ -172,8 +172,17 @@ function get_spaces(parsed_args, params, comms_ctx)
         else
             Meshes.Uniform()
         end
-        # make_hybrid_spaces(h_space, z_max, z_elem, z_stretch; parsed_args)
-        make_column_spaces(z_max, z_elem, z_stretch, comms_ctx)
+        center_space = CommonSpaces.ColumnSpace(
+            FT;
+            z_elem,
+            z_max,
+            z_min = 0,
+            context = comms_ctx,
+            staggering = Grids.CellCenter(),
+            stretch = z_stretch,
+        )
+        face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
+        (center_space, face_space)
     elseif parsed_args["config"] == "box"
         FT = eltype(params)
         nh_poly = parsed_args["nh_poly"]

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -359,6 +359,17 @@ function surface_temperature(
     return T
 end
 
+function surface_temperature(
+    ::RCEMIPIISST,
+    coordinates::Geometry.ZPoint,
+    surface_temp_params,
+)
+    (; z) = coordinates
+    (; SST_mean) = surface_temp_params
+    FT = eltype(z)
+    return FT(SST_mean)
+end
+
 #For non-RCEMIPII box models with prescribed surface temp, assume that the latitude is 0.
 function surface_temperature(
     ::Union{ZonallySymmetricSST, ZonallyAsymmetricSST},
@@ -367,6 +378,16 @@ function surface_temperature(
 )
     (; x) = coordinates
     FT = eltype(x)
+    return FT(300)
+end
+
+function surface_temperature(
+    ::Union{ZonallySymmetricSST, ZonallyAsymmetricSST},
+    coordinates::Geometry.ZPoint,
+    surface_temp_params,
+)
+    (; z) = coordinates
+    FT = eltype(z)
     return FT(300)
 end
 

--- a/src/utils/common_spaces.jl
+++ b/src/utils/common_spaces.jl
@@ -57,29 +57,6 @@ function make_horizontal_space(
     return space
 end
 
-function make_column_spaces(
-    z_max,
-    z_elem,
-    z_stretch,
-    comms_ctx::ClimaComms.SingletonCommsContext,
-)
-    z_domain = Domains.IntervalDomain(
-        Geometry.ZPoint(zero(z_max)),
-        Geometry.ZPoint(z_max);
-        boundary_names = (:bottom, :top),
-    )
-    z_mesh = Meshes.IntervalMesh(z_domain, z_stretch; nelems = z_elem)
-    @info "z heights" z_mesh.faces
-    device = ClimaComms.device(comms_ctx)
-    z_topology = Topologies.IntervalTopology(
-        ClimaComms.SingletonCommsContext(device),
-        z_mesh,
-    )
-    cspace = Spaces.CenterFiniteDifferenceSpace(z_topology)
-    fspace = Spaces.CenterFiniteDifferenceSpace(cspace)
-    return (cspace, fspace)
-end
-
 function make_horizontal_space(mesh, quad, comms_ctx, bubble)
     if mesh isa Meshes.AbstractMesh1D
         error("Distributed mode does not work with 1D horizontal spaces.")
@@ -171,7 +148,7 @@ function make_hybrid_spaces(
         )
         # Coefficient for horizontal diffusion may alternatively be
         # determined from the empirical parameters suggested by
-        # E3SM  v1/v2 Topography documentation found here: 
+        # E3SM  v1/v2 Topography documentation found here:
         # https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/1456603764/V1+Topography+GLL+grids
         z_surface = @. mask(z_surface)
         if parsed_args["mesh_warp_type"] == "SLEVE"

--- a/src/utils/common_spaces.jl
+++ b/src/utils/common_spaces.jl
@@ -57,6 +57,29 @@ function make_horizontal_space(
     return space
 end
 
+function make_column_spaces(
+    z_max,
+    z_elem,
+    z_stretch,
+    comms_ctx::ClimaComms.SingletonCommsContext,
+)
+    z_domain = Domains.IntervalDomain(
+        Geometry.ZPoint(zero(z_max)),
+        Geometry.ZPoint(z_max);
+        boundary_names = (:bottom, :top),
+    )
+    z_mesh = Meshes.IntervalMesh(z_domain, z_stretch; nelems = z_elem)
+    @info "z heights" z_mesh.faces
+    device = ClimaComms.device(comms_ctx)
+    z_topology = Topologies.IntervalTopology(
+        ClimaComms.SingletonCommsContext(device),
+        z_mesh,
+    )
+    cspace = Spaces.CenterFiniteDifferenceSpace(z_topology)
+    fspace = Spaces.CenterFiniteDifferenceSpace(cspace)
+    return (cspace, fspace)
+end
+
 function make_horizontal_space(mesh, quad, comms_ctx, bubble)
     if mesh isa Meshes.AbstractMesh1D
         error("Distributed mode does not work with 1D horizontal spaces.")

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -271,6 +271,10 @@ function do_dss(space::Spaces.AbstractSpace)
            Quadratures.GLL
 end
 
+function do_dss(space::Spaces.FiniteDifferenceSpace)
+    return false
+end
+
 
 using ClimaComms
 is_distributed(::ClimaComms.SingletonCommsContext) = false
@@ -463,16 +467,7 @@ function promote_period(period::Dates.OtherPeriod)
 end
 
 function iscolumn(space)
-    # TODO: Our columns are 2+1D boxes with one element at the base. Fix this
-    isbox =
-        Meshes.domain(Spaces.topology(Spaces.horizontal_space(space))) isa
-        Domains.RectangleDomain
-    isbox || return false
-    has_one_element =
-        Meshes.nelements(
-            Spaces.topology(Spaces.horizontal_space(space)).mesh,
-        ) == 1
-    has_one_element && return true
+    return space isa Spaces.FiniteDifferenceSpace
 end
 
 function issphere(space)

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -174,11 +174,16 @@ function CTh_vector_type(space)
         Geometry.Contravariant1Vector
     elseif full_CT_axis == Geometry.Contravariant23Axis()
         Geometry.Contravariant2Vector
+    elseif full_CT_axis == Geometry.Contravariant3Axis()
+        # Even though there is no horizontal space, horizontal curl operators return the same
+        # type as if there was a 2d horizontal space
+        # TODO: I have no idea if this is OK
+        Geometry.Contravariant12Vector
     else
         error("$full_CT_axis is missing either vertical or horizontal sub-axes")
     end
 end
-
+has_topography(space::Spaces.FiniteDifferenceSpace) = false
 has_topography(space) = Spaces.grid(space).hypsography != Spaces.Grids.Flat()
 
 """

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -364,6 +364,11 @@ if MANYTESTS
             turbconv_models = ["diagnostic_edmfx"]
             radiations = ["gray", "allskywithclear"]
         end
+        if configuration == "column"
+            hyperdiff = "false"
+        else
+            hyperdiff = "true"
+        end
 
         for turbconv_mode in turbconv_models
             for radiation in radiations
@@ -403,6 +408,7 @@ if MANYTESTS
                             "dt" => "1secs",
                             "bubble" => bubble,
                             "viscous_sponge" => true,
+                            "hyperdiff" => hyperdiff,
                             "rayleigh_sponge" => true,
                             "insolation" => "timevarying",
                             "rad" => radiation,


### PR DESCRIPTION
While looking at calibrations, I realized that we seem to always generate `VIJFH` datalayouts, even for column cases. Our CPU and GPU code paths for each datalayout is split so that we can optimize kernels specifically for those datalayouts. So, we should probably allow these spaces to be flexible so that we get the most out of the true datalayout.