### PR TITLE
Add float-type constructor for ClimaAtmosParameters

### DIFF
--- a/calibration/experiments/gcm_driven_scm/helper_funcs.jl
+++ b/calibration/experiments/gcm_driven_scm/helper_funcs.jl
@@ -22,7 +22,7 @@ CLIMADIAGNOSTICS_LES_NAME_MAP =
 
 """Get z cell centers coordinates for CA run, given config. """
 function get_z_grid(atmos_config; z_max = nothing)
-    params = CA.create_parameter_set(atmos_config)
+    params = CA.ClimaAtmosParameters(atmos_config)
     spaces =
         CA.get_spaces(atmos_config.parsed_args, params, atmos_config.comms_ctx)
     coord = CA.Fields.coordinate_field(spaces.center_space)

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -259,9 +259,6 @@ implicit_diffusion:
 approximate_linear_solve_iters:
   help: "Number of iterations for the approximate linear solve (used when `implicit_diffusion` is true)"
   value: 1
-override_precip_timescale:
-  help: "If true, sets τ_precip to dt. Otherwise, τ_precip is set to the value in the toml dictionary"
-  value: true
 output_default_diagnostics:
   help: "Output the default diagnostics associated to the selected atmospheric model"
   value: true

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -9,7 +9,6 @@ dt_save_state_to_disk: "20days"
 moist: "equil"
 cloud_model: "quadrature_sgs"
 precip_model: "0M"
-override_precip_timescale: false
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -25,5 +25,4 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_diagedmf.toml]

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
@@ -27,5 +27,4 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_progedmf.toml]

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -15,7 +15,6 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
-override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -16,7 +16,6 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
-override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -16,7 +16,6 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_precip_timescale: false
 dt: 30secs
 t_end: 3600secs
 dt_save_state_to_disk: 12hours

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -15,7 +15,6 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_precip_timescale: false
 dt: 100secs
 t_end: 12hours
 dt_save_state_to_disk: 12hours

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -324,7 +324,8 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     end
 
     thermo_params = CAP.thermodynamics_params(params)
-    microphys_params = CAP.microphysics_precipitation_params(params)
+    microphys_0m_params = CAP.microphysics_0m_params(params)
+    microphys_1m_params = CAP.microphysics_1m_params(params)
     turbconv_params = CAP.turbconv_params(params)
 
     ᶠΦ = p.scratch.ᶠtemp_scalar
@@ -541,7 +542,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                 @. S_q_totʲ_prev_level = q_tot_precipitation_sources(
                     precip_model,
                     thermo_params,
-                    microphys_params,
+                    microphys_0m_params,
                     dt,
                     q_totʲ_prev_level,
                     tsʲ_prev_level,
@@ -560,7 +561,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                     tsʲ_prev_level,
                     Φ_prev_level,
                     dt,
-                    microphys_params,
+                    microphys_1m_params,
                     thermo_params,
                 )
             end
@@ -1032,7 +1033,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
     precip_model::Microphysics0Moment,
 )
     thermo_params = CAP.thermodynamics_params(p.params)
-    microphys_params = CAP.microphysics_precipitation_params(p.params)
+    microphys_0m_params = CAP.microphysics_0m_params(p.params)
     (; dt) = p
     (; ᶜts, ᶜSqₜᵖ⁰) = p.precomputed
     (; q_tot) = p.precomputed.ᶜspecific
@@ -1041,7 +1042,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
     @. ᶜSqₜᵖ⁰ = q_tot_precipitation_sources(
         precip_model,
         thermo_params,
-        microphys_params,
+        microphys_0m_params,
         dt,
         q_tot,
         ᶜts,
@@ -1055,7 +1056,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
     precip_model::Microphysics1Moment,
 )
     thermo_params = CAP.thermodynamics_params(p.params)
-    microphys_params = CAP.microphysics_precipitation_params(p.params)
+    microphys_1m_params = CAP.microphysics_1m_params(p.params)
 
     (; ᶜts, ᶜSqₜᵖ⁰, ᶜSeₜᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰) = p.precomputed
     (; q_tot) = p.precomputed.ᶜspecific
@@ -1078,7 +1079,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
         ᶜts,
         p.core.ᶜΦ,
         p.dt,
-        microphys_params,
+        microphys_1m_params,
         thermo_params,
     )
     return nothing

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -19,7 +19,7 @@ function set_precipitation_precomputed_quantities!(Y, p, t)
 
     (; ᶜwᵣ, ᶜwₛ, ᶜqᵣ, ᶜqₛ) = p.precomputed
 
-    cmp = CAP.microphysics_precipitation_params(p.params)
+    cmp = CAP.microphysics_1m_params(p.params)
 
     # compute the precipitation specific humidities
     @. ᶜqᵣ = qₚ(Y.c.ρq_rai, Y.c.ρ)

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -390,7 +390,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
 
     (; params, dt) = p
     thp = CAP.thermodynamics_params(params)
-    cmp = CAP.microphysics_precipitation_params(params)
+    cmp = CAP.microphysics_0m_params(params)
     (; ᶜts⁰, ᶜq_tot⁰, ᶜtsʲs, ᶜSqₜᵖʲs, ᶜSqₜᵖ⁰) = p.precomputed
 
     # Sources from the updrafts
@@ -426,7 +426,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     (; params, dt) = p
     (; ᶜΦ,) = p.core
     thp = CAP.thermodynamics_params(params)
-    cmp = CAP.microphysics_precipitation_params(params)
+    cmp = CAP.microphysics_1m_params(params)
 
     (; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs, ᶜρʲs, ᶜtsʲs) = p.precomputed
     (; ᶜSeₜᵖ⁰, ᶜSqₜᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜρ⁰, ᶜts⁰) = p.precomputed

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -83,7 +83,7 @@ end
 function q_tot_precipitation_sources(
     ::Microphysics0Moment,
     thp,
-    cmp,
+    cmp::CMP.Parameters0M,
     dt,
     qₜ,
     ts,

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -47,7 +47,7 @@ function compute_precipitation_cache!(Y, p, ::Microphysics0Moment, _)
     (; ᶜts) = p.precomputed
     (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precipitation
     (; ᶜΦ) = p.core
-    cm_params = CAP.microphysics_precipitation_params(params)
+    cm_params = CAP.microphysics_0m_params(params)
     thermo_params = CAP.thermodynamics_params(params)
     @. ᶜS_ρq_tot =
         Y.c.ρ * q_tot_precipitation_sources(
@@ -206,7 +206,7 @@ function compute_precipitation_cache!(Y, p, ::Microphysics1Moment, _)
 
     # get thermodynamics and 1-moment microphysics params
     (; params) = p
-    cmp = CAP.microphysics_precipitation_params(params)
+    cmp = CAP.microphysics_1m_params(params)
     thp = CAP.thermodynamics_params(params)
 
     # compute precipitation source terms on the grid mean
@@ -265,7 +265,7 @@ function compute_precipitation_cache!(
 
     # get thermodynamics and 1-moment microphysics params
     (; params) = p
-    cmp = CAP.microphysics_precipitation_params(params)
+    cmp = CAP.microphysics_1m_params(params)
     thp = CAP.thermodynamics_params(params)
 
     # zero out the helper source terms

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -66,7 +66,6 @@ Base.@kwdef struct ClimaAtmosParameters{
     MPC,
     MP0M,
     MP1M,
-    WP,
     SFP,
     TCP,
     STP,
@@ -77,8 +76,7 @@ Base.@kwdef struct ClimaAtmosParameters{
     insolation_params::IP
     microphysics_cloud_params::MPC
     microphysics_0m_params::MP0M
-    microphysics_1m_params:: MP1M
-    water_params::WP
+    microphysics_1m_params::MP1M
     surface_fluxes_params::SFP
     turbconv_params::TCP
     surface_temp_params::STP
@@ -129,10 +127,6 @@ end
 for var in [:molmass_ratio, :R_d, :R_v, :e_int_v0, :cp_d, :cv_v, :cv_l, :cv_d]
     @eval $var(ps::ACAP) = TD.Parameters.$var(thermodynamics_params(ps))
 end
-
-# Forwarding CloudMicrophysics parameters
-ρ_cloud_liq(ps::ACAP) = ps.water_params.ρw
-ρ_cloud_ice(ps::ACAP) = ps.water_params.ρi
 
 # Forwarding SurfaceFluxes parameters
 von_karman_const(ps::ACAP) =

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -64,7 +64,8 @@ Base.@kwdef struct ClimaAtmosParameters{
     RP,
     IP,
     MPC,
-    MPP,
+    MP0M,
+    MP1M,
     WP,
     SFP,
     TCP,
@@ -75,7 +76,8 @@ Base.@kwdef struct ClimaAtmosParameters{
     rrtmgp_params::RP
     insolation_params::IP
     microphysics_cloud_params::MPC
-    microphysics_precipitation_params::MPP
+    microphysics_0m_params::MP0M
+    microphysics_1m_params:: MP1M
     water_params::WP
     surface_fluxes_params::SFP
     turbconv_params::TCP

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -7,12 +7,141 @@ import Thermodynamics.Parameters.ThermodynamicsParameters
 import CloudMicrophysics as CM
 import StaticArrays as SA
 
+function ClimaAtmosParameters(config::AtmosConfig)
+    (;toml_dict, parsed_args ) = config
+    FT = CP.float_type(toml_dict)
+    return ClimaAtmosParameters(toml_dict, FT(CA.time_to_seconds(parsed_args["dt"])))
+end
+
+ClimaAtmosParameters(::Type{FT}, dt = nothing) where {FT} = 
+    ClimaAtmosParameters(CP.create_toml_dict(FT), dt)
+
+function ClimaAtmosParameters(toml_dict::TD, dt = nothing) where {TD<:CP.AbstractTOMLDict}
+    if !isnothing(dt)
+        toml_dict["precipitation_timescale"]["value"] = dt
+    end
+    FT = CP.float_type(toml_dict)
+
+    turbconv_params = TurbulenceConvectionParameters(toml_dict)
+    TCP = typeof(turbconv_params)
+
+    thermodynamics_params = ThermodynamicsParameters(toml_dict)
+    TP = typeof(thermodynamics_params)
+
+    rrtmgp_params = RRTMGPParameters(toml_dict)
+    RP = typeof(rrtmgp_params)
+
+    insolation_params = InsolationParameters(toml_dict)
+    IP = typeof(insolation_params)
+
+    water_params = CM.Parameters.WaterProperties(toml_dict)
+    WP = typeof(water_params)
+
+    surface_fluxes_params =
+        SF.Parameters.SurfaceFluxesParameters(toml_dict, UF.BusingerParams)
+    SFP = typeof(surface_fluxes_params)
+
+    surface_temp_params = SurfaceTemperatureParameters(toml_dict)
+    STP = typeof(surface_temp_params)
+
+    microphysics_cloud_params = cloud_parameters(toml_dict)
+    MPC = typeof(microphysics_cloud_params)
+
+    microphysics_0m_params = CM.Parameters.Parameters0M(toml_dict)
+    microphysics_1m_params = microphys_1m_parameters(toml_dict)
+    MP0M = typeof(microphysics_0m_params)
+    MP1M = typeof(microphysics_1m_params)
+
+    vert_diff_params = vert_diff_parameters(toml_dict)
+    VDP = typeof(vert_diff_params)
+
+    parameters =
+        CP.get_parameter_values(toml_dict, atmos_name_map, "ClimaAtmos")
+    return CAP.ClimaAtmosParameters{FT, TP, RP, IP, MPC, MP0M, MP1M, WP, SFP, TCP, STP, VDP}(;
+        parameters...,
+        thermodynamics_params,
+        rrtmgp_params,
+        insolation_params,
+        microphysics_cloud_params,
+        microphysics_0m_params,
+        microphysics_1m_params,
+        water_params,
+        surface_fluxes_params,
+        turbconv_params,
+        surface_temp_params,
+        vert_diff_params,
+    )
+end
+
+atmos_name_map = (;
+    :f_plane_coriolis_frequency => :f_plane_coriolis_frequency,
+    :equator_pole_temperature_gradient_wet => :ΔT_y_wet,
+    :angular_velocity_planet_rotation => :Omega,
+    :equator_pole_temperature_gradient_dry => :ΔT_y_dry,
+    :held_suarez_T_equator_wet => :T_equator_wet,
+    :zd_rayleigh => :zd_rayleigh,
+    :zd_viscous => :zd_viscous,
+    :planet_radius => :planet_radius,
+    :potential_temp_vertical_gradient => :Δθ_z,
+    :C_H => :C_H,
+    :c_smag => :c_smag,
+    :alpha_rayleigh_w => :alpha_rayleigh_w,
+    :alpha_rayleigh_uh => :alpha_rayleigh_uh,
+    :astronomical_unit => :astro_unit,
+    :held_suarez_T_equator_dry => :T_equator_dry,
+    :drag_layer_vertical_extent => :σ_b,
+    :kappa_2_sponge => :kappa_2_sponge,
+    :held_suarez_minimum_temperature => :T_min_hs,
+    :ocean_surface_albedo => :idealized_ocean_albedo,
+    :water_refractive_index => :water_refractive_index,
+    :optics_lookup_temperature_min => :optics_lookup_temperature_min,
+    :optics_lookup_temperature_max => :optics_lookup_temperature_max,
+)
+
+cloud_parameters(FT_or_toml) = (;
+    liquid = CM.Parameters.CloudLiquid(FT_or_toml),
+    ice = CM.Parameters.CloudIce(FT_or_toml),
+)
+
+microphys_1m_parameters(::Type{FT}) where {FT <: AbstractFloat} =
+    microphys_1m_parameters(CP.create_toml_dict(FT))
+
+microphys_1m_parameters(toml_dict::CP.AbstractTOMLDict) = (;
+    cl = CM.Parameters.CloudLiquid(toml_dict),
+    ci = CM.Parameters.CloudIce(toml_dict),
+    pr = CM.Parameters.Rain(toml_dict),
+    ps = CM.Parameters.Snow(toml_dict),
+    ce = CM.Parameters.CollisionEff(toml_dict),
+    tv = CM.Parameters.Blk1MVelType(toml_dict),
+    aps = CM.Parameters.AirProperties(toml_dict),
+    var = CM.Parameters.VarTimescaleAcnv(toml_dict),
+    Ndp = CP.get_parameter_values(
+        toml_dict,
+        "prescribed_cloud_droplet_number_concentration",
+        "ClimaAtmos",
+    ).prescribed_cloud_droplet_number_concentration,
+)
+
+function vert_diff_parameters(toml_dict)
+    name_map = (; :C_E => :C_E, :H_diffusion => :H, :D_0_diffusion => :D₀)
+    return CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
+end
+
 
 to_svec(x::AbstractArray) = SA.SVector{length(x)}(x)
 to_svec(x) = x
 to_svec(x::NamedTuple) = map(x -> to_svec(x), x)
 
-function TurbulenceConvectionParameters(toml_dict::CP.AbstractTOMLDict)
+TurbulenceConvectionParameters(
+    ::Type{FT},
+    overrides = NamedTuple(),
+) where {FT <: AbstractFloat} =
+    TurbulenceConvectionParameters(CP.create_toml_dict(FT), overrides)
+
+function TurbulenceConvectionParameters(
+    toml_dict::CP.AbstractTOMLDict,
+    overrides = NamedTuple(),
+)
     name_map = (;
         :min_area_limiter_scale => :min_area_limiter_scale,
         :max_area_limiter_scale => :max_area_limiter_scale,
@@ -46,14 +175,24 @@ function TurbulenceConvectionParameters(toml_dict::CP.AbstractTOMLDict)
         :entr_inv_tau => :entr_tau,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
-    FT = CP.float_type(toml_dict)
+    parameters = merge(parameters, overrides)
     parameters = to_svec(parameters)
     VFT1 = typeof(parameters.entr_param_vec)
     VFT2 = typeof(parameters.turb_entr_param_vec)
+    FT = CP.float_type(toml_dict)
     CAP.TurbulenceConvectionParameters{FT, VFT1, VFT2}(; parameters...)
 end
 
-function SurfaceTemperatureParameters(toml_dict::CP.AbstractTOMLDict)
+SurfaceTemperatureParameters(
+    ::Type{FT},
+    overrides = NamedTuple(),
+) where {FT <: AbstractFloat} =
+    SurfaceTemperatureParameters(CP.create_toml_dict(FT), overrides)
+
+function SurfaceTemperatureParameters(
+    toml_dict::CP.AbstractTOMLDict,
+    overrides = NamedTuple(),
+)
     name_map = (;
         :SST_mean => :SST_mean,
         :SST_delta => :SST_delta,
@@ -61,153 +200,7 @@ function SurfaceTemperatureParameters(toml_dict::CP.AbstractTOMLDict)
         :SST_wavelength_latitude => :SST_wavelength_latitude,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
+    parameters = merge(parameters, overrides)
     FT = CP.float_type(toml_dict)
     CAP.SurfaceTemperatureParameters{FT}(; parameters...)
-end
-
-function create_parameter_set(config::AtmosConfig)
-    (; toml_dict, parsed_args) = config
-    FT = CP.float_type(toml_dict)
-
-    turbconv_params = TurbulenceConvectionParameters(toml_dict)
-    TCP = typeof(turbconv_params)
-
-    thermodynamics_params = ThermodynamicsParameters(toml_dict)
-    TP = typeof(thermodynamics_params)
-
-    rrtmgp_params = RRTMGPParameters(toml_dict)
-    RP = typeof(rrtmgp_params)
-
-    insolation_params = InsolationParameters(toml_dict)
-    IP = typeof(insolation_params)
-
-    water_params = CM.Parameters.WaterProperties(toml_dict)
-    WP = typeof(water_params)
-
-    surface_fluxes_params =
-        SF.Parameters.SurfaceFluxesParameters(toml_dict, UF.BusingerParams)
-    SFP = typeof(surface_fluxes_params)
-
-    surface_temp_params = SurfaceTemperatureParameters(toml_dict)
-    STP = typeof(surface_temp_params)
-
-    moisture_model = parsed_args["moist"]
-    microphysics_cloud_params = if moisture_model == "nonequil"
-        (;
-            liquid = CM.Parameters.CloudLiquid(toml_dict),
-            ice = CM.Parameters.CloudIce(toml_dict),
-        )
-    else
-        nothing
-    end
-    MPC = typeof(microphysics_cloud_params)
-
-    # Microphysics scheme parameters (from CloudMicrophysics.jl)
-    # TODO - repeating the logic from solver/model_getters.jl...
-    if parsed_args["override_precip_timescale"]
-        toml_dict["precipitation_timescale"]["value"] =
-            FT(CA.time_to_seconds(parsed_args["dt"]))
-    end
-    precip_model = parsed_args["precip_model"]
-    microphysics_precipitation_params =
-        if precip_model == nothing || precip_model == "nothing"
-            nothing
-        elseif precip_model == "0M"
-            CM.Parameters.Parameters0M(toml_dict)
-        elseif precip_model == "1M"
-            (;
-                cl = CM.Parameters.CloudLiquid(toml_dict),
-                ci = CM.Parameters.CloudIce(toml_dict),
-                pr = CM.Parameters.Rain(toml_dict),
-                ps = CM.Parameters.Snow(toml_dict),
-                ce = CM.Parameters.CollisionEff(toml_dict),
-                tv = CM.Parameters.Blk1MVelType(toml_dict),
-                aps = CM.Parameters.AirProperties(toml_dict),
-                var = CM.Parameters.VarTimescaleAcnv(toml_dict),
-                Ndp = CP.get_parameter_values(
-                    toml_dict,
-                    "prescribed_cloud_droplet_number_concentration",
-                    "ClimaAtmos",
-                ).prescribed_cloud_droplet_number_concentration,
-            )
-        else
-            error("Invalid precip_model $(precip_model)")
-        end
-    MPP = typeof(microphysics_precipitation_params)
-
-    vert_diff_model = parsed_args["vert_diff"]
-    name_map_vert_diff =
-        if vert_diff_model in
-           ("true", true, "VerticalDiffusion", "FriersonDiffusion")
-            (; :C_E => :C_E,)
-        elseif vert_diff_model in ("DecayWithHeightDiffusion",)
-            (; :H_diffusion => :H, :D_0_diffusion => :D₀)
-        else
-            nothing
-        end
-    vert_diff_params = if vert_diff_model in ("false", false, "none")
-        nothing
-    elseif vert_diff_model in (
-        "true",
-        true,
-        "VerticalDiffusion",
-        "FriersonDiffusion",
-        "DecayWithHeightDiffusion",
-    )
-        CP.get_parameter_values(toml_dict, name_map_vert_diff, "ClimaAtmos")
-    else
-        error("Invalid diffusion model `$vert_diff_model`.")
-    end
-    VDP = typeof(vert_diff_params)
-
-    name_map = (;
-        :f_plane_coriolis_frequency => :f_plane_coriolis_frequency,
-        :equator_pole_temperature_gradient_wet => :ΔT_y_wet,
-        :angular_velocity_planet_rotation => :Omega,
-        :equator_pole_temperature_gradient_dry => :ΔT_y_dry,
-        :held_suarez_T_equator_wet => :T_equator_wet,
-        :zd_rayleigh => :zd_rayleigh,
-        :zd_viscous => :zd_viscous,
-        :planet_radius => :planet_radius,
-        :potential_temp_vertical_gradient => :Δθ_z,
-        :C_H => :C_H,
-        :c_smag => :c_smag,
-        :alpha_rayleigh_w => :alpha_rayleigh_w,
-        :alpha_rayleigh_uh => :alpha_rayleigh_uh,
-        :astronomical_unit => :astro_unit,
-        :held_suarez_T_equator_dry => :T_equator_dry,
-        :drag_layer_vertical_extent => :σ_b,
-        :kappa_2_sponge => :kappa_2_sponge,
-        :held_suarez_minimum_temperature => :T_min_hs,
-        :ocean_surface_albedo => :idealized_ocean_albedo,
-        :water_refractive_index => :water_refractive_index,
-        :optics_lookup_temperature_min => :optics_lookup_temperature_min,
-        :optics_lookup_temperature_max => :optics_lookup_temperature_max,
-    )
-    parameters = CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
-    return CAP.ClimaAtmosParameters{
-        FT,
-        TP,
-        RP,
-        IP,
-        MPC,
-        MPP,
-        WP,
-        SFP,
-        TCP,
-        STP,
-        VDP,
-    }(;
-        parameters...,
-        thermodynamics_params,
-        rrtmgp_params,
-        insolation_params,
-        microphysics_cloud_params,
-        microphysics_precipitation_params,
-        water_params,
-        surface_fluxes_params,
-        turbconv_params,
-        surface_temp_params,
-        vert_diff_params,
-    )
 end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -621,7 +621,7 @@ function silence_non_root_processes(comms_ctx)
 end
 
 function get_simulation(config::AtmosConfig)
-    params = create_parameter_set(config)
+    params = ClimaAtmosParameters(config)
     atmos = get_atmos(config, params)
 
     sim_info = get_sim_info(config)

--- a/test/parameters/parameter_tests.jl
+++ b/test/parameters/parameter_tests.jl
@@ -33,7 +33,7 @@ end
         config =
             CA.AtmosConfig(config_dict, job_id = "paremter_tests$(index + 1)")
         # Ensure that there are no errors
-        @test CA.create_parameter_set(config) isa
+        @test CA.ClimaAtmosParameters(config) isa
               CA.Parameters.ClimaAtmosParameters
     end
 end


### PR DESCRIPTION
This PR allows us to create a minimal parameter set for all model configurations using FT as input. 

`create_parameter_set` has been replaced with direct `ClimaAtmosParameters` constructors which are not dependent on the AtmosConfig, but we should not see any simulation changes.

ClimaAtmosParameters (CAP) now contains parameters for all configurations to prevent the use of parsed_args. CAP already contained parameters that were unused by certain configurations, such as RRTMGP parameters. This primarily affects the microphysics parameters - both 0m and 1m params are now stored regardless of config. This PR touches a lot of files because the access to specific microphysics parameters structs in tendencies had to be changed.

The main method is `ClimaAtmosParameters(toml_dict::TD, dt = nothing)`. If `dt` is passed in, it is used to override the `precipitation_timescale` used in microphysics. Since the config key `override_precip_timescale` is no longer used it has been removed.

Other constructors are available, which end up calling the toml_dict method:
- `ClimaAtmosParameters(config::AtmosConfig)`
- `ClimaAtmosParameters(::Type{FT}, dt = nothing)`

This PR also removes water_params, they are unused