### PR TITLE
Add constructor for AtmosSimulation

### DIFF
--- a/examples/hybrid/driver.jl
+++ b/examples/hybrid/driver.jl
@@ -14,7 +14,7 @@ if !(@isdefined config)
     (; config_file, job_id) = CA.commandline_kwargs()
     config = CA.AtmosConfig(config_file; job_id)
 end
-simulation = CA.get_simulation(config)
+simulation = CA.AtmosSimulation(config)
 sol_res = CA.solve_atmos!(simulation)
 
 include(joinpath(pkgdir(CA), "post_processing", "ci_plots.jl"))

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -23,3 +23,19 @@ function Base.show(io::IO, sim::AtmosSimulation)
         "└── Stop time: $(sim.t_end) seconds",
     )
 end
+
+
+"""
+    AtmosSimulation(config::AtmosConfig)
+    AtmosSimulation(config_file_path)
+    AtmosSimulation(config_dict)
+
+Construct a simulation.
+"""
+function AtmosSimulation(config::AtmosConfig)
+    return get_simulation(config)
+end
+
+function AtmosSimulation(args...; kwargs...)
+    return AtmosSimulation(AtmosConfig(args...; kwargs...))
+end

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -44,7 +44,7 @@ const T2 = 290
         );
         job_id = "coupler_compatibility1",
     )
-    simulation = CA.get_simulation(config)
+    simulation = CA.AtmosSimulation(config)
     (; integrator) = simulation
     (; p, t) = integrator
     Y = integrator.u
@@ -111,7 +111,7 @@ end
         );
         job_id = "coupler_compatibility2",
     )
-    simulation = CA.get_simulation(config)
+    simulation = CA.AtmosSimulation(config)
 
     # Check: ρ_flux_uₕ is initialized to zero
     @test all(
@@ -229,5 +229,5 @@ end
         );
         job_id = "coupler_compatibility3",
     )
-    simulation = CA.get_simulation(config)
+    simulation = CA.AtmosSimulation(config)
 end

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -225,9 +225,7 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
 
     local_success = true
 
-    config = CA.AtmosConfig(test_dict; job_id, comms_ctx)
-
-    simulation = CA.get_simulation(config)
+    simulation = CA.AtmosSimulation(test_dict; job_id, comms_ctx)
     CA.solve_atmos!(simulation)
 
     # Check re-importing the same state
@@ -244,7 +242,7 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
         comms_ctx,
     )
 
-    simulation_restarted = CA.get_simulation(config_should_be_same)
+    simulation_restarted = CA.AtmosSimulation(config_should_be_same)
 
     if pkgversion(CA.RRTMGP) < v"0.22"
         # Versions of RRTMGP older than 0.22 have a bug and do not set the
@@ -303,7 +301,7 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
         comms_ctx,
     )
 
-    simulation_restarted2 = CA.get_simulation(config2)
+    simulation_restarted2 = CA.AtmosSimulation(config2)
     CA.fill_with_nans!(simulation_restarted2.integrator.p)
 
     CA.solve_atmos!(simulation_restarted2)

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -14,7 +14,7 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     config.parsed_args["rad"] = "clearsky"
     config.parsed_args["FLOAT_TYPE"] = string(FT)
     config.parsed_args["output_default_diagnostics"] = false
-    simulation = ClimaAtmos.get_simulation(config)
+    simulation = ClimaAtmos.AtmosSimulation(config)
     (; u, p, t) = simulation.integrator
     ClimaAtmos.set_surface_albedo!(u, p, t, p.atmos.surface_albedo)
 
@@ -24,7 +24,7 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     # test set_surface_albedo!(Y, p, t, α_type::RegressionFunctionAlbedo)
     config.parsed_args["rad"] = "clearsky"
     config.parsed_args["albedo_model"] = "RegressionFunctionAlbedo"
-    simulation = ClimaAtmos.get_simulation(config)
+    simulation = ClimaAtmos.AtmosSimulation(config)
     (; u, p, t) = simulation.integrator
 
     ClimaAtmos.set_surface_albedo!(u, p, t, p.atmos.surface_albedo)
@@ -36,7 +36,7 @@ redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
     # test set_surface_albedo!(Y, p, t, α_type::CouplerAlbedo)
     config.parsed_args["rad"] = "clearsky"
     config.parsed_args["albedo_model"] = "CouplerAlbedo"
-    simulation = ClimaAtmos.get_simulation(config)
+    simulation = ClimaAtmos.AtmosSimulation(config)
     (; u, p) = simulation.integrator
 
     ClimaAtmos.set_surface_albedo!(u, p, Float64(0), p.atmos.surface_albedo)

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -21,7 +21,7 @@ import ClimaCore:
 
 function generate_test_simulation(config)
     parsed_args = config.parsed_args
-    simulation = CA.get_simulation(config)
+    simulation = CA.AtmosSimulation(config)
     (; integrator) = simulation
     Y = integrator.u
     p = integrator.p

--- a/test/test_init_with_file.jl
+++ b/test/test_init_with_file.jl
@@ -1,6 +1,6 @@
 import ClimaAtmos as CA
 
-simulation = CA.get_simulation(
+simulation = CA.AtmosSimulation(
     CA.AtmosConfig(
         Dict(
             "initial_condition" => "artifact\"DYAMOND_SUMMER_ICS_p98deg\"/DYAMOND_SUMMER_ICS_p98deg.nc",


### PR DESCRIPTION
A common pattern is to write:
```julia
config = AtmosConfig(file)
simulation = get_simulation(config)
```

This commit adds a constructor `AtmosSimulation` to skip the intermediate step where the configuration is built.
