### PR TITLE
Update moist baro wave config, [ci skip]

### DIFF
--- a/config/longrun_configs/longrun_moist_baroclinic_wave.yml
+++ b/config/longrun_configs/longrun_moist_baroclinic_wave.yml
@@ -4,9 +4,10 @@ dz_bottom: 30.0
 dt: "90secs"
 t_end: "120days"
 initial_condition: "MoistBaroclinicWave"
-moist: "nonequil"
-precip_model: "1M"
+moist: "equil"
+precip_model: "0M"
 dt_save_state_to_disk: "10days"
+toml: [toml/longrun_baroclinic_wave.toml]
 diagnostics:
-  - short_name: [pfull, wa, va, ua, ta, rhoa, rv, hus, ke, clw, cli, husra, hussn]
+  - short_name: [pfull, wa, va, ua, ta, rhoa, rv, hus, ke, clw, cli]
     period: 1days


### PR DESCRIPTION

The final config for equilibrium 0M moist baroclinic wave.

The model time step is 90s and the precipitation timescale is 120s