### PR TITLE
Add `override_precipitation_timescale` option back in

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -259,6 +259,9 @@ implicit_diffusion:
 approximate_linear_solve_iters:
   help: "Number of iterations for the approximate linear solve (used when `implicit_diffusion` is true)"
   value: 1
+override_precip_timescale:
+  help: "If true, sets τ_precip to dt. Otherwise, τ_precip is set to the value in the toml dictionary"
+  value: true
 output_default_diagnostics:
   help: "Output the default diagnostics associated to the selected atmospheric model"
   value: true

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -9,6 +9,7 @@ dt_save_state_to_disk: "20days"
 moist: "equil"
 cloud_model: "quadrature_sgs"
 precip_model: "0M"
+override_precip_timescale: false
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -25,4 +25,5 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
+override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_diagedmf.toml]

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
@@ -27,4 +27,5 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
+override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_progedmf.toml]

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -15,6 +15,7 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
+override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -16,6 +16,7 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
+override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -16,6 +16,7 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
+override_precip_timescale: false
 dt: 30secs
 t_end: 3600secs
 dt_save_state_to_disk: 12hours

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -15,6 +15,7 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
+override_precip_timescale: false
 dt: 100secs
 t_end: 12hours
 dt_save_state_to_disk: 12hours

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -7,15 +7,6 @@ import Thermodynamics.Parameters.ThermodynamicsParameters
 import CloudMicrophysics as CM
 import StaticArrays as SA
 
-function ClimaAtmosParameters(config::AtmosConfig)
-    (; toml_dict, parsed_args) = config
-    FT = CP.float_type(toml_dict)
-    return ClimaAtmosParameters(
-        toml_dict,
-        FT(CA.time_to_seconds(parsed_args["dt"])),
-    )
-end
-
 """
     ClimaAtmosParameters(FT, dt)
     ClimaAtmosParameters(toml_dict, dt)
@@ -25,6 +16,16 @@ Construct the parameter set for any ClimaAtmos configuration.
 
 If dt is passed in, it will be used to override the `precipitation_timescale` parameter.
 """
+function ClimaAtmosParameters(config::AtmosConfig)
+    (; toml_dict, parsed_args) = config
+    FT = CP.float_type(toml_dict)
+    override_dt =
+        parsed_args["override_precip_timescale"] ?
+        FT(CA.time_to_seconds(parsed_args["dt"])) : nothing
+
+    return ClimaAtmosParameters(toml_dict, override_dt)
+end
+
 ClimaAtmosParameters(::Type{FT}, dt = nothing) where {FT} =
     ClimaAtmosParameters(CP.create_toml_dict(FT), dt)
 

--- a/test/parameters/parameter_tests.jl
+++ b/test/parameters/parameter_tests.jl
@@ -37,3 +37,25 @@ end
               CA.Parameters.ClimaAtmosParameters
     end
 end
+
+@testset "Test that `override_precip_timescale` is handled properly" begin
+    # precipitation_timescale should NOT be overridden by DT
+    config = CA.AtmosConfig(
+        Dict("dt" => "1secs", "override_precip_timescale" => false),
+    )
+    @test config.parsed_args["override_precip_timescale"] == false
+    @test config.parsed_args["dt"] == "1secs"
+    (; precipitation_timescale) =
+        CP.get_parameter_values(config.toml_dict, "precipitation_timescale")
+    parameters = CA.ClimaAtmosParameters(config)
+    @test parameters.microphysics_0m_params.τ_precip == precipitation_timescale
+
+    # precipitation_timescale should be overridden by DT
+    config = CA.AtmosConfig(Dict("dt" => "1secs"))
+    @test config.parsed_args["override_precip_timescale"] == true
+    @test config.parsed_args["dt"] == "1secs"
+    (; precipitation_timescale) =
+        CP.get_parameter_values(config.toml_dict, "precipitation_timescale")
+    parameters = CA.ClimaAtmosParameters(config)
+    @test parameters.microphysics_0m_params.τ_precip == 1.0
+end


### PR DESCRIPTION
This PR reverts part of #3481, which removed the `override_precipitation_timescale` config argument. 
This was not caught by our regression tests, but the the PR build shows changed plots.

This PR also adds a small unit test to ensure that this option is being set correctly.