### PR TITLE
Add density in cloud condensate RHS

### DIFF
--- a/src/parameterized_tendencies/microphysics/cloud_condensate.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_condensate.jl
@@ -2,7 +2,7 @@
 ##### DryModel, EquilMoistModel
 #####
 
-cloud_condensate_tendency!(Yₜ, p, _, _) = nothing
+cloud_condensate_tendency!(Yₜ, Y, p, _, _) = nothing
 
 #####
 ##### NonEquilMoistModel
@@ -10,6 +10,7 @@ cloud_condensate_tendency!(Yₜ, p, _, _) = nothing
 
 function cloud_condensate_tendency!(
     Yₜ,
+    Y,
     p,
     ::NonEquilMoistModel,
     ::Union{NoPrecipitation, Microphysics0Moment},
@@ -21,6 +22,7 @@ end
 
 function cloud_condensate_tendency!(
     Yₜ,
+    Y,
     p,
     ::NonEquilMoistModel,
     ::Microphysics1Moment,
@@ -32,6 +34,6 @@ function cloud_condensate_tendency!(
     thp = CAP.thermodynamics_params(params)
     cmc = CAP.microphysics_cloud_params(params)
 
-    @. Yₜ.c.ρq_liq += cloud_sources(cmc.liquid, thp, ᶜts, q_rai, dt)
-    @. Yₜ.c.ρq_ice += cloud_sources(cmc.ice, thp, ᶜts, q_sno, dt)
+    @. Yₜ.c.ρq_liq += Y.c.ρ * cloud_sources(cmc.liquid, thp, ᶜts, q_rai, dt)
+    @. Yₜ.c.ρq_ice += Y.c.ρ * cloud_sources(cmc.ice, thp, ᶜts, q_sno, dt)
 end

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -126,13 +126,14 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
 
     @. Yₜ.c.ρ -= ᶜdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠu³)
 
-    # Central advection of active tracers (e_tot and q_tot)
+    # Central advection of active tracers (e_tot and all the q_...)
     vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜh_tot, dt, Val(:none))
     @. Yₜ.c.ρe_tot += vtt
 
-    if !(moisture_model isa DryModel)
-        vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜspecific.q_tot, dt, Val(:none))
-        @. Yₜ.c.ρq_tot += vtt
+    for (ᶜρχₜ, ᶜχ, χ_name) in matching_subfields(Yₜ.c, ᶜspecific)
+        χ_name == :e_tot && continue
+        vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜχ, dt, Val(:none))
+        @. ᶜρχₜ += vtt
     end
 
     #vertical_advection_of_water_tendency!(Yₜ, Y, p, t)

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -120,6 +120,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     # Non-equilibrium cloud formation
     cloud_condensate_tendency!(
         Yₜ,
+        Y,
         p,
         p.atmos.moisture_model,
         p.atmos.precip_model,

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -68,6 +68,7 @@ import Test
     # No cloud condensation tendency for the equilibrium model
     @test CA.cloud_condensate_tendency!(
         ᶜYₜ,
+        Y,
         p,
         moisture_model,
         precip_model,
@@ -135,7 +136,7 @@ end
     @assert iszero(ᶜYₜ.c.ρ)
 
     # test nonequilibrium cloud condensate
-    CA.cloud_condensate_tendency!(ᶜYₜ, p, moisture_model, precip_model)
+    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, precip_model)
     @assert !any(isnan, ᶜYₜ.c.ρq_liq)
     @assert !any(isnan, ᶜYₜ.c.ρq_ice)
 

--- a/toml/longrun_aquaplanet_1M.toml
+++ b/toml/longrun_aquaplanet_1M.toml
@@ -1,8 +1,14 @@
 [condensation_evaporation_timescale]
-value = 100
+value = 150
 
 [sublimation_deposition_timescale]
-value = 100
+value = 150
+
+[snow_autoconversion_timescale]
+value = 1e4
+
+[rain_autoconversion_timescale]
+value = 150
 
 [zd_rayleigh]
 value = 40000.0

--- a/toml/longrun_baroclinic_wave_1M.toml
+++ b/toml/longrun_baroclinic_wave_1M.toml
@@ -3,3 +3,6 @@ value = 100
 
 [sublimation_deposition_timescale]
 value = 100
+
+[snow_autoconversion_timescale]
+value = 1e4

--- a/toml/sphere_aquaplanet_1M.toml
+++ b/toml/sphere_aquaplanet_1M.toml
@@ -1,8 +1,11 @@
 [condensation_evaporation_timescale]
-value = 100
+value = 400
 
 [sublimation_deposition_timescale]
-value = 100
+value = 400
+
+[snow_autoconversion_timescale]
+value = 1e4
 
 [zd_viscous]
 value = 40000.0


### PR DESCRIPTION
This PR:
- fixes the density bug in cloud condensate formation tendensices
- sets the microphysics condensation and precipitation timescales to be longer than dt in different configs
- fixes tracer vertical advection bug
