### PR TITLE
Lower slurm requirements for calibration tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,11 +34,6 @@ steps:
       - "julia --project=.buildkite -e 'using CUDA; CUDA.precompile_runtime()'"
       - "julia --project=.buildkite -e 'using Pkg; Pkg.status()'"
 
-      - echo "--- Instantiate calibration/test"
-      - "julia --project=calibration/test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.instantiate(;verbose=true)'"
-      - "julia --project=calibration/test -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=calibration/test -e 'using Pkg; Pkg.status()'"
-
     agents:
       slurm_cpus_per_task: 8
       slurm_gpus: 1

--- a/calibration/test/e2e_test.jl
+++ b/calibration/test/e2e_test.jl
@@ -42,7 +42,7 @@ function process_member_data(simdir::SimDir)
     return slice(average_xy(rsut); time = 30days).data
 end
 
-addprocs(CAL.SlurmManager(10))
+addprocs(CAL.SlurmManager())
 
 @everywhere begin
     import ClimaCalibrate as CAL

--- a/calibration/test/pipeline.yml
+++ b/calibration/test/pipeline.yml
@@ -38,9 +38,8 @@ steps:
       - label: "end to end test"
         command: julia --project=calibration/test calibration/test/e2e_test.jl
         agents:
-          slurm_ntasks: 10
+          slurm_ntasks: 4
           slurm_cpus_per_task: 1
-          slurm_mem: 96GB
+          slurm_mem: 32GB
           slurm_reservation: "false"
-          slurm_time: "00:30:00"
         artifact_paths: "calibration_end_to_end_test/*"


### PR DESCRIPTION
This PR lowers the slurm resource requirements for the calibration test, we could enable the reservation for it now.

The job itself now takes ~20min instead of ~15.