### PR TITLE
Add flag for running updraft massflux implicitly in GM equations

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -315,6 +315,9 @@ zero_tendency:
 implicit_sgs_advection:
   help: "Whether to treat the subgrid-scale vertical advection tendency implicitly [`false` (default), `true`]"
   value: false
+implicit_sgs_mass_flux:
+  help: "Whether to treat the subgrid-scale mass flux tendency implicitly or explicitly in grid-mean equations. Currently updraft only with Jacobian terms 0. [`false` (default), `true`]"
+  value: false
 edmf_coriolis:
   help: "EDMF coriolis [`nothing` (default), `Bomex`,`LifeCycleTan2018`,`Rico`,`ARM_SGP`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
   value: ~

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -3,7 +3,8 @@ surface_setup: "Soares"
 rayleigh_sponge: true
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: false
+implicit_sgs_advection: true
+implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -29,6 +29,11 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
         )
         edmfx_sgs_diffusive_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
+
+    if p.atmos.sgs_mf_mode == Implicit()
+        edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+    end
+
     # NOTE: All ρa tendencies should be applied before calling this function
     pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -111,7 +111,9 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
     radiation_tendency!(Yₜ, Y, p, t, p.atmos.radiation_mode)
     edmfx_entr_detr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+    if p.atmos.sgs_mf_mode == Explicit()
+        edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+    end
     edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     edmfx_filter_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     edmfx_tke_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -55,6 +55,9 @@ function get_atmos(config::AtmosConfig, params)
     implicit_sgs_advection = parsed_args["implicit_sgs_advection"]
     @assert implicit_sgs_advection in (true, false)
 
+    implicit_sgs_mass_flux = parsed_args["implicit_sgs_mass_flux"]
+    @assert implicit_sgs_mass_flux in (true, false)
+
     edmfx_model = EDMFXModel(;
         entr_model = get_entrainment_model(parsed_args),
         detr_model = get_detrainment_model(parsed_args),
@@ -96,6 +99,7 @@ function get_atmos(config::AtmosConfig, params)
         vert_diff,
         diff_mode = implicit_diffusion ? Implicit() : Explicit(),
         sgs_adv_mode = implicit_sgs_advection ? Implicit() : Explicit(),
+        sgs_mf_mode = implicit_sgs_mass_flux ? Implicit() : Explicit(),
         viscous_sponge = get_viscous_sponge_model(parsed_args, params, FT),
         smagorinsky_lilly = get_smagorinsky_lilly_model(parsed_args),
         rayleigh_sponge = get_rayleigh_sponge_model(parsed_args, params, FT),

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -516,6 +516,7 @@ Base.@kwdef struct AtmosModel{
     VD,
     DM,
     SAM,
+    SMM,
     VS,
     SL,
     RS,
@@ -553,6 +554,7 @@ Base.@kwdef struct AtmosModel{
     vert_diff::VD = nothing
     diff_mode::DM = nothing
     sgs_adv_mode::SAM = nothing
+    sgs_mf_mode::SMM = nothing
     viscous_sponge::VS = nothing
     smagorinsky_lilly::SL = nothing
     rayleigh_sponge::RS = nothing


### PR DESCRIPTION
Add flag for running updraft massflux implicitly, with grid-mean jacobian terms zero as a placeholder.
