### PR TITLE
Read CO2 from file

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -36,7 +36,14 @@ lazy = true
     [[earth_orography_60arcseconds.download]]
     sha256 = "eca66c0701d1c2b9e271742314915ffbf4a0fae92709df611c323f38e019966e"
     url = "https://caltech.box.com/shared/static/4asrxcgl6xsgenfcug9p0wkkyhtqilgk.gz"
-    
+
+[co2_dataset]
+git-tree-sha1 = "9c3bd05b68e820fceb43d130ce6b4e86ce788e4e"
+
+    [[co2_dataset.download]]
+    sha256 = "46923ec3e1f9028a11899c47e6b13d675d84daa9db2f37351a19ec9187f87865"
+    url = "https://caltech.box.com/shared/static/fuwajscgyblccy8y9aq01d0pgy91gwut.gz"
+
 [era5_cloud]
 git-tree-sha1 = "10742e0a2e343d13bb04df379e300a83402d4106"
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ ClimaAtmos.jl Release Notes
 Main
 -------
 
+### Features
+
+### Read CO2 from file
+
+`ClimaAtmos` now support using data from the Mauna Loa CO2 measurements to set
+CO2 concentration. This is currently only relevant for radiation transfer with
+RRTGMP.
 
 v0.28.2
 -------
@@ -11,13 +18,9 @@ v0.28.2
 
 ### Add van Leer class operator
 
-Added a new vertical transport option `vanleer_limiter` (for tracer and energy variables)
-which uses methods described in Lin et al. (1994) to apply slope-limited upwinding. Adds
-operator
-
-v0.28.1
--------
-### Features
+Added a new vertical transport option `vanleer_limiter` (for tracer and energy
+variables) which uses methods described in Lin et al. (1994) to apply
+slope-limited upwinding. Adds operator
 
 ### Read initial conditions from NetCDF files
 

--- a/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
@@ -25,6 +25,7 @@ z_elem: 60
 z_stretch: true
 dz_bottom: 30
 rad: allskywithclear
+co2_model: fixed
 insolation: "gcmdriven"
 dt: "100secs"
 t_end: "72hours"

--- a/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
@@ -25,6 +25,7 @@ z_elem: 60
 z_stretch: true
 dz_bottom: 30
 rad: allskywithclear
+co2_model: fixed
 insolation: "gcmdriven"
 perturb_initstate: false
 dt: "10secs"

--- a/calibration/test/model_config.yml
+++ b/calibration/test/model_config.yml
@@ -8,6 +8,7 @@ output_dir: calibration_end_to_end_test
 output_default_diagnostics: false
 dt_rad: 6hours
 rad: clearsky
+co2_model: fixed
 diagnostics:
   - reduction_time: average
     short_name: rsut

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -289,6 +289,9 @@ restart_file:
 prescribe_ozone:
   help: "Prescribe time and spatially varying ozone from a file [`false` (default), `true`]"
   value: false
+co2_model:
+  help: "What CO2 concentration to use for RRTGMP. When fixed, it is set to 397.547 parts per million. Otherwise, it is read from the MaunaLoa measuraments. [`nothing` (default), `Fixed`, `MaunaLoa`]"
+  value: ~
 detect_restart_file:
   help: "When true, try finding a restart file and use it to restart the simulation. Only works with ActiveLink."
   value: false

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
@@ -9,6 +9,7 @@ viscous_sponge: true
 moist: equil
 precip_model: 1M
 rad: allskywithclear
+co2_model: fixed
 idealized_insolation: false
 dt_rad: 1hours
 vert_diff: "DecayWithHeightDiffusion"

--- a/config/model_configs/aquaplanet_diagedmf.yml
+++ b/config/model_configs/aquaplanet_diagedmf.yml
@@ -10,6 +10,7 @@ viscous_sponge: true
 moist: equil
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
+co2_model: maunaloa
 insolation: "timevarying"
 dt_rad: 1hours
 dt_cloud_fraction: 1hours

--- a/config/model_configs/aquaplanet_progedmf.yml
+++ b/config/model_configs/aquaplanet_progedmf.yml
@@ -10,6 +10,7 @@ viscous_sponge: true
 moist: equil
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
+co2_model: fixed
 insolation: "timevarying"
 dt_rad: 1hours
 dt_cloud_fraction: 1hours

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -4,6 +4,7 @@ dz_bottom: 50.0
 rayleigh_sponge: true
 surface_setup: DefaultMoninObukhov
 rad: clearsky
+co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -3,6 +3,7 @@ z_elem: 31
 dz_bottom: 50.0
 surface_setup: DefaultMoninObukhov
 rad: clearsky
+co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -5,6 +5,7 @@
 # rayleigh_sponge: true
 surface_setup: DefaultMoninObukhov
 rad: clearsky
+co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_upwinding: first_order

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -34,6 +34,7 @@ netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
 output_default_diagnostics: false
 rad: allskywithclear
+co2_model: fixed
 insolation: "gcmdriven"
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -3,6 +3,7 @@ surface_temperature: RCEMIPII
 insolation: rcemipii
 config: box
 rad: allskywithclear
+co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -1,6 +1,7 @@
 surface_setup: DefaultMoninObukhov
 surface_temperature: RCEMIPII
 rad: allskywithclear
+co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
+++ b/config/perf_configs/flame_perf_target_prognostic_edmfx_aquaplanet.yml
@@ -7,6 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 surface_setup: DefaultExchangeCoefficients
 rad: gray
+co2_model: fixed
 vert_diff: false
 turbconv: prognostic_edmfx 
 implicit_diffusion: true

--- a/docs/src/tracers.md
+++ b/docs/src/tracers.md
@@ -39,10 +39,21 @@ We interpolate the data from file in time every time radiation is called. The
 interpolation used is the `LinerPeriodFilling` from `ClimaUtilities`. This is a
 linear period-aware interpolation that preserves the annual cycle.
 
+### Prescribed CO2 Profile
+
+In addition to ozone, `ClimaAtmos` can prescribe CO2 concentration using data
+from [Mauna Loa CO2 measurements](https://gml.noaa.gov/ccgg/trends/data.html).
+This option is enabled with `MaunaLoaCO2`. Alternatively, `FixedCO2`
+utilizes a constant value that can be prescribed (by default, 397.547 ppm).
+
 ### More docstrings
 
 ```@docs
 ClimaAtmos.AbstractOzone
 ClimaAtmos.IdealizedOzone
 ClimaAtmos.PrescribedOzone
+
+ClimaAtmos.AbstractCO2
+ClimaAtmos.FixedCO2
+ClimaAtmos.MaunaLoaCO2
 ```

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-201
+202
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+202
+- Slightly changed CO2 prescription
+
 201
 - Updated ClimaTimeSteppers to 0.7.39, slightly improving conservation properties
 

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -147,7 +147,14 @@ function build_cache(Y, atmos, params, surface_setup, sim_info, aerosol_names)
 
     radiation_args =
         atmos.radiation_mode isa RRTMGPI.AbstractRRTMGPMode ?
-        (start_date, params, atmos.ozone, aerosol_names, atmos.insolation) : ()
+        (
+            start_date,
+            params,
+            atmos.ozone,
+            atmos.co2,
+            aerosol_names,
+            atmos.insolation,
+        ) : ()
 
     hyperdiff = hyperdiffusion_cache(Y, atmos)
     precipitation = precipitation_cache(Y, atmos)

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -308,6 +308,18 @@ function get_ozone(parsed_args)
     return parsed_args["prescribe_ozone"] ? PrescribedOzone() : IdealizedOzone()
 end
 
+function get_co2(parsed_args)
+    if isnothing(parsed_args["co2_model"])
+        return nothing
+    elseif lowercase(parsed_args["co2_model"]) == "fixed"
+        return FixedCO2()
+    elseif lowercase(parsed_args["co2_model"]) == "maunaloa"
+        return MaunaLoaCO2()
+    else
+        error("The CO2 models supported are $(subtypes(AbstractCO2))")
+    end
+end
+
 function get_cloud_in_radiation(parsed_args)
     isnothing(parsed_args["prescribe_clouds_in_radiation"]) && return nothing
     return parsed_args["prescribe_clouds_in_radiation"] ?

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -128,6 +128,42 @@ Refer to ClimaArtifacts for more information on how to obtain the artifact.
 struct PrescribedOzone <: AbstractOzone end
 
 """
+    AbstractCO2
+
+Describe how CO2 concentration should be set.
+"""
+abstract type AbstractCO2 end
+
+"""
+    FixedCO2
+
+Implement a static CO2 profile as read from disk.
+
+The data used is the one distributed with `RRTGMP.jl`.
+
+By default, this is 397.547 parts per million.
+
+This is the volume mixing ratio.
+"""
+struct FixedCO2{FT} <: AbstractCO2
+    value::FT
+
+    function FixedCO2(; FT = Float64, value = FT(397.547e-6))
+        return new{FT}(value)
+    end
+end
+
+"""
+    MuanaLoaCO2
+
+Implement a time-varying CO2 profile as read from disk.
+
+The data from the Mauna Loa CO2 measurements is used. It is a assumed that the
+concentration is constant.
+"""
+struct MaunaLoaCO2 <: AbstractCO2 end
+
+"""
     AbstractCloudInRadiation
 
 Describe how cloud properties should be set in radiation.
@@ -456,6 +492,7 @@ Base.@kwdef struct AtmosModel{
     F,
     S,
     OZ,
+    CO2,
     RM,
     LA,
     EXTFORCING,
@@ -486,8 +523,12 @@ Base.@kwdef struct AtmosModel{
     forcing_type::F = nothing
     subsidence::S = nothing
 
+    # Currently only relevant for RRTGMP, but will hopefully become standalone
+    # in the future
     """What to do with ozone for radiation (when using RRTGMP)"""
     ozone::OZ = nothing
+    """What to do with co2 for radiation (when using RRTGMP)"""
+    co2::CO2 = nothing
 
     radiation_mode::RM = nothing
     ls_adv::LA = nothing

--- a/src/utils/AtmosArtifacts.jl
+++ b/src/utils/AtmosArtifacts.jl
@@ -72,7 +72,7 @@ end
 
 Construct the file path for the 60arcsecond orography data NetCDF file.
 
-Downloads the 60arc-second dataset by default. 
+Downloads the 60arc-second dataset by default.
 """
 function earth_orography_file_path(; context = nothing)
     filename = "ETOPO_2022_v1_60s_N90W180_surface.nc"
@@ -80,6 +80,15 @@ function earth_orography_file_path(; context = nothing)
         @clima_artifact("earth_orography_60arcseconds", context),
         filename,
     )
+end
+
+"""
+    co2_concentration_file_path(; context = nothing)
+
+Construct the file path for the co2 concentration CSV file.
+"""
+function co2_concentration_file_path(; context = nothing)
+    return joinpath(@clima_artifact("co2_dataset", context), "co2_mm_mlo.txt")
 end
 
 end

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -213,6 +213,7 @@ end
             "surface_setup" => "PrescribedSurface",
             "moist" => "equil",
             "rad" => "clearsky",
+            "co2_model" => "fixed",
             "turbconv" => "diagnostic_edmfx",
             # NOTE: We do not output diagnostics because it leads to problems with Ubuntu on
             # GitHub actions taking too long to run (for unknown reasons). If you need this,

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -406,6 +406,7 @@ if MANYTESTS
                             "rayleigh_sponge" => true,
                             "insolation" => "timevarying",
                             "rad" => radiation,
+                            "co2_model" => "fixed",
                             "dt_rad" => "1secs",
                             "surface_setup" => "DefaultMoninObukhov",
                             "call_cloud_diagnostics_per_stage" => true,  # Needed to ensure that cloud variables are computed


### PR DESCRIPTION
Currently, when running AMIP, ClimaCoupler is responsible for updating the concentration of CO2 used for the radiation transport. This means that:
1. ClimaAtmos by itself cannot use observed CO2 concentrations
2. ClimaCoupler has to maintain specialized code just to update these values

The reason for why this was done is because originally only ClimaCoupler had the infrastructure to read in files. However, this is no longer the case and ClimaAtmos is already updating values read from files for aerosols and ozone.
This PR adds CO2 to the list.