### PR TITLE
Revert 3430 and 3425

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,12 @@ steps:
 
   - wait
 
+  - group: "Reproducibility tests"
+    steps:
+
+      - label: ":computer: Ensure mse tables are reset when necessary"
+        command: "julia --color=yes --project=examples reproducibility_tests/test_reset.jl"
+
   - group: "Radiation"
     steps:
 
@@ -138,13 +144,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/single_column_hydrostatic_balance_ft64.yml
           --job_id single_column_hydrostatic_balance_ft64
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id single_column_hydrostatic_balance_ft64
-          --out_dir single_column_hydrostatic_balance_ft64/output_active
         artifact_paths: "single_column_hydrostatic_balance_ft64/output_active/*"
-        env:
-          test_reproducibility: "true"
 
   - group: "Box Examples"
     steps:
@@ -154,39 +154,21 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/box_hydrostatic_balance_rhoe.yml
           --job_id box_hydrostatic_balance_rhoe
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id box_hydrostatic_balance_rhoe
-          --out_dir box_hydrostatic_balance_rhoe/output_active
         artifact_paths: "box_hydrostatic_balance_rhoe/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: 3D density current"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/box_density_current_test.yml
           --job_id box_density_current_test
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id box_density_current_test
-          --out_dir box_density_current_test/output_active
         artifact_paths: "box_density_current_test/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: Box (ρe_tot) rcemipii with diagnostic edmf"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/rcemipii_box_diagnostic_edmfx.yml
           --job_id rcemipii_box_diagnostic_edmfx
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id rcemipii_box_diagnostic_edmfx
-          --out_dir rcemipii_box_diagnostic_edmfx/output_active
         artifact_paths: "rcemipii_box_diagnostic_edmfx/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -195,13 +177,8 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/les_isdac_box.yml
           --job_id les_isdac_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id les_isdac_box
-          --out_dir les_isdac_box/output_active
         artifact_paths: "les_isdac_box/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_mem: 16G
@@ -215,39 +192,21 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/plane_agnesi_mountain_test_uniform.yml
           --job_id plane_agnesi_mountain_test_uniform
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id plane_agnesi_mountain_test_uniform
-          --out_dir plane_agnesi_mountain_test_uniform/output_active
         artifact_paths: "plane_agnesi_mountain_test_uniform/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: Agnesi linear hydrostatic mountain experiment (stretched)"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/plane_agnesi_mountain_test_stretched.yml
           --job_id plane_agnesi_mountain_test_stretched
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id plane_agnesi_mountain_test_stretched
-          --out_dir plane_agnesi_mountain_test_stretched/output_active
         artifact_paths: "plane_agnesi_mountain_test_stretched/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: Density current experiment"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/plane_density_current_test.yml
           --job_id plane_density_current_test
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id plane_density_current_test
-          --out_dir plane_density_current_test/output_active
         artifact_paths: "plane_density_current_test/output_active/*"
-        env:
-          test_reproducibility: "true"
 
 
   - group: "Conservation check"
@@ -279,15 +238,9 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_hydrostatic_balance_rhoe_ft64.yml
           --job_id sphere_hydrostatic_balance_rhoe_ft64
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_hydrostatic_balance_rhoe_ft64
-          --out_dir sphere_hydrostatic_balance_rhoe_ft64/output_active
         artifact_paths: "sphere_hydrostatic_balance_rhoe_ft64/output_active/*"
         agents:
           slurm_mem: 20GB
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: baroclinic wave (ρe)"
         key: sphere_baroclinic_wave_rhoe
@@ -295,13 +248,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_baroclinic_wave_rhoe.yml
           --job_id sphere_baroclinic_wave_rhoe
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_baroclinic_wave_rhoe
-          --out_dir sphere_baroclinic_wave_rhoe/output_active
         artifact_paths: "sphere_baroclinic_wave_rhoe/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: no lim baroclinic wave (ρe) equilmoist"
         command: >
@@ -315,8 +262,6 @@ steps:
         artifact_paths: "sphere_baroclinic_wave_rhoe_equilmoist/output_active/*"
         agents:
           slurm_constraint: icelake|cascadelake|skylake|epyc
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: no lim baroclinic wave (ρe) equilmoist (deep sphere)"
         command: >
@@ -330,8 +275,6 @@ steps:
         artifact_paths: "deep_sphere_baroclinic_wave_rhoe_equilmoist/output_active/*"
         agents:
           slurm_constraint: icelake|cascadelake|skylake|epyc
-        env:
-          test_reproducibility: "true"
 
       # Add this back when we figure out what to do with SSP and zalesak
       # - label: ":computer: SSP zalesak tracer & energy upwind baroclinic wave (ρe_tot) equilmoist"
@@ -351,13 +294,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_held_suarez_rhoe_hightop.yml
           --job_id sphere_held_suarez_rhoe_hightop
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_held_suarez_rhoe_hightop
-          --out_dir sphere_held_suarez_rhoe_hightop/output_active
         artifact_paths: "sphere_held_suarez_rhoe_hightop/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: no lim held suarez (ρe) equilmoist hightop sponge"
         command: >
@@ -371,8 +308,6 @@ steps:
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_hightop_sponge/output_active/*"
         agents:
           slurm_constraint: icelake|cascadelake|skylake|epyc
-        env:
-          test_reproducibility: "true"
 
   - group: "Sphere Examples (Aquaplanet)"
     steps:
@@ -389,8 +324,6 @@ steps:
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res/output_active/*"
         agents:
           slurm_mem: 20GB
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: aquaplanet (ρe_tot) equil allsky monin_obukhov varying insol gravity wave (raw_topo) high top zonally asymmetric"
         command: >
@@ -402,8 +335,6 @@ steps:
           --job_id sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric
           --out_dir sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric/output_active
         artifact_paths: "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
           slurm_constraint: icelake|cascadelake|skylake|epyc
@@ -413,13 +344,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_aquaplanet_rhoe_nonequilmoist_allsky.yml
           --job_id sphere_aquaplanet_rhoe_nonequilmoist_allsky
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_aquaplanet_rhoe_nonequilmoist_allsky
-          --out_dir sphere_aquaplanet_rhoe_nonequilmoist_allsky/output_active
         artifact_paths: "sphere_aquaplanet_rhoe_nonequilmoist_allsky/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -428,13 +353,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
           --job_id aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean
-          --out_dir aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean/output_active
         artifact_paths: "aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -443,13 +362,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
           --job_id aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64
-          --out_dir aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64/output_active
         artifact_paths: "aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -458,13 +371,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/rcemipii_sphere_diagnostic_edmfx.yml
           --job_id rcemipii_sphere_diagnostic_edmfx
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id rcemipii_sphere_diagnostic_edmfx
-          --out_dir rcemipii_sphere_diagnostic_edmfx/output_active
         artifact_paths: "rcemipii_sphere_diagnostic_edmfx/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -476,39 +383,21 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_baroclinic_wave_rhoe_topography_dcmip_rs.yml
           --job_id sphere_baroclinic_wave_rhoe_topography_dcmip_rs
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_baroclinic_wave_rhoe_topography_dcmip_rs
-          --out_dir sphere_baroclinic_wave_rhoe_topography_dcmip_rs/output_active
         artifact_paths: "sphere_baroclinic_wave_rhoe_topography_dcmip_rs/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: held suarez (ρe) topography (dcmip)"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_held_suarez_rhoe_topography_dcmip.yml
           --job_id sphere_held_suarez_rhoe_topography_dcmip
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_held_suarez_rhoe_topography_dcmip
-          --out_dir sphere_held_suarez_rhoe_topography_dcmip/output_active
         artifact_paths: "sphere_held_suarez_rhoe_topography_dcmip/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: held suarez (ρe) equilmoist topography (dcmip)"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_held_suarez_rhoe_equilmoist_topography_dcmip.yml
           --job_id sphere_held_suarez_rhoe_equilmoist_topography_dcmip
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_held_suarez_rhoe_equilmoist_topography_dcmip
-          --out_dir sphere_held_suarez_rhoe_equilmoist_topography_dcmip/output_active
         artifact_paths: "sphere_held_suarez_rhoe_equilmoist_topography_dcmip/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -517,26 +406,14 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200.yml
           --job_id sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200
-          --out_dir sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200/output_active
         artifact_paths: "sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200/output_active/*"
-        env:
-          test_reproducibility: "true"
 
       - label: ":computer: Diagnostic Earth surface elevation spectra"
         command: >
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth.yml
           --job_id sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth
-          --out_dir sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth/output_active
         artifact_paths: "sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth/output_active/*"
-        env:
-          test_reproducibility: "true"
 
   - group: "Restarting"
     steps:
@@ -644,13 +521,8 @@ steps:
           srun julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $MPI_CONFIG_PATH/mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky.yml
           --job_id mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky
-          --out_dir mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky/output_active
         artifact_paths: "mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 2
@@ -708,13 +580,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_test_box.yml
           --job_id diagnostic_edmfx_test_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_test_box
-          --out_dir diagnostic_edmfx_test_box/output_active
         artifact_paths: "diagnostic_edmfx_test_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -723,13 +589,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_gabls_box.yml
           --job_id diagnostic_edmfx_gabls_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_gabls_box
-          --out_dir diagnostic_edmfx_gabls_box/output_active
         artifact_paths: "diagnostic_edmfx_gabls_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -738,13 +598,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_bomex_box.yml
           --job_id diagnostic_edmfx_bomex_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_bomex_box
-          --out_dir diagnostic_edmfx_bomex_box/output_active
         artifact_paths: "diagnostic_edmfx_bomex_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -753,13 +607,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_bomex_stretched_box.yml
           --job_id diagnostic_edmfx_bomex_stretched_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_bomex_stretched_box
-          --out_dir diagnostic_edmfx_bomex_stretched_box/output_active
         artifact_paths: "diagnostic_edmfx_bomex_stretched_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -768,13 +616,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
           --job_id diagnostic_edmfx_dycoms_rf01_explicit_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_dycoms_rf01_explicit_box
-          --out_dir diagnostic_edmfx_dycoms_rf01_explicit_box/output_active
         artifact_paths: "diagnostic_edmfx_dycoms_rf01_explicit_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -783,13 +625,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf01_box.yml
           --job_id diagnostic_edmfx_dycoms_rf01_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_dycoms_rf01_box
-          --out_dir diagnostic_edmfx_dycoms_rf01_box/output_active
         artifact_paths: "diagnostic_edmfx_dycoms_rf01_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -798,13 +634,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf02_box.yml
           --job_id diagnostic_edmfx_dycoms_rf02_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_dycoms_rf02_box
-          --out_dir diagnostic_edmfx_dycoms_rf02_box/output_active
         artifact_paths: "diagnostic_edmfx_dycoms_rf02_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -813,13 +643,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_rico_box.yml
           --job_id diagnostic_edmfx_rico_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_rico_box
-          --out_dir diagnostic_edmfx_rico_box/output_active
         artifact_paths: "diagnostic_edmfx_rico_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -828,13 +652,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_box.yml
           --job_id diagnostic_edmfx_trmm_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_trmm_box
-          --out_dir diagnostic_edmfx_trmm_box/output_active
         artifact_paths: "diagnostic_edmfx_trmm_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -843,13 +661,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_stretched_box.yml
           --job_id diagnostic_edmfx_trmm_stretched_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_trmm_stretched_box
-          --out_dir diagnostic_edmfx_trmm_stretched_box/output_active
         artifact_paths: "diagnostic_edmfx_trmm_stretched_box/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -858,13 +670,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_box_0M.yml
           --job_id diagnostic_edmfx_trmm_box_0M
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_trmm_box_0M
-          --out_dir diagnostic_edmfx_trmm_box_0M/output_active
         artifact_paths: "diagnostic_edmfx_trmm_box_0M/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -878,8 +684,6 @@ steps:
           --job_id diagnostic_edmfx_aquaplanet
           --out_dir diagnostic_edmfx_aquaplanet/output_active
         artifact_paths: "diagnostic_edmfx_aquaplanet/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
           slurm_constraint: icelake|cascadelake|skylake|epyc
@@ -892,13 +696,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_adv_test_column.yml
           --job_id prognostic_edmfx_adv_test_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_adv_test_column
-          --out_dir prognostic_edmfx_adv_test_column/output_active
         artifact_paths: "prognostic_edmfx_adv_test_column/output_active/*"
-        env:
-          test_reproducibility: "true"
 
         agents:
           slurm_mem: 20GB
@@ -908,13 +706,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_simpleplume_column.yml
           --job_id prognostic_edmfx_simpleplume_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_simpleplume_column
-          --out_dir prognostic_edmfx_simpleplume_column/output_active
         artifact_paths: "prognostic_edmfx_simpleplume_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -923,13 +715,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_gabls_column.yml
           --job_id prognostic_edmfx_gabls_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_gabls_column
-          --out_dir prognostic_edmfx_gabls_column/output_active
         artifact_paths: "prognostic_edmfx_gabls_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -938,13 +724,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_pigroup_column.yml
           --job_id prognostic_edmfx_bomex_pigroup_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_pigroup_column
-          --out_dir prognostic_edmfx_bomex_pigroup_column/output_active
         artifact_paths: "prognostic_edmfx_bomex_pigroup_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -953,13 +733,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_fixtke_column.yml
           --job_id prognostic_edmfx_bomex_fixtke_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_fixtke_column
-          --out_dir prognostic_edmfx_bomex_fixtke_column/output_active
         artifact_paths: "prognostic_edmfx_bomex_fixtke_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -968,13 +742,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_stretched_column.yml
           --job_id prognostic_edmfx_bomex_stretched_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_stretched_column
-          --out_dir prognostic_edmfx_bomex_stretched_column/output_active
         artifact_paths: "prognostic_edmfx_bomex_stretched_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -983,13 +751,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_column.yml
           --job_id prognostic_edmfx_bomex_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_column
-          --out_dir prognostic_edmfx_bomex_column/output_active
         artifact_paths: "prognostic_edmfx_bomex_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -998,13 +760,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_implicit_column.yml
           --job_id prognostic_edmfx_bomex_column_implicit
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_column_implicit
-          --out_dir prognostic_edmfx_bomex_column_implicit/output_active
         artifact_paths: "prognostic_edmfx_bomex_column_implicit/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1013,13 +769,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_dycoms_rf01_column.yml
           --job_id prognostic_edmfx_dycoms_rf01_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_dycoms_rf01_column
-          --out_dir prognostic_edmfx_dycoms_rf01_column/output_active
         artifact_paths: "prognostic_edmfx_dycoms_rf01_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1028,13 +778,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_rico_column.yml
           --job_id prognostic_edmfx_rico_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_rico_column
-          --out_dir prognostic_edmfx_rico_column/output_active
         artifact_paths: "prognostic_edmfx_rico_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1043,13 +787,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column.yml
           --job_id prognostic_edmfx_trmm_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_trmm_column
-          --out_dir prognostic_edmfx_trmm_column/output_active
         artifact_paths: "prognostic_edmfx_trmm_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1058,13 +796,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column_0M.yml
           --job_id prognostic_edmfx_trmm_column_0M
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_trmm_column_0M
-          --out_dir prognostic_edmfx_trmm_column_0M/output_active
         artifact_paths: "prognostic_edmfx_trmm_column_0M/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1073,13 +805,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_gcmdriven_column.yml
           --job_id prognostic_edmfx_gcmdriven_column
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_gcmdriven_column
-          --out_dir prognostic_edmfx_gcmdriven_column/output_active
         artifact_paths: "prognostic_edmfx_gcmdriven_column/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
         soft_fail: true
@@ -1089,13 +815,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_box.yml
           --job_id prognostic_edmfx_bomex_box
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_bomex_box
-          --out_dir prognostic_edmfx_bomex_box/output_active
         artifact_paths: "prognostic_edmfx_bomex_box/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1104,13 +824,7 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_aquaplanet.yml
           --job_id prognostic_edmfx_aquaplanet
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_aquaplanet
-          --out_dir prognostic_edmfx_aquaplanet/output_active
         artifact_paths: "prognostic_edmfx_aquaplanet/output_active/*"
-        env:
-          test_reproducibility: "true"
         agents:
           slurm_mem: 20GB
 
@@ -1135,13 +849,8 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/sphere_baroclinic_wave_rhoe.yml
           --job_id sphere_baroclinic_wave_rhoe_gpu
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id sphere_baroclinic_wave_rhoe_gpu
-          --out_dir sphere_baroclinic_wave_rhoe_gpu/output_active
         artifact_paths: "sphere_baroclinic_wave_rhoe_gpu/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_mem: 16G
@@ -1192,13 +901,8 @@ steps:
             julia --threads=3 --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${GPU_CONFIG_PATH}/target_gpu_implicit_baroclinic_wave.yml
             --job_id target_gpu_implicit_baroclinic_wave_4process
-
-            julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-            --job_id target_gpu_implicit_baroclinic_wave_4process
-            --out_dir target_gpu_implicit_baroclinic_wave_4process/output_active
         artifact_paths: "target_gpu_implicit_baroclinic_wave_4process/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -1214,13 +918,8 @@ steps:
             julia --color=yes --project=examples examples/hybrid/driver.jl
             --config_file $CONFIG_PATH/central_gpu_hs_rhoe_equil_55km_nz63_0M.yml
             --job_id central_gpu_hs_rhoe_equil_55km_nz63_0M
-
-            julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-            --job_id central_gpu_hs_rhoe_equil_55km_nz63_0M
-            --out_dir central_gpu_hs_rhoe_equil_55km_nz63_0M/output_active
         artifact_paths: "central_gpu_hs_rhoe_equil_55km_nz63_0M/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
@@ -1233,13 +932,8 @@ steps:
             julia --color=yes --project=examples examples/hybrid/driver.jl
             --config_file $CONFIG_PATH/central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M.yml
             --job_id central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M
-
-            julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-            --job_id central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M
-            --out_dir central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M/output_active
         artifact_paths: "central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
@@ -1252,13 +946,8 @@ steps:
             julia --color=yes --project=examples examples/hybrid/driver.jl
             --config_file ${CONFIG_PATH}/gpu_aquaplanet_dyamond.yml
             --job_id gpu_aquaplanet_dyamond
-
-            julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-            --job_id gpu_aquaplanet_dyamond
-            --out_dir gpu_aquaplanet_dyamond/output_active
         artifact_paths: "gpu_aquaplanet_dyamond/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
@@ -1270,13 +959,8 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/diagnostic_edmfx_aquaplanet_gpu.yml
           --job_id diagnostic_edmfx_aquaplanet_gpu
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id diagnostic_edmfx_aquaplanet_gpu
-          --out_dir diagnostic_edmfx_aquaplanet_gpu/output_active
         artifact_paths: "diagnostic_edmfx_aquaplanet_gpu/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1
@@ -1287,13 +971,8 @@ steps:
           julia --color=yes --project=examples examples/hybrid/driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_aquaplanet.yml
           --job_id prognostic_edmfx_aquaplanet_gpu
-
-          julia --color=yes --project=examples reproducibility_tests/test_mse.jl
-          --job_id prognostic_edmfx_aquaplanet_gpu
-          --out_dir prognostic_edmfx_aquaplanet_gpu/output_active
         artifact_paths: "prognostic_edmfx_aquaplanet_gpu/output_active/*"
         env:
-          test_reproducibility: "true"
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
           slurm_gpus: 1

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -217,6 +217,9 @@ non_orographic_gravity_wave:
 nh_poly:
   help: "Horizontal polynomial degree. Note: The number of quadrature points in 1D within each horizontal element is then Nq = <--nh_poly> + 1"
   value: 3
+reproducibility_test:
+  help: "(Bool) perform reproducibility test"
+  value: false
 check_conservation:
   help: "Check conservation of mass and energy [`false` (default), `true`]"
   value: false

--- a/config/model_configs/deep_sphere_baroclinic_wave_rhoe_equilmoist.yml
+++ b/config/model_configs/deep_sphere_baroclinic_wave_rhoe_equilmoist.yml
@@ -1,5 +1,6 @@
 precip_model: "0M"
 dt_save_state_to_disk: "2days"
+reproducibility_test: true
 initial_condition: "MoistBaroclinicWave"
 dt: "450secs"
 t_end: "10days"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -19,5 +19,6 @@ cloud_model: "quadrature_sgs"
 precip_model: 1M
 dt: 120secs
 t_end: 3hours
+reproducibility_test: true
 toml: [toml/diagnostic_edmfx.toml]
 ode_algo: ARS343

--- a/config/model_configs/single_column_precipitation_test.yml
+++ b/config/model_configs/single_column_precipitation_test.yml
@@ -14,6 +14,7 @@ precip_model: "1M"
 vert_diff: "FriersonDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+reproducibility_test: false
 toml: [toml/single_column_precipitation_test.toml]
 diagnostics:
   - short_name: [hus, clw, cli, husra, hussn, ta, wa]

--- a/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
+++ b/config/model_configs/sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric.yml
@@ -16,6 +16,7 @@ cloud_model: "grid_scale"
 surface_temperature: "ZonallyAsymmetric"
 moist: "equil"
 albedo_model: "RegressionFunctionAlbedo"
+reproducibility_test: true
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "OC1", "OC2", "SO4"]
 toml: [toml/sphere_aquaplanet.toml]

--- a/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist.yml
+++ b/config/model_configs/sphere_baroclinic_wave_rhoe_equilmoist.yml
@@ -1,5 +1,6 @@
 precip_model: "0M"
 dt_save_state_to_disk: "2days"
+reproducibility_test: true
 initial_condition: "MoistBaroclinicWave"
 dt: "450secs"
 t_end: "10days"

--- a/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
+++ b/config/model_configs/sphere_held_suarez_rhoe_equilmoist_hightop_sponge.yml
@@ -9,5 +9,6 @@ t_end: "4days"
 vert_diff: true
 forcing: "held_suarez"
 precip_model: "0M"
+reproducibility_test: true
 moist: "equil"
 toml: [toml/sphere_held_suarez.toml]

--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -87,8 +87,8 @@ end
 include(
     joinpath(@__DIR__, "..", "..", "reproducibility_tests", "mse_tables.jl"),
 )
-if get(ENV, "test_reproducibility", "false") == "true"
-    # Export reproducibility results, to later test against the main branch
+if config.parsed_args["reproducibility_test"]
+    # Test results against main branch
     include(
         joinpath(
             @__DIR__,
@@ -98,10 +98,17 @@ if get(ENV, "test_reproducibility", "false") == "true"
             "reproducibility_tests.jl",
         ),
     )
-    export_reproducibility_results(
-        config.comms_ctx,
+    @testset "Test reproducibility table entries" begin
+        mse_keys = sort(collect(keys(all_best_mse[simulation.job_id])))
+        pcs = collect(Fields.property_chains(sol.u[end]))
+        for prop_chain in mse_keys
+            @test prop_chain in pcs
+        end
+    end
+    perform_reproducibility_tests(
         simulation.job_id,
         sol.u[end],
+        all_best_mse,
         simulation.output_dir,
     )
 end

--- a/reproducibility_tests/compute_mse.jl
+++ b/reproducibility_tests/compute_mse.jl
@@ -5,67 +5,67 @@ import ClimaCoreTempestRemap as CCTR
 
 include("latest_comparable_paths.jl")
 
-"""
-    to_dict(filename::String, comms_ctx)
+function get_nc_data(ds, var::String)
+    if haskey(ds, var)
+        return ds[var]
+    else
+        for key in keys(ds.group)
+            if haskey(ds.group[key], var)
+                return ds.group[key][var]
+            end
+        end
+    end
+    error("No key $var for mse computation.")
+    return nothing
+end
 
-Convert the HDF5 file containing the
-prognostic field `Y` into a `Dict`
-using ClimaCore's `property_chains` and
-`single_field` functions.
 """
-function to_dict(filename::String, comms_ctx)
-    dict = Dict{Any, AbstractArray}()
-    reader = InputOutput.HDF5Reader(filename, comms_ctx)
-    Y = InputOutput.read_field(reader, "Y")
-    Base.close(reader)
-    for prop_chain in Fields.property_chains(Y)
-        dict[prop_chain] =
-            vec(Array(parent(Fields.single_field(Y, prop_chain))))
+    to_dict(nc_filename::String, reference_keys::Vector{String})
+
+Convert an NCDatasets file to a `Dict`.
+"""
+function to_dict(nc_filename::String, reference_keys::Vector{String})
+    dict = Dict{String, AbstractArray}()
+    NCDatasets.Dataset(nc_filename, "r") do ds
+        for key in reference_keys
+            dict[key] = vec(Array(get_nc_data(ds, key)))
+        end
     end
     return dict
 end
 
 """
-    zero_dict(filename::String, comms_ctx)
-
-Return a dict of zeros for all `ClimaCore.Fields.property_chains`
-in the fieldvector `Y` contained in the HDF5 file `filename`.
-"""
-function zero_dict(filename::String, comms_ctx)
-    dict = Dict{Any, AbstractArray}()
-    reader = InputOutput.HDF5Reader(filename, comms_ctx)
-    Y = InputOutput.read_field(reader, "Y")
-    Base.close(reader)
-    for prop_chain in Fields.property_chains(Y)
-        dict[prop_chain] =
-            vec(Array(parent(Fields.single_field(Y, prop_chain)))) .* 0
-    end
-    return dict
-end
-
-"""
-    reproducibility_results(
-        comms_ctx;
+    reproducibility_test(;
         job_id,
+        reference_mse,
         ds_filename_computed,
         ds_filename_reference = nothing,
+        varname,
     )
 
 Returns a `Dict` of mean-squared errors between
-datasets `ds_filename_computed` and
-`ds_filename_reference` for all variables.
+`NCDataset`s `ds_filename_computed` and
+`ds_filename_reference` for all keys in `reference_mse`.
+Keys in `reference_mse` may directly map to keys in
+the `NCDataset`s, or they may be mapped to the keys
+via `varname`.
 
 If running on buildkite, we get `ds_filename_reference`
 from the latest merged dataset on Caltech central.
 """
-function reproducibility_results(comms_ctx; job_id, ds_filename_computed)
+function reproducibility_test(;
+    job_id,
+    reference_mse,
+    ds_filename_computed,
+    varname,
+)
     local ds_filename_reference
+    reference_keys = map(k -> varname(k), collect(keys(reference_mse)))
     paths = String[] # initialize for later handling
 
     if haskey(ENV, "BUILDKITE_COMMIT")
         paths = latest_comparable_paths(10)
-        isempty(paths) &&
-            return (zero_dict(ds_filename_computed, comms_ctx), paths)
+        isempty(paths) && return (reference_mse, paths)
         @info "`ds_filename_computed`: `$ds_filename_computed`"
         ds_filename_references =
             map(p -> joinpath(p, ds_filename_computed), paths)
@@ -94,41 +94,40 @@ function reproducibility_results(comms_ctx; job_id, ds_filename_computed)
                     @warn "There is no reference dataset, and no NC tar file."
                 end
             end
-        end
-        non_existent_files = filter(x -> !isfile(x), ds_filename_references)
-        if !isempty(non_existent_files)
-            msg = "\n\n"
-            msg *= "Pull request author:\n"
-            msg *= "    It seems that a new dataset,\n"
-            msg *= "\n"
-            msg *= "dataset file(s):`$(non_existent_files)`,"
-            msg *= "\n"
-            msg *= "    was created, or the name of the dataset\n"
-            msg *= "    has changed. Please increment the reference\n"
-            msg *= "    counter in `reproducibility_tests/ref_counter.jl`.\n"
-            msg *= "\n"
-            msg *= "    If this is not the case, then please\n"
-            msg *= "    open an issue with a link pointing to this\n"
-            msg *= "    PR and build.\n"
-            msg *= "\n"
-            msg *= "For more information, please find\n"
-            msg *= "`reproducibility_tests/README.md` and read the section\n\n"
-            msg *= "  `How to merge pull requests (PR) that get approved\n"
-            msg *= "   but *break* reproducibility tests`\n\n"
-            msg *= "for how to merge this PR."
-            error(msg)
+            if !isfile(ds_filename_reference)
+                msg = "\n\n"
+                msg *= "Pull request author:\n"
+                msg *= "    It seems that a new dataset,\n"
+                msg *= "\n"
+                msg *= "dataset file:`$(ds_filename_computed)`,"
+                msg *= "\n"
+                msg *= "    was created, or the name of the dataset\n"
+                msg *= "    has changed. Please increment the reference\n"
+                msg *= "    counter in `reproducibility_tests/ref_counter.jl`.\n"
+                msg *= "\n"
+                msg *= "    If this is not the case, then please\n"
+                msg *= "    open an issue with a link pointing to this\n"
+                msg *= "    PR and build.\n"
+                msg *= "\n"
+                msg *= "For more information, please find\n"
+                msg *= "`reproducibility_tests/README.md` and read the section\n\n"
+                msg *= "  `How to merge pull requests (PR) that get approved\n"
+                msg *= "   but *break* reproducibility tests`\n\n"
+                msg *= "for how to merge this PR."
+                error(msg)
+            end
         end
     else
         @warn "Buildkite not detected. Skipping reproducibility tests."
         @info "Please review output results before merging."
-        return (zero_dict(ds_filename_computed, comms_ctx), paths)
+        return (reference_mse, paths)
     end
 
     local computed_mse
-    dict_computed = to_dict(ds_filename_computed, comms_ctx)
-    dict_references = map(ds -> to_dict(ds, comms_ctx), ds_filename_references)
-    reference_keys = keys(first(dict_references))
-    @info "Reference keys $reference_keys"
+    @info "Prescribed reference keys $reference_keys"
+    dict_computed = to_dict(ds_filename_computed, reference_keys)
+    dict_references =
+        map(ds -> to_dict(ds, reference_keys), ds_filename_references)
     @info "Computed keys $(collect(keys(dict_computed)))"
     @info "Reference keys $(collect(keys(first(dict_references))))"
     if all(dr -> keys(dict_computed) == keys(dr), dict_references) && all(
@@ -153,4 +152,63 @@ function reproducibility_results(comms_ctx; job_id, ds_filename_computed)
     end
     return (computed_mses, paths)
 
+end
+
+
+##### TODO: move below functions to ClimaCore
+
+function first_center_space(fv::Fields.FieldVector)
+    for prop_chain in Fields.property_chains(fv)
+        f = Fields.single_field(fv, prop_chain)
+        space = axes(f)
+        if space isa Spaces.CenterExtrudedFiniteDifferenceSpace
+            return space
+        end
+    end
+    error("Unfound space")
+end
+
+function first_face_space(fv::Fields.FieldVector)
+    for prop_chain in Fields.property_chains(fv)
+        f = Fields.single_field(fv, prop_chain)
+        space = axes(f)
+        if space isa Spaces.FaceExtrudedFiniteDifferenceSpace
+            return space
+        end
+    end
+    error("Unfound space")
+end
+
+function export_nc(
+    Y::Fields.FieldVector;
+    nc_filename,
+    t_now = 0.0,
+    center_space = first_center_space,
+    face_space = first_face_space,
+    filter_prop_chain = pn -> true, # use all fields
+    varname::Function,
+)
+    prop_chains = Fields.property_chains(Y)
+    filter!(filter_prop_chain, prop_chains)
+    cspace = center_space(Y)
+    fspace = face_space(Y)
+    # create a temporary dir for intermediate data
+    FT = eltype(Y)
+    NCDatasets.NCDataset(nc_filename, "c") do nc
+        # defines the appropriate dimensions and variables for a space coordinate
+        # defines the appropriate dimensions and variables for a time coordinate (by default, unlimited size)
+        nc_time = CCTR.def_time_coord(nc)
+        CCTR.def_space_coord(nc, cspace, type = "cgll")
+        CCTR.def_space_coord(nc, fspace, type = "cgll")
+        # define variables for the prognostic states
+        for prop_chain in Fields.property_chains(Y)
+            f = Fields.single_field(Y, prop_chain)
+            space = axes(f)
+            nc_var = CCTR.defVar(nc, varname(prop_chain), FT, space, ("time",))
+            nc_var[:, 1] = f
+        end
+        # TODO: interpolate w onto center space and save it the same way as the other vars
+        nc_time[1] = t_now
+    end
+    return nothing
 end

--- a/reproducibility_tests/move_output.jl
+++ b/reproducibility_tests/move_output.jl
@@ -2,8 +2,12 @@
 include(joinpath(@__DIR__, "latest_comparable_paths.jl"))
 paths = latest_comparable_paths()
 
-include(joinpath(@__DIR__, "mse_tables.jl"))
-job_ids = reproducibility_test_job_ids
+all_lines = readlines(joinpath(@__DIR__, "mse_tables.jl"))
+lines = deepcopy(all_lines)
+filter!(x -> occursin("] = OrderedCollections", x), lines)
+job_ids = getindex.(split.(lines, "\""), 2)
+@assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
+@assert length(job_ids) ≠ 0 # safety net
 
 # Note: cluster_data_prefix is also defined in compute_mse.jl
 cluster_data_prefix = "/central/scratch/esm/slurm-buildkite/climaatmos-main"
@@ -17,7 +21,7 @@ if buildkite_ci
     @info "commit = $(commit)"
 
     using Glob
-    # @show readdir(joinpath(@__DIR__, ".."))
+    @show readdir(joinpath(@__DIR__, ".."))
     # if a contributor manually merged, we still want to move data
     # from scratch to `cluster_data_prefix`. So, let's also try moving
     # data if this is running on the main branch.

--- a/reproducibility_tests/mse_tables.jl
+++ b/reproducibility_tests/mse_tables.jl
@@ -1,62 +1,60 @@
-reproducibility_test_job_ids = [ # TODO: can we instead automatically grab this from the .buildkite file?
-    "sphere_baroclinic_wave_rhoe_equilmoist",
-    "sphere_held_suarez_rhoe_equilmoist_hightop_sponge",
-    "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res",
-    "sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric",
-    "deep_sphere_baroclinic_wave_rhoe_equilmoist",
-    "diagnostic_edmfx_aquaplanet",
-    "single_column_hydrostatic_balance_ft64",
-    "box_hydrostatic_balance_rhoe",
-    "box_density_current_test",
-    "rcemipii_box_diagnostic_edmfx",
-    "les_isdac_box",
-    "plane_agnesi_mountain_test_uniform",
-    "plane_agnesi_mountain_test_stretched",
-    "plane_density_current_test",
-    "sphere_hydrostatic_balance_rhoe_ft64",
-    "sphere_baroclinic_wave_rhoe",
-    "sphere_held_suarez_rhoe_hightop",
-    "sphere_aquaplanet_rhoe_nonequilmoist_allsky",
-    "aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean",
-    "aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64",
-    "rcemipii_sphere_diagnostic_edmfx",
-    "sphere_baroclinic_wave_rhoe_topography_dcmip_rs",
-    "sphere_held_suarez_rhoe_topography_dcmip",
-    "sphere_held_suarez_rhoe_equilmoist_topography_dcmip",
-    "sphere_ssp_baroclinic_wave_rhoe_equilmoist_dcmip200",
-    "sphere_ssp_baroclinic_wave_rhoe_equilmoist_earth",
-    "mpi_sphere_aquaplanet_rhoe_equilmoist_clearsky",
-    "diagnostic_edmfx_test_box",
-    "diagnostic_edmfx_gabls_box",
-    "diagnostic_edmfx_bomex_box",
-    "diagnostic_edmfx_bomex_stretched_box",
-    "diagnostic_edmfx_dycoms_rf01_explicit_box",
-    "diagnostic_edmfx_dycoms_rf01_box",
-    "diagnostic_edmfx_dycoms_rf02_box",
-    "diagnostic_edmfx_rico_box",
-    "diagnostic_edmfx_trmm_box",
-    "diagnostic_edmfx_trmm_stretched_box",
-    "diagnostic_edmfx_trmm_box_0M",
-    "prognostic_edmfx_adv_test_column",
-    "prognostic_edmfx_simpleplume_column",
-    "prognostic_edmfx_gabls_column",
-    "prognostic_edmfx_bomex_pigroup_column",
-    "prognostic_edmfx_bomex_fixtke_column",
-    "prognostic_edmfx_bomex_stretched_column",
-    "prognostic_edmfx_bomex_column",
-    "prognostic_edmfx_bomex_column_implicit",
-    "prognostic_edmfx_dycoms_rf01_column",
-    "prognostic_edmfx_rico_column",
-    "prognostic_edmfx_trmm_column",
-    "prognostic_edmfx_trmm_column_0M",
-    "prognostic_edmfx_gcmdriven_column",
-    "prognostic_edmfx_bomex_box",
-    "prognostic_edmfx_aquaplanet",
-    "sphere_baroclinic_wave_rhoe_gpu",
-    "diagnostic_edmfx_aquaplanet_gpu",
-    "prognostic_edmfx_aquaplanet_gpu",
-    "central_gpu_hs_rhoe_equil_55km_nz63_0M",
-    "central_cloud_diag_gpu_hs_rhoe_equil_55km_nz63_0M",
-    "gpu_aquaplanet_dyamond",
-    "target_gpu_implicit_baroclinic_wave_4process",
-]
+#################################
+################################# MSE tables
+#################################
+#! format: off
+#
+all_best_mse = OrderedCollections.OrderedDict()
+#
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0
+all_best_mse["sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :u₃, :components, :data, 1)] = 0
+#
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρ)] = 0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρe_tot)] = 0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:c, :ρq_tot)] = 0
+all_best_mse["sphere_held_suarez_rhoe_equilmoist_hightop_sponge"][(:f, :u₃, :components, :data, 1)] = 0
+#
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:c, :ρ)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:c, :ρe_tot)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:c, :ρq_tot)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_res"][(:f, :u₃, :components, :data, 1)] = 0
+#
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"] = OrderedCollections.OrderedDict()
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:c, :ρ)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:c, :ρe_tot)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:c, :ρq_tot)] = 0
+all_best_mse["sphere_aquaplanet_rhoe_equilmoist_allsky_gw_raw_zonallyasymmetric"][(:f, :u₃, :components, :data, 1)] = 0
+#
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"] = OrderedCollections.OrderedDict()
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρ)] = 0
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρe_tot)] = 0
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:c, :ρq_tot)] = 0
+all_best_mse["deep_sphere_baroclinic_wave_rhoe_equilmoist"][(:f, :u₃, :components, :data, 1)] = 0
+#
+all_best_mse["diagnostic_edmfx_aquaplanet"] = OrderedCollections.OrderedDict()
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :ρ)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :uₕ, :components, :data, 1)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :uₕ, :components, :data, 2)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :ρe_tot)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :ρq_tot)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:c, :sgs⁰, :ρatke)] = 0
+all_best_mse["diagnostic_edmfx_aquaplanet"][(:f, :u₃, :components, :data, 1)] = 0
+#
+#! format: on
+#################################
+#################################
+#################################

--- a/reproducibility_tests/print_new_mse.jl
+++ b/reproducibility_tests/print_new_mse.jl
@@ -5,8 +5,14 @@ import JSON
 include(joinpath(@__DIR__, "latest_comparable_paths.jl"))
 paths = latest_comparable_paths()
 
+all_lines = readlines(joinpath(@__DIR__, "mse_tables.jl"))
+lines = deepcopy(all_lines)
+filter!(x -> occursin("] = OrderedCollections", x), lines)
+job_ids = getindex.(split.(lines, "\""), 2)
+@assert count(x -> occursin("OrderedDict", x), all_lines) == length(job_ids) + 1
+@assert length(job_ids) ≠ 0 # safety net
+
 include(joinpath(@__DIR__, "mse_tables.jl"))
-job_ids = reproducibility_test_job_ids
 
 computed_mse = OrderedCollections.OrderedDict()
 files_skipped = OrderedCollections.OrderedDict()
@@ -15,11 +21,10 @@ for job_id in job_ids
     files_skipped[job_id] = false
 end
 
-@info "length(job_ids) = $(length(job_ids))"
 for job_id in job_ids
     all_filenames = readdir(joinpath(job_id, "output_active"); join = true)
     mse_filenames = filter(is_mse_file, all_filenames)
-    isempty(mse_filenames) || @info "mse_filenames: $mse_filenames"
+    @info "mse_filenames: $mse_filenames"
     for filename in mse_filenames
         if !isfile(filename)
             @warn "File $filename skipped"
@@ -36,22 +41,26 @@ for job_id in job_ids
     end
 end
 
-println("################################# Computed MSEs")
+println("#################################")
+println("################################# MSE tables")
+println("#################################")
 println("#! format: off")
 println("#")
 
+println("all_best_mse = OrderedCollections.OrderedDict()\n#")
 for job_id in keys(computed_mse)
+    println("all_best_mse[\"$job_id\"] = OrderedCollections.OrderedDict()")
     for var in keys(computed_mse[job_id])
         if computed_mse[job_id][var] == "NA"
             println(
-                "mse_dict[\"$job_id\"][$(var)] = \"$(computed_mse[job_id][var])\"",
+                "all_best_mse[\"$job_id\"][$(var)] = \"$(computed_mse[job_id][var])\"",
             )
         else
             # It's easier to update the reference counter, rather than updating
             # the mse tables, so let's always print zeros:
             computed_mse[job_id][var] = 0
             println(
-                "mse_dict[\"$job_id\"][$(var)] = $(computed_mse[job_id][var])",
+                "all_best_mse[\"$job_id\"][$(var)] = $(computed_mse[job_id][var])",
             )
         end
     end
@@ -60,8 +69,16 @@ end
 println("#! format: on")
 
 println("#################################")
+println("#################################")
+println("#################################")
 
-isempty(paths) && @warn string("No comparable references.")
+if isempty(paths)
+    @warn string(
+        "The printed `all_best_mse` values have",
+        "been set to zero, due to no comparable references,",
+        "for copy-paste convenience.",
+    )
+end
 
 # Cleanup
 for job_id in job_ids
@@ -73,6 +90,15 @@ for job_id in job_ids
 end
 
 println("-- DO NOT COPY --")
+
+for job_id in keys(computed_mse)
+    for var in keys(computed_mse[job_id])
+        if haskey(all_best_mse[job_id], var)
+            all_best_mse[job_id][var] isa Real || continue # skip if "NA"
+            computed_mse[job_id][var] isa Real || continue # skip if "NA"
+        end
+    end
+end
 
 if any(values(files_skipped))
     @info "Skipped files:"

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-187
+186
 
 # **README**
 #
@@ -20,12 +20,6 @@
 
 
 #=
-
-187
-- Data for reproducibility tests are now exported via HDF5 instead of NC files,
-  and incrementing the reference counter is far easier to update our system
-  than supporting the comparison of data exported (and some pre-processed)
-  from different formats.
 
 186
 - Topography dataset has been modified to the 60 arc-second ETOPO2022 dataset. 

--- a/reproducibility_tests/reproducibility_tests.jl
+++ b/reproducibility_tests/reproducibility_tests.jl
@@ -1,28 +1,41 @@
 import JSON
-import ClimaCore.Fields
-import ClimaCore.InputOutput
+import ClimaCore.Fields as Fields
 include(joinpath(@__DIR__, "compute_mse.jl"))
 
-function export_reproducibility_results(
-    comms_ctx,
+function perform_reproducibility_tests(
     job_id::String,
     Y_last::Fields.FieldVector,
+    all_best_mse::AbstractDict,
     output_dir::String,
 )
     # This is helpful for starting up new tables
-    @info "Comparing variables:"
+    @info "Job-specific MSE table format:"
+    println("all_best_mse[\"$job_id\"] = OrderedCollections.OrderedDict()")
     for prop_chain in Fields.property_chains(Y_last)
-        println("   $prop_chain")
+        println("all_best_mse[\"$job_id\"][$prop_chain] = 0.0")
     end
+    # Extract best mse for this job:
+    best_mse = all_best_mse[job_id]
 
-    ds_filename_computed = joinpath(output_dir, "prog_state.hdf5")
+    ds_filename_computed = joinpath(output_dir, "prog_state.nc")
 
-    hdfwriter = InputOutput.HDF5Writer(ds_filename_computed, comms_ctx)
-    InputOutput.write!(hdfwriter, Y_last, "Y")
-    Base.close(hdfwriter)
+    function process_name(s::AbstractString)
+        # "c_ρ", "c_ρe", "c_uₕ_1", "c_uₕ_2", "f_w_1", "c_sgs⁰_ρatke"
+        s = replace(s, "components_data_" => "")
+        s = replace(s, "ₕ" => "_h")
+        s = replace(s, "ρ" => "rho")
+        s = replace(s, "⁰" => "_0")
+        return s
+    end
+    varname(pc::Tuple) = process_name(join(pc, "_"))
 
-    (computed_mses, paths) =
-        reproducibility_results(config.comms_ctx; job_id, ds_filename_computed)
+    export_nc(Y_last; nc_filename = ds_filename_computed, varname)
+    (computed_mses, paths) = reproducibility_test(;
+        job_id,
+        reference_mse = best_mse,
+        ds_filename_computed,
+        varname,
+    )
 
     for (computed_mse, path) in zip(computed_mses, paths)
         commit_hash = basename(path)

--- a/reproducibility_tests/test_mse.jl
+++ b/reproducibility_tests/test_mse.jl
@@ -2,7 +2,9 @@
 Please see ClimaAtmos.jl/reproducibility_tests/README.md
 for a more detailed information on how reproducibility tests work.
 =#
+@info "##########################################"
 @info "########################################## Reproducibility tests"
+@info "##########################################"
 
 import OrderedCollections
 import JSON
@@ -35,6 +37,10 @@ function get_params()
 end
 
 (; job_id, out_dir, test_broken_report_flakiness) = get_params()
+include(joinpath(@__DIR__, "mse_tables.jl"))
+best_mse = all_best_mse[job_id]
+best_mse_string =
+    Dict(map(x -> string(x) => best_mse[x], collect(keys(best_mse))))
 
 import ClimaReproducibilityTests as CRT
 using Test
@@ -91,4 +97,6 @@ test_reproducibility_results(
     test_broken_report_flakiness,
 )
 
+@info "##########################################"
+@info "##########################################"
 @info "##########################################"

--- a/reproducibility_tests/test_reset.jl
+++ b/reproducibility_tests/test_reset.jl
@@ -1,0 +1,14 @@
+import OrderedCollections
+
+# Get cases from JobIDs in mse_tables file:
+include(joinpath(@__DIR__, "latest_comparable_paths.jl"))
+paths = latest_comparable_paths()
+include(joinpath(@__DIR__, "mse_tables.jl"))
+
+#### Test that mse values are all zero if ref counter is incremented
+mse_vals = collect(Iterators.flatten(map(x -> values(x), values(all_best_mse))))
+if isempty(paths) && !all(mse_vals .== 0)
+    error(
+        "All mse values in `reproducibility_tests/mse_tables.jl` must be set to zero when the reference counter is incremented",
+    )
+end


### PR DESCRIPTION
There are more issues that surfaced with the reproducibility tests-- our infrastructure is not finding the old files, and they're either not getting moved properly, or we're converting them to tarballs and they're not re-found/extracted properly.

This PR reverts us back to https://github.com/CliMA/ClimaAtmos.jl/commit/dd35435923bee42bb18595286166bce96c93baa5. I'm going to rm the output folders on central associated with PRs after https://github.com/CliMA/ClimaAtmos.jl/commit/dd35435923bee42bb18595286166bce96c93baa5, so that we're back at that state.