### PR TITLE
fix indivisible reduction periods warning

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -777,7 +777,8 @@ function get_simulation(config::AtmosConfig)
                 x -> !CA.isdivisible(x, checkpoint_frequency),
                 periods_reductions,
             )
-                accum_str = join(CA.promote_period.(collect(periods_reductions)), ", ")
+                accum_str = 
+                    join(CA.promote_period.(collect(periods_reductions)), ", ")
                 checkpt_str = CA.promote_period(checkpoint_frequency)
                 @warn "Diagnostics are accumulated at frequencies ($accum_str), which may not be evenly divisible by the checkpointing frequency (dt_save_state_to_disk = $checkpt_str)"
             end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -774,10 +774,12 @@ function get_simulation(config::AtmosConfig)
 
         if checkpoint_frequency != Inf
             if any(
-                x -> !CA.isdivisible(checkpoint_frequency, x),
+                x -> !CA.isdivisible(x, checkpoint_frequency),
                 periods_reductions,
             )
-                @warn "Some accumulated diagnostics might not be evenly divisible by the checkpointing frequency ($(CA.promote_period(checkpoint_frequency)))"
+                accum_str = join(CA.promote_period.(collect(periods_reductions)), ", ")
+                checkpt_str = CA.promote_period(checkpoint_frequency)
+                @warn "Diagnostics are accumulated at frequencies ($accum_str), which may not be evenly divisible by the checkpointing frequency (dt_save_state_to_disk = $checkpt_str)"
             end
         end
     else

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -774,13 +774,13 @@ function get_simulation(config::AtmosConfig)
 
         if checkpoint_frequency != Inf
             if any(
-                x -> !CA.isdivisible(x, checkpoint_frequency),
+                x -> !CA.isdivisible(checkpoint_frequency, x),
                 periods_reductions,
             )
                 accum_str =
                     join(CA.promote_period.(collect(periods_reductions)), ", ")
                 checkpt_str = CA.promote_period(checkpoint_frequency)
-                @warn "Diagnostics are accumulated at frequencies ($accum_str), which may not be evenly divisible by the checkpointing frequency (dt_save_state_to_disk = $checkpt_str)"
+                @warn "The checkpointing frequency (dt_save_state_to_disk = $checkpt_str) should be an integer multiple of all diagnostics accumulation periods ($accum_str) to simulations can be safely restarted from any checkpoint"
             end
         end
     else

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -777,7 +777,7 @@ function get_simulation(config::AtmosConfig)
                 x -> !CA.isdivisible(x, checkpoint_frequency),
                 periods_reductions,
             )
-                accum_str = 
+                accum_str =
                     join(CA.promote_period.(collect(periods_reductions)), ", ")
                 checkpt_str = CA.promote_period(checkpoint_frequency)
                 @warn "Diagnostics are accumulated at frequencies ($accum_str), which may not be evenly divisible by the checkpointing frequency (dt_save_state_to_disk = $checkpt_str)"


### PR DESCRIPTION
As far as I can tell, #3396 implemented the warning for indivisible frequencies incorrectly.

e.g., if 
```julia
periods_reductions = Set([Dates.Second(3600)])  # every hour
checkpoint_frequency = Dates.Millisecond(1800000)  # every 30 minutes, i.e. the value of dt_save_state_to_disk
```
I currently get the warning: `Warning: Some accumulated diagnostics might not be evenly divisible by the checkpointing frequency (30 minutes)`

but, unless I am misunderstanding what's going on here, this should be perfectly fine.

------

This PR essentially reverses the order of the arguments to `CA.isdivisible` so that we now have:
```julia
if any(
    x -> !CA.isdivisible(x, checkpoint_frequency),
    periods_reductions,
)
    accum_str = join(CA.promote_period.(collect(periods_reductions)), ", ")
    checkpt_str = CA.promote_period(checkpoint_frequency)
    @warn "Diagnostics are accumulated at frequencies ($accum_str), which may not be evenly divisible by the checkpointing frequency (dt_save_state_to_disk = $checkpt_str)"
end
```