### PR TITLE
Change density on cell faces to match dycore paper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@ If `netcdf_interpolation_num_points` is not provided, `ClimaAtmos` will
 determine it automatically by matching approximately the same number of points
 as the model grid.
 
+### Change reconstruction of density on cell faces for stretched grids
+
+PR [3584](https://github.com/CliMA/ClimaAtmos.jl/pull/3584) changes the weighted
+interpolation of density from centers to faces so that it uses `ᶜJ` and `ᶠJ`,
+rather than `ᶜJ` and `ᶠint(ᶜJ)`. As of ClimaCore v0.14.25, `ᶠJ` is no longer
+equivalent to `ᶠint(ᶜJ)` for stretched grids.
+
 v0.28.5
 -------
 

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-216
+217
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+
+217
+- Change reconstruction of density on cell faces
 
 216
 - Change prescribed aerosols in `aquaplanet_nonequil_allsky_gw_res.yml`

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -325,30 +325,31 @@ function compute_precipitation_surface_fluxes!(
     (; surface_rain_flux, surface_snow_flux) = p.precipitation
     (; col_integrated_precip_energy_tendency,) = p.conservation_check
     (; ᶜwᵣ, ᶜwₛ, ᶜspecific) = p.precomputed
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠJ = Fields.local_geometry_field(Y.f).J
+    sfc_J = Fields.level(ᶠJ, Fields.half)
+    sfc_space = axes(sfc_J)
 
-    (; ᶠtemp_scalar) = p.scratch
-    slg = Fields.level(Fields.local_geometry_field(ᶠtemp_scalar), Fields.half)
+    # Jacobian-weighted extrapolation from interior to surface, consistent with
+    # the reconstruction of density on cell faces, ᶠρ = ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ
+    int_J = Fields.Field(Fields.field_values(Fields.level(ᶜJ, 1)), sfc_space)
+    int_ρ = Fields.Field(Fields.field_values(Fields.level(Y.c.ρ, 1)), sfc_space)
+    sfc_ρ = @. lazy(int_ρ * int_J / sfc_J)
 
-    # Constant extrapolation: - put values from bottom cell center to bottom cell face
-    ˢρ = Fields.Field(Fields.field_values(Fields.level(Y.c.ρ, 1)), axes(slg))
-    # For density this is equivalent with ᶠwinterp(ᶜJ, Y.c.ρ) and therefore
-    # consistent with the way we do vertical advection
-    ˢqᵣ = Fields.Field(
+    # Constant extrapolation to surface, consistent with simple downwinding
+    sfc_qᵣ = Fields.Field(
         Fields.field_values(Fields.level(ᶜspecific.q_rai, 1)),
-        axes(slg),
+        sfc_space,
     )
-    ˢqₛ = Fields.Field(
+    sfc_qₛ = Fields.Field(
         Fields.field_values(Fields.level(ᶜspecific.q_sno, 1)),
-        axes(slg),
+        sfc_space,
     )
-    ˢwᵣ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵣ, 1)), axes(slg))
-    ˢwₛ = Fields.Field(Fields.field_values(Fields.level(ᶜwₛ, 1)), axes(slg))
+    sfc_wᵣ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵣ, 1)), sfc_space)
+    sfc_wₛ = Fields.Field(Fields.field_values(Fields.level(ᶜwₛ, 1)), sfc_space)
 
-    # Project the flux to CT3 vector and convert to physical units.
-    @. surface_rain_flux =
-        -projected_vector_data(CT3, ˢρ * ˢqᵣ * Geometry.WVector(ˢwᵣ), slg)
-    @. surface_snow_flux =
-        -projected_vector_data(CT3, ˢρ * ˢqₛ * Geometry.WVector(ˢwₛ), slg)
+    @. surface_rain_flux = sfc_ρ * sfc_qᵣ * (-sfc_wᵣ)
+    @. surface_snow_flux = sfc_ρ * sfc_qₛ * (-sfc_wₛ)
 end
 
 function precipitation_tendency!(

--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -531,6 +531,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
     ᶜuₕ = Y.c.uₕ
     ᶠu₃ = Y.f.u₃
     ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠJ = Fields.local_geometry_field(Y.f).J
     ᶜgⁱʲ = Fields.local_geometry_field(Y.c).gⁱʲ
     ᶠgⁱʲ = Fields.local_geometry_field(Y.f).gⁱʲ
 
@@ -552,7 +553,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
     @. ᶠp_grad_matrix = DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix()
 
     @. ᶜadvection_matrix =
-        -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ))
+        -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ)
 
     if use_derivative(topography_flag)
         ∂ᶜρ_err_∂ᶜuₕ = matrix[@name(c.ρ), @name(c.uₕ)]
@@ -634,7 +635,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
         #TODO: tetsing explicit vs implicit
         #@. ∂ᶜρe_tot_err_∂ᶜρe_tot +=
         #    dtγ * -(ᶜprecipdivᵥ_matrix()) ⋅
-        #    DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ)) ⋅ ᶠright_bias_matrix() ⋅
+        #    DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ) ⋅ ᶠright_bias_matrix() ⋅
         #    DiagonalMatrixRow(
         #        -(1 + ᶜkappa_m) / ᶜρ * ifelse(
         #            ᶜh_tot == 0,
@@ -648,7 +649,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
         #TODO: tetsing explicit vs implicit
         #@. ∂ᶜρe_tot_err_∂ᶜρq_tot =
         #    dtγ * -(ᶜprecipdivᵥ_matrix()) ⋅
-        #    DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ)) ⋅ ᶠright_bias_matrix() ⋅
+        #    DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ) ⋅ ᶠright_bias_matrix() ⋅
         #    DiagonalMatrixRow(
         #        -(ᶜkappa_m) * ∂e_int_∂q_tot / ᶜρ * ifelse(
         #            ᶜh_tot == 0,
@@ -662,7 +663,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
         #TODO: tetsing explicit vs implicit
         #@. ∂ᶜρq_tot_err_∂ᶜρq_tot =
         #    dtγ * -(ᶜprecipdivᵥ_matrix()) ⋅
-        #    DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ)) ⋅ ᶠright_bias_matrix() ⋅
+        #    DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ) ⋅ ᶠright_bias_matrix() ⋅
         #    DiagonalMatrixRow(
         #        -1 / ᶜρ * ifelse(
         #            ᶜspecific.q_tot == 0,
@@ -677,7 +678,8 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
             ᶜwₚ = MatrixFields.get_field(p, wₚ_name)
             @. ∂ᶜρqₚ_err_∂ᶜρqₚ =
                 dtγ * -(ᶜprecipdivᵥ_matrix()) ⋅
-                DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ)) ⋅ ᶠright_bias_matrix() ⋅
+                DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ) ⋅
+                ᶠright_bias_matrix() ⋅
                 DiagonalMatrixRow(-Geometry.WVector(ᶜwₚ) / ᶜρ) - (I,)
         end
 
@@ -852,13 +854,13 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
                             ᶠu³ʲs.:(1),
                             draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)),
                         ),
-                    ),
-                ) ⋅ ᶠwinterp_matrix(ᶜJ) ⋅ DiagonalMatrixRow(
-                    ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp) *
+                    ) / ᶠJ,
+                ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
+                    ᶜJ * ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp) *
                     ∂e_int_∂q_tot,
                 )
             @. ᶠbidiagonal_matrix_ct3_2 =
-                DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρʲs.:(1))) ⋅
+                DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ) ⋅
                 ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅
                 DiagonalMatrixRow(
                     Y.c.sgsʲs.:(1).ρa * ᶜkappa_mʲ / ((ᶜkappa_mʲ + 1) * ᶜp) *
@@ -877,12 +879,12 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
                             ᶠu³ʲs.:(1),
                             draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)),
                         ),
-                    ),
-                ) ⋅ ᶠwinterp_matrix(ᶜJ) ⋅ DiagonalMatrixRow(
-                    ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp),
+                    ) / ᶠJ,
+                ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
+                    ᶜJ * ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp),
                 )
             @. ᶠbidiagonal_matrix_ct3_2 =
-                DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρʲs.:(1))) ⋅
+                DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ) ⋅
                 ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅
                 DiagonalMatrixRow(
                     Y.c.sgsʲs.:(1).ρa * ᶜkappa_mʲ / ((ᶜkappa_mʲ + 1) * ᶜp),
@@ -894,7 +896,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
                 matrix[@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).ρa)]
             @. ᶜadvection_matrix =
                 -(ᶜadvdivᵥ_matrix()) ⋅
-                DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρʲs.:(1)))
+                DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ)
             @. ∂ᶜρaʲ_err_∂ᶜρaʲ =
                 dtγ * ᶜadvection_matrix ⋅
                 ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅

--- a/src/prognostic_equations/water_advection.jl
+++ b/src/prognostic_equations/water_advection.jl
@@ -3,14 +3,16 @@ import ClimaCore: Fields
 function vertical_advection_of_water_tendency!(Yₜ, Y, p, t)
 
     ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠJ = Fields.local_geometry_field(Y.f).J
     (; ᶜwₜqₜ, ᶜwₕhₜ) = p.precomputed
 
     if !(p.atmos.moisture_model isa DryModel)
-        @. Yₜ.c.ρ -= ᶜprecipdivᵥ(ᶠwinterp(ᶜJ, Y.c.ρ) * ᶠright_bias(-(ᶜwₜqₜ)))
+        @. Yₜ.c.ρ -=
+            ᶜprecipdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(-(ᶜwₜqₜ)))
         @. Yₜ.c.ρe_tot -=
-            ᶜprecipdivᵥ(ᶠwinterp(ᶜJ, Y.c.ρ) * ᶠright_bias(-(ᶜwₕhₜ)))
+            ᶜprecipdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(-(ᶜwₕhₜ)))
         @. Yₜ.c.ρq_tot -=
-            ᶜprecipdivᵥ(ᶠwinterp(ᶜJ, Y.c.ρ) * ᶠright_bias(-(ᶜwₜqₜ)))
+            ᶜprecipdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(-(ᶜwₜqₜ)))
     end
     return nothing
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR is a followup to #3552 that changes the density on cell faces from `ᶠ⟨ᶜJ * ᶜρ⟩ / ᶠ⟨ᶜJ⟩ = ᶠwinterp(ᶜJ, ᶜρ)` to `ᶠ⟨ᶜJ * ᶜρ⟩ / ᶠJ = ᶠinterp(ᶜJ * ᶜρ) / ᶠJ`. This probably won't have much of an impact now, since `ᶠJ` is currently equivalent to `ᶠ⟨ᶜJ⟩`, but that will no longer be the case following CliMA/ClimaCore.jl#2167. Once that PR is in, we will need to test this change with the longruns to determine whether it improves stability. **Update**: The ClimaCore PR was included in v0.14.25.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
