### PR TITLE
Automatically choose diagnostic grid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,17 @@
 ClimaAtmos.jl Release Notes
 ============================
 
+v0.28.6
+-------
+
+### Features
+
+### Automatically determine diagnostic resolution based on model resolution
+
+If `netcdf_interpolation_num_points` is not provided, `ClimaAtmos` will
+determine it automatically by matching approximately the same number of points
+as the model grid.
+
 v0.28.5
 -------
 

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -11,6 +11,7 @@ function get_diagnostics(
     (; dt, start_date) = sim_info
 
     FT = Spaces.undertype(axes(Y.c))
+    context = ClimaComms.context(axes(Y.c))
 
     # We either get the diagnostics section in the YAML file, or we return an empty list
     # (which will result in an empty list being created by the map below)
@@ -40,9 +41,26 @@ function get_diagnostics(
         num_netcdf_points =
             tuple(parsed_args["netcdf_interpolation_num_points"]...)
     else
-        # TODO: Once https://github.com/CliMA/ClimaCore.jl/pull/1567 is merged,
-        # dispatch over the Grid type
-        num_netcdf_points = (180, 90, 50)
+        # Estimate the number of points we need to cover the entire domain
+        # ncolumns is the number of local columns
+        tot_num_columns =
+            ClimaComms.nprocs(context) * Fields.ncolumns(axes(Y.c))
+        if parsed_args["config"] == "plane"
+            num1, num2 = tot_num_columns, 0
+        elseif parsed_args["config"] == "sphere"
+            num2 = round(Int, sqrt(tot_num_columns / 2))
+            num1 = 2num2
+        elseif parsed_args["config"] == "box"
+            num2 = round(Int, sqrt(tot_num_columns))
+            num1 = num2
+        elseif parsed_args["config"] == "column"
+            # We need at least two points horizontally because our column is
+            # actually a box
+            num1, num2 = 2, 2
+        else
+            error("Uncaught case")
+        end
+        num_netcdf_points = (num1, num2, Spaces.nlevels(axes(Y.c)))
     end
 
     z_sampling_method =


### PR DESCRIPTION
If `netcdf_interpolation_num_points` is not provided, `ClimaAtmos` will to determine it automatically by matching approximately choosing the same number of points as the model grid. In this, we distribute points equally along the two horizontal dimensions.

Closes #3651 
