### PR TITLE
Use two Newton iterations for implicit diffusion with ARS343

### DIFF
--- a/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
@@ -15,6 +15,7 @@ dt_rad: 1hours
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt_cloud_fraction: 1hours
 surface_setup: DefaultMoninObukhov
 dt: 90secs

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
@@ -16,6 +16,7 @@ dt_cloud_fraction: "1hours"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 surface_setup: "DefaultMoninObukhov"
 dt: "90secs"
 t_end: "1days"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
@@ -16,6 +16,7 @@ turbconv: "edonly_edmfx"
 edmfx_sgs_diffusive_flux: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 surface_setup: "DefaultMoninObukhov"
 dt: "60secs"
 t_end: "1hours"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -16,6 +16,7 @@ dt_cloud_fraction: "1hours"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "90secs"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -16,6 +16,7 @@ dt_cloud_fraction: "1hours"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 surface_setup: "DefaultMoninObukhov"
 rayleigh_sponge: true
 dt: "90secs"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -16,6 +16,7 @@ dt_cloud_fraction: "1hours"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 surface_setup: "DefaultMoninObukhov"
 dt: "90secs"
 t_end: "1days"

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -21,6 +21,7 @@ surface_setup: "DefaultMoninObukhov"
 turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"

--- a/config/longrun_configs/amip_target_edonly.yml
+++ b/config/longrun_configs/amip_target_edonly.yml
@@ -21,6 +21,7 @@ surface_setup: "DefaultMoninObukhov"
 turbconv: "edonly_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "120days"
 toml: [toml/longrun_aquaplanet.toml]

--- a/config/longrun_configs/longrun_aquaplanet_allsky_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_0M.yml
@@ -7,6 +7,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "360days"
 dt_save_state_to_disk: "10days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_0M_earth.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_0M_earth.yml
@@ -9,6 +9,7 @@ topography: "Earth"
 topo_smoothing: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "360days"
 dt_save_state_to_disk: "30days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_1M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_1M.yml
@@ -7,6 +7,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "360days"
 dt_save_state_to_disk: "10days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -7,6 +7,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "240days"
 dt_save_state_to_disk: "30days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
@@ -7,6 +7,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 dt: "120secs"
 t_end: "360days"
 dt_save_state_to_disk: "30days"

--- a/config/longrun_configs/longrun_aquaplanet_dyamond.yml
+++ b/config/longrun_configs/longrun_aquaplanet_dyamond.yml
@@ -6,6 +6,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 topography: "Earth"
 start_date: "20160801"
 initial_condition: "artifact\"DYAMOND_SUMMER_ICS_p98deg\"/DYAMOND_SUMMER_ICS_p98deg.nc"

--- a/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean.yml
@@ -7,8 +7,9 @@ surface_setup: "DefaultMoninObukhov"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 rad: "clearsky"
 insolation: "timevarying"
 dt_rad: "1hours"
 prognostic_surface: "PrognosticSurfaceTemperature"
-#check_conservation: true
+check_conservation: true

--- a/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
+++ b/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
@@ -7,8 +7,9 @@ surface_setup: "DefaultMoninObukhov"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 rad: "clearsky"
 insolation: "timevarying"
 dt_rad: "1hours"
 prognostic_surface: "PrognosticSurfaceTemperature"
-#check_conservation: true
+check_conservation: true

--- a/config/model_configs/aquaplanet_for_coupler.yml
+++ b/config/model_configs/aquaplanet_for_coupler.yml
@@ -7,6 +7,7 @@ topography: "Earth"
 rayleigh_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"
 vert_diff: "DecayWithHeightDiffusion"

--- a/config/model_configs/aquaplanet_nonequil_allsky_gw_res.yml
+++ b/config/model_configs/aquaplanet_nonequil_allsky_gw_res.yml
@@ -8,6 +8,7 @@ dt_save_state_to_disk: "24hours"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "nonequil"
 precip_model: "1M"
 rad: "allskywithclear"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -8,6 +8,7 @@ co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -7,6 +7,7 @@ co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -6,6 +6,7 @@ surface_setup: "Bomex"
 turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
@@ -6,6 +6,7 @@ surface_setup: "Bomex"
 turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -6,6 +6,7 @@ surface_setup: DYCOMS_RF01
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -6,6 +6,7 @@ surface_setup: DYCOMS_RF02
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -4,6 +4,7 @@ surface_setup: GABLS
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -5,6 +5,7 @@ surface_setup: Rico
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -4,6 +4,7 @@ surface_setup: TRMM_LBA
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -4,6 +4,7 @@ surface_setup: TRMM_LBA
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -5,6 +5,7 @@ surface_setup: TRMM_LBA
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/edonly_edmfx_aquaplanet.yml
+++ b/config/model_configs/edonly_edmfx_aquaplanet.yml
@@ -3,6 +3,7 @@ rad: allskywithclear
 co2_model: fixed
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_sgs_diffusive_flux: true
 turbconv: edonly_edmfx
 moist: equil

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -7,6 +7,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
@@ -7,6 +7,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -7,6 +7,7 @@ turbconv: prognostic_edmfx
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -5,6 +5,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -7,6 +7,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 rayleigh_sponge: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -6,6 +6,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -6,6 +6,7 @@ implicit_diffusion: true
 implicit_sgs_advection: true
 implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "SmoothArea"

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -5,6 +5,7 @@ turbconv: prognostic_edmfx
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -5,6 +5,7 @@ turbconv: prognostic_edmfx
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -7,6 +7,7 @@ co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -5,6 +5,7 @@ co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 insolation: rcemipii
 prognostic_tke: true
 edmfx_upwinding: first_order

--- a/config/model_configs/single_column_precipitation_test.yml
+++ b/config/model_configs/single_column_precipitation_test.yml
@@ -14,6 +14,7 @@ precip_model: "1M"
 vert_diff: "DecayWithHeightDiffusion"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 reproducibility_test: false
 toml: [toml/single_column_precipitation_test.toml]
 diagnostics:

--- a/config/perf_configs/bm_aquaplanet_diagedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_diagedmf.yml
@@ -9,6 +9,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: equil
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -10,13 +10,13 @@ viscous_sponge: true
 implicit_diffusion: true
 implicit_sgs_advection: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 3
 moist: equil
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
 dt_rad: 1hours
 dt_cloud_fraction: 1hours
 turbconv: prognostic_edmfx
-max_newton_iters_ode: 3
 prognostic_tke: true
 edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"

--- a/config/perf_configs/bm_callbacks.yml
+++ b/config/perf_configs/bm_callbacks.yml
@@ -9,6 +9,7 @@ dt_save_to_sol: "Inf"
 dt_save_state_to_disk: "1secs"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 log_progress: false
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"

--- a/config/perf_configs/bm_default.yml
+++ b/config/perf_configs/bm_default.yml
@@ -6,6 +6,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"

--- a/config/perf_configs/bm_default_1m.yml
+++ b/config/perf_configs/bm_default_1m.yml
@@ -7,6 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "nonequil"
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"

--- a/config/perf_configs/bm_diagnostics.yml
+++ b/config/perf_configs/bm_diagnostics.yml
@@ -7,6 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"

--- a/config/perf_configs/bm_diffusion.yml
+++ b/config/perf_configs/bm_diffusion.yml
@@ -7,6 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"

--- a/config/perf_configs/bm_gravity_wave.yml
+++ b/config/perf_configs/bm_gravity_wave.yml
@@ -7,6 +7,7 @@ dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
+max_newton_iters_ode: 2
 moist: "equil"
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -459,8 +459,12 @@ function ode_configuration(::Type{FT}, parsed_args) where {FT}
     elseif !is_implicit_type(alg_or_tableau)
         return alg_or_tableau()
     elseif is_imex_CTS_algo_type(alg_or_tableau)
+        max_iters = parsed_args["max_newton_iters_ode"]
+        (max_iters == 1 && parsed_args["implicit_diffusion"]) &&
+            @warn "Implicit diffusion typically requires at least 2 Newton \
+                   iterations to avoid conservation errors!"
         newtons_method = CTS.NewtonsMethod(;
-            max_iters = parsed_args["max_newton_iters_ode"],
+            max_iters,
             krylov_method = if parsed_args["use_krylov_method"]
                 CTS.KrylovMethod(;
                     jacobian_free_jvp = CTS.ForwardDiffJVP(;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR changes the value of `max_newton_iters_ode` from 1 to 2 for all configurations with `implicit_diffusion` set to `true`. From the ClimaTimeSteppers convergence tests, we know that simulations with implicit diffusion and IMEX ARK timestepping typically require 2 Newton iterations to show correct convergence behavior. From recent testing in ClimaAtmos, it appears that they also require 2 iterations to avoid large conservation errors for specific humidity.

Since we were previously using SSPKnoth for our `ode_algo`, the value of `max_newton_iters_ode` was ignored. Now that we are using ARS343, the value is no longer ignored, and the default of 1 is only valid when `implicit_diffusion` is `false`. This PR adds a warning to `type_getters.jl` so that developers will be notified when the default number of iterations is too low.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
