### PR TITLE
Use tke based eddy diffusion for `aquaplanet_dyamond` longrun

### DIFF
--- a/config/longrun_configs/amip_target_edonly.yml
+++ b/config/longrun_configs/amip_target_edonly.yml
@@ -8,7 +8,6 @@ viscous_sponge: true
 dt_save_to_sol: "10days"
 dt_save_state_to_disk: "20days"
 moist: "equil"
-cloud_model: "quadrature"
 precip_model: "0M"
 rad: "allskywithclear"
 dt_rad: "1hours"
@@ -25,7 +24,7 @@ implicit_diffusion: true
 approximate_linear_solve_iters: 2
 dt: "120secs"
 t_end: "120days"
-toml: [toml/longrun_aquaplanet_edonly.toml]
+toml: [toml/longrun_aquaplanet.toml]
 netcdf_output_at_levels: true
 diagnostics:
   - short_name: [mmrso4, mmrdust, mmrss, o3]

--- a/config/longrun_configs/longrun_aquaplanet_dyamond.yml
+++ b/config/longrun_configs/longrun_aquaplanet_dyamond.yml
@@ -18,14 +18,15 @@ insolation: "timevarying"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"
 surface_setup: "DefaultMoninObukhov"
-vert_diff: "DecayWithHeightDiffusion"
 precip_model: "0M"
+turbconv: "edonly_edmfx"
+edmfx_sgs_diffusive_flux: true
 toml: [toml/longrun_aquaplanet.toml]
 netcdf_interpolation_num_points:  [720, 360, 63]
 diagnostics:
- - short_name: [pfull, ps, ua, va, ta, ts, wa, rv, ke, hus, clw, cli, pr]
+ - short_name: [pfull, ua, va, ta, ts, wa, rv, ke, hus, clw, cli, pr]
    reduction: inst
    period: 10days
- - short_name: [pfull, ps, ua, va, ta, ts, wa, rv, ke, hus, clw, cli, pr]
+ - short_name: [pfull, ua, va, ta, ts, wa, rv, ke, hus, clw, cli, pr]
    reduction: average
    period: 30days

--- a/toml/longrun_aquaplanet_edonly.toml
+++ b/toml/longrun_aquaplanet_edonly.toml
@@ -1,8 +1,0 @@
-[zd_rayleigh]
-value = 40000.0
-
-[zd_viscous]
-value = 40000.0
-
-[precipitation_timescale]
-value = 600


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update `longrun_aquaplanet_dyamond` to use tke based eddy diffusion. Also use the same toml for amip_target_edonly.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
