### PR TITLE
Refactor RRTMGP interface

### DIFF
--- a/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
+++ b/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
@@ -404,12 +404,35 @@ array.
     - `center_z`: z-coordinate in m at cell centers
     - `face_z`: z-coordinate in m at cell faces
 """
-function RRTMGPModel(
+RRTMGPModel(
     params::RRTMGP.Parameters.ARP,
     context;
     ncol::Int,
     domain_nlay::Int,
     radiation_mode::AbstractRRTMGPMode = ClearSkyRadiation(),
+    interpolation::AbstractInterpolation = NoInterpolation(),
+    bottom_extrapolation::AbstractBottomExtrapolation = SameAsInterpolation(),
+    use_global_means_for_well_mixed_gases::Bool = false,
+    kwargs...,
+) = _RRTMGPModel(
+    params,
+    context,
+    radiation_mode;
+    ncol,
+    domain_nlay,
+    interpolation,
+    bottom_extrapolation,
+    use_global_means_for_well_mixed_gases,
+    kwargs...,
+)
+
+# TODO: make this the new interface for the next breaking release.
+function _RRTMGPModel(
+    params::RRTMGP.Parameters.ARP,
+    context,
+    radiation_mode::AbstractRRTMGPMode = ClearSkyRadiation();
+    ncol::Int,
+    domain_nlay::Int,
     interpolation::AbstractInterpolation = NoInterpolation(),
     bottom_extrapolation::AbstractBottomExtrapolation = SameAsInterpolation(),
     use_global_means_for_well_mixed_gases::Bool = false,


### PR DESCRIPTION
This PR:

 - Assumes `implied_values = :face`, which is the only setting that we currently support, and supporting `implied_values = :center` would involve changing pressure and temperature to live on cell faces, which would be very complicated in terms of a model feature.
 - Moves `radiation_mode` from a keyword arg to a positional arg, so that we can dispatch on it. This should allow us to simplify, and make assumptions inside, the `GrayRadiation`, `ClearSkyRadiation` etc. constructors.

This is technically a breaking change, since the `RRTMGPModel` interface is changing. We could add internal method constructors and pass it to a keyword constructor. Do people prefer that?