### PR TITLE
Implicit updraft massflux for prognostic EDMF aquaplanet

### DIFF
--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -9,6 +9,7 @@ rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true
 implicit_sgs_advection: true
+implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 moist: equil
 surface_setup: DefaultMoninObukhov


### PR DESCRIPTION
Make prognostic EDMF aquaplanet benchmark sgs massflux implicit by default.