### PR TITLE
Fix calibration test instantiation

### DIFF
--- a/calibration/test/pipeline.yml
+++ b/calibration/test/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_12_16
+  modules: climacommon/2025_01_27
 env:
   OPENBLAS_NUM_THREADS: 1
   SLURM_KILL_BAD_EXIT: 1
@@ -18,7 +18,7 @@ steps:
       - "echo $$JULIA_DEPOT_PATH"
 
       - echo "--- Instantiate calibration/test"
-      - "julia --project=calibration/test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.instantiate(;verbose=true)'"
+      - "julia --project=calibration/test -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.develop(;path=\".\")'"
       - "julia --project=calibration/test -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=calibration/test -e 'using Pkg; Pkg.status()'"
 
@@ -41,5 +41,4 @@ steps:
           slurm_ntasks: 4
           slurm_cpus_per_task: 1
           slurm_mem: 32GB
-          slurm_reservation: "false"
         artifact_paths: "calibration_end_to_end_test/*"


### PR DESCRIPTION
`Pkg.develop(".")` does not update the registry, so if an updated version of a package is required but not in the registry this test would break. `instantiate` updates the registry, so we call that before `dev`ing now