### PR TITLE
Make `set_velocity_at_surface!` independent of the cache

### DIFF
--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -114,12 +114,12 @@ function compute_strain_rate_face(u::Fields.Field)
 end
 
 """
-    g³³_field(field)
+    g³³_field(space)
 
-Extracts the value of `g³³` from `Fields.local_geometry_field(field)`.
+Extracts the value of `g³³` from `Fields.local_geometry_field(space)`.
 """
-function g³³_field(field)
-    g_field = Fields.local_geometry_field(field).gⁱʲ.components.data
+function g³³_field(space)
+    g_field = Fields.local_geometry_field(space).gⁱʲ.components.data
     end_index = fieldcount(eltype(g_field)) # This will be 4 in 2D and 9 in 3D.
     return g_field.:($end_index) # For both 2D and 3D spaces, g³³ = g[end].
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -170,9 +170,8 @@ end
     (; cent_space, face_space) = get_cartesian_spaces()
     lg_gⁱʲ = cent_space.grid.center_local_geometry.gⁱʲ
     lg_g³³ = lg_gⁱʲ.components.data.:9
-    @test Fields.field_values(
-        CA.g³³_field(Fields.coordinate_field(cent_space).x),
-    ) == lg_g³³
+    (; x) = Fields.coordinate_field(cent_space)
+    @test Fields.field_values(CA.g³³_field(axes(x))) == lg_g³³
     @test maximum(abs.(lg_g³³ .- CA.g³³.(lg_gⁱʲ).components.data.:1)) == 0
     @test maximum(abs.(CA.g³ʰ.(lg_gⁱʲ).components.data.:1)) == 0
     @test maximum(abs.(CA.g³ʰ.(lg_gⁱʲ).components.data.:2)) == 0


### PR DESCRIPTION
This PR makes `set_velocity_at_surface!` independent of the cache (specifically, `ᶠtemp_CT3`).