### PR TITLE
fix: logging for preset comms device

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -589,18 +589,7 @@ function get_comms_context(parsed_args)
     end
     comms_ctx = ClimaComms.context(device)
     ClimaComms.init(comms_ctx)
-    if ClimaComms.iamroot(comms_ctx)
-        Logging.global_logger(Logging.ConsoleLogger(stderr, Logging.Info))
-    else
-        Logging.global_logger(Logging.NullLogger())
-    end
-    @info "Running on $(nameof(typeof(device)))."
-    if comms_ctx isa ClimaComms.SingletonCommsContext
-        @info "Setting up single-process ClimaAtmos run"
-    else
-        @info "Setting up distributed ClimaAtmos run" nprocs =
-            ClimaComms.nprocs(comms_ctx)
-    end
+
     if NVTX.isactive()
         # makes output on buildkite a bit nicer
         if ClimaComms.iamroot(comms_ctx)
@@ -611,6 +600,26 @@ function get_comms_context(parsed_args)
     end
 
     return comms_ctx
+end
+
+"""
+    silence_non_root_processes(comms_ctx)
+
+Set the logging behavior based on the process rank within the given communication context `comms_ctx`.
+If the process is the root process, logging is set to display messages to the console with `Info` level.
+For all other processes, logging is silenced by setting it to a `NullLogger`.
+
+# Arguments
+- `comms_ctx`: The communication context used to determine the rank of the process.
+
+"""
+function silence_non_root_processes(comms_ctx)
+    # Set logging to only display for the root process
+    if ClimaComms.iamroot(comms_ctx)
+        Logging.global_logger(Logging.ConsoleLogger(stderr, Logging.Info))
+    else
+        Logging.global_logger(Logging.NullLogger())
+    end
 end
 
 function get_simulation(config::AtmosConfig)

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -647,17 +647,25 @@ function AtmosConfig(
         override_file = CP.merge_toml_files(config["toml"]),
     )
     comms_ctx = isnothing(comms_ctx) ? get_comms_context(config) : comms_ctx
+    device = ClimaComms.device(comms_ctx)
+    silence_non_root_processes(comms_ctx)
+    @info "Running on $(nameof(typeof(device)))"
+    if comms_ctx isa ClimaComms.SingletonCommsContext
+        @info "Setting up single-process ClimaAtmos run"
+    else
+        @info "Setting up distributed ClimaAtmos run" nprocs =
+            ClimaComms.nprocs(comms_ctx)
+    end
 
     config = config_with_resolved_and_acquired_artifacts(config, comms_ctx)
-    device = ClimaComms.device(comms_ctx)
     if device isa ClimaComms.CPUMultiThreaded
-        @info "Running ClimaCore in threaded mode, with $(Threads.nthreads()) threads."
+        @info "Running ClimaCore in threaded mode, with $(Threads.nthreads()) threads"
     else
-        @info "Running ClimaCore in unthreaded mode."
+        @info "Running ClimaCore in unthreaded mode"
     end
 
     isempty(job_id) &&
-        @warn "`job_id` is empty and likely not passed to AtmosConfig."
+        @warn "`job_id` is empty and likely not passed to AtmosConfig"
 
     @info "Making AtmosConfig with config files: $(sprint(config_summary, config_files))"
 


### PR DESCRIPTION
Correctly set `Logging` options if `comms_ctx` is already supplied to `AtmosConfig`.
