### PR TITLE
Change buildkite badge to only reflect main

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ClimaAtmos.jl
 [gha-ci-img]: https://github.com/CliMA/ClimaAtmos.jl/actions/workflows/ci.yml/badge.svg
 [gha-ci-url]: https://github.com/CliMA/ClimaAtmos.jl/actions/workflows/ci.yml
 
-[bk-ci-img]: https://badge.buildkite.com/2a31b42d67409c27660a0dcce65b49294cd9c6b9f14c12f21e.svg
+[bk-ci-img]: https://badge.buildkite.com/2a31b42d67409c27660a0dcce65b49294cd9c6b9f14c12f21e.svg/?branch=main
 [bk-ci-url]: https://buildkite.com/clima/climaatmos-ci
 
 [codecov-img]: https://codecov.io/gh/CliMA/ClimaAtmos.jl/branch/main/graph/badge.svg


### PR DESCRIPTION
The buildkite badge previously showed the status of the most recent build on buildkite. This changes it to show the status of the most recent build of main.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Sometimes the build kite badge shows a failing status even when the latest build of main passes.


## To-do
- maybe change the link to direct to builds of main instead of all builds?


## Content
- change badge scope to main

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
