### PR TITLE
Split implicit and explicit precomputed quantities

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-219
+220
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+220
+- Split out cached variables that should be treated implicitly, so that all
+  other cached variables are no longer updated by the implicit solver
+
 219
 - Change the operations order in vertical advection upwinding
 

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -962,7 +962,6 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
     )
     ᶜtke_exch = p.scratch.ᶜtemp_scalar_2
     @. ᶜtke_exch = 0
-    @. ᶜtke⁰ = Y.c.sgs⁰.ρatke / Y.c.ρ
     # using ᶜu⁰ would be more correct, but this is more consistent with the
     # TKE equation, where using ᶜu⁰ results in allocation
     for j in 1:n

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -50,27 +50,22 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
 end
 
 """
-    set_prognostic_edmf_precomputed_quantities_draft_and_bc!(Y, p, ᶠuₕ³, t)
+    set_prognostic_edmf_precomputed_quantities_draft!(Y, p, ᶠuₕ³, t)
 
-Updates the draft thermo state and boundary conditions
-precomputed quantities stored in `p` for edmfx.
+Updates velocity and thermodynamics quantities in each SGS draft.
 """
-NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft_and_bc!(
+NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
     Y,
     p,
     ᶠuₕ³,
     t,
 )
     (; moisture_model, turbconv_model) = p.atmos
-    #EDMFX BCs only support total energy as state variable
     @assert !(moisture_model isa DryModel)
 
-    FT = Spaces.undertype(axes(Y.c))
     n = n_mass_flux_subdomains(turbconv_model)
-
-    (; params) = p
-    thermo_params = CAP.thermodynamics_params(params)
-    turbconv_params = CAP.turbconv_params(params)
+    thermo_params = CAP.thermodynamics_params(p.params)
+    turbconv_params = CAP.turbconv_params(p.params)
 
     (; ᶜΦ,) = p.core
     (; ᶜspecific, ᶜp, ᶜh_tot, ᶜK) = p.precomputed
@@ -92,8 +87,36 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft_and_bc!
         @. ᶠKᵥʲ = (adjoint(CT3(ᶠu₃ʲ)) * ᶠu₃ʲ) / 2
         @. ᶜtsʲ = TD.PhaseEquil_phq(thermo_params, ᶜp, ᶜmseʲ - ᶜΦ, ᶜq_totʲ)
         @. ᶜρʲ = TD.air_density(thermo_params, ᶜtsʲ)
+    end
+    return nothing
+end
 
-        # EDMFX boundary condition:
+"""
+    set_prognostic_edmf_precomputed_quantities_bottom_bc!(Y, p, ᶠuₕ³, t)
+
+Updates velocity and thermodynamics quantities at the surface in each SGS draft.
+"""
+NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
+    Y,
+    p,
+    t,
+)
+    (; moisture_model, turbconv_model) = p.atmos
+    @assert !(moisture_model isa DryModel)
+
+    FT = Spaces.undertype(axes(Y.c))
+    n = n_mass_flux_subdomains(turbconv_model)
+    thermo_params = CAP.thermodynamics_params(p.params)
+    turbconv_params = CAP.turbconv_params(p.params)
+
+    (; ᶜΦ,) = p.core
+    (; ᶜspecific, ᶜp, ᶜh_tot, ᶜK, ᶜtsʲs, ᶜρʲs) = p.precomputed
+    (; ustar, obukhov_length, buoyancy_flux) = p.precomputed.sfc_conditions
+
+    for j in 1:n
+        ᶜtsʲ = ᶜtsʲs.:($j)
+        ᶜmseʲ = Y.c.sgsʲs.:($j).mse
+        ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
 
         # We need field_values everywhere because we are mixing
         # information from surface and first interior inside the

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -654,8 +654,8 @@ function args_integrator(parsed_args, Y, p, tspan, ode_algo, callback)
                     lim! = limiters_func!,
                     dss!,
                     cache! = set_precomputed_quantities!,
-                    cache_imp! = set_precomputed_quantities!,
-                ) # TODO: Split implicit precomputed quantities from the rest.
+                    cache_imp! = set_implicit_precomputed_quantities!,
+                )
             else
                 SciMLBase.SplitFunction(implicit_func, remaining_tendency!)
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR splits the precomputed quantities that need to be handled implicitly (i.e., updated on each Newton iteration) from those that can be handled explicitly (i.e., held constant throughout each Newton solve).

This change should improve performance for all simulations with more than one Newton iteration, since we are currently spending a significant chunk of time updating precomputed quantities that can be handled explicitly. Specifically, this should reduce the performance penalty that we have observed in #3662 from increasing the number of Newton iterations for configurations with implicit diffusion.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
