### PR TITLE
Initialize tke to 0 for DYAMOND

### DIFF
--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -484,6 +484,12 @@ function overwrite_initial_conditions!(
                 center_space,
             ) .* Y.c.ρ
     end
+
+    if hasproperty(Y.c, :sgs⁰) && hasproperty(Y.c.sgs⁰, :ρatke)
+        # NOTE: This is not the most consistent, but it is better than NaNs
+        fill!(Y.c.ρatke, 0)
+    end
+
     return nothing
 end
 


### PR DESCRIPTION
The DYAMOND initial conditions did not set `Y.c.ρatke`, which was filled with NaNs.
