### PR TITLE
Zero out the surface momentum flux during initialization

### DIFF
--- a/src/surface_conditions/SurfaceConditions.jl
+++ b/src/surface_conditions/SurfaceConditions.jl
@@ -16,6 +16,7 @@ import ..get_wstar
 
 import ClimaCore: DataLayouts, Geometry, Fields
 import ClimaCore.Geometry: ⊗
+import ClimaCore.Utilities: half
 import SurfaceFluxes as SF
 import Thermodynamics as TD
 

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -94,6 +94,13 @@ function set_dummy_surface_conditions!(p)
         @. sfc_conditions.ρ_flux_q_tot = C3(FT(0))
     end
     @. sfc_conditions.ρ_flux_h_tot = C3(FT(0))
+
+    # Zero out the surface momentum flux
+    c = p.scratch.ᶠtemp_scalar
+    # elsewhere known as 𝒢
+    sfc_local_geometry = Fields.level(Fields.local_geometry_field(c), half)
+    @. sfc_conditions.ρ_flux_uₕ =
+        tensor_from_components(0, 0, sfc_local_geometry)
 end
 
 """

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -112,6 +112,13 @@ end
         job_id = "coupler_compatibility2",
     )
     simulation = CA.get_simulation(config)
+
+    # Check: ρ_flux_uₕ is initialized to zero
+    @test all(
+        iszero,
+        parent(simulation.integrator.p.precomputed.sfc_conditions.ρ_flux_uₕ),
+    )
+
     (; integrator) = simulation
     (; p, t) = integrator
     Y = integrator.u


### PR DESCRIPTION
Otherwise it has random values including NaNs.

With @juliasloan25 and @Sbozzolo 