### PR TITLE
test that entries in default config have "help" and "value"

### DIFF
--- a/test/config.jl
+++ b/test/config.jl
@@ -37,3 +37,17 @@ repeated_job_ids = filter(kv -> length(kv[2]) > 1, value_to_keys)
 file, io = mktemp()
 config_err = ErrorException("File $(CA.normrelpath(file)) is empty or missing.")
 @test_throws config_err CA.AtmosConfig(file)
+
+@testset "Check that entries in `default_config.yml` have `help` and `value` keys" begin
+    config = CA.load_yaml_file(CA.default_config_file)
+    missing_help = String[]
+    missing_value = String[]
+    for (key, value) in config
+        !haskey(value, "help") && push!(missing_help, key)
+        !haskey(value, "value") && push!(missing_value, key)
+    end
+    # Every key in the default config should have a `help` and `value` key
+    # If not, these tests will fail, indicating which keys are missing
+    @test isempty(missing_help)
+    @test isempty(missing_value)
+end


### PR DESCRIPTION
All entries in `default_config.yml` should have both "value" and "help" entries. If not set, the added test will fail. Tests are written in a way to make it easier for developers to see which keys are missing one of the entries. e.g.:
```julia
Check that entries to `default_config.yml` has `help` and `value` keys: Test Failed at ClimaAtmos.jl/test/config.jl:62
  Expression: isempty(missing_help)
   Evaluated: isempty(["forcing"])
```