### PR TITLE
set bubble to false

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -150,7 +150,7 @@ smagorinsky_lilly:
   value: false
 bubble:
   help: "Enable bubble correction for more accurate surface areas"
-  value: true
+  value: false
 start_date:
   help: "Start date of the simulation"
   value: "20100101"

--- a/config/model_configs/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/model_configs/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean.yml
@@ -12,4 +12,3 @@ insolation: "timevarying"
 dt_rad: "1hours"
 prognostic_surface: "PrognosticSurfaceTemperature"
 check_conservation: true
-bubble: false

--- a/config/model_configs/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
+++ b/config/model_configs/aquaplanet_rhoe_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
@@ -12,4 +12,3 @@ insolation: "timevarying"
 dt_rad: "1hours"
 prognostic_surface: "PrognosticSurfaceTemperature"
 check_conservation: true
-bubble: false

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-195
+196
 
 # **README**
 #
@@ -20,6 +20,8 @@
 
 
 #=
+196
+- Set bubble correction to false as default
 
 195
 - Use `vanleer_limiter` as default.


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Our current implementation of the bubble correction is not internally consistent, as it modifies the volume element J without modifying the metric tensor g, so that we no longer satisfy the discrete identity J = sqrt(det(g)). Our current implementation also does not account for volume distortions due to topography, as it is only applied to the horizontal component of the volume element. In order to fix this (and be more similar to HOMME's implementation), we would need to apply the bubble correction to the full 3D metric Jacobian, and then compute J and g from the corrected Jacobian.

However, as Paul Ullrich pointed out, modifying g on interior nodal points without modifying it on boundary nodal points will have the consequence of changing the discrete curvature. I think this is basically the point of the bubble correction (trading accuracy in curvature for accuracy in volume integrals), but Tapio is not a fan of this tradeoff. Our current plan is to eliminate the bubble correction from ClimaCore altogether, and instead handle volume integral discrepancies during remapping, which will allow us to avoid changes in curvature terms.

We might end up revisiting the bubble correction later if this strategy does not work well, but we will still need to implement it in a completely different way to fix the current issues. So, there is no point in keeping the current implementation.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
