### PR TITLE
lower conservation error threshold

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -127,19 +127,9 @@ if config.parsed_args["check_conservation"]
     @info "    Net mass change / total mass: $mass_conservation"
     @info "    Net water change / total water: $water_conservation"
 
-    sfc = p.atmos.surface_model
-
-    if CA.has_no_source_or_sink(config.parsed_args)
-        @test energy_conservation ≈ 0 atol = 50 * eps(FT)
-        @test mass_conservation ≈ 0 atol = 50 * eps(FT)
-        @test water_conservation ≈ 0 atol = 50 * eps(FT)
-    else
-        @test energy_conservation ≈ 0 atol = sqrt(eps(FT))
-        @test mass_conservation ≈ 0 atol = sqrt(eps(FT))
-        if sfc isa CA.PrognosticSurfaceTemperature
-            @test water_conservation ≈ 0 atol = sqrt(eps(FT))
-        end
-    end
+    @test energy_conservation ≈ 0 atol = 100 * eps(FT)
+    @test mass_conservation ≈ 0 atol = 100 * eps(FT)
+    @test water_conservation ≈ 0 atol = 100 * eps(FT)
 end
 
 # Visualize the solution

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -16,13 +16,6 @@ is_tracer_var(symbol) = !(
     is_turbconv_var(symbol)
 )
 
-has_no_source_or_sink(parsed_args) = all((
-    isnothing(parsed_args["forcing"]),
-    parsed_args["vert_diff"] == "false",
-    isnothing(parsed_args["turbconv"]),
-    isnothing(parsed_args["precip_model"]),
-))
-
 # we may be hitting a slow path:
 # https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1
 fast_pow(x, y) = exp(y * log(x))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
The sources and sinks are integrated correctly when using `PrognosticSurfaceTempertature`, so I removed the branch that checks for sources and sinks. We should run conservation tests with `PrognosticSurfaceTemperature`. I have to increase the threshold as previously the simulations go to the branch with `has_no_source_or_sink`, which has a much larger tolerance, due to an error in the check of `vert_diff`.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
