### PR TITLE
Improve high-order horizontal derivatives

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -330,7 +330,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     @. ᶠΦ = CAP.grav(params) * ᶠz
     ᶜ∇Φ³ = p.scratch.ᶜtemp_CT3
     @. ᶜ∇Φ³ = CT3(ᶜgradᵥ(ᶠΦ))
-    @. ᶜ∇Φ³ += CT3(gradₕ(ᶜΦ))
+    @. ᶜ∇Φ³ += CT3(wgradₕ(ᶜΦ))
     ᶜ∇Φ₃ = p.scratch.ᶜtemp_C3
     @. ᶜ∇Φ₃ = ᶜgradᵥ(ᶠΦ)
 

--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -37,6 +37,7 @@ function temporary_quantities(Y, atmos)
         ᶜtemp_C12 = Fields.Field(C12{FT}, center_space), # ᶜuₕ_mean
         ᶜtemp_C3 = Fields.Field(C3{FT}, center_space), # ᶜ∇Φ₃
         ᶜtemp_CT3 = Fields.Field(CT3{FT}, center_space), # ᶜω³, ᶜ∇Φ³
+        ᶜtemp_C123 = Fields.Field(C123{FT}, center_space),
         ᶜtemp_CT123 = Fields.Field(CT123{FT}, center_space),
         ᶠtemp_CT3 = Fields.Field(CT3{FT}, face_space), # ᶠuₕ³
         ᶠtemp_CT12 = Fields.Field(CT12{FT}, face_space), # ᶠω¹²
@@ -44,6 +45,7 @@ function temporary_quantities(Y, atmos)
             NTuple{n_mass_flux_subdomains(atmos.turbconv_model), CT12{FT}},
             face_space,
         ), # ᶠω¹²ʲs
+        ᶠtemp_C12 = Fields.Field(C12{FT}, face_space),
         ᶠtemp_C123 = Fields.Field(C123{FT}, face_space), # χ₁₂₃
         ᶜtemp_UVWxUVW = Fields.Field(
             typeof(UVW(FT(0), FT(0), FT(0)) * UVW(FT(0), FT(0), FT(0))'),
@@ -68,5 +70,12 @@ function temporary_quantities(Y, atmos)
         ᶜdiffusion_h_matrix = similar(Y.c, TridiagonalMatrixRow{FT}),
         ᶜdiffusion_u_matrix = similar(Y.c, TridiagonalMatrixRow{FT}),
         ᶠtridiagonal_matrix_c3 = similar(Y.f, TridiagonalMatrixRow{C3{FT}}),
+        ghost_buffer = (;
+            ᶜtemp_scalar = Spaces.create_dss_buffer(similar(Y.c, FT)),
+            ᶜtemp_C3 = Spaces.create_dss_buffer(similar(Y.c, C3{FT})),
+            ᶜtemp_C12 = Spaces.create_dss_buffer(similar(Y.c, C12{FT})),
+            ᶜtemp_C123 = Spaces.create_dss_buffer(similar(Y.c, C123{FT})),
+            ᶠtemp_C12 = Spaces.create_dss_buffer(similar(Y.f, C12{FT})),
+        ),
     )
 end

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -278,7 +278,7 @@ function compute_precipitation_heating!(
 
     # compute full temperature gradient
     @. ᶜ∇T = CT123(ᶜgradᵥ(ᶠinterp(Tₐ(thp, ᶜts))))
-    @. ᶜ∇T += CT123(gradₕ(Tₐ(thp, ᶜts)))
+    @. ᶜ∇T += CT123(wgradₕ(Tₐ(thp, ᶜts)))
     # dot product with effective velocity of precipitation
     # (times q and specific heat)
     @. ᶜSeₜᵖ -= dot(ᶜ∇T, (ᶜu - C123(Geometry.WVector(ᶜwᵣ)))) * cᵥₗ(thp) * ᶜqᵣ

--- a/src/parameterized_tendencies/sponge/viscous_sponge.jl
+++ b/src/parameterized_tendencies/sponge/viscous_sponge.jl
@@ -29,20 +29,25 @@ function viscous_sponge_tendency!(Yₜ, Y, p, t, ::ViscousSponge)
     (; ᶜβ_viscous, ᶠβ_viscous) = p.viscous_sponge
     (; ᶜh_tot, ᶜspecific) = p.precomputed
     ᶜuₕ = Y.c.uₕ
-    @. Yₜ.c.uₕ +=
-        ᶜβ_viscous * (
-            wgradₕ(divₕ(ᶜuₕ)) - Geometry.project(
-                Geometry.Covariant12Axis(),
-                wcurlₕ(Geometry.project(Geometry.Covariant3Axis(), curlₕ(ᶜuₕ))),
-            )
-        )
-    @. Yₜ.f.u₃.components.data.:1 +=
-        ᶠβ_viscous * wdivₕ(gradₕ(Y.f.u₃.components.data.:1))
 
-    @. Yₜ.c.ρe_tot += ᶜβ_viscous * wdivₕ(Y.c.ρ * gradₕ(ᶜh_tot))
+    ᶜdivₕ_uₕ = @. p.scratch.ᶜtemp_scalar = wdivₕ(ᶜuₕ)
+    Spaces.weighted_dss!(ᶜdivₕ_uₕ => p.scratch.ghost_buffer.ᶜtemp_scalar)
+    ᶜcurlₕ_uₕ = @. p.scratch.ᶜtemp_C3 = C3(wcurlₕ(ᶜuₕ))
+    Spaces.weighted_dss!(ᶜcurlₕ_uₕ => p.scratch.ghost_buffer.ᶜtemp_C3)
+    @. Yₜ.c.uₕ += ᶜβ_viscous * (C12(wgradₕ(ᶜdivₕ_uₕ)) - C12(wcurlₕ(ᶜcurlₕ_uₕ)))
+
+    ᶠgradₕ_u₃ = @. p.scratch.ᶠtemp_C12 = C12(wgradₕ(Y.f.u₃.components.data.:1))
+    Spaces.weighted_dss!(ᶠgradₕ_u₃ => p.scratch.ghost_buffer.ᶠtemp_C12)
+    @. Yₜ.f.u₃.components.data.:1 += ᶠβ_viscous * wdivₕ(ᶠgradₕ_u₃)
+
+    ᶜgradₕ_h_tot = @. p.scratch.ᶜtemp_C12 = C12(wgradₕ(ᶜh_tot))
+    Spaces.weighted_dss!(ᶜgradₕ_h_tot => p.scratch.ghost_buffer.ᶜtemp_C12)
+    @. Yₜ.c.ρe_tot += ᶜβ_viscous * wdivₕ(Y.c.ρ * ᶜgradₕ_h_tot)
     for (ᶜρχₜ, ᶜχ, χ_name) in matching_subfields(Yₜ.c, ᶜspecific)
         χ_name == :e_tot && continue
-        @. ᶜρχₜ += ᶜβ_viscous * wdivₕ(Y.c.ρ * gradₕ(ᶜχ))
-        @. Yₜ.c.ρ += ᶜβ_viscous * wdivₕ(Y.c.ρ * gradₕ(ᶜχ))
+        ᶜgradₕ_χ = @. p.scratch.ᶜtemp_C12 = C12(wgradₕ(ᶜχ))
+        Spaces.weighted_dss!(ᶜgradₕ_χ => p.scratch.ghost_buffer.ᶜtemp_C12)
+        @. ᶜρχₜ += ᶜβ_viscous * wdivₕ(Y.c.ρ * ᶜgradₕ_χ)
+        @. Yₜ.c.ρ += ᶜβ_viscous * wdivₕ(Y.c.ρ * ᶜgradₕ_χ)
     end
 end

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -39,7 +39,7 @@ NVTX.@annotate function horizontal_advection_tendency!(Yₜ, Y, p, t)
         @. Yₜ.c.sgs⁰.ρatke -= wdivₕ(Y.c.sgs⁰.ρatke * ᶜu⁰)
     end
 
-    @. Yₜ.c.uₕ -= C12(gradₕ(ᶜp) / Y.c.ρ + gradₕ(ᶜK + ᶜΦ))
+    @. Yₜ.c.uₕ -= C12(wgradₕ(ᶜp) / Y.c.ρ + wgradₕ(ᶜK + ᶜΦ))
     # Without the C12(), the right-hand side would be a C1 or C2 in 2D space.
     return nothing
 end
@@ -90,7 +90,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     ᶠω¹²ʲs = p.scratch.ᶠtemp_CT12ʲs
 
     if point_type <: Geometry.Abstract3DPoint
-        @. ᶜω³ = curlₕ(Y.c.uₕ)
+        @. ᶜω³ = wcurlₕ(Y.c.uₕ)
     elseif point_type <: Geometry.Abstract2DPoint
         @. ᶜω³ = zero(ᶜω³)
     end
@@ -99,9 +99,9 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     for j in 1:n
         @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
     end
-    @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
+    @. ᶠω¹² += CT12(wcurlₕ(Y.f.u₃))
     for j in 1:n
-        @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
+        @. ᶠω¹²ʲs.:($$j) += CT12(wcurlₕ(Y.f.sgsʲs.:($$j).u₃))
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -13,11 +13,8 @@ const CT3 = Geometry.Contravariant3Vector
 const CT123 = Geometry.Contravariant123Vector
 const UVW = Geometry.UVWVector
 
-const divₕ = Operators.Divergence()
 const wdivₕ = Operators.WeakDivergence()
-const gradₕ = Operators.Gradient()
 const wgradₕ = Operators.WeakGradient()
-const curlₕ = Operators.Curl()
 const wcurlₕ = Operators.WeakCurl()
 
 const ᶜinterp = Operators.InterpolateF2C()


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes a potential issue with high-order horizontal derivatives at element boundaries that was identified while writing the dycore paper. Specifically, it replaces every "strong derivative" (an ill-defined notion for our hybrid CG-DG discretization) with a "weak derivative" (defined in terms of the weak formulation and GLL quadrature rule) and a call to DSS. Hopefully this will reduce numerical oscillations at element boundaries from hyperdiffusion and the viscous sponge layer.

## To-do
Find a specific example where this leads to a behavioral change.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
