### PR TITLE
change the default size of sea salt aerosols

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
@@ -25,4 +25,4 @@ diagnostics:
     period: "12hours"
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
@@ -22,4 +22,4 @@ t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
@@ -21,7 +21,7 @@ t_end: "1hours"
 toml: [toml/longrun_aquaplanet.toml]
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]
 start_date: "20160801"
 initial_condition: "artifact\"DYAMOND_SUMMER_ICS_p98deg\"/DYAMOND_SUMMER_ICS_p98deg.nc"
 topography: "Earth"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -23,4 +23,4 @@ t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -23,4 +23,4 @@ t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -22,4 +22,4 @@ t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -15,7 +15,7 @@ dt_cloud_fraction: "1hours"
 insolation: "timevarying"
 prescribe_ozone: true
 aerosol_radiation: true
-prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT03", "SSLT04"]
 surface_setup: "DefaultMoninObukhov"
 turbconv: "diagnostic_edmfx"
 ode_algo: ARS343
@@ -33,7 +33,7 @@ t_end: "120days"
 toml: [toml/longrun_aquaplanet_diagedmf.toml]
 netcdf_output_at_levels: true
 diagnostics:
-  - short_name: [mmrso4, o3]
+  - short_name: [mmrso4, mmrdust, mmrss, o3]
     reduction_time: average
     period: "1months"
 

--- a/src/diagnostics/tracer_diagnostics.jl
+++ b/src/diagnostics/tracer_diagnostics.jl
@@ -27,6 +27,82 @@ function compute_aerosol!(out, state, cache, time, aerosol_name)
     end
 end
 
+function compute_dust!(out, state, cache, time)
+    :prescribed_aerosols_field in propertynames(cache.tracers) ||
+        error("Aerosols do not exist in the model")
+    any(
+        x -> x in propertynames(cache.tracers.prescribed_aerosols_field),
+        [:DST01, :DST02, :DST03, :DST04],
+    ) || error("Dust does not exist in the model")
+    if isnothing(out)
+        aero_conc = cache.scratch.ᶜtemp_scalar
+        @. aero_conc = 0
+        for prescribed_aerosol_name in [:DST01, :DST02, :DST03, :DST04]
+            if prescribed_aerosol_name in
+               propertynames(cache.tracers.prescribed_aerosols_field)
+                aerosol_field = getproperty(
+                    cache.tracers.prescribed_aerosols_field,
+                    prescribed_aerosol_name,
+                )
+                @. aero_conc += aerosol_field
+            end
+        end
+        return aero_conc
+    else
+        aero_conc = cache.scratch.ᶜtemp_scalar
+        @. aero_conc = 0
+        for prescribed_aerosol_name in [:DST01, :DST02, :DST03, :DST04]
+            if prescribed_aerosol_name in
+               propertynames(cache.tracers.prescribed_aerosols_field)
+                aerosol_field = getproperty(
+                    cache.tracers.prescribed_aerosols_field,
+                    prescribed_aerosol_name,
+                )
+                @. aero_conc += aerosol_field
+            end
+        end
+        out .= aero_conc
+    end
+end
+
+function compute_sea_salt!(out, state, cache, time)
+    :prescribed_aerosols_field in propertynames(cache.tracers) ||
+        error("Aerosols do not exist in the model")
+    any(
+        x -> x in propertynames(cache.tracers.prescribed_aerosols_field),
+        [:SSLT01, :SSLT02, :SSLT03, :SSLT04],
+    ) || error("Sea salt does not exist in the model")
+    if isnothing(out)
+        aero_conc = cache.scratch.ᶜtemp_scalar
+        @. aero_conc = 0
+        for prescribed_aerosol_name in [:SSLT01, :SSLT02, :SSLT03, :SSLT04]
+            if prescribed_aerosol_name in
+               propertynames(cache.tracers.prescribed_aerosols_field)
+                aerosol_field = getproperty(
+                    cache.tracers.prescribed_aerosols_field,
+                    prescribed_aerosol_name,
+                )
+                @. aero_conc += aerosol_field
+            end
+        end
+        return aero_conc
+    else
+        aero_conc = cache.scratch.ᶜtemp_scalar
+        @. aero_conc = 0
+        for prescribed_aerosol_name in [:SSLT01, :SSLT02, :SSLT03, :SSLT04]
+            if prescribed_aerosol_name in
+               propertynames(cache.tracers.prescribed_aerosols_field)
+                aerosol_field = getproperty(
+                    cache.tracers.prescribed_aerosols_field,
+                    prescribed_aerosol_name,
+                )
+                @. aero_conc += aerosol_field
+            end
+        end
+        out .= aero_conc
+    end
+end
+
 ###
 # Ozone concentration (3d)
 ###
@@ -46,8 +122,8 @@ add_diagnostic_variable!(
     long_name = "Dust Aerosol Mass Mixing Ratio",
     standard_name = "mass_fraction_of_dust_dry_aerosol_particles_in_air",
     units = "kg kg^-1",
-    comments = "Prescribed dry mass fraction of dust aerosol particles in air. Only the smallest size is included.",
-    compute! = (out, u, p, t) -> compute_aerosol!(out, u, p, t, :DST01),
+    comments = "Prescribed dry mass fraction of dust aerosol particles in air.",
+    compute! = (out, u, p, t) -> compute_dust!(out, u, p, t),
 )
 
 ###
@@ -58,8 +134,8 @@ add_diagnostic_variable!(
     long_name = "Sea-Salt Aerosol Mass Mixing Ratio",
     standard_name = "mass_fraction_of_sea_salt_dry_aerosol_particles_in_air",
     units = "kg kg^-1",
-    comments = "Prescribed dry mass fraction of sea salt aerosol particles in air. Only the smallest size is included.",
-    compute! = (out, u, p, t) -> compute_aerosol!(out, u, p, t, :SSLT01),
+    comments = "Prescribed dry mass fraction of sea salt aerosol particles in air.",
+    compute! = (out, u, p, t) -> compute_sea_salt!(out, u, p, t),
 )
 
 ###

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -104,7 +104,21 @@ function radiation_model_cache(
         (; aerosol_radiation) = radiation_mode
         if aerosol_radiation && !(any(
             x -> x in aerosol_names,
-            ["DST01", "SSLT01", "SO4", "CB1", "CB2", "OC1", "OC2"],
+            [
+                "DST01",
+                "DST02",
+                "DST03",
+                "DST04",
+                "SSLT01",
+                "SSLT02",
+                "SSLT03",
+                "SSLT04",
+                "SO4",
+                "CB1",
+                "CB2",
+                "OC1",
+                "OC2",
+            ],
         ))
             error(
                 "Need at least one aerosol type when aerosol radiation is turned on",
@@ -218,7 +232,7 @@ function radiation_model_cache(
                     kwargs...,
                     # assuming fixed aerosol radius
                     center_dust_radius = 0.2,
-                    center_ss_radius = 0.2,
+                    center_ss_radius = 11.5,
                     center_dust_column_mass_density = NaN, # initialized in callback
                     center_ss_column_mass_density = NaN, # initialized in callback
                     center_so4_column_mass_density = NaN, # initialized in callback


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Currently, RRTMGP only supports one size for each aerosol. This PR changes the default sea salt size to the largest size bin which has the strongest radiative effect.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
