### PR TITLE
Move precipitation cache to precomputed quantities

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -350,7 +350,7 @@ version = "0.5.13"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "DiffEqBase", "FastGaussQuadrature", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.28.6"
+version = "0.29.0"
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaAtmos.jl Release Notes
 main
 -------
 
+v0.29.0
+-------
+
+### Remove precipitation from cache
+And move all the fields into precomputed
 
 v0.28.6
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.28.6"
+version = "0.29.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -9,7 +9,6 @@ struct AtmosCache{
     PREC,
     SCRA,
     HYPE,
-    PR,
     EXTFORCING,
     NONGW,
     ORGW,
@@ -52,7 +51,6 @@ struct AtmosCache{
     hyperdiff::HYPE
 
     """Additional parameters used by the various tendencies"""
-    precipitation::PR
     external_forcing::EXTFORCING
     non_orographic_gravity_wave::NONGW
     orographic_gravity_wave::ORGW
@@ -147,8 +145,16 @@ function build_cache(
     scratch = temporary_quantities(Y, atmos)
 
     precomputed = precomputed_quantities(Y, atmos)
-    precomputing_arguments =
-        (; atmos, core, params, sfc_setup, precomputed, scratch, dt)
+    precomputing_arguments = (;
+        atmos,
+        core,
+        params,
+        sfc_setup,
+        precomputed,
+        scratch,
+        dt,
+        conservation_check,
+    )
 
     # Coupler compatibility
     isnothing(precomputing_arguments.sfc_setup) &&
@@ -168,7 +174,6 @@ function build_cache(
         ) : ()
 
     hyperdiff = hyperdiffusion_cache(Y, atmos)
-    precipitation = precipitation_cache(Y, atmos)
     external_forcing = external_forcing_cache(Y, atmos, params)
     non_orographic_gravity_wave = non_orographic_gravity_wave_cache(Y, atmos)
     orographic_gravity_wave = orographic_gravity_wave_cache(Y, atmos)
@@ -186,7 +191,6 @@ function build_cache(
         precomputed,
         scratch,
         hyperdiff,
-        precipitation,
         external_forcing,
         non_orographic_gravity_wave,
         orographic_gravity_wave,

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -1,20 +1,57 @@
 #####
-##### Precomputed quantities
+##### Precomputed quantities for precipitation processes
 #####
-import CloudMicrophysics.Microphysics1M as CM1
+
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
+import CloudMicrophysics.Microphysics1M as CM1
+
+import Thermodynamics as TD
+import ClimaCore.Operators as Operators
+import ClimaCore.Fields as Fields
+
+const Iₗ = TD.internal_energy_liquid
+const Iᵢ = TD.internal_energy_ice
 
 """
-    set_precipitation_precomputed_quantities!(Y, p, t)
+   Kin(ᶜw_precip, ᶜu_air)
 
-Updates the precipitation terminal velocity stored in `p`
-for the 1-moment microphysics scheme
+    - ᶜw_precip - teminal velocity of cloud consensate or precipitation
+    - ᶜu_air - air velocity
+
+Helper function to compute the kinetic energy of cloud condensate and
+precipitation.
 """
-function set_precipitation_precomputed_quantities!(Y, p, t)
-    @assert (p.atmos.precip_model isa Microphysics1Moment)
+function Kin(ᶜw_precip, ᶜu_air)
+    return @. lazy(
+        norm_sqr(
+            Geometry.UVWVector(0, 0, -(ᶜw_precip)) + Geometry.UVWVector(ᶜu_air),
+        ) / 2,
+    )
+end
 
-    (; ᶜwᵣ, ᶜwₛ) = p.precomputed
+"""
+    set_precipitation_velocities!(Y, p, moisture_model, precip_model)
+
+Updates the precipitation terminal velocity, cloud sedimentation velocity,
+and their contribution to total water and energy advection.
+"""
+function set_precipitation_velocities!(Y, p, _, _)
+    (; ᶜwₜqₜ, ᶜwₕhₜ) = p.precomputed
+    @. ᶜwₜqₜ = Geometry.WVector(0)
+    @. ᶜwₕhₜ = Geometry.WVector(0)
+    return nothing
+end
+function set_precipitation_velocities!(
+    Y,
+    p,
+    moisture_model::NonEquilMoistModel,
+    precip_model::Microphysics1Moment,
+)
+    (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ, ᶜts, ᶜu) = p.precomputed
+    (; ᶜΦ) = p.core
+    cmc = CAP.microphysics_cloud_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
+    thp = CAP.thermodynamics_params(p.params)
 
     # compute the precipitation terminal velocity [m/s]
     @. ᶜwᵣ = CM1.terminal_velocity(
@@ -29,21 +66,6 @@ function set_precipitation_precomputed_quantities!(Y, p, t)
         Y.c.ρ,
         max(zero(Y.c.ρ), Y.c.ρq_sno / Y.c.ρ),
     )
-    return nothing
-end
-
-"""
-    set_sedimentation_precomputed_quantities!(Y, p, t)
-
-Updates the sedimentation terminal velocity stored in `p`
-for the non-equilibrium microphysics scheme
-"""
-function set_sedimentation_precomputed_quantities!(Y, p, t)
-    @assert (p.atmos.moisture_model isa NonEquilMoistModel)
-
-    (; ᶜwₗ, ᶜwᵢ) = p.precomputed
-    cmc = CAP.microphysics_cloud_params(p.params)
-
     # compute sedimentation velocity for cloud condensate [m/s]
     @. ᶜwₗ = CMNe.terminal_velocity(
         cmc.liquid,
@@ -57,5 +79,286 @@ function set_sedimentation_precomputed_quantities!(Y, p, t)
         Y.c.ρ,
         max(zero(Y.c.ρ), Y.c.ρq_ice / Y.c.ρ),
     )
+
+    # compute their contributions to energy and total water advection
+    @. ᶜwₜqₜ =
+        Geometry.WVector(
+            ᶜwₗ * Y.c.ρq_liq +
+            ᶜwᵢ * Y.c.ρq_ice +
+            ᶜwᵣ * Y.c.ρq_rai +
+            ᶜwₛ * Y.c.ρq_sno,
+        ) / Y.c.ρ
+    @. ᶜwₕhₜ =
+        Geometry.WVector(
+            ᶜwₗ * Y.c.ρq_liq * (Iₗ(thp, ᶜts) + ᶜΦ + $(Kin(ᶜwₗ, ᶜu))) +
+            ᶜwᵢ * Y.c.ρq_ice * (Iᵢ(thp, ᶜts) + ᶜΦ + $(Kin(ᶜwᵢ, ᶜu))) +
+            ᶜwᵣ * Y.c.ρq_rai * (Iₗ(thp, ᶜts) + ᶜΦ + $(Kin(ᶜwᵣ, ᶜu))) +
+            ᶜwₛ * Y.c.ρq_sno * (Iᵢ(thp, ᶜts) + ᶜΦ + $(Kin(ᶜwₛ, ᶜu))),
+        ) / Y.c.ρ
+    return nothing
+end
+
+"""
+    set_precipitation_cache!(Y, p, precip_model, turbconv_model)
+
+Computes the cache needed for precipitation tendencies. When run without edmf
+model this involves computing precipitation sources based on the grid mean
+properties. When running with edmf model this means summing the precipitation
+sources from the sub-domains.
+"""
+set_precipitation_cache!(Y, p, _, _) = nothing
+function set_precipitation_cache!(Y, p, ::Microphysics0Moment, _)
+    (; params, dt) = p
+    dt = float(dt)
+    (; ᶜts) = p.precomputed
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
+    (; ᶜΦ) = p.core
+    cm_params = CAP.microphysics_0m_params(params)
+    thermo_params = CAP.thermodynamics_params(params)
+    @. ᶜS_ρq_tot =
+        Y.c.ρ * q_tot_0M_precipitation_sources(
+            thermo_params,
+            cm_params,
+            dt,
+            Y.c.ρq_tot / Y.c.ρ,
+            ᶜts,
+        )
+    @. ᶜS_ρe_tot =
+        ᶜS_ρq_tot *
+        e_tot_0M_precipitation_sources_helper(thermo_params, ᶜts, ᶜΦ)
+    return nothing
+end
+function set_precipitation_cache!(
+    Y,
+    p,
+    ::Microphysics0Moment,
+    ::DiagnosticEDMFX,
+)
+    # For environment we multiply by grid mean ρ and not byᶜρa⁰
+    # assuming a⁰=1
+    (; ᶜΦ) = p.core
+    (; ᶜSqₜᵖ⁰, ᶜSqₜᵖʲs, ᶜρaʲs) = p.precomputed
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
+    (; ᶜts, ᶜtsʲs) = p.precomputed
+    thermo_params = CAP.thermodynamics_params(p.params)
+
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    ρ = Y.c.ρ
+
+    @. ᶜS_ρq_tot = ᶜSqₜᵖ⁰ * ρ
+    @. ᶜS_ρe_tot =
+        ᶜSqₜᵖ⁰ *
+        ρ *
+        e_tot_0M_precipitation_sources_helper(thermo_params, ᶜts, ᶜΦ)
+    for j in 1:n
+        @. ᶜS_ρq_tot += ᶜSqₜᵖʲs.:($$j) * ᶜρaʲs.:($$j)
+        @. ᶜS_ρe_tot +=
+            ᶜSqₜᵖʲs.:($$j) *
+            ᶜρaʲs.:($$j) *
+            e_tot_0M_precipitation_sources_helper(
+                thermo_params,
+                ᶜtsʲs.:($$j),
+                ᶜΦ,
+            )
+    end
+    return nothing
+end
+function set_precipitation_cache!(
+    Y,
+    p,
+    ::Microphysics0Moment,
+    ::PrognosticEDMFX,
+)
+    (; ᶜΦ) = p.core
+    (; ᶜSqₜᵖ⁰, ᶜSqₜᵖʲs, ᶜρa⁰) = p.precomputed
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
+    (; ᶜts⁰, ᶜtsʲs) = p.precomputed
+    thermo_params = CAP.thermodynamics_params(p.params)
+
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+
+    @. ᶜS_ρq_tot = ᶜSqₜᵖ⁰ * ᶜρa⁰
+    @. ᶜS_ρe_tot =
+        ᶜSqₜᵖ⁰ *
+        ᶜρa⁰ *
+        e_tot_0M_precipitation_sources_helper(thermo_params, ᶜts⁰, ᶜΦ)
+    for j in 1:n
+        @. ᶜS_ρq_tot += ᶜSqₜᵖʲs.:($$j) * Y.c.sgsʲs.:($$j).ρa
+        @. ᶜS_ρe_tot +=
+            ᶜSqₜᵖʲs.:($$j) *
+            Y.c.sgsʲs.:($$j).ρa *
+            e_tot_0M_precipitation_sources_helper(
+                thermo_params,
+                ᶜtsʲs.:($$j),
+                ᶜΦ,
+            )
+    end
+    return nothing
+end
+function set_precipitation_cache!(Y, p, ::Microphysics1Moment, _)
+    (; dt) = p
+    (; ᶜts, ᶜwᵣ, ᶜwₛ, ᶜu) = p.precomputed
+    (; ᶜSqₗᵖ, ᶜSqᵢᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ) = p.precomputed
+
+    (; q_rai, q_sno) = p.precomputed.ᶜspecific
+
+    ᶜSᵖ = p.scratch.ᶜtemp_scalar
+    ᶜSᵖ_snow = p.scratch.ᶜtemp_scalar_2
+    ᶜ∇T = p.scratch.ᶜtemp_CT123
+
+    # get thermodynamics and 1-moment microphysics params
+    (; params) = p
+    cmp = CAP.microphysics_1m_params(params)
+    thp = CAP.thermodynamics_params(params)
+
+    # compute precipitation source terms on the grid mean
+    compute_precipitation_sources!(
+        ᶜSᵖ,
+        ᶜSᵖ_snow,
+        ᶜSqₗᵖ,
+        ᶜSqᵢᵖ,
+        ᶜSqᵣᵖ,
+        ᶜSqₛᵖ,
+        Y.c.ρ,
+        q_rai,
+        q_sno,
+        ᶜts,
+        dt,
+        cmp,
+        thp,
+    )
+
+    # compute precipitation sinks
+    # (For now only done on the grid mean)
+    compute_precipitation_sinks!(
+        ᶜSᵖ,
+        ᶜSqᵣᵖ,
+        ᶜSqₛᵖ,
+        Y.c.ρ,
+        q_rai,
+        q_sno,
+        ᶜts,
+        dt,
+        cmp,
+        thp,
+    )
+    return nothing
+end
+function set_precipitation_cache!(
+    Y,
+    p,
+    ::Microphysics1Moment,
+    ::Union{DiagnosticEDMFX, PrognosticEDMFX},
+)
+    error("Not implemented yet")
+
+    #FT = Spaces.undertype(axes(Y.c))
+    #(; dt) = p
+    #(; ᶜts, ᶜqᵣ, ᶜqₛ, ᶜwᵣ, ᶜwₛ, ᶜu) = p.precomputed
+    #(; ᶜΦ) = p.core
+    ## Grid mean precipitation sinks
+    #(; ᶜSqₜᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ, ᶜSeₜᵖ) = p.precipitation
+    ## additional scratch storage
+    #ᶜSᵖ = p.scratch.ᶜtemp_scalar
+    #ᶜ∇T = p.scratch.ᶜtemp_CT123
+
+    ## get thermodynamics and 1-moment microphysics params
+    #(; params) = p
+    #cmp = CAP.microphysics_1m_params(params)
+    #thp = CAP.thermodynamics_params(params)
+
+    ## zero out the helper source terms
+    #@. ᶜSqₜᵖ = FT(0)
+    #@. ᶜSqᵣᵖ = FT(0)
+    #@. ᶜSqₛᵖ = FT(0)
+    #@. ᶜSeₜᵖ = FT(0)
+    ## compute precipitation sinks
+    ## (For now only done on the grid mean)
+    #compute_precipitation_sinks!(
+    #    ᶜSᵖ,
+    #    ᶜSqₜᵖ,
+    #    ᶜSqᵣᵖ,
+    #    ᶜSqₛᵖ,
+    #    ᶜSeₜᵖ,
+    #    Y.c.ρ,
+    #    ᶜqᵣ,
+    #    ᶜqₛ,
+    #    ᶜts,
+    #    ᶜΦ,
+    #    dt,
+    #    cmp,
+    #    thp,
+    #)
+    return nothing
+end
+
+"""
+    set_precipitation_surface_fluxes!(Y, p, precipitation model)
+
+Computes the flux of rain and snow at the surface. For the 0-moment microphysics
+it is an integral of the source terms in the column. For 1-moment microphysics
+it is the flux through the bottom cell face.
+"""
+set_precipitation_surface_fluxes!(Y, p, _) = nothing
+function set_precipitation_surface_fluxes!(
+    Y,
+    p,
+    precip_model::Microphysics0Moment,
+)
+    ᶜT = p.scratch.ᶜtemp_scalar
+    (; ᶜts) = p.precomputed  # assume ᶜts has been updated
+    (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
+    (; surface_rain_flux, surface_snow_flux) = p.precomputed
+    (; col_integrated_precip_energy_tendency) = p.conservation_check
+
+    # update total column energy source for surface energy balance
+    Operators.column_integral_definite!(
+        col_integrated_precip_energy_tendency,
+        ᶜS_ρe_tot,
+    )
+    # update surface precipitation fluxes in cache for coupler's use
+    thermo_params = CAP.thermodynamics_params(p.params)
+    T_freeze = TD.Parameters.T_freeze(thermo_params)
+    FT = eltype(p.params)
+    @. ᶜT = TD.air_temperature(thermo_params, ᶜts)
+    ᶜ3d_rain = @. lazy(ifelse(ᶜT >= T_freeze, ᶜS_ρq_tot, FT(0)))
+    ᶜ3d_snow = @. lazy(ifelse(ᶜT < T_freeze, ᶜS_ρq_tot, FT(0)))
+    Operators.column_integral_definite!(surface_rain_flux, ᶜ3d_rain)
+    Operators.column_integral_definite!(surface_snow_flux, ᶜ3d_snow)
+    return nothing
+end
+function set_precipitation_surface_fluxes!(
+    Y,
+    p,
+    precip_model::Microphysics1Moment,
+)
+    (; surface_rain_flux, surface_snow_flux) = p.precomputed
+    (; col_integrated_precip_energy_tendency,) = p.conservation_check
+    (; ᶜwᵣ, ᶜwₛ, ᶜspecific) = p.precomputed
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠJ = Fields.local_geometry_field(Y.f).J
+    sfc_J = Fields.level(ᶠJ, Fields.half)
+    sfc_space = axes(sfc_J)
+
+    # Jacobian-weighted extrapolation from interior to surface, consistent with
+    # the reconstruction of density on cell faces, ᶠρ = ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ
+    int_J = Fields.Field(Fields.field_values(Fields.level(ᶜJ, 1)), sfc_space)
+    int_ρ = Fields.Field(Fields.field_values(Fields.level(Y.c.ρ, 1)), sfc_space)
+    sfc_ρ = @. lazy(int_ρ * int_J / sfc_J)
+
+    # Constant extrapolation to surface, consistent with simple downwinding
+    sfc_qᵣ = Fields.Field(
+        Fields.field_values(Fields.level(ᶜspecific.q_rai, 1)),
+        sfc_space,
+    )
+    sfc_qₛ = Fields.Field(
+        Fields.field_values(Fields.level(ᶜspecific.q_sno, 1)),
+        sfc_space,
+    )
+    sfc_wᵣ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵣ, 1)), sfc_space)
+    sfc_wₛ = Fields.Field(Fields.field_values(Fields.level(ᶜwₛ, 1)), sfc_space)
+
+    @. surface_rain_flux = sfc_ρ * sfc_qᵣ * (-sfc_wᵣ)
+    @. surface_snow_flux = sfc_ρ * sfc_qₛ * (-sfc_wₛ)
     return nothing
 end

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -710,12 +710,12 @@ function compute_pr!(
     },
 )
     if isnothing(out)
-        return cache.precipitation.surface_rain_flux .+
-               cache.precipitation.surface_snow_flux
+        return cache.precomputed.surface_rain_flux .+
+               cache.precomputed.surface_snow_flux
     else
         out .=
-            cache.precipitation.surface_rain_flux .+
-            cache.precipitation.surface_snow_flux
+            cache.precomputed.surface_rain_flux .+
+            cache.precomputed.surface_snow_flux
     end
 end
 
@@ -745,9 +745,9 @@ function compute_prra!(
     },
 )
     if isnothing(out)
-        return cache.precipitation.surface_rain_flux
+        return cache.precomputed.surface_rain_flux
     else
-        out .= cache.precipitation.surface_rain_flux
+        out .= cache.precomputed.surface_rain_flux
     end
 end
 
@@ -777,9 +777,9 @@ function compute_prsn!(
     },
 )
     if isnothing(out)
-        return cache.precipitation.surface_snow_flux
+        return cache.precomputed.surface_snow_flux
     else
-        out .= cache.precipitation.surface_snow_flux
+        out .= cache.precomputed.surface_snow_flux
     end
 end
 
@@ -933,7 +933,7 @@ add_diagnostic_variable!(
     standard_name = "atmosphere_mass_content_of_cloud_condensed_water",
     units = "kg m-2",
     comments = """
-    Mass of condensed (liquid + ice) water in the column divided by the area of the column 
+    Mass of condensed (liquid + ice) water in the column divided by the area of the column
     (not just the area of the cloudy portion of the column). It doesn't include precipitating hydrometeors.
     """,
     compute! = compute_clwvi!,

--- a/src/prognostic_equations/surface_temp.jl
+++ b/src/prognostic_equations/surface_temp.jl
@@ -64,8 +64,8 @@ function surface_temp_tendency!(Yₜ, Y, p, t, slab::PrognosticSurfaceTemperatur
         end
 
         # precipitation
-        P_liq = p.precipitation.surface_rain_flux
-        P_snow = p.precipitation.surface_snow_flux
+        P_liq = p.precomputed.surface_rain_flux
+        P_snow = p.precomputed.surface_snow_flux
 
         @. Yₜ.sfc.water -= P_liq + P_snow + sfc_turb_w_flux # d(water)/dt = P - E [kg/m²/s]
 

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -75,7 +75,6 @@ const T2 = 290
         p.precomputed,
         p.scratch,
         p.hyperdiff,
-        p.precipitation,
         p.external_forcing,
         p.non_orographic_gravity_wave,
         p.orographic_gravity_wave,

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -10,6 +10,8 @@ import CloudMicrophysics as CM
 include("../../test_helpers.jl")
 
 import Test
+import Test: @testset
+import Test: @test
 
 @testset "Equilibrium Moisture + 0-moment precipitation RHS terms" begin
 
@@ -33,22 +35,23 @@ import Test
     (; turbconv_model, moisture_model, precip_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    precip_cache = CA.precipitation_cache(Y, precip_model)
+    CA.set_precipitation_velocities!(Y, p, moisture_model, precip_model)
+    CA.set_precipitation_cache!(Y, p, precip_model, turbconv_model)
+    CA.set_precipitation_surface_fluxes!(Y, p, precip_model)
     test_varnames = (
         :ᶜS_ρq_tot,
         :ᶜS_ρe_tot,
-        :ᶜ3d_rain,
-        :ᶜ3d_snow,
         :surface_rain_flux,
         :surface_snow_flux,
+        :ᶜwₜqₜ,
+        :ᶜwₕhₜ,
     )
     for var_name in test_varnames
-        @test var_name ∈ propertynames(precip_cache)
+        @test var_name ∈ propertynames(p.precomputed)
     end
 
     # No NaNs in cache
-    CA.compute_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    @test maximum(abs.(p.precipitation.ᶜS_ρq_tot)) <= sqrt(eps(FT))
+    @test maximum(abs.(p.precomputed.ᶜS_ρq_tot)) <= sqrt(eps(FT))
 
     # Test that tendencies result in correct water-mass budget,
     # and that the tendency modification corresponds exactly to the
@@ -63,7 +66,7 @@ import Test
         turbconv_model,
     )
     @test ᶜYₜ.c.ρ == ᶜYₜ.c.ρq_tot
-    @test ᶜYₜ.c.ρ == p.precipitation.ᶜS_ρq_tot
+    @test ᶜYₜ.c.ρ == p.precomputed.ᶜS_ρq_tot
 
     # No cloud condensation tendency for the equilibrium model
     @test CA.cloud_condensate_tendency!(
@@ -97,11 +100,25 @@ end
     (; turbconv_model, moisture_model, precip_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    precip_cache = CA.precipitation_cache(Y, precip_model)
-    test_varnames =
-        (:ᶜSqₗᵖ, :ᶜSqᵢᵖ, :ᶜSqᵣᵖ, :ᶜSqₛᵖ, :surface_rain_flux, :surface_snow_flux)
+    CA.set_precipitation_velocities!(Y, p, moisture_model, precip_model)
+    CA.set_precipitation_cache!(Y, p, precip_model, turbconv_model)
+    CA.set_precipitation_surface_fluxes!(Y, p, precip_model)
+    test_varnames = (
+        :ᶜSqₗᵖ,
+        :ᶜSqᵢᵖ,
+        :ᶜSqᵣᵖ,
+        :ᶜSqₛᵖ,
+        :surface_rain_flux,
+        :surface_snow_flux,
+        :ᶜwₗ,
+        :ᶜwᵢ,
+        :ᶜwᵣ,
+        :ᶜwₛ,
+        :ᶜwₜqₜ,
+        :ᶜwₕhₜ,
+    )
     for var_name in test_varnames
-        @test var_name ∈ propertynames(precip_cache)
+        @test var_name ∈ propertynames(p.precomputed)
     end
 
     # test helper functions

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -276,7 +276,6 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
             :ghost_buffer,
             # Computed in tendencies (which are not computed in this case)
             :hyperdiff,
-            :precipitation,
             # rc is some CUDA/CuArray internal object that we don't care about
             :rc,
             # DataHandlers contains caches, so they are stateful


### PR DESCRIPTION
Precipitation cache followed an old pattern and was:
- defined separately from precomputed quantities
- updated when the precipitation tendency was called.

This was making it difficult to track "who gets updated when" when coupling 1M microphysics with EDMF. This PR moves all precipitation cache into precomputed quantities 