### PR TITLE
Add docs, unit tests, and refactor repro test infra

### DIFF
--- a/reproducibility_tests/move_output.jl
+++ b/reproducibility_tests/move_output.jl
@@ -67,5 +67,8 @@ else
 end
 
 if buildkite_ci && in_merge_queue
-    cleanup_central(cluster_data_prefix)
+    folders = get_reference_paths_to_delete(; root_path = cluster_data_prefix)
+    for f in folders
+        rm(f; recursive = true, force = true)
+    end
 end

--- a/reproducibility_tests/reproducibility_utils.jl
+++ b/reproducibility_tests/reproducibility_utils.jl
@@ -1,3 +1,44 @@
+#=
+################################################################################
+Reproducibility Terminology.
+
+Consider the following set of reproducibility
+folders, prefixed by "reference counters", which
+allow users to compare against other reproducible
+states in that column.
+
+Note that reference counter changes can "rewind"
+(which may happen in the case of reverted commits).
+In such cases, we do consider the rewound state as
+an entirely new state, in order to fully preserve
+the history (to some depth).
+
+An important consequence of this requires precise
+terminology to avoid ambiguous descriptions.
+
+For example, "comparable references per reference counter"
+is not well defined, because the reference counter can
+be reverted. So, let's introduce the concept of a "bin",
+which can be defined as a collection of folders
+created in a period with the same reference counter.
+Folders created before and after that bin have a different
+reference counter. Also, `n_bins == n_reference_changes + 1`
+(modulo the edge case of when there are no bins)
+because, if the reference counter doesn't change, new results
+are put into the same bin.
+```
+comparable states
+         |                           ref counter changes ---->                         | oldest
+         |                                                                             |
+         |  bin 1      bin 2      bin 3      bin 4      bin 5      bin 6      bin 7    |
+         |                                                                             |
+         |  02_49f92   04_36ebe   05_beb8a   06_4d837   05_8c311   08_45875   10_bc1e0 |
+         |             04_d6e48              06_d6d73              08_1cc58            |
+         v             04_4c042                                                        v newest
+```
+################################################################################
+=#
+
 import Dates
 
 read_ref_counter(filename) = parse(Int, first(readlines(filename)))
@@ -118,57 +159,153 @@ function latest_comparable_paths(;
     return comparable_paths
 end
 
-function reason(path)
-    f = joinpath(path, "ref_counter.jl")
-    if !isfile(f)
-        return "ref_counter.jl does not exist"
-    else
-        ref_counter = parse(Int, first(readlines(f)))
-        return "ref_counter: $ref_counter"
+"""
+    invalid_reference_folders(; root_path)
+
+Return all subfolders in `root_path`
+that meet the following criteria:
+
+ - A `ref_counter.jl` file is missing
+"""
+function invalid_reference_folders(; root_path)
+    paths = sorted_dataset_folder(; dir = root_path)
+    invalid_folders = filter(paths) do p
+        !isfile(joinpath(p, "ref_counter.jl"))
     end
+    return invalid_folders
 end
 
-function cleanup_central(cluster_data_prefix)
-    @warn "Cleaning up old files on central"
-    # Get (sorted) array of paths, `pop!(sorted_paths)`
-    # is the most recent merged folder.
-    sorted_paths = sorted_dataset_folder(; dir = cluster_data_prefix)
-    keep_latest_n = 0
-    keep_latest_ref_counters = 5
-    if !isempty(sorted_paths)
-        N = length(sorted_paths) - keep_latest_n
-        paths_to_delete = []
-        ref_counters_main = ref_counters_per_path(sorted_paths)
-        i_largest_reference = argmax(ref_counters_main)
-        path = sorted_paths[i_largest_reference]
-        ref_counter_file_main = joinpath(path, "ref_counter.jl")
-        @assert isfile(ref_counter_file_main)
-        ref_counter_main = parse(Int, first(readlines(ref_counter_file_main)))
+"""
+    compute_bins(root_path::String)
+    compute_bins(sorted_paths::Vector{String})
 
-        for i in 1:N
-            path = sorted_paths[i]
-            ref_counter_file = joinpath(path, "ref_counter.jl")
-            if !isfile(ref_counter_file)
-                push!(paths_to_delete, path)
+Return a vector of reproducibility bins.
+
+Bins are sorted from newest to oldest:
+ - `bins[1], bins[end]` are the newest and oldest bins
+ - `bins[i][1], bins[i][end]` are the newest oldest comparable states.
+
+```
+comparable states
+         |                           ref counter changes ---->                         | oldest
+         |                                                                             |
+         |  bin 1      bin 2      bin 3      bin 4      bin 5      bin 6      bin 7    |
+         |                                                                             |
+         |  02_49f92   04_36ebe   05_beb8a   06_4d837   05_8c311   08_45875   10_bc1e0 |
+         |             04_d6e48              06_d6d73              08_1cc58            |
+         v             04_4c042                                                        v newest
+```
+"""
+compute_bins(root_path::String) =
+    compute_bins(reverse(sorted_dataset_folder(; dir = root_path)))
+function compute_bins(sorted_paths::Vector{String})
+    bins = Vector{String}[]
+    path_index = 1
+    while path_index ≤ length(sorted_paths)
+        paths_per_bin = String[]
+        while path_index ≤ length(sorted_paths)
+            path = sorted_paths[path_index]
+            if isempty(paths_per_bin)
+                push!(paths_per_bin, path)
+                path_index += 1
             else
-                ref_counter = parse(Int, first(readlines(ref_counter_file)))
-                # Just to be safe, let's also make sure that we don't delete
-                # any paths with recent (let's say 5) ref counter increments ago.
-                if ref_counter + keep_latest_ref_counters < ref_counter_main
-                    push!(paths_to_delete, path)
+                ref_counter_bin = read_ref_counter(
+                    joinpath(first(paths_per_bin), "ref_counter.jl"),
+                )
+                ref_counter_path =
+                    read_ref_counter(joinpath(path, "ref_counter.jl"))
+                if ref_counter_bin == ref_counter_path
+                    push!(paths_per_bin, path)
+                    path_index += 1
+                else
+                    break
                 end
             end
         end
-        @show ref_counter_main
-        @show length(sorted_paths)
-        @show length(paths_to_delete)
-        @info "Deleting files:"
-        for i in 1:length(paths_to_delete)
-            f = paths_to_delete[i]
-            @info "     (File, date): ($(f), $(Dates.unix2datetime(stat(f).mtime))). Reason: $(reason(f))"
-        end
-        for i in 1:length(paths_to_delete)
-            rm(paths_to_delete[i]; recursive = true, force = true)
+        push!(bins, paths_per_bin)
+    end
+    return bins
+end
+
+"""
+    get_reference_paths_to_delete(;
+        root_path,
+        keep_n_comparable_states = 5,
+        keep_n_bins_back = 7,
+    )
+
+Return a list of folders to delete.
+
+Our reference folders are saved, and can
+therefore build up significantly and take
+a lot of storage.
+
+Consider a collection of folders whose
+names are prepended by the reference
+counter:
+
+```
+keep_n_comparable_states
+         |                           <---- keep_n_bins_back                            | oldest
+         |                                                                             |
+         |  bin 1      bin 2      bin 3      bin 4      bin 5      bin 6      bin 7    |
+         |                                                                             |
+         |  02_49f92   04_36ebe   05_beb8a   06_4d837   05_8c311   08_45875   10_bc1e0 |
+         |             04_d6e48              06_d6d73              08_1cc58            |
+         v             04_4c042                                                        v newest
+```
+With these folders, and given a reference
+counter of 10, we'll see the following
+behavior:
+```
+    get_reference_paths_to_delete(;
+        keep_n_comparable_states = 4,
+        keep_n_bins_back = 3
+    ) -> [02_49f92, 04_36ebe, 04_d6e48, 04_4c042]
+
+    get_reference_paths_to_delete(;
+        keep_n_comparable_states = 1,
+        keep_n_bins_back = 5
+    ) -> [02_49f92, 04_d6e48, 04_4c042, 06_d6d73, 08_1cc58]
+```
+
+Note:
+    `keep_n_references_back` is sorted _chronologically_,
+    in order to correctly operate in the case of
+    reverted pull requests. In other words, the above
+    references may look like this:
+```
+keep_n_comparable_states
+         |                           <---- keep_n_bins_back                            | oldest
+         |                                                                             |
+         |  bin 1      bin 2      bin 3      bin 4      bin 5      bin 6      bin 7    |
+         |                                                                             |
+         |  02_49f92   04_36ebe   05_beb8a   06_4d837   05_8c311   08_45875   10_bc1e0 |
+         |             04_d6e48              06_d6d73              08_1cc58            |
+         v             04_4c042                                                        v newest
+```
+
+"""
+function get_reference_paths_to_delete(;
+    root_path,
+    keep_n_comparable_states = 5,
+    keep_n_bins_back = 7,
+)
+    @assert isempty(invalid_reference_folders(; root_path))
+    paths_to_delete = String[]
+    sorted_paths = reverse(sorted_dataset_folder(; dir = root_path))
+    if !isempty(sorted_paths)
+        # Now, sorted_paths[1] is newest, sorted_paths[end] is oldest
+        bins = compute_bins(sorted_paths)
+        for i in 1:length(bins), j in 1:length(bins[i])
+            if i ≤ keep_n_bins_back
+                if !(j ≤ keep_n_comparable_states)
+                    push!(paths_to_delete, bins[i][j])
+                end
+            else
+                push!(paths_to_delete, bins[i][j])
+            end
         end
     end
+    return paths_to_delete
 end

--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -2,9 +2,20 @@
 using Revise; include("test/unit_reproducibility_infra.jl")
 =#
 using Test
-using Dates
+import Dates
+import Logging
 
 include(joinpath("..", "reproducibility_tests/reproducibility_utils.jl"))
+
+quiet_latest_comparable_paths(args...; kwargs...) =
+    Logging.with_logger(Logging.NullLogger()) do
+        latest_comparable_paths(args...; kwargs...)
+    end
+basenames(x) = map(basename, x) # for debugging
+function make_path(dir, pathname)
+    d = mkdir(pathname)
+    return joinpath(dir, d)
+end
 
 function make_ref_file_counter(dir, pathname, i)
     d = mkdir(pathname)
@@ -16,8 +27,10 @@ end
     # No paths at all
     mktempdir() do path
         cd(path) do
-            paths =
-                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            paths = quiet_latest_comparable_paths(;
+                root_path = path,
+                ref_counter_PR = 2,
+            )
             @test paths == []
         end
     end
@@ -26,8 +39,10 @@ end
     mktempdir() do path
         cd(path) do
             p1 = mkdir("d1")
-            paths =
-                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            paths = quiet_latest_comparable_paths(;
+                root_path = path,
+                ref_counter_PR = 2,
+            )
             @test paths == []
         end
     end
@@ -36,8 +51,10 @@ end
     mktempdir() do path
         cd(path) do
             p1 = make_ref_file_counter(path, "d1", 1)
-            paths =
-                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            paths = quiet_latest_comparable_paths(;
+                root_path = path,
+                ref_counter_PR = 2,
+            )
             @test paths == []
         end
     end
@@ -48,8 +65,10 @@ end
             p1 = make_ref_file_counter(path, "d1", 1)
             p2 = make_ref_file_counter(path, "d2", 2)
             p3 = make_ref_file_counter(path, "d3", 3)
-            paths =
-                latest_comparable_paths(; root_path = path, ref_counter_PR = 2)
+            paths = quiet_latest_comparable_paths(;
+                root_path = path,
+                ref_counter_PR = 2,
+            )
             @test paths == [p2]
         end
     end
@@ -63,8 +82,10 @@ end
             p4 = make_ref_file_counter(path, "d4", 3)
             p5 = make_ref_file_counter(path, "d5", 3)
             p6 = make_ref_file_counter(path, "d6", 3)
-            paths =
-                latest_comparable_paths(; root_path = path, ref_counter_PR = 3)
+            paths = quiet_latest_comparable_paths(;
+                root_path = path,
+                ref_counter_PR = 3,
+            )
             @test paths == [p6, p5, p4, p3] # p6 is most recent
         end
     end
@@ -78,12 +99,246 @@ end
             p4 = make_ref_file_counter(path, "d4", 3)
             p5 = make_ref_file_counter(path, "d5", 3)
             p6 = make_ref_file_counter(path, "d6", 3)
-            paths = latest_comparable_paths(;
+            paths = quiet_latest_comparable_paths(;
                 n = 2,
                 root_path = path,
                 ref_counter_PR = 3,
             )
             @test paths == [p6, p5] # p6 is most recent
+        end
+    end
+
+    # reverted commits examples
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 4)
+            p5 = make_ref_file_counter(path, "d5", 5)
+            p6 = make_ref_file_counter(path, "d6", 3)
+            paths = quiet_latest_comparable_paths(;
+                n = 2,
+                root_path = path,
+                ref_counter_PR = 3,
+            )
+            # TODO: do we want to compare against p3 here?
+            # This could be problematic for reverted commits
+            @test paths == [p6, p3]
+        end
+    end
+
+    # appending to p7 now, confusingly, removes p3:
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 4)
+            p5 = make_ref_file_counter(path, "d5", 5)
+            p6 = make_ref_file_counter(path, "d6", 3)
+            p7 = make_ref_file_counter(path, "d7", 3)
+            paths = quiet_latest_comparable_paths(;
+                n = 2,
+                root_path = path,
+                ref_counter_PR = 3,
+            )
+            @test paths == [p7, p6]
+        end
+    end
+end
+
+@testset "Reproducibility infrastructure: validate_reference_folders" begin
+    # No paths at all
+    mktempdir() do path
+        cd(path) do
+            @test invalid_reference_folders(; root_path = path) == []
+        end
+    end
+
+    # 1 path without ref counter
+    mktempdir() do path
+        cd(path) do
+            p1 = make_path(path, "d1")
+            @test invalid_reference_folders(; root_path = path) == [p1]
+        end
+    end
+
+    # mix
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            r1 = make_path(path, "r1")
+            p2 = make_ref_file_counter(path, "d2", 2)
+            r2 = make_path(path, "r2")
+            p3 = make_ref_file_counter(path, "d3", 3)
+            r3 = make_path(path, "r3")
+            @test invalid_reference_folders(; root_path = path) == [r1, r2, r3]
+        end
+    end
+end
+
+@testset "Reproducibility infrastructure: compute_bins" begin
+    # No paths at all
+    mktempdir() do path
+        cd(path) do
+            @test compute_bins(path) == []
+        end
+    end
+
+    # 1 ref counter
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            @test compute_bins(path) == [[p1]]
+        end
+    end
+
+    # 2 ref counter
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            @test compute_bins(path) == [[p2], [p1]]
+        end
+    end
+
+    # 4 ref counter
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 3)
+            p5 = make_ref_file_counter(path, "d5", 5)
+            p6 = make_ref_file_counter(path, "d6", 5)
+            p7 = make_ref_file_counter(path, "d7", 6)
+            @test compute_bins(path) == [[p7], [p6, p5], [p4, p3], [p2], [p1]]
+        end
+    end
+
+    # simulating reverted PR
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            p2 = make_ref_file_counter(path, "d2", 2)
+            p3 = make_ref_file_counter(path, "d3", 3)
+            p4 = make_ref_file_counter(path, "d4", 4)
+            p5 = make_ref_file_counter(path, "d5", 3)
+            p6 = make_ref_file_counter(path, "d6", 4)
+            p7 = make_ref_file_counter(path, "d7", 5)
+            @test compute_bins(path) ==
+                  [[p7], [p6], [p5], [p4], [p3], [p2], [p1]]
+        end
+    end
+end
+
+@testset "Reproducibility infrastructure: get_reference_paths_to_delete" begin
+    # No paths at all
+    mktempdir() do path
+        cd(path) do
+            paths = get_reference_paths_to_delete(; root_path = path)
+            @test paths == []
+        end
+    end
+
+    # Paths without ref counters (error)
+    mktempdir() do path
+        cd(path) do
+            p1 = mkdir("d1")
+            @test_throws AssertionError get_reference_paths_to_delete(;
+                root_path = path,
+            )
+        end
+    end
+
+    # keep everything case
+    mktempdir() do path
+        cd(path) do
+            p1 = make_ref_file_counter(path, "d1", 1)
+            paths = get_reference_paths_to_delete(; root_path = path)
+            @test paths == []
+        end
+    end
+
+    #=
+    # typical example, consider:
+
+    keep_n_comparable_states
+             |    <---- keep_n_bins_back    | oldest
+             |                              |
+             |  B01 B02 B03 B04 B05 B06 B07 |
+             |                              |
+             |  p01 p02 p05 p06 p08 p09 p11 |
+             |      p03     p07     p10     |
+             v      p04                     v newest
+    =#
+    mktempdir() do path
+        cd(path) do
+            p01 = make_ref_file_counter(path, "01", 1)
+            p02 = make_ref_file_counter(path, "02", 2)
+            p03 = make_ref_file_counter(path, "03", 2)
+            p04 = make_ref_file_counter(path, "04", 2)
+            p05 = make_ref_file_counter(path, "05", 3)
+            p06 = make_ref_file_counter(path, "06", 4)
+            p07 = make_ref_file_counter(path, "07", 4)
+            p08 = make_ref_file_counter(path, "08", 5)
+            p09 = make_ref_file_counter(path, "09", 6)
+            p10 = make_ref_file_counter(path, "10", 6)
+            p11 = make_ref_file_counter(path, "11", 7)
+            paths = get_reference_paths_to_delete(;
+                root_path = path,
+                keep_n_comparable_states = 1,
+                keep_n_bins_back = 5,
+            )
+            @test paths == reverse([p01, p02, p03, p04, p06, p09])
+            paths = get_reference_paths_to_delete(;
+                root_path = path,
+                keep_n_comparable_states = 4,
+                keep_n_bins_back = 3,
+            )
+            @test paths == reverse([p01, p02, p03, p04, p05, p06, p07])
+        end
+    end
+
+    #=
+    # Reverted commits example, consider:
+
+    keep_n_comparable_states
+             |    <---- keep_n_bins_back    | oldest
+             |                              |
+             |  B01 B02 B03 B01 B02 B03 B04 |
+             |                              |
+             |  p01 p02 p05 p06 p08 p09 p11 |
+             |      p03     p07     p10     |
+             v      p04                     v newest
+    =#
+
+    mktempdir() do path
+        cd(path) do
+            p01 = make_ref_file_counter(path, "01", 1)
+            p02 = make_ref_file_counter(path, "02", 2)
+            p03 = make_ref_file_counter(path, "03", 2)
+            p04 = make_ref_file_counter(path, "04", 2)
+            p05 = make_ref_file_counter(path, "05", 3)
+            p06 = make_ref_file_counter(path, "06", 1)
+            p07 = make_ref_file_counter(path, "07", 1)
+            p08 = make_ref_file_counter(path, "08", 2)
+            p09 = make_ref_file_counter(path, "09", 3)
+            p10 = make_ref_file_counter(path, "10", 3)
+            p11 = make_ref_file_counter(path, "11", 4)
+            paths = get_reference_paths_to_delete(;
+                root_path = path,
+                keep_n_comparable_states = 1,
+                keep_n_bins_back = 5,
+            )
+            @test paths == reverse([p01, p02, p03, p04, p06, p09])
+            paths = get_reference_paths_to_delete(;
+                root_path = path,
+                keep_n_comparable_states = 4,
+                keep_n_bins_back = 3,
+            )
+            @test paths == reverse([p01, p02, p03, p04, p05, p06, p07])
         end
     end
 end


### PR DESCRIPTION
This PR adds docs, unit tests, and refactors the reproducibility test infrastructure. In adding unit tests and documentation, I've realized that some of the terminology around the repro tests needs revised for certain terminology to be well defined.

In particular, if we consider the situation where commits are reverted, we can end up with multiple and diverging paths (multiple paths with the same reference counter, but made at different periods in development). For example, if our reference counter history looks like (top being most recent):

```julia
137
     /PR10 # is PR6 even valid to compare against, here?
136
     /PR9
     /PR10 # should this compare with PRs 4 and 5?
135  # Reverted
     /PR8 # should this compare with commits in PRs 1,2,3?
138
     /PR7
137
     /PR6
136
     /PR4
     /PR5
135
     /PR1
     /PR2
     /PR3
```
We could clean up older commits, but I think a safer option is to change the `latest_comparable_paths` to use the (newly) added function `compute_bins`. I originally used the term `bundle` (e.g., `compute_bundles`), which I'm almost leaning towards returning to. It's a longer name but sounds more...tidy.

This was previously not an issue when `latest_comparable_paths` was `latest_comparable_path`, because we always grabbed the most _recent_ matched reference to compare against, eliminating this potential issue.

I'll update the README once we land on a design that is coherent, but I think it might take a bit more refactoring to get there.