### PR TITLE
Add unit tests for some reproducibility infrastructure

### DIFF
--- a/reproducibility_tests/compute_mse.jl
+++ b/reproducibility_tests/compute_mse.jl
@@ -64,7 +64,7 @@ function reproducibility_test(;
     paths = String[] # initialize for later handling
 
     if haskey(ENV, "BUILDKITE_COMMIT")
-        paths = latest_comparable_paths(10)
+        paths = latest_comparable_paths(; n = 10)
         isempty(paths) && return (reference_mse, paths)
         @info "`ds_filename_computed`: `$ds_filename_computed`"
         ds_filename_references =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using Test
 @safetestset "Model getters" begin @time include("solver/model_getters.jl") end
 @safetestset "Topography tests" begin @time include("topography.jl") end
 @safetestset "Restarts" begin @time include("restart.jl") end
+@safetestset "Reproducibility infra" begin @time include("unit_reproducibility_infra.jl") end
 
 #! format: on
 

--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -1,0 +1,89 @@
+#=
+using Revise; include("test/unit_reproducibility_infra.jl")
+=#
+using Test
+using Dates
+
+include(joinpath("..", "reproducibility_tests/latest_comparable_paths.jl"))
+
+function make_ref_file_counter(dir, pathname, i)
+    d = mkdir(pathname)
+    open(io -> println(io, i), joinpath(d, "ref_counter.jl"), "w")
+    return joinpath(dir, d)
+end
+
+@testset "Reproducibility infrastructure: latest_comparable_paths" begin
+    # No paths at all
+    mktempdir() do path
+        cd(path) do
+            paths =
+                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            @test paths == []
+        end
+    end
+
+    # No paths with ref counters
+    mktempdir() do path
+        cd(path) do
+            p1 = mkdir("d1")
+            paths =
+                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            @test paths == []
+        end
+    end
+
+    # No paths with matching ref counters
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            paths =
+                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            @test paths == []
+        end
+    end
+
+    # 1 matching ref counter
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            paths =
+                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            @test paths == [p2]
+        end
+    end
+
+    # multiple matching ref counters
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 3)
+            p5 = make_ref_file_counter(path, "d5", 3)
+            p6 = make_ref_file_counter(path, "d6", 3)
+            paths =
+                latest_comparable_paths(; root_path = path, ref_counter_PR = 3)
+            @test paths == [p6, p5, p4, p3] # p6 is most recent
+        end
+    end
+
+    # matching ref counters that exceed n
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 3)
+            p5 = make_ref_file_counter(path, "d5", 3)
+            p6 = make_ref_file_counter(path, "d6", 3)
+            paths = latest_comparable_paths(;
+                n = 2,
+                root_path = path,
+                ref_counter_PR = 3,
+            )
+            @test paths == [p6, p5] # p6 is most recent
+        end
+    end
+end


### PR DESCRIPTION
This PR adds some unit tests for the reproducibility infrastructure, and attempts to improve the documentation.

Thanks for suggesting this, @Sbozzolo.

One downside of this PR is that I've removed this check:

```julia
    ref_counters_main = map(read_ref_counter, ref_counter_files_main)
    if all(rc -> ref_counter_PR == rc + 1, ref_counters_main) # new reference
        @warn "`ref_counter.jl` incremented, assuming no comparable references"
        @info "Ref counters main: $ref_counters_main."
        @info "Please review output results before merging."
        return String[]
    elseif all(rc -> ref_counter_PR == rc, ref_counters_main) # unchanged reference
        @info "Ref counters main: $ref_counters_main."
        @info "Comparing results against main path:$paths"
    else
        error(
            "Unexpected reference. Please open an issue pointing to this build.",
        )
    end
```
But I think it no longer makes sense in the context of `latest_comparable_paths` returning comparable paths, because the path must contain the same ref counter as the main branch (which is now specified as a function argument).

Am I missing any edge cases that could happen?