### PR TITLE
set dt_save_to_sol default to Inf

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -165,7 +165,7 @@ dt_save_state_to_disk:
   value: "Inf"
 dt_save_to_sol:
   help: "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"
-  value: "1days"
+  value: "Inf"
 moist:
   help: "Moisture model [`dry` (default), `equil`, `nonequil`]"
   value: "dry"

--- a/config/gpu_configs/baroclinic_wave_helem30.yml
+++ b/config/gpu_configs/baroclinic_wave_helem30.yml
@@ -3,8 +3,6 @@ z_elem: 63
 dz_bottom: 30.0
 t_end: "1days"
 dt: "90secs"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false
 initial_condition: "DryBaroclinicWave"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
@@ -1,5 +1,3 @@
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 30
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
@@ -1,5 +1,3 @@
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 h_elem: 16
 z_max: 60000.0
 z_elem: 63

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -1,5 +1,3 @@
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 30
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -1,5 +1,3 @@
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 42
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -1,5 +1,3 @@
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 60
 z_max: 60000.0

--- a/config/gpu_configs/held_suarez_equil_helem30.yml
+++ b/config/gpu_configs/held_suarez_equil_helem30.yml
@@ -6,8 +6,6 @@ rayleigh_sponge: true
 viscous_sponge: true
 dt: "90secs"
 t_end: "1days"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 moist: "equil"
 vert_diff: true

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ss.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_170_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_170_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ss.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ss.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_340_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_340_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_42_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_42_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_480_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_480_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ss.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ws.yml
@@ -7,7 +7,5 @@ ode_algo: ARS343
 initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_84_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_84_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/model_configs/baroclinic_wave.yml
+++ b/config/model_configs/baroclinic_wave.yml
@@ -2,6 +2,7 @@ dt_save_state_to_disk: "2days"
 initial_condition: "DryBaroclinicWave"
 dt: "400secs"
 t_end: "10days"
+dt_save_to_sol: "1days"
 deep_atmosphere: false
 disable_surface_flux_tendency: true
 diagnostics:

--- a/config/model_configs/test_env.yml
+++ b/config/model_configs/test_env.yml
@@ -5,7 +5,6 @@ rad: "allskywithclear"
 precip_model: "0M"
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 z_elem: 20
 h_elem: 8
 dt_rad: "5secs"

--- a/config/perf_configs/bm_aquaplanet_diagedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_diagedmf.yml
@@ -2,8 +2,6 @@ h_elem: 12
 z_elem: 25
 dt: 90secs
 t_end: 61mins
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 log_progress: false
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -2,8 +2,6 @@ h_elem: 12
 z_elem: 25
 dt: 10secs
 t_end: 61mins
-dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 log_progress: false
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/perf_configs/bm_baroclinic_wave_moist.yml
+++ b/config/perf_configs/bm_baroclinic_wave_moist.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "1mins"
-dt_save_to_sol: "Inf"
 log_progress: false
 moist: "equil"
 initial_condition: "MoistBaroclinicWave"

--- a/config/perf_configs/bm_callbacks.yml
+++ b/config/perf_configs/bm_callbacks.yml
@@ -5,7 +5,6 @@ dt: "1secs"
 dt_rad: "1secs"
 dt_cloud_fraction: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 dt_save_state_to_disk: "1secs"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_default.yml
+++ b/config/perf_configs/bm_default.yml
@@ -2,7 +2,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_default_1m.yml
+++ b/config/perf_configs/bm_default_1m.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_diagnostics.yml
+++ b/config/perf_configs/bm_diagnostics.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_diffusion.yml
+++ b/config/perf_configs/bm_diffusion.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_gravity_wave.yml
+++ b/config/perf_configs/bm_gravity_wave.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
`dt_save_to_sol` was default to 1 day, which causes memory errors when running long simulations (e.g. 10 year of 200km dry baroclinic wave). This PR sets the default to Inf. Also removes `dt_save_to_sol: Inf` and `dt_save_state_to_disk: Inf` in any config as those are the default.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
