### PR TITLE
Remove `override_precip_timescale`, modify some TOMLs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@ Main
 CO2 concentration. This is currently only relevant for radiation transfer with
 RRTGMP.
 
+### Maintenance
+
+### Remove override_precip_timescale config
+![][badge-🔥behavioralΔ] The override_precip_timescale config has been removed.
+To recover the previous behavior, set `precipitation_timescale` to `dt` in the
+toml. PR [3534](https://github.com/CliMA/ClimaAtmos.jl/pull/3534)
+
 v0.28.2
 -------
 ### Features

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -259,9 +259,6 @@ implicit_diffusion:
 approximate_linear_solve_iters:
   help: "Number of iterations for the approximate linear solve (used when `implicit_diffusion` is true)"
   value: 1
-override_precip_timescale:
-  help: "If true, sets τ_precip to dt. Otherwise, τ_precip is set to the value in the toml dictionary"
-  value: true
 output_default_diagnostics:
   help: "Output the default diagnostics associated to the selected atmospheric model"
   value: true

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -9,7 +9,6 @@ dt_save_state_to_disk: "20days"
 moist: "equil"
 cloud_model: "quadrature_sgs"
 precip_model: "0M"
-override_precip_timescale: false
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -25,5 +25,4 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_diagedmf.toml]

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_diffonly_0M.yml
@@ -27,5 +27,4 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: false
 edmfx_sgs_diffusive_flux: true
 precip_model: "0M"
-override_precip_timescale: false
 toml: [toml/longrun_aquaplanet_progedmf.toml]

--- a/config/longrun_configs/longrun_moist_baroclinic_wave.yml
+++ b/config/longrun_configs/longrun_moist_baroclinic_wave.yml
@@ -8,6 +8,7 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "10days"
+toml: [toml/longrun_baroclinic_wave.toml]
 diagnostics:
   - short_name: [pfull, wa, va, rv, hus, ke]
     period: 1days

--- a/config/longrun_configs/longrun_moist_baroclinic_wave_he60.yml
+++ b/config/longrun_configs/longrun_moist_baroclinic_wave_he60.yml
@@ -9,6 +9,7 @@ moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "10days"
 netcdf_interpolation_num_points: [360, 180, 2]
+toml: [toml/longrun_baroclinic_wave.toml]
 diagnostics:
   - short_name: [pfull, wa, va, rv, hus, ke]
     period: 1days

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -15,7 +15,6 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
-override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -16,7 +16,6 @@ moist: equil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
-override_precip_timescale: false
 config: box
 x_max: 1e8
 y_max: 1e8

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -17,7 +17,6 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_precip_timescale: false
 dt: 30secs
 t_end: 3600secs
 dt_save_state_to_disk: 12hours

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -16,7 +16,6 @@ edmfx_sgs_diffusive_flux: true
 rayleigh_sponge: true
 moist: equil
 precip_model: 0M
-override_precip_timescale: false
 dt: 100secs
 t_end: 12hours
 dt_save_state_to_disk: 12hours

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-202
+203
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+203
+- Remove `override_precip_timescale`
+
 202
 - Slightly changed CO2 prescription
 

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -8,34 +8,19 @@ import CloudMicrophysics as CM
 import StaticArrays as SA
 
 """
-    ClimaAtmosParameters(FT, dt)
-    ClimaAtmosParameters(toml_dict, dt)
+    ClimaAtmosParameters(FT::AbstractFloat)
+    ClimaAtmosParameters(toml_dict)
     ClimaAtmosParameters(config::AtmosConfig)
 
 Construct the parameter set for any ClimaAtmos configuration.
-
-If dt is passed in, it will be used to override the `precipitation_timescale` parameter.
 """
-function ClimaAtmosParameters(config::AtmosConfig)
-    (; toml_dict, parsed_args) = config
-    FT = CP.float_type(toml_dict)
-    override_dt =
-        parsed_args["override_precip_timescale"] ?
-        FT(CA.time_to_seconds(parsed_args["dt"])) : nothing
+ClimaAtmosParameters(config::AtmosConfig) =
+    ClimaAtmosParameters(config.toml_dict)
 
-    return ClimaAtmosParameters(toml_dict, override_dt)
-end
+ClimaAtmosParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    ClimaAtmosParameters(CP.create_toml_dict(FT))
 
-ClimaAtmosParameters(::Type{FT}, dt = nothing) where {FT} =
-    ClimaAtmosParameters(CP.create_toml_dict(FT), dt)
-
-function ClimaAtmosParameters(
-    toml_dict::TD,
-    dt = nothing,
-) where {TD <: CP.AbstractTOMLDict}
-    if !isnothing(dt)
-        toml_dict["precipitation_timescale"]["value"] = dt
-    end
+function ClimaAtmosParameters(toml_dict::TD) where {TD <: CP.AbstractTOMLDict}
     FT = CP.float_type(toml_dict)
 
     turbconv_params = TurbulenceConvectionParameters(toml_dict)

--- a/test/parameters/parameter_tests.jl
+++ b/test/parameters/parameter_tests.jl
@@ -37,25 +37,3 @@ end
               CA.Parameters.ClimaAtmosParameters
     end
 end
-
-@testset "Test that `override_precip_timescale` is handled properly" begin
-    # precipitation_timescale should NOT be overridden by DT
-    config = CA.AtmosConfig(
-        Dict("dt" => "1secs", "override_precip_timescale" => false),
-    )
-    @test config.parsed_args["override_precip_timescale"] == false
-    @test config.parsed_args["dt"] == "1secs"
-    (; precipitation_timescale) =
-        CP.get_parameter_values(config.toml_dict, "precipitation_timescale")
-    parameters = CA.ClimaAtmosParameters(config)
-    @test parameters.microphysics_0m_params.τ_precip == precipitation_timescale
-
-    # precipitation_timescale should be overridden by DT
-    config = CA.AtmosConfig(Dict("dt" => "1secs"))
-    @test config.parsed_args["override_precip_timescale"] == true
-    @test config.parsed_args["dt"] == "1secs"
-    (; precipitation_timescale) =
-        CP.get_parameter_values(config.toml_dict, "precipitation_timescale")
-    parameters = CA.ClimaAtmosParameters(config)
-    @test parameters.microphysics_0m_params.τ_precip == 1.0
-end

--- a/toml/longrun_aquaplanet.toml
+++ b/toml/longrun_aquaplanet.toml
@@ -3,3 +3,6 @@ value = 40000.0
 
 [zd_viscous]
 value = 40000.0
+
+[precipitation_timescale]
+value = 120

--- a/toml/longrun_baroclinic_wave.toml
+++ b/toml/longrun_baroclinic_wave.toml
@@ -1,0 +1,2 @@
+[precipitation_timescale]
+value = 120

--- a/toml/longrun_held_suarez.toml
+++ b/toml/longrun_held_suarez.toml
@@ -3,3 +3,6 @@ value = 40000.0
 
 [zd_viscous]
 value = 40000.0
+
+[precipitation_timescale]
+value = 120

--- a/toml/sphere_aquaplanet.toml
+++ b/toml/sphere_aquaplanet.toml
@@ -4,3 +4,5 @@ value = 40000.0
 [zd_rayleigh]
 value = 40000.0
 
+[precipitation_timescale]
+value = 400

--- a/toml/sphere_held_suarez.toml
+++ b/toml/sphere_held_suarez.toml
@@ -4,3 +4,5 @@ value = 35000.0
 [zd_rayleigh]
 value = 35000.0
 
+[precipitation_timescale]
+value = 400


### PR DESCRIPTION
This PR removes usage of `override_precip_timescale` and adds the parameter manually in some TOML files.

I didn't change the toml for all the configs so some of the jobs have small behavior changes.