### PR TITLE
Modify velocity, kinetic energy, and curl terms to match dycore paper

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -47,6 +47,7 @@ function precomputed_quantities(Y, atmos)
     gs_quantities = (;
         ᶜspecific = specific_gs.(Y.c),
         ᶜu = similar(Y.c, C123{FT}),
+        ᶠu = similar(Y.f, C123{FT}),
         ᶠu³ = similar(Y.f, CT3{FT}),
         ᶜwₜqₜ = similar(Y.c, Geometry.WVector{FT}),
         ᶜwₕhₜ = similar(Y.c, Geometry.WVector{FT}),
@@ -238,11 +239,14 @@ function set_velocity_at_top!(Y, turbconv_model)
     return nothing
 end
 
-# This is used to set the grid-scale velocity quantities ᶜu, ᶠu³, ᶜK based on
-# ᶠu₃, and it is also used to set the SGS quantities based on ᶠu₃⁰ and ᶠu₃ʲ.
-function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠu₃, ᶜuₕ, ᶠuₕ³)
-    @. ᶜu = C123(ᶜuₕ) + ᶜinterp(C123(ᶠu₃))
-    @. ᶠu³ = ᶠuₕ³ + CT3(ᶠu₃)
+# Set the grid-scale velocity quantities ᶜu, ᶠu, ᶠu³, and ᶜK based on ᶠu₃, and
+# set the SGS quantities based on ᶠu₃⁰ and ᶠu₃ʲ.
+function set_velocity_quantities!(ᶜu, ᶠu, ᶠu³, ᶜK, ᶠu₃, ᶜuₕ, ᶠuₕ³, ᶜρ)
+    ᶜJ = Fields.local_geometry_field(ᶜu).J
+    ᶜgⁱʲ = Fields.local_geometry_field(ᶜu).gⁱʲ
+    @. ᶜu = C123(ᶜuₕ) + C123(ᶜinterp(ᶠu₃))
+    @. ᶠu³ = ᶠuₕ³ + ᶠwinterp(ᶜρ * ᶜJ, g³³(ᶜgⁱʲ)) * ᶠu₃
+    @. ᶠu = CT123(ᶠu³) + CT123(ᶠwinterp(ᶜρ * ᶜJ, CT12(ᶜu)))
     compute_kinetic!(ᶜK, ᶜuₕ, ᶠu₃)
     return nothing
 end
@@ -472,7 +476,7 @@ NVTX.@annotate function set_precomputed_quantities!(Y, p, t)
     n = n_mass_flux_subdomains(turbconv_model)
     thermo_args = (thermo_params, moisture_model)
     (; ᶜΦ) = p.core
-    (; ᶜspecific, ᶜu, ᶠu³, ᶜK, ᶜts, ᶜp) = p.precomputed
+    (; ᶜspecific, ᶜu, ᶠu, ᶠu³, ᶜK, ᶜts, ᶜp) = p.precomputed
     ᶠuₕ³ = p.scratch.ᶠtemp_CT3
 
     @. ᶜspecific = specific_gs(Y.c)
@@ -483,7 +487,7 @@ NVTX.@annotate function set_precomputed_quantities!(Y, p, t)
     set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
     set_velocity_at_top!(Y, turbconv_model)
 
-    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.u₃, Y.c.uₕ, ᶠuₕ³)
+    set_velocity_quantities!(ᶜu, ᶠu, ᶠu³, ᶜK, Y.f.u₃, Y.c.uₕ, ᶠuₕ³, Y.c.ρ)
     if n > 0
         # TODO: In the following increments to ᶜK, we actually need to add
         # quantities of the form ᶜρaχ⁰ / ᶜρ⁰ and ᶜρaχʲ / ᶜρʲ to ᶜK, rather than
@@ -705,15 +709,16 @@ function output_prognostic_sgs_quantities(Y, p, t)
     (; ᶜρa⁰, ᶜρ⁰, ᶜtsʲs) = p.precomputed
     ᶠuₕ³ = p.scratch.ᶠtemp_CT3
     set_ᶠuₕ³!(ᶠuₕ³, Y)
-    (ᶠu₃⁺, ᶜu⁺, ᶠu³⁺, ᶜK⁺) =
+    (ᶠu₃⁺, ᶜu⁺, ᶠu⁺, ᶠu³⁺, ᶜK⁺) =
         similar.((
             p.precomputed.ᶠu₃⁰,
             p.precomputed.ᶜu⁰,
+            p.precomputed.ᶠu,
             p.precomputed.ᶠu³⁰,
             p.precomputed.ᶜK⁰,
         ))
     set_sgs_ᶠu₃!(u₃⁺, ᶠu₃⁺, Y, turbconv_model)
-    set_velocity_quantities!(ᶜu⁺, ᶠu³⁺, ᶜK⁺, ᶠu₃⁺, Y.c.uₕ, ᶠuₕ³)
+    set_velocity_quantities!(ᶜu⁺, ᶠu⁺, ᶠu³⁺, ᶜK⁺, ᶠu₃⁺, Y.c.uₕ, ᶠuₕ³, Y.c.ρ)
     ᶜts⁺ = ᶜtsʲs.:1
     ᶜa⁺ = @. draft_area(ρa⁺(Y.c), TD.air_density(thermo_params, ᶜts⁺))
     ᶜa⁰ = @. draft_area(ᶜρa⁰, ᶜρ⁰)

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -90,7 +90,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     ᶠω¹²ʲs = p.scratch.ᶠtemp_CT12ʲs
 
     if point_type <: Geometry.Abstract3DPoint
-        @. ᶜω³ = curlₕ(Y.c.uₕ)
+        @. ᶜω³ = wcurlₕ(Y.c.uₕ)
     elseif point_type <: Geometry.Abstract2DPoint
         @. ᶜω³ = zero(ᶜω³)
     end
@@ -99,7 +99,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     for j in 1:n
         @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
     end
-    @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
+    @. ᶠω¹² += CT12(wcurlₕ(Y.f.u₃))
     for j in 1:n
         @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
     end
@@ -131,9 +131,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
 
     if isnothing(ᶠf¹²)
         # shallow atmosphere
-        @. Yₜ.c.uₕ -=
-            ᶜinterp(ᶠω¹² × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
-            (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.c.uₕ -= ᶜinterp(ᶠω¹² × ᶠu³) + (ᶜf³ + ᶜω³) × CT12(ᶜu)
         @. Yₜ.f.u₃ -= ᶠω¹² × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
@@ -142,9 +140,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         end
     else
         # deep atmosphere
-        @. Yₜ.c.uₕ -=
-            ᶜinterp((ᶠf¹² + ᶠω¹²) × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) /
-            (Y.c.ρ * ᶜJ) + (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.c.uₕ -= ᶜinterp((ᶠf¹² + ᶠω¹²) × ᶠu³) + (ᶜf³ + ᶜω³) × CT12(ᶜu)
         @. Yₜ.f.u₃ -= (ᶠf¹² + ᶠω¹²) × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -48,24 +48,28 @@ sort_files_by_time(files) =
     permute!(files, sortperm(time_from_filename.(files)))
 
 """
-    compute_kinetic!(κ::Field, uₕ::Field, uᵥ::Field)
+    compute_kinetic!(ᶜκ::Field, ᶜuₕ::Field, ᶠuᵥ::Field)
 
-Compute the specific kinetic energy at cell centers, storing in `κ` from
+Compute the specific kinetic energy at cell centers, storing in `ᶜκ` from
 individual velocity components:
-κ = 1/2 (uₕ⋅uʰ + 2uʰ⋅ᶜI(uᵥ) + ᶜI(uᵥ⋅uᵛ))
-- `uₕ` should be a `Covariant1Vector` or `Covariant12Vector`-valued field at
+ᶜκ = ((ᶜgʰʰ⋅ᶜuₕ)⋅ᶜuₕ + 2(ᶜgᵛʰ⋅ᶜuₕ)⋅ᶜI(ᶠuᵥ) + ᶜg³³*ᶜI(ᶠu₃^2))/2
+- `ᶜuₕ` should be a `Covariant1Vector` or `Covariant12Vector`-valued field at
     cell centers, and
-- `uᵥ` should be a `Covariant3Vector`-valued field at cell faces.
+- `ᶠuᵥ` should be a `Covariant3Vector`-valued field at cell faces.
 """
-function compute_kinetic!(κ::Fields.Field, uₕ::Fields.Field, uᵥ::Fields.Field)
-    @assert eltype(uₕ) <: Union{C1, C2, C12}
-    @assert eltype(uᵥ) <: C3
-    @. κ =
-        1 / 2 * (
-            dot(C123(uₕ), CT123(uₕ)) +
-            ᶜinterp(dot(C123(uᵥ), CT123(uᵥ))) +
-            2 * dot(CT123(uₕ), ᶜinterp(C123(uᵥ)))
-        )
+function compute_kinetic!(
+    ᶜκ::Fields.Field,
+    ᶜuₕ::Fields.Field,
+    ᶠuᵥ::Fields.Field,
+)
+    @assert eltype(ᶜuₕ) <: Union{C1, C2, C12}
+    @assert eltype(ᶠuᵥ) <: C3
+    @. ᶜκ =
+        (
+            dot(CT12(ᶜuₕ), C12(ᶜuₕ)) +
+            2 * dot(CT3(ᶜuₕ), ᶜinterp(ᶠuᵥ)) +
+            $g³³_field(ᶜκ) * ᶜinterp((ᶠuᵥ.components.data.:1)^2)
+        ) / 2
 end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR modifies the reconstructions of cell face velocity, cell center kinetic energy, and the curl terms in the velocity tendencies to exactly match the dycore paper.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
