### PR TITLE
Refactor `latest_comparable_paths`

### DIFF
--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -30,6 +30,7 @@ end
             paths = quiet_latest_comparable_paths(;
                 root_path = path,
                 ref_counter_PR = 2,
+                skip = false,
             )
             @test paths == []
         end
@@ -42,6 +43,7 @@ end
             paths = quiet_latest_comparable_paths(;
                 root_path = path,
                 ref_counter_PR = 2,
+                skip = false,
             )
             @test paths == []
         end
@@ -54,6 +56,7 @@ end
             paths = quiet_latest_comparable_paths(;
                 root_path = path,
                 ref_counter_PR = 2,
+                skip = false,
             )
             @test paths == []
         end
@@ -68,6 +71,7 @@ end
             paths = quiet_latest_comparable_paths(;
                 root_path = path,
                 ref_counter_PR = 2,
+                skip = false,
             )
             @test paths == [p2]
         end
@@ -85,6 +89,7 @@ end
             paths = quiet_latest_comparable_paths(;
                 root_path = path,
                 ref_counter_PR = 3,
+                skip = false,
             )
             @test paths == [p6, p5, p4, p3] # p6 is most recent
         end
@@ -103,6 +108,7 @@ end
                 n = 2,
                 root_path = path,
                 ref_counter_PR = 3,
+                skip = false,
             )
             @test paths == [p6, p5] # p6 is most recent
         end
@@ -121,10 +127,9 @@ end
                 n = 2,
                 root_path = path,
                 ref_counter_PR = 3,
+                skip = false,
             )
-            # TODO: do we want to compare against p3 here?
-            # This could be problematic for reverted commits
-            @test paths == [p6, p3]
+            @test paths == [p6]
         end
     end
 
@@ -142,6 +147,7 @@ end
                 n = 2,
                 root_path = path,
                 ref_counter_PR = 3,
+                skip = false,
             )
             @test paths == [p7, p6]
         end


### PR DESCRIPTION
@szy21 pointed out that our long runs were broken due to the reproducibility tests. It looks like #3437 removed [this check](https://github.com/CliMA/ClimaAtmos.jl/pull/3437/files#diff-fd99dc8960514e7a27ca9720b6557562d62ddee7cf84c7580569ffd72cdbc960L50), which means that the long runs try to run some reproducibility infrastructure in the plot comparison against main part of the driver.

We should probably make that orthogonal to the repro tests, but I had plans to refactor `latest_comparable_paths` anyway, so this PR adds that check back in, and changes to using `compute_bins`, which is unit tested (as well as `latest_comparable_paths`), and this fixes a bug in `latest_comparable_paths` in that we will no longer incorrectly compare against potentially incompatible commits after reverted commits (when duplicate reference counters exist on main).