### PR TITLE
Clean up duplicated log messages when using MPI

### DIFF
--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -21,12 +21,12 @@ walltime_in_days(es::EfficiencyStats) = es.walltime * (1 / (24 * 3600)) #=second
 
 function timed_solve!(integrator)
     device = ClimaComms.device(integrator.u.c)
+    comms_ctx = ClimaComms.context(device)
     local sol
-    @time "solve!:" begin
-        walltime = ClimaComms.elapsed(device) do
-            sol = SciMLBase.solve!(integrator)
-        end
+    walltime = ClimaComms.elapsed(device) do
+        sol = SciMLBase.solve!(integrator)
     end
+    @info "solve! walltime = $(round(walltime, digits = 3))"
     (; tspan) = integrator.sol.prob
     es = EfficiencyStats(tspan, walltime)
     _sypd = simulated_years_per_day(es)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -574,7 +574,6 @@ function get_sim_info(config::AtmosConfig)
         start_date = epoch,
         t_end = t_end,
     )
-    @show sim.t_end, sim.dt
     n_steps = floor(Int, sim.t_end / sim.dt)
     @info(
         "Time info:",
@@ -639,15 +638,17 @@ end
 
 import ClimaComms, Logging, NVTX
 function get_comms_context(parsed_args)
-    device = if parsed_args["device"] == "auto"
-        ClimaComms.device()
-    elseif parsed_args["device"] == "CUDADevice"
-        ClimaComms.CUDADevice()
-    elseif parsed_args["device"] == "CPUMultiThreaded" || Threads.nthreads() > 1
-        ClimaComms.CPUMultiThreaded()
-    else
-        ClimaComms.CPUSingleThreaded()
-    end
+    device =
+        if !haskey(parsed_args, "device") || parsed_args["device"] === "auto"
+            ClimaComms.device()
+        elseif parsed_args["device"] == "CUDADevice"
+            ClimaComms.CUDADevice()
+        elseif parsed_args["device"] == "CPUMultiThreaded" ||
+               Threads.nthreads() > 1
+            ClimaComms.CPUMultiThreaded()
+        else
+            ClimaComms.CPUSingleThreaded()
+        end
     comms_ctx = ClimaComms.context(device)
     ClimaComms.init(comms_ctx)
 

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -59,7 +59,6 @@ override_default_config(config_dicts::ContainerType(AbstractDict)) =
     override_default_config(merge(config_dicts...))
 
 function override_default_config(::Nothing)
-    @info "Using default configuration"
     return default_config_dict()
 end
 


### PR DESCRIPTION
This PR cleans up log message duplication when running with MPI:
- `src/solver/types.jl`: `@info "Loading yaml file $config_file"`
- `src/solver/solve.jl`: `@time "solve!:"`
- `src/solver/type_getters.jl`: `@show sim.t_end, sim.dt`