### PR TITLE
Add dry baro wave example

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.3"
 manifest_format = "2.0"
-project_hash = "04945e2a7116cfacb2d57340f477dbe23e208227"
+project_hash = "a25db2ac38461b28c1b3a6176008dee03780354b"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "fb97701c117c8162e84dfcf80215caa904aef44f"
@@ -58,12 +58,13 @@ version = "0.1.41"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
-git-tree-sha1 = "50c3c56a52972d78e8be9fd135bfb91c9574c140"
+git-tree-sha1 = "cd8b948862abee8f3d3e9b73a102a9ca924debb0"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.1.1"
-weakdeps = ["StaticArrays"]
+version = "4.2.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
 
     [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
     AdaptStaticArraysExt = "StaticArrays"
 
 [[deps.AdaptivePredicates]]
@@ -127,9 +128,9 @@ version = "7.18.0"
 
 [[deps.ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "2bf6e01f453284cb61c312836b4680331ddfc44b"
+git-tree-sha1 = "4e25216b8fea1908a0ce0f5d87368587899f75be"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "1.11.0"
+version = "1.11.1"
 weakdeps = ["SparseArrays"]
 
     [deps.ArrayLayouts.extensions]
@@ -264,9 +265,9 @@ version = "1.11.0"
 
 [[deps.CRlibm]]
 deps = ["CRlibm_jll"]
-git-tree-sha1 = "32abd86e3c2025db5172aa182b982debed519834"
+git-tree-sha1 = "66188d9d103b92b6cd705214242e27f5737a1e5e"
 uuid = "96374032-68de-5a5b-8d9e-752f78720389"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.CRlibm_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -667,9 +668,9 @@ version = "1.15.1"
 
 [[deps.DiskArrays]]
 deps = ["LRUCache", "Mmap", "OffsetArrays"]
-git-tree-sha1 = "64650943240652ebedc6c43d03cccda247b327a3"
+git-tree-sha1 = "5109a9314f8904f96a14b80d40dce5c9972c584f"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
-version = "0.4.9"
+version = "0.4.10"
 
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -871,9 +872,9 @@ version = "0.8.5"
 
 [[deps.FlameGraphs]]
 deps = ["AbstractTrees", "Colors", "FileIO", "FixedPointNumbers", "IndirectArrays", "LeftChildRightSiblingTrees", "Profile"]
-git-tree-sha1 = "c8bb515422866a684d9e67870fc5791e3292ad01"
+git-tree-sha1 = "0166baf81babb91cf78bfcc771d8e87c43d568df"
 uuid = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
-version = "1.0.1"
+version = "1.1.0"
 
 [[deps.Fontconfig_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Zlib_jll"]
@@ -1040,10 +1041,10 @@ weakdeps = ["MPI"]
     MPIExt = "MPI"
 
 [[deps.HDF5_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
-git-tree-sha1 = "87bd95f99219dc3b86d4ee11a9a7bfa6075000a9"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
+git-tree-sha1 = "38c8874692d48d5440d5752d6c74b0c6b0b60739"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.14.5+0"
+version = "1.14.2+1"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
@@ -1120,9 +1121,9 @@ uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 version = "0.1.5"
 
 [[deps.InlineStrings]]
-git-tree-sha1 = "45521d31238e87ee9f9732561bfee12d4eebd52d"
+git-tree-sha1 = "6a9fde685a7ac1eb3495f8e812c5a7c3711c2d5e"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.4.2"
+version = "1.4.3"
 
     [deps.InlineStrings.extensions]
     ArrowTypesExt = "ArrowTypes"
@@ -1566,9 +1567,9 @@ version = "0.20.22"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "7715e65c47ba3941c502bffb7f266a41a7f54423"
+git-tree-sha1 = "e7159031670cee777cc2840aef7a521c3603e36c"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.2.3+0"
+version = "4.3.0+0"
 
 [[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
@@ -1678,10 +1679,10 @@ uuid = "5da4648a-3479-48b8-97b9-01cb529c0a1f"
 version = "0.3.5"
 
 [[deps.NVTX_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ce3269ed42816bf18d500c9f63418d4b0d9f5a3b"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "2c7b791c1eba364e4a70aabdea4ddc1f5ca53911"
 uuid = "e98f9f5b-d649-5603-91fd-7774390e6439"
-version = "3.1.0+2"
+version = "3.1.1+0"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
@@ -1691,15 +1692,15 @@ version = "1.1.2"
 
 [[deps.NaNStatistics]]
 deps = ["PrecompileTools", "Static", "StaticArrayInterface"]
-git-tree-sha1 = "1529c48f8c63a815c985890e0192b006b06de528"
+git-tree-sha1 = "c1a9def67b8a871b51ccf84512f173e7979c186b"
 uuid = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
-version = "0.6.45"
+version = "0.6.47"
 
 [[deps.NetCDF_jll]]
-deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
-git-tree-sha1 = "4686378c4ae1d1948cfbe46c002a11a4265dcb07"
+deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenMPI_jll", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
+git-tree-sha1 = "a8af1798e4eb9ff768ce7fdefc0e957097793f15"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
-version = "400.902.211+1"
+version = "400.902.209+0"
 
 [[deps.Netpbm]]
 deps = ["FileIO", "ImageCore", "ImageMetadata"]
@@ -1772,9 +1773,9 @@ version = "0.8.1+2"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
-git-tree-sha1 = "2dace87e14256edb1dd0724ab7ba831c779b96bd"
+git-tree-sha1 = "6c1cf6181ffe0aa33eb33250ca2a60e54a15ea66"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "5.0.6+0"
+version = "5.0.7+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1812,9 +1813,9 @@ version = "0.11.32"
 
 [[deps.PNGFiles]]
 deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
-git-tree-sha1 = "67186a2bc9a90f9f85ff3cc8277868961fb57cbd"
+git-tree-sha1 = "cf181f0b1e6a18dfeb0ee8acc4a9d1672499626c"
 uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
-version = "0.4.3"
+version = "0.4.4"
 
 [[deps.PackageExtensionCompat]]
 git-tree-sha1 = "fb28e33b8a95c4cee25ce296c817d89cc2e53518"
@@ -2032,9 +2033,9 @@ version = "1.3.4"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "fe9d37a17ab4d41a98951332ee8067f8dca8c4c2"
+git-tree-sha1 = "a967273b0c96f9e55ccb93322ada38f43e685c49"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.29.0"
+version = "3.30.0"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -2088,10 +2089,10 @@ uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
 version = "0.5.1+0"
 
 [[deps.RootSolvers]]
-deps = ["ForwardDiff"]
-git-tree-sha1 = "a87fd671f7a298de98f2f3c5a9cd9890714eb9dd"
+deps = ["ForwardDiff", "Printf"]
+git-tree-sha1 = "c30edf81d7c22e90a5f9f5489eded5984e4ddcf0"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-version = "0.4.2"
+version = "0.4.3"
 
 [[deps.RoundingEmulator]]
 git-tree-sha1 = "40b9edad2e5287e05bd413a38f61a8ff55b9557b"
@@ -2413,9 +2414,9 @@ weakdeps = ["ClimaParams"]
 
 [[deps.SymbolicIndexingInterface]]
 deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
-git-tree-sha1 = "fd2d4f0499f6bb4a0d9f5030f5c7d61eed385e03"
+git-tree-sha1 = "d6c04e26aa1c8f7d144e1a8c47f1c73d3013e289"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.37"
+version = "0.3.38"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -2498,9 +2499,13 @@ version = "0.11.3"
 
 [[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]
-git-tree-sha1 = "d7298ebdfa1654583468a487e8e83fae9d72dac3"
+git-tree-sha1 = "3832505b94c1868baea47764127e6d36b5c9f29e"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.26"
+version = "0.5.27"
+weakdeps = ["FlameGraphs"]
+
+    [deps.TimerOutputs.extensions]
+    FlameGraphsExt = "FlameGraphs"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -2593,9 +2598,9 @@ version = "1.0.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "ee6f41aac16f6c9a8cab34e2f7a200418b1cc1e3"
+git-tree-sha1 = "b8b243e47228b4a3877f1dd6aee0c5d56db7fcf4"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.6+0"
+version = "2.13.6+1"
 
 [[deps.XSLT_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "XML2_jll", "Zlib_jll"]
@@ -2670,9 +2675,9 @@ version = "1.2.13+1"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "622cf78670d067c738667aaa96c553430b65e269"
+git-tree-sha1 = "446b23e73536f84e8037f5dce465e92275f6a308"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.7+0"
+version = "1.5.7+1"
 
 [[deps.demumble_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -38,6 +38,7 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]

--- a/examples/dry_baro_wave.jl
+++ b/examples/dry_baro_wave.jl
@@ -1,0 +1,394 @@
+#=
+       .-.      Welcome to ClimaAtmos!
+      (   ).    ----------------------
+     (___(__)   A state-of-the-art Julia model for
+    ⌜^^^^^^^⌝   simulating atmospheric dynamics.
+   ⌜  ~  ~  ⌝
+  ⌜ ~  ~  ~  ⌝  This example: *Dry Baroclinic Wave*
+ ⌜  ~   ~  ~ ⌝
+⌜~~~~~~~~~~~~~⌝  ⚡ Harnessing GPU acceleration with CUDA.jl
+    “““““““      🌎 Pushing the frontiers of climate science!
+
+Run with
+```
+julia +1.11 --project=.buildkite
+using Revise; include("examples/dry_baro_wave.jl")
+=#
+
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore.CommonSpaces
+import ClimaAtmos as CA
+using LazyBroadcast: lazy
+using LinearAlgebra: ×
+import ClimaAtmos.Parameters as CAP
+import Thermodynamics as TD
+import SciMLBase
+import ClimaTimeSteppers as CTS
+import ClimaCore.Geometry
+import ClimaCore.MatrixFields: @name, ⋅
+import ClimaCore.MatrixFields: DiagonalMatrixRow, BidiagonalMatrixRow
+import LinearAlgebra: Adjoint
+import LinearAlgebra: adjoint
+import LinearAlgebra as LA
+import ClimaCore.MatrixFields
+import ClimaCore.Spaces
+import ClimaCore.Fields
+
+import ClimaAtmos: C1, C2, C12, C3, C123, CT1, CT2, CT12, CT3, CT123, UVW
+import ClimaAtmos:
+    divₕ, wdivₕ, gradₕ, wgradₕ, curlₕ, wcurlₕ, ᶜinterp, ᶜdivᵥ, ᶜgradᵥ
+import ClimaAtmos: ᶠinterp, ᶠgradᵥ, ᶠcurlᵥ, ᶜinterp_matrix, ᶠgradᵥ_matrix
+import ClimaAtmos: ᶜadvdivᵥ_matrix, ᶠwinterp, ᶠinterp_matrix
+
+# Define tendency functions
+function implicit_tendency!(Yₜ, Y, p, t)
+    # Yₜ .= zero(eltype(Yₜ))
+    (; rayleigh_sponge, params, dt) = p
+    (; ᶜh_tot, ᶠu³, ᶜp) = p.precomputed
+    ᶜz = Fields.coordinate_field(Y.c).z
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠz = Fields.coordinate_field(Y.f).z
+    grav = FT(CAP.grav(params))
+    zmax = CA.z_max(axes(Y.f))
+
+    @. Yₜ.c.ρ -= ᶜdivᵥ(ᶠwinterp(ᶜJ, Y.c.ρ) * ᶠu³)
+    # Central advection of active tracers (e_tot and q_tot)
+    Yₜ.c.ρe_tot .+= CA.vertical_transport(Y.c.ρ, ᶠu³, ᶜh_tot, dt, Val(:none))
+    @. Yₜ.f.u₃ -= ᶠgradᵥ(ᶜp) / ᶠinterp(Y.c.ρ) + ᶠgradᵥ(Φ(grav, ᶜz))
+
+    @. Yₜ.f.u₃ -= CA.β_rayleigh_w(rayleigh_sponge, ᶠz, zmax) * Y.f.u₃
+    return nothing
+end
+
+function ImplicitEquationJacobian(
+    Y::Fields.FieldVector;
+    approximate_solve_iters = 1,
+    transform_flag = false,
+)
+    FT = Spaces.undertype(axes(Y.c))
+    CTh = CA.CTh_vector_type(axes(Y.c))
+
+    BidiagonalRow_C3 = MatrixFields.BidiagonalMatrixRow{CA.C3{FT}}
+    BidiagonalRow_ACT3 =
+        MatrixFields.BidiagonalMatrixRow{LA.Adjoint{FT, CA.CT3{FT}}}
+    BidiagonalRow_C3xACTh = MatrixFields.BidiagonalMatrixRow{
+        typeof(zero(CA.C3{FT}) * zero(CTh{FT})'),
+    }
+    TridiagonalRow_C3xACT3 = MatrixFields.TridiagonalMatrixRow{
+        typeof(zero(CA.C3{FT}) * zero(CA.CT3{FT})'),
+    }
+
+    is_in_Y(name) = MatrixFields.has_field(Y, name)
+
+    sfc_if_available = is_in_Y(@name(sfc)) ? (@name(sfc),) : ()
+
+
+    # Note: We have to use FT(-1) * I instead of -I because inv(-1) == -1.0,
+    # which means that multiplying inv(-1) by a Float32 will yield a Float64.
+    identity_blocks = MatrixFields.unrolled_map(
+        name -> (name, name) => FT(-1) * LA.I,
+        (@name(c.ρ), sfc_if_available...),
+    )
+
+    active_scalar_names = (@name(c.ρ), @name(c.ρe_tot))
+    advection_blocks = (
+        MatrixFields.unrolled_map(
+            name -> (name, @name(f.u₃)) => similar(Y.c, BidiagonalRow_ACT3),
+            active_scalar_names,
+        )...,
+        MatrixFields.unrolled_map(
+            name -> (@name(f.u₃), name) => similar(Y.f, BidiagonalRow_C3),
+            active_scalar_names,
+        )...,
+        (@name(f.u₃), @name(c.uₕ)) => similar(Y.f, BidiagonalRow_C3xACTh),
+        (@name(f.u₃), @name(f.u₃)) => similar(Y.f, TridiagonalRow_C3xACT3),
+    )
+
+    diffused_scalar_names = (@name(c.ρe_tot),)
+    diffusion_blocks = MatrixFields.unrolled_map(
+        name -> (name, name) => FT(-1) * LA.I,
+        (diffused_scalar_names..., @name(c.uₕ)),
+    )
+
+    matrix = MatrixFields.FieldMatrix(
+        identity_blocks...,
+        advection_blocks...,
+        diffusion_blocks...,
+    )
+
+    names₁_group₁ = (@name(c.ρ), sfc_if_available...)
+    names₁_group₃ = (@name(c.ρe_tot),)
+    names₁ = (names₁_group₁..., names₁_group₃...)
+
+    alg₂ = MatrixFields.BlockLowerTriangularSolve(@name(c.uₕ))
+    alg = MatrixFields.BlockArrowheadSolve(names₁...; alg₂)
+
+    return CA.ImplicitEquationJacobian(
+        matrix,
+        MatrixFields.FieldMatrixSolver(alg, matrix, Y),
+        CA.IgnoreDerivative(), # diffusion_flag
+        CA.IgnoreDerivative(), # topography_flag
+        CA.IgnoreDerivative(), # sgs_advection_flag
+        similar(Y),
+        similar(Y),
+        transform_flag,
+        Ref{FT}(),
+    )
+end
+
+function Wfact!(A, Y, p, dtγ, t)
+    FT = Spaces.undertype(axes(Y.c))
+    dtγ′ = FT(float(dtγ))
+    A.dtγ_ref[] = dtγ′
+    update_implicit_equation_jacobian!(A, Y, p, dtγ′)
+end
+
+Φ(grav, z) = grav * z
+
+function update_implicit_equation_jacobian!(A, Y, p, dtγ)
+    (; matrix) = A
+    (; ᶜK, ᶜts, ᶜp, ᶜh_tot) = p.precomputed
+    (; ∂ᶜK_∂ᶜuₕ, ∂ᶜK_∂ᶠu₃, ᶠp_grad_matrix, ᶜadvection_matrix) = p
+    (; params) = p
+
+    FT = Spaces.undertype(axes(Y.c))
+    CTh = CA.CTh_vector_type(axes(Y.c))
+    one_C3xACT3 = C3(FT(1)) * CT3(FT(1))'
+    rs = p.rayleigh_sponge
+    ᶠz = Fields.coordinate_field(Y.f).z
+    zmax = CA.z_max(axes(Y.f))
+
+    T_0 = FT(CAP.T_0(params))
+    cp_d = FT(CAP.cp_d(params))
+    thermo_params = CAP.thermodynamics_params(params)
+    ᶜz = Fields.coordinate_field(Y.c).z
+    grav = FT(CAP.grav(params))
+
+    ᶜρ = Y.c.ρ
+    ᶜuₕ = Y.c.uₕ
+    ᶠu₃ = Y.f.u₃
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠgⁱʲ = Fields.local_geometry_field(Y.f).gⁱʲ
+
+    ᶜkappa_m = p.ᶜtemp_scalar
+    @. ᶜkappa_m =
+        TD.gas_constant_air(thermo_params, ᶜts) / TD.cv_m(thermo_params, ᶜts)
+
+    @. ∂ᶜK_∂ᶜuₕ = DiagonalMatrixRow(adjoint(CTh(ᶜuₕ)))
+    @. ∂ᶜK_∂ᶠu₃ =
+        ᶜinterp_matrix() ⋅ DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) +
+        DiagonalMatrixRow(adjoint(CT3(ᶜuₕ))) ⋅ ᶜinterp_matrix()
+
+    @. ᶠp_grad_matrix = DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix()
+
+    @. ᶜadvection_matrix =
+        -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠwinterp(ᶜJ, ᶜρ))
+
+    ∂ᶜρ_err_∂ᶠu₃ = matrix[@name(c.ρ), @name(f.u₃)]
+    @. ∂ᶜρ_err_∂ᶠu₃ = dtγ * ᶜadvection_matrix ⋅ DiagonalMatrixRow(CA.g³³(ᶠgⁱʲ))
+
+    ∂ᶜρχ_err_∂ᶠu₃ = matrix[@name(c.ρe_tot), @name(f.u₃)]
+    @. ∂ᶜρχ_err_∂ᶠu₃ =
+        dtγ * ᶜadvection_matrix ⋅
+        DiagonalMatrixRow(ᶠinterp(ᶜh_tot) * CA.g³³(ᶠgⁱʲ))
+
+    ∂ᶠu₃_err_∂ᶜρ = matrix[@name(f.u₃), @name(c.ρ)]
+    ∂ᶠu₃_err_∂ᶜρe_tot = matrix[@name(f.u₃), @name(c.ρe_tot)]
+
+    @. ∂ᶠu₃_err_∂ᶜρ =
+        dtγ * (
+            ᶠp_grad_matrix ⋅
+            DiagonalMatrixRow(ᶜkappa_m * (T_0 * cp_d - ᶜK - Φ(grav, ᶜz))) +
+            DiagonalMatrixRow(ᶠgradᵥ(ᶜp) / abs2(ᶠinterp(ᶜρ))) ⋅
+            ᶠinterp_matrix()
+        )
+    @. ∂ᶠu₃_err_∂ᶜρe_tot = dtγ * ᶠp_grad_matrix ⋅ DiagonalMatrixRow(ᶜkappa_m)
+
+    ∂ᶠu₃_err_∂ᶜuₕ = matrix[@name(f.u₃), @name(c.uₕ)]
+    ∂ᶠu₃_err_∂ᶠu₃ = matrix[@name(f.u₃), @name(f.u₃)]
+    I_u₃ = DiagonalMatrixRow(one_C3xACT3)
+    @. ∂ᶠu₃_err_∂ᶜuₕ =
+        dtγ * ᶠp_grad_matrix ⋅ DiagonalMatrixRow(-(ᶜkappa_m) * ᶜρ) ⋅ ∂ᶜK_∂ᶜuₕ
+
+    @. ∂ᶠu₃_err_∂ᶠu₃ =
+        dtγ * (
+            ᶠp_grad_matrix ⋅ DiagonalMatrixRow(-(ᶜkappa_m) * ᶜρ) ⋅ ∂ᶜK_∂ᶠu₃ +
+            DiagonalMatrixRow(-CA.β_rayleigh_w(rs, ᶠz, zmax) * (one_C3xACT3,))
+        ) - (I_u₃,)
+
+end
+
+function set_precomputed_quantities!(Y, p, t)
+    thermo_params = CAP.thermodynamics_params(p.params)
+    (; ᶜu, ᶠu³, ᶠu, ᶜK, ᶜts, ᶜp) = p.precomputed
+
+    ᶜρ = Y.c.ρ
+    ᶜuₕ = Y.c.uₕ
+    ᶜz = Fields.coordinate_field(Y.c).z
+    grav = FT(CAP.grav(params))
+    ᶠu₃ = Y.f.u₃
+    @. ᶜu = C123(ᶜuₕ) + ᶜinterp(C123(ᶠu₃))
+    ᶠu³ .= CA.compute_ᶠuₕ³(ᶜuₕ, ᶜρ) .+ CT3.(ᶠu₃)
+    ᶜK .= CA.compute_kinetic(ᶜuₕ, ᶠu₃)
+
+    @. ᶜts = TD.PhaseDry_ρe(
+        thermo_params,
+        Y.c.ρ,
+        Y.c.ρe_tot / Y.c.ρ - ᶜK - Φ(grav, ᶜz),
+    )
+    @. ᶜp = TD.air_pressure(thermo_params, ᶜts)
+
+    (; ᶜh_tot) = p.precomputed
+    @. ᶜh_tot =
+        TD.total_specific_enthalpy(thermo_params, ᶜts, Y.c.ρe_tot / Y.c.ρ)
+    return nothing
+end
+
+function dss!(Y, p, t)
+    Spaces.weighted_dss!(Y.c => p.ghost_buffer.c, Y.f => p.ghost_buffer.f)
+    return nothing
+end
+
+function remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+    # Yₜ_lim .= zero(eltype(Yₜ_lim))
+    Yₜ .= zero(eltype(Yₜ))
+    (; dt, params, rayleigh_sponge) = p
+    (; ᶜh_tot) = p.precomputed
+    (; ᶠu³, ᶜu, ᶜK, ᶜp) = p.precomputed
+    (; ᶜf³, ᶠf¹²) = p.precomputed
+    ᶜz = Fields.coordinate_field(Y.c).z
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    grav = FT(CAP.grav(params))
+    ᶜuₕ = Y.c.uₕ
+    ᶠu₃ = Y.f.u₃
+    ᶜρ = Y.c.ρ
+
+    @. Yₜ.c.ρ -= wdivₕ(ᶜρ * ᶜu)
+    @. Yₜ.c.ρe_tot -= wdivₕ(ᶜρ * ᶜh_tot * ᶜu)
+    @. Yₜ.c.uₕ -= C12(gradₕ(ᶜp) / ᶜρ + gradₕ(ᶜK + Φ(grav, ᶜz)))
+
+    ᶜω³ = p.scratch.ᶜtemp_CT3
+    ᶠω¹² = p.scratch.ᶠtemp_CT12
+
+    point_type = eltype(Fields.coordinate_field(Y.c))
+    if point_type <: Geometry.Abstract3DPoint
+        @. ᶜω³ = curlₕ(ᶜuₕ)
+    elseif point_type <: Geometry.Abstract2DPoint
+        @. ᶜω³ = zero(ᶜω³)
+    end
+
+    @. ᶠω¹² = ᶠcurlᵥ(ᶜuₕ)
+    @. ᶠω¹² += CT12(curlₕ(ᶠu₃))
+    # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
+
+    ᶠω¹²′ = if isnothing(ᶠf¹²)
+        ᶠω¹² # shallow atmosphere
+    else
+        @. lazy(ᶠf¹² + ᶠω¹²) # deep atmosphere
+    end
+
+    @. Yₜ.c.uₕ -=
+        ᶜinterp(ᶠω¹²′ × (ᶠinterp(ᶜρ * ᶜJ) * ᶠu³)) / (ᶜρ * ᶜJ) +
+        (ᶜf³ + ᶜω³) × CT12(ᶜu)
+    @. Yₜ.f.u₃ -= ᶠω¹²′ × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
+
+    Yₜ.c.uₕ .+= CA.rayleigh_sponge_tendency_uₕ(ᶜuₕ, rayleigh_sponge)
+
+    return Yₜ
+end
+
+FT = Float64;
+ᶜspace = ExtrudedCubedSphereSpace(
+    FT;
+    z_elem = 10,
+    z_min = 0,
+    z_max = 30000.0,
+    radius = 6.371e6,
+    h_elem = 6,
+    n_quad_points = 4,
+    staggering = CellCenter(),
+);
+ᶠspace = Spaces.face_space(ᶜspace);
+cnt = (; ρ = zero(FT), uₕ = zero(CA.C12{FT}), ρe_tot = zero(FT));
+Yc = Fields.fill(cnt, ᶜspace);
+Yf = Fields.fill((; u₃ = zero(CA.C3{FT})), ᶠspace);
+Y = Fields.FieldVector(; c = Yc, f = Yf);
+
+A = ImplicitEquationJacobian(
+    Y;
+    approximate_solve_iters = 2,
+    transform_flag = false, # assumes use_transform returns false
+)
+
+implicit_func = SciMLBase.ODEFunction(
+    implicit_tendency!;
+    jac_prototype = A,
+    Wfact = Wfact!, # assumes use_transform returns false
+    tgrad = (∂Y∂t, Y, p, t) -> (∂Y∂t .= 0),
+)
+
+func = CTS.ClimaODEFunction(;
+    T_exp_T_lim! = remaining_tendency!,
+    T_imp! = implicit_func,
+    # Can we just pass implicit_tendency! and jac_prototype etc.?
+    lim! = (Y, p, t, ref_Y) -> nothing, # limiters_func!
+    dss!,
+    cache! = set_precomputed_quantities!,
+    cache_imp! = set_precomputed_quantities!,
+)
+
+newtons_method = CTS.NewtonsMethod(; max_iters = 2)
+params = CA.ClimaAtmosParameters(FT)
+ᶠcoord = Fields.coordinate_field(ᶠspace);
+ᶜcoord = Fields.coordinate_field(ᶜspace);
+(; ᶜf³, ᶠf¹²) = CA.compute_coriolis(ᶜcoord, ᶠcoord, params);
+scratch = (;
+    ᶜtemp_CT3 = Fields.Field(CT3{FT}, ᶜspace),
+    ᶠtemp_CT12 = Fields.Field(CT12{FT}, ᶠspace),
+)
+precomputed = (;
+    ᶜh_tot = Fields.Field(FT, ᶜspace),
+    ᶠu³ = Fields.Field(CA.CT3{FT}, ᶠspace),
+    ᶜf³,
+    ᶠf¹²,
+    ᶜp = Fields.Field(FT, ᶜspace),
+    ᶜK = Fields.Field(FT, ᶜspace),
+    ᶜts = Fields.Field(TD.PhaseDry{FT}, ᶜspace),
+    ᶠu = Fields.Field(C123{FT}, ᶠspace),
+    ᶜu = Fields.Field(C123{FT}, ᶜspace),
+)
+dt = FT(0.1)
+
+ghost_buffer =
+    !CA.do_dss(axes(Y.c)) ? (;) :
+    (; c = Spaces.create_dss_buffer(Y.c), f = Spaces.create_dss_buffer(Y.f))
+
+CTh = CA.CTh_vector_type(axes(Y.c))
+p = (;
+    rayleigh_sponge = CA.RayleighSponge{FT}(;
+        zd = params.zd_rayleigh,
+        α_uₕ = params.alpha_rayleigh_uh,
+        α_w = params.alpha_rayleigh_w,
+    ),
+    params,
+    ∂ᶜK_∂ᶜuₕ = Fields.Field(DiagonalMatrixRow{Adjoint{FT, CTh{FT}}}, ᶜspace),
+    ∂ᶜK_∂ᶠu₃ = Fields.Field(BidiagonalMatrixRow{Adjoint{FT, CT3{FT}}}, ᶜspace),
+    ᶜadvection_matrix = Fields.Field(
+        BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
+        ᶜspace,
+    ),
+    ᶜtemp_scalar = Fields.Field(FT, ᶜspace),
+    ᶠp_grad_matrix = Fields.Field(BidiagonalMatrixRow{C3{FT}}, ᶠspace),
+    scratch,
+    ghost_buffer,
+    dt,
+    precomputed,
+)
+ode_algo = CTS.IMEXAlgorithm(CTS.ARS343(), newtons_method)
+problem = SciMLBase.ODEProblem(func, Y, (FT(0), FT(1)), p)
+integrator = SciMLBase.init(problem, ode_algo; dt)
+
+SciMLBase.solve!(integrator)
+
+nothing


### PR DESCRIPTION
This PR is an attempt to add a dry baroclinic wave example, where we use ClimaAtmos as a library. This is very much in a draft state, there's no documentation, there's likely unused variables, but it compiles and runs.

There is:
 - effectively no arg parsing, so it's relatively type-stable.
 - no callbacks or diagnostics 😅, so we can't easily verify the results

One nice thing is that, while it only runs for 10 timesteps, the whole script takes ~80 seconds to run (most of which is compilation). I _think_ that this may be an improvement over the existing CI driver, but I've not yet timed it to compare.

cc @Sbozzolo / @dennisYatunin , who were interested in adding examples like this.

I wanted to see what a script like this might look like. It's pretty clear that an explicit version of this example would be hundreds of lines fewer, but I thought it'd be helpful if the example at least included implicit tendency complexity.

Oh, and I used chatgpt to make the intro ascii art.