### PR TITLE
Add dates to diagnostics

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -40,12 +40,18 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, t_start)
         parsed_args["netcdf_output_at_levels"] ? CAD.LevelsMethod() :
         CAD.FakePressureLevelsMethod()
 
+    # The start_date keyword was added in v0.2.9. For prior versions, the diagnostics will
+    # not contain the date
+    maybe_add_start_date =
+        pkgversion(CAD.ClimaDiagnostics) >= v"0.2.9" ? (; start_date) : (;)
+
     netcdf_writer = CAD.NetCDFWriter(
         axes(Y.c),
         p.output_dir,
         num_points = num_netcdf_points;
         z_sampling_method,
         sync_schedule = CAD.EveryStepSchedule(),
+        maybe_add_start_date...,
     )
     writers = (hdf5_writer, netcdf_writer)
 

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -47,6 +47,8 @@ import ..compute_gm_mixing_length!
 # We need the abbreviations for symbols like curl, grad, and so on
 include(joinpath("..", "utils", "abbreviations.jl"))
 
+import ClimaDiagnostics
+
 import ClimaDiagnostics:
     DiagnosticVariable, ScheduledDiagnostic, average_pre_output_hook!
 


### PR DESCRIPTION
Removing `p.start_date` meant that the diagnostics no longer have dates by default. Here, I add it back.

Failure here: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/170#0193948c-b940-4532-b497-c3ce4ec2991e

