### PR TITLE
Make all steps in buildkite pipeline use reservation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -549,20 +549,6 @@ steps:
         agents:
           slurm_mem: 20GB
 
-  - group: "Calibration"
-    steps:
-      - label: "Calibration interface unit tests"
-        command: julia --project=calibration/test calibration/test/interface.jl
-      - label: "end to end test"
-        command: julia --project=calibration/test calibration/test/e2e_test.jl
-        agents:
-          slurm_ntasks: 10
-          slurm_cpus_per_task: 1
-          slurm_mem: 96GB
-          slurm_reservation: "false"
-          slurm_time: "00:30:00"
-        artifact_paths: "calibration_end_to_end_test/*"
-
   - group: "Diagnostic EDMFX"
     steps:
 
@@ -1047,16 +1033,6 @@ steps:
           slurm_mem: 24GB
           slurm_gpus: 1
 
-      - label: ":computer: Benchmark: CPU perf target (Threaded)"
-        command: >
-          julia --color=yes --threads 8 --project=.buildkite perf/benchmark.jl
-          --config_file $PERF_CONFIG_PATH/bm_perf_target_threaded.yml
-          --job_id bm_perf_target_threaded
-        agents:
-          slurm_mem: 24GB
-          slurm_cpus_per_task: 8
-          slurm_reservation: "false"
-
       - label: ":computer: Benchmark: GPU diag edmf"
         command: >
           julia --color=yes --project=.buildkite perf/benchmark.jl
@@ -1117,29 +1093,7 @@ steps:
           --job_id flame_perf_target_prognostic_edmfx_aquaplanet
         artifact_paths: "flame_perf_target_prognostic_edmfx_aquaplanet/*"
         agents:
-          slurm_mem: 48GB
-          slurm_reservation: "false"
-
-      - label: ":fire: Flame graph: perf target (frierson diffusion)"
-        command: >
-          julia --color=yes --project=.buildkite perf/flame.jl
-          --config_file $PERF_CONFIG_PATH/flame_perf_target_frierson.yml
-          --job_id flame_perf_target_frierson
-        artifact_paths: "flame_perf_target_frierson/*"
-        agents:
-          slurm_mem: 48GB
-          slurm_reservation: "false"
-
-      - label: ":fire: Flame graph: perf target (Threaded)"
-        command: >
-          julia --threads 8 --color=yes --project=.buildkite perf/flame.jl
-          --config_file $PERF_CONFIG_PATH/flame_perf_target_threaded.yml
-          --job_id flame_perf_target_threaded
-        artifact_paths: "flame_perf_target_threaded/*"
-        agents:
-          slurm_cpus_per_task: 8
-          slurm_mem: 24GB
-          slurm_reservation: "false"
+          slurm_mem: 32GB
 
       - label: ":fire: Flame graph: perf target (Callbacks)"
         command: >

--- a/calibration/test/pipeline.yml
+++ b/calibration/test/pipeline.yml
@@ -1,0 +1,46 @@
+agents:
+  queue: new-central
+  slurm_mem: 8G
+  modules: climacommon/2024_12_16
+env:
+  OPENBLAS_NUM_THREADS: 1
+  SLURM_KILL_BAD_EXIT: 1
+  JULIA_NVTX_CALLBACKS: gc
+  JULIA_MAX_NUM_PRECOMPILE_FILES: 100
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
+
+steps:
+  - label: "init :computer:"
+    key: "init_cpu_env"
+    concurrency: 1
+    concurrency_group: 'depot/climaatmos-calibration'
+    command:
+      - "echo $$JULIA_DEPOT_PATH"
+
+      - echo "--- Instantiate calibration/test"
+      - "julia --project=calibration/test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.instantiate(;verbose=true)'"
+      - "julia --project=calibration/test -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=calibration/test -e 'using Pkg; Pkg.status()'"
+
+    agents:
+      slurm_cpus_per_task: 8
+      slurm_gpus: 1
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+
+  - wait
+
+  - group: "Calibration"
+    steps:
+      - label: "Calibration interface unit tests"
+        command: julia --project=calibration/test calibration/test/interface.jl
+      - label: "end to end test"
+        command: julia --project=calibration/test calibration/test/e2e_test.jl
+        agents:
+          slurm_ntasks: 10
+          slurm_cpus_per_task: 1
+          slurm_mem: 96GB
+          slurm_reservation: "false"
+          slurm_time: "00:30:00"
+        artifact_paths: "calibration_end_to_end_test/*"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
There were five steps in the build kite pipeline that did not use the slurm reservation:

1. Calibration interface unit tests
2. CPU perf target (Threaded)
3. Flame graph: perf target (frierson diffusion)
4. Flame graph: perf target (Threaded)
5. Flame graph: perf target (prognostic edmfx aquaplanet)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
The above steps were modified as following:

1.  moved to new pipeline
2. removed
3. removed
4. removed
5. slurm memory reduced to 32GB. 



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
