### PR TITLE
fix: wrong atmos model hash should warn, not error

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -310,9 +310,7 @@ function get_state_restart(config::AtmosConfig, restart_file, atmos_model_hash)
         atmos_model_hash_in_restart =
             InputOutput.HDF5.read_attribute(reader.file, "atmos_model_hash")
         if atmos_model_hash_in_restart != atmos_model_hash
-            error(
-                "Restart file $(restart_file) was constructed with a different AtmosModel",
-            )
+            @warn "Restart file $(restart_file) was constructed with a different AtmosModel"
         end
     end
     return (Y, t_start)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
