### PR TITLE
Use deep atmosphere equations by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@ Main
 -------
 ### Features
 
+### Update default configuration to use deep-atmosphere eqns, fix diagnostic bug
+PR [3422](https://github.com/CliMA/ClimaAtmos.jl/pull/3422)
+Updates the `default_config` to set `deep_atmosphere=true`, and updates the 
+`rv` relative vorticity diagnostic to store the curl of horizontal velocity.
+
 ### Allow different sizes of dust and sea salt for radiation
 
 Added functionality to allow five different size bins of dust and sea salt aerosols
@@ -17,6 +22,7 @@ PR [3555](https://github.com/CliMA/ClimaAtmos.jl/pull/3555)
 
 The option `FriersonDiffusion` is removed from `vert_diff` config. Use `DecayWithHeightDiffusion` instead.
 PR [3592](https://github.com/CliMA/ClimaAtmos.jl/pull/3592)
+
 
 v0.28.4
 -------

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -278,8 +278,8 @@ log_progress:
   help: "Log simulation progress, including wall-time estimates"
   value: true
 deep_atmosphere:
-  help: "If true, use deep atmosphere equations and metric terms, otherwise assume columns are cylindrical (shallow atmosphere) [`true`, `false` (default)]"
-  value: false
+  help: "If true, use deep atmosphere equations and metric terms, otherwise assume columns are cylindrical (shallow atmosphere) [`true` (default), `false`]"
+  value: true
 restart_file:
   help: "Path to HDF5 file to use as simulation starting point"
   value: ~

--- a/config/model_configs/sphere_baroclinic_wave_rhoe.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe.yml
@@ -3,6 +3,7 @@ initial_condition: "DryBaroclinicWave"
 deep_atmosphere: true
 dt: "400secs"
 t_end: "10days"
+deep_atmosphere: false
 diagnostics:
   - short_name: [pfull, ua, wa, va, rv, ta, ke]
     period: 1days

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-212
+213
 
 # **README**
 #
@@ -20,6 +20,8 @@
 
 
 #=
+213 
+- Update to deep-atmos eqns by default, fix vorticity diagnostic
 
 212
 - Update RRTMGP, which changes aerosol optics calculation

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -199,7 +199,7 @@ add_diagnostic_variable!(
     units = "s^-1",
     comments = "Vertical component of relative vorticity",
     compute! = (out, state, cache, time) -> begin
-        vort = @. w_component.(Geometry.WVector.(cache.precomputed.ᶜu))
+        vort = @. w_component.(Geometry.WVector(curlₕ(cache.precomputed.ᶜu)))
         # We need to ensure smoothness, so we call DSS
         Spaces.weighted_dss!(vort)
         if isnothing(out)


### PR DESCRIPTION
Updates config arguments to set `deep_atmosphere: true` as default. Retains one experiment in shallow atmos configuration. 