### PR TITLE
Remove start_date from cache

### DIFF
--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -2,7 +2,6 @@ struct AtmosCache{
     FT <: AbstractFloat,
     FTE,
     WTE,
-    SD,
     AM,
     NUM,
     CAP,
@@ -35,9 +34,6 @@ struct AtmosCache{
 
     """Walltime estimate"""
     walltime_estimate::WTE
-
-    """Start date (used for insolation and for data files)."""
-    start_date::SD
 
     """AtmosModel"""
     atmos::AM
@@ -190,7 +186,6 @@ function build_cache(Y, atmos, params, surface_setup, sim_info, aerosol_names)
         dt,
         t_end,
         WallTimeEstimate(),
-        start_date,
         atmos,
         numerics,
         params,

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -297,16 +297,17 @@ function set_insolation_variables!(Y, p, t, ::IdealizedInsolation)
     rrtmgp_model.weighted_irradiance .= weighted_irradiance
 end
 
-function set_insolation_variables!(Y, p, t, ::TimeVaryingInsolation)
+function set_insolation_variables!(Y, p, t, tvi::TimeVaryingInsolation)
     FT = Spaces.undertype(axes(Y.c))
     params = p.params
     insolation_params = CAP.insolation_params(params)
     (; insolation_tuple, rrtmgp_model) = p.radiation
 
-    current_datetime = p.start_date + Dates.Second(round(Int, t)) # current time
+    current_datetime = tvi.start_date + Dates.Second(round(Int, t)) # current time
     max_zenith_angle = FT(π) / 2 - eps(FT)
     irradiance = FT(CAP.tot_solar_irrad(params))
     au = FT(CAP.astro_unit(params))
+    # TODO: Where does this date0 come from?
     date0 = DateTime("2000-01-01T11:58:56.816")
     d, δ, η_UTC =
         FT.(

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -1,4 +1,6 @@
-function get_diagnostics(parsed_args, atmos_model, Y, p, dt, t_start)
+function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, t_start)
+
+    (; dt, start_date) = sim_info
 
     FT = Spaces.undertype(axes(Y.c))
 
@@ -110,11 +112,11 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, dt, t_start)
 
             output_schedule = CAD.EveryCalendarDtSchedule(
                 period_dates;
-                reference_date = p.start_date,
+                reference_date = start_date,
             )
             compute_schedule = CAD.EveryCalendarDtSchedule(
                 period_dates;
-                reference_date = p.start_date,
+                reference_date = start_date,
             )
 
             if isnothing(output_name)
@@ -152,7 +154,7 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, dt, t_start)
             CAD.default_diagnostics(
                 atmos_model,
                 FT(time_to_seconds(parsed_args["t_end"]) - t_start),
-                p.start_date;
+                start_date;
                 output_writer = netcdf_writer,
             )...,
             diagnostics...,
@@ -214,7 +216,7 @@ end
 function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
     (; parsed_args, comms_ctx) = config
     FT = eltype(params)
-    (; dt, output_dir) = sim_info
+    (; dt, output_dir, start_date) = sim_info
 
     callbacks = ()
     if parsed_args["log_progress"]
@@ -256,8 +258,8 @@ function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
     if dt_save_state_to_disk_dates != Inf
         schedule = CAD.EveryCalendarDtSchedule(
             dt_save_state_to_disk_dates;
-            reference_date = p.start_date,
-            date_last = p.start_date + Dates.Second(t_start),
+            reference_date = start_date,
+            date_last = start_date + Dates.Second(t_start),
         )
         cond = let schedule = schedule
             (u, t, integrator) -> schedule(integrator)

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -53,7 +53,10 @@ function get_insolation_form(parsed_args)
     return if insolation == "idealized"
         IdealizedInsolation()
     elseif insolation == "timevarying"
-        TimeVaryingInsolation()
+        # TODO: Remove this argument once we have support for integer time and
+        # we can easily convert from time to date
+        start_date = DateTime(parsed_args["start_date"], dateformat"yyyymmdd")
+        TimeVaryingInsolation(start_date)
     elseif insolation == "rcemipii"
         RCEMIPIIInsolation()
     elseif insolation == "gcmdriven"

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -711,7 +711,7 @@ function get_simulation(config::AtmosConfig)
                     atmos,
                     Y,
                     p,
-                    sim_info.dt,
+                    sim_info,
                     t_start,
                 )
         end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -1,6 +1,7 @@
 import FastGaussQuadrature
 import StaticArrays as SA
 import Thermodynamics as TD
+import Dates
 
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import LazyArtifacts
@@ -33,7 +34,10 @@ struct RCEMIPIISST <: AbstractSST end
 
 abstract type AbstractInsolation end
 struct IdealizedInsolation <: AbstractInsolation end
-struct TimeVaryingInsolation <: AbstractInsolation end
+struct TimeVaryingInsolation <: AbstractInsolation
+    # TODO: Remove when we can easily go from time to date
+    start_date::Dates.DateTime
+end
 struct RCEMIPIIInsolation <: AbstractInsolation end
 struct GCMDrivenInsolation <: AbstractInsolation end
 

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -68,7 +68,6 @@ const T2 = 290
         p.dt,
         simulation.t_end,
         CA.WallTimeEstimate(),
-        p.start_date,
         p.atmos,
         p.numerics,
         p.params,


### PR DESCRIPTION
`start_date` is constant and only used to initialize diagnostics and in the computation of insolation. Here, I remove it from the cache. For insolation, I moved it to the constructor. In the future, once we have the integer time, we will be able to remove it from there as well.