### PR TITLE
Move SG_quad out of cache

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -6,7 +6,6 @@ struct AtmosCache{
     COR,
     SFC,
     GHOST,
-    SGQ,
     PREC,
     SCRA,
     HYPE,
@@ -43,9 +42,6 @@ struct AtmosCache{
 
     """Center and face ghost buffers used by DSS"""
     ghost_buffer::GHOST
-
-    """Struct with sub-grid sampling quadrature"""
-    SG_quad::SGQ
 
     """Quantities that are updated with set_precomputed_quantities!"""
     precomputed::PREC
@@ -144,11 +140,10 @@ function build_cache(Y, atmos, params, surface_setup, sim_info, aerosol_names)
 
     sfc_setup = surface_setup(params)
     scratch = temporary_quantities(Y, atmos)
-    SG_quad = SGSQuadrature(FT)
 
     precomputed = precomputed_quantities(Y, atmos)
     precomputing_arguments =
-        (; atmos, core, params, sfc_setup, precomputed, scratch, dt, SG_quad)
+        (; atmos, core, params, sfc_setup, precomputed, scratch, dt)
 
     # Coupler compatibility
     isnothing(precomputing_arguments.sfc_setup) &&
@@ -178,7 +173,6 @@ function build_cache(Y, atmos, params, surface_setup, sim_info, aerosol_names)
         core,
         sfc_setup,
         ghost_buffer,
-        SG_quad,
         precomputed,
         scratch,
         hyperdiff,

--- a/src/cache/cloud_fraction.jl
+++ b/src/cache/cloud_fraction.jl
@@ -223,7 +223,8 @@ end
                        coeff, ᶜlength_scale, thermo_params)
 
 where:
-  - SG_quad is a struct containing information about quadrature type and order
+  - SG_quad is a struct containing information about Gaussian quadrature order,
+    sampling point values and weights
   - ts is the thermodynamic state
   - ᶜ∇q, ᶜ∇θ are the gradients of q_tot and liquid ice potential temperature
   - coeff - a free parameter (to be moved into params)
@@ -251,7 +252,6 @@ function quad_loop(
     # and limited covarainces
     function get_x_hat(χ1, χ2)
 
-        @assert SG_quad.quadrature_type isa GaussianQuad
         FT = eltype(χ1)
 
         q′q′ = covariance_from_grad(coeff, ᶜlength_scale, ᶜ∇q, ᶜ∇q)

--- a/src/cache/cloud_fraction.jl
+++ b/src/cache/cloud_fraction.jl
@@ -60,9 +60,10 @@ NVTX.@annotate function set_cloud_fraction!(
     Y,
     p,
     ::Union{EquilMoistModel, NonEquilMoistModel},
-    ::QuadratureCloud,
+    qc::QuadratureCloud,
 )
-    (; SG_quad, params) = p
+    SG_quad = qc.SG_quad
+    (; params) = p
 
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
@@ -112,10 +113,11 @@ NVTX.@annotate function set_cloud_fraction!(
     Y,
     p,
     ::Union{EquilMoistModel, NonEquilMoistModel},
-    ::SGSQuadratureCloud,
+    qc::SGSQuadratureCloud,
     ::DiagnosticEDMFX,
 )
-    (; SG_quad, params) = p
+    SG_quad = qc.SG_quad
+    (; params) = p
 
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)
@@ -162,10 +164,11 @@ NVTX.@annotate function set_cloud_fraction!(
     Y,
     p,
     ::Union{EquilMoistModel, NonEquilMoistModel},
-    ::SGSQuadratureCloud,
+    qc::SGSQuadratureCloud,
     ::PrognosticEDMFX,
 )
-    (; SG_quad, params) = p
+    SG_quad = qc.SG_quad
+    (; params) = p
 
     FT = eltype(params)
     thermo_params = CAP.thermodynamics_params(params)

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -313,12 +313,13 @@ end
 
 function get_cloud_model(parsed_args)
     cloud_model = parsed_args["cloud_model"]
+    FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
     return if cloud_model == "grid_scale"
         GridScaleCloud()
     elseif cloud_model == "quadrature"
-        QuadratureCloud()
+        QuadratureCloud(SGSQuadrature(FT))
     elseif cloud_model == "quadrature_sgs"
-        SGSQuadratureCloud()
+        SGSQuadratureCloud(SGSQuadrature(FT))
     else
         error("Invalid cloud_model $(cloud_model)")
     end

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -72,7 +72,6 @@ const T2 = 290
         p.core,
         sfc_setup,
         p.ghost_buffer,
-        p.SG_quad,
         p.precomputed,
         p.scratch,
         p.hyperdiff,


### PR DESCRIPTION
There is no reason for SG_quad to be in AtmosCache: it is constant and is firmly attached to a specific function.
