### PR TITLE
rename override_τ_precip to override_precip_timescale

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -265,7 +265,7 @@ implicit_diffusion:
 approximate_linear_solve_iters:
   help: "Number of iterations for the approximate linear solve (used when `implicit_diffusion` is true)"
   value: 1
-override_τ_precip:
+override_precip_timescale:
   help: "If true, sets τ_precip to dt. Otherwise, τ_precip is set to the value in the toml dictionary"
   value: true
 output_default_diagnostics:

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -9,7 +9,7 @@ dt_save_state_to_disk: "20days"
 moist: "equil"
 cloud_model: "quadrature_sgs"
 precip_model: "0M"
-override_τ_precip: false
+override_precip_timescale: false
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -25,5 +25,5 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_τ_precip: false
+override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_diagedmf.toml]

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
@@ -27,5 +27,5 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_τ_precip: false
+override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_progedmf.toml]

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -15,7 +15,7 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
-override_τ_precip: false
+override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -16,7 +16,7 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
-override_τ_precip: false
+override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -16,7 +16,7 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_τ_precip: false
+override_precip_timescale: false
 dt: 30secs
 t_end: 3600secs
 dt_save_state_to_disk: 12hours

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -15,7 +15,7 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_τ_precip: false
+override_precip_timescale: false
 dt: 100secs
 t_end: 12hours
 dt_save_state_to_disk: 12hours

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -104,7 +104,7 @@ function create_parameter_set(config::AtmosConfig)
 
     # Microphysics scheme parameters (from CloudMicrophysics.jl)
     # TODO - repeating the logic from solver/model_getters.jl...
-    if parsed_args["override_τ_precip"]
+    if parsed_args["override_precip_timescale"]
         toml_dict["precipitation_timescale"]["value"] =
             FT(CA.time_to_seconds(parsed_args["dt"]))
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
A bikeshedding PR, but I don't like unicode in the config as it could be hard for people who use e.g. vim. What do others think? 

I think the coupler uses override_τ_precip in a few places. I can make a following up PR in the coupler. Should I mark this as breaking?

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
