### PR TITLE
Add smooth area entrainment with multiplicative area limiter.

### DIFF
--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -44,6 +44,7 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, VFT1, VFT2} <: ATCP
     detr_vertdiv_coeff::FT
     entr_param_vec::VFT1
     turb_entr_param_vec::VFT2
+    entr_mult_limiter_coeff::FT
     detr_massflux_vertdiv_coeff::FT
     min_area_limiter_scale::FT
     min_area_limiter_power::FT

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -177,6 +177,7 @@ function TurbulenceConvectionParameters(
         :EDMF_surface_area => :surface_area,
         :entr_param_vec => :entr_param_vec,
         :turb_entr_param_vec => :turb_entr_param_vec,
+        :entr_mult_limiter_coeff => :entr_mult_limiter_coeff,
         :minimum_updraft_top => :min_updraft_top,
         :mixing_length_eddy_viscosity_coefficient => :tke_ed_coeff,
         :mixing_length_smin_ub => :smin_ub,


### PR DESCRIPTION
Add smooth area entrainment with multiplicative area limiter, to help area fraction stay below 1.
