### PR TITLE
Prognostic EDMF + 1M

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -398,7 +398,7 @@ steps:
         artifact_paths: "aquaplanet_equil_clearsky_tvinsol_0M_slabocean_ft64/output_active/*"
         agents:
           slurm_mem: 20GB
-      
+
       - label: ":computer: aquaplanet for coupler"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
@@ -725,7 +725,7 @@ steps:
         artifact_paths: "prognostic_edmfx_simpleplume_column/output_active/*"
         agents:
           slurm_mem: 20GB
-      
+
       - label: ":genie: Prognostic EDMFX Soares in a column"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
@@ -811,7 +811,6 @@ steps:
         artifact_paths: "prognostic_edmfx_rico_column/output_active/*"
         agents:
           slurm_mem: 20GB
-        soft_fail: true
 
       - label: ":umbrella: Prognostic EDMFX TRMM in a column"
         command: >
@@ -906,7 +905,7 @@ steps:
         depends_on:
           - "baroclinic_wave"
           - "baroclinic_wave_gpu"
-          
+
 
       - label: "GPU: baroclinic wave - 2 gpus"
         key: "baroclinic_wave_2gpu"
@@ -956,7 +955,7 @@ steps:
         agents:
           slurm_gpus: 1
           slurm_mem: 20GB
-          
+
       - label: "GPU: Diagnostic EDMFX aquaplanet"
         key: "diagnostic_edmfx_aquaplanet_gpu"
         command: >
@@ -1011,7 +1010,7 @@ steps:
           --job_id bm_default
         agents:
           slurm_mem: 24GB
-      
+
       - label: ":computer: Benchmark: GPU default"
         command: >
           julia --color=yes --project=.buildkite perf/benchmark.jl
@@ -1078,7 +1077,7 @@ steps:
         artifact_paths: "flame_default_1m/*"
         agents:
           slurm_mem: 24GB
-      
+
       - label: ":fire: Flame graph: diagnostics"
         command: >
           julia --color=yes --project=.buildkite perf/flame.jl
@@ -1105,7 +1104,7 @@ steps:
         artifact_paths: "flame_aquaplanet_progedmf/*"
         agents:
           slurm_mem: 32GB
-      
+
       - label: ":fire: Flame graph: diffusion"
         command: >
           julia --color=yes --project=.buildkite perf/flame.jl

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -3,7 +3,7 @@ subsidence: "Rico"
 ls_adv: "Rico"
 surface_setup: "Rico"
 turbconv: "prognostic_edmfx"
-implicit_diffusion: true
+implicit_diffusion: false
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_upwinding: first_order
@@ -33,7 +33,7 @@ netcdf_interpolation_num_points: [8, 8, 100]
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
     period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
     period: 10mins
   - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
     period: 10mins

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -25,7 +25,7 @@ y_elem: 2
 z_elem: 82
 z_stretch: false
 dt: 10secs
-t_end: 6hours
+t_end: 285mins
 dt_save_state_to_disk: 10mins
 FLOAT_TYPE: "Float64"
 toml: [toml/prognostic_edmfx_1M.toml]
@@ -37,5 +37,5 @@ diagnostics:
     period: 10mins
   - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
     period: 10mins
-  - short_name: [husra, hussn]
+  - short_name: [husra, hussn, husraup, hussnup, husraen, hussnen]
     period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1460,7 +1460,9 @@ function make_plots(
 )
     simdirs = SimDir.(output_paths)
 
-    precip_names = sim_type isa EDMFBoxPlotsWithPrecip ? ("husra", "hussn") : ()
+    precip_names =
+        sim_type isa EDMFBoxPlotsWithPrecip ?
+        ("husra", "hussn", "husraup", "hussnup", "husraen", "hussnen") : ()
 
     short_names = [
         "wa",

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -228,8 +228,7 @@ function set_precipitation_cache!(Y, p, ::Microphysics1Moment, _)
         thp,
     )
 
-    # compute precipitation sinks
-    # (For now only done on the grid mean)
+    # compute precipitation sinks on the grid mean
     compute_precipitation_sinks!(
         ᶜSᵖ,
         ᶜSqᵣᵖ,
@@ -248,47 +247,19 @@ function set_precipitation_cache!(
     Y,
     p,
     ::Microphysics1Moment,
-    ::Union{DiagnosticEDMFX, PrognosticEDMFX},
+    ::DiagnosticEDMFX,
 )
     error("Not implemented yet")
-
-    #FT = Spaces.undertype(axes(Y.c))
-    #(; dt) = p
-    #(; ᶜts, ᶜqᵣ, ᶜqₛ, ᶜwᵣ, ᶜwₛ, ᶜu) = p.precomputed
-    #(; ᶜΦ) = p.core
-    ## Grid mean precipitation sinks
-    #(; ᶜSqₜᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ, ᶜSeₜᵖ) = p.precipitation
-    ## additional scratch storage
-    #ᶜSᵖ = p.scratch.ᶜtemp_scalar
-    #ᶜ∇T = p.scratch.ᶜtemp_CT123
-
-    ## get thermodynamics and 1-moment microphysics params
-    #(; params) = p
-    #cmp = CAP.microphysics_1m_params(params)
-    #thp = CAP.thermodynamics_params(params)
-
-    ## zero out the helper source terms
-    #@. ᶜSqₜᵖ = FT(0)
-    #@. ᶜSqᵣᵖ = FT(0)
-    #@. ᶜSqₛᵖ = FT(0)
-    #@. ᶜSeₜᵖ = FT(0)
-    ## compute precipitation sinks
-    ## (For now only done on the grid mean)
-    #compute_precipitation_sinks!(
-    #    ᶜSᵖ,
-    #    ᶜSqₜᵖ,
-    #    ᶜSqᵣᵖ,
-    #    ᶜSqₛᵖ,
-    #    ᶜSeₜᵖ,
-    #    Y.c.ρ,
-    #    ᶜqᵣ,
-    #    ᶜqₛ,
-    #    ᶜts,
-    #    ᶜΦ,
-    #    dt,
-    #    cmp,
-    #    thp,
-    #)
+    return nothing
+end
+function set_precipitation_cache!(
+    Y,
+    p,
+    ::Microphysics1Moment,
+    ::PrognosticEDMFX,
+)
+    # Nothing needs to be done on the grid mean. The Sources are computed
+    # in edmf sub-domains.
     return nothing
 end
 

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -37,7 +37,7 @@ For every other `AbstractEDMF`, only `ᶜtke⁰` is added as a precomputed quant
 TODO: Rename `ᶜK` to `ᶜκ`.
 """
 function implicit_precomputed_quantities(Y, atmos)
-    (; moisture_model, turbconv_model) = atmos
+    (; moisture_model, turbconv_model, precip_model) = atmos
     FT = eltype(Y)
     TST = thermo_state_type(moisture_model, FT)
     n = n_mass_flux_subdomains(turbconv_model)
@@ -53,6 +53,17 @@ function implicit_precomputed_quantities(Y, atmos)
     )
     sgs_quantities =
         turbconv_model isa AbstractEDMF ? (; ᶜtke⁰ = similar(Y.c, FT)) : (;)
+    moisture_sgs_quantities =
+        (
+            moisture_model isa NonEquilMoistModel &&
+            precip_model isa Microphysics1Moment
+        ) ?
+        (;
+            ᶜq_liq⁰ = similar(Y.c, FT),
+            ᶜq_ice⁰ = similar(Y.c, FT),
+            ᶜq_rai⁰ = similar(Y.c, FT),
+            ᶜq_sno⁰ = similar(Y.c, FT),
+        ) : (;)
     prognostic_sgs_quantities =
         turbconv_model isa PrognosticEDMFX ?
         (;
@@ -71,6 +82,7 @@ function implicit_precomputed_quantities(Y, atmos)
             ᶠKᵥʲs = similar(Y.f, NTuple{n, FT}),
             ᶜtsʲs = similar(Y.c, NTuple{n, TST}),
             ᶜρʲs = similar(Y.c, NTuple{n, FT}),
+            moisture_sgs_quantities...,
         ) : (;)
     return (; gs_quantities..., sgs_quantities..., prognostic_sgs_quantities...)
 end
@@ -133,12 +145,12 @@ function precomputed_quantities(Y, atmos)
         (; ᶜSqₜᵖʲs = similar(Y.c, NTuple{n, FT}), ᶜSqₜᵖ⁰ = similar(Y.c, FT)) :
         atmos.precip_model isa Microphysics1Moment ?
         (;
-            ᶜSeₜᵖʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜSqₜᵖʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜSqₗᵖʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜSqᵢᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSqᵣᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSqₛᵖʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜSeₜᵖ⁰ = similar(Y.c, FT),
-            ᶜSqₜᵖ⁰ = similar(Y.c, FT),
+            ᶜSqₗᵖ⁰ = similar(Y.c, FT),
+            ᶜSqᵢᵖ⁰ = similar(Y.c, FT),
             ᶜSqᵣᵖ⁰ = similar(Y.c, FT),
             ᶜSqₛᵖ⁰ = similar(Y.c, FT),
         ) : (;)

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -24,6 +24,10 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     (; ᶜp, ᶜh_tot, ᶜK) = p.precomputed
     (; ᶜtke⁰, ᶜρa⁰, ᶠu₃⁰, ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜρ⁰, ᶜmse⁰, ᶜq_tot⁰) =
         p.precomputed
+    if p.atmos.moisture_model isa NonEquilMoistModel &&
+       p.atmos.precip_model isa Microphysics1Moment
+        (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
+    end
 
     @. ᶜρa⁰ = ρa⁰(Y.c)
     @. ᶜtke⁰ = divide_by_ρa(Y.c.sgs⁰.ρatke, ᶜρa⁰, 0, Y.c.ρ, turbconv_model)
@@ -41,10 +45,51 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
         Y.c.ρ,
         turbconv_model,
     )
+    if p.atmos.moisture_model isa NonEquilMoistModel &&
+       p.atmos.precip_model isa Microphysics1Moment
+        @. ᶜq_liq⁰ = divide_by_ρa(
+            Y.c.ρq_liq - ρaq_liq⁺(Y.c.sgsʲs),
+            ᶜρa⁰,
+            Y.c.ρq_liq,
+            Y.c.ρ,
+            turbconv_model,
+        )
+        @. ᶜq_ice⁰ = divide_by_ρa(
+            Y.c.ρq_ice - ρaq_ice⁺(Y.c.sgsʲs),
+            ᶜρa⁰,
+            Y.c.ρq_ice,
+            Y.c.ρ,
+            turbconv_model,
+        )
+        @. ᶜq_rai⁰ = divide_by_ρa(
+            Y.c.ρq_rai - ρaq_rai⁺(Y.c.sgsʲs),
+            ᶜρa⁰,
+            Y.c.ρq_rai,
+            Y.c.ρ,
+            turbconv_model,
+        )
+        @. ᶜq_sno⁰ = divide_by_ρa(
+            Y.c.ρq_sno - ρaq_sno⁺(Y.c.sgsʲs),
+            ᶜρa⁰,
+            Y.c.ρq_sno,
+            Y.c.ρ,
+            turbconv_model,
+        )
+    end
     set_sgs_ᶠu₃!(u₃⁰, ᶠu₃⁰, Y, turbconv_model)
     set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.uₕ, ᶠuₕ³)
     # @. ᶜK⁰ += ᶜtke⁰
-    @. ᶜts⁰ = TD.PhaseEquil_phq(thermo_params, ᶜp, ᶜmse⁰ - ᶜΦ, ᶜq_tot⁰)
+    if p.atmos.moisture_model isa NonEquilMoistModel &&
+       p.atmos.precip_model isa Microphysics1Moment
+        @. ᶜts⁰ = TD.PhaseNonEquil_phq(
+            thermo_params,
+            ᶜp,
+            ᶜmse⁰ - ᶜΦ,
+            TD.PhasePartition(ᶜq_tot⁰, ᶜq_liq⁰ + ᶜq_rai⁰, ᶜq_ice⁰ + ᶜq_sno⁰),
+        )
+    else
+        @. ᶜts⁰ = TD.PhaseEquil_phq(thermo_params, ᶜp, ᶜmse⁰ - ᶜΦ, ᶜq_tot⁰)
+    end
     @. ᶜρ⁰ = TD.air_density(thermo_params, ᶜts⁰)
     return nothing
 end
@@ -82,10 +127,31 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
         ᶜρʲ = ᶜρʲs.:($j)
         ᶜmseʲ = Y.c.sgsʲs.:($j).mse
         ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            ᶜq_liqʲ = Y.c.sgsʲs.:($j).q_liq
+            ᶜq_iceʲ = Y.c.sgsʲs.:($j).q_ice
+            ᶜq_raiʲ = Y.c.sgsʲs.:($j).q_rai
+            ᶜq_snoʲ = Y.c.sgsʲs.:($j).q_sno
+        end
 
         set_velocity_quantities!(ᶜuʲ, ᶠu³ʲ, ᶜKʲ, ᶠu₃ʲ, Y.c.uₕ, ᶠuₕ³)
         @. ᶠKᵥʲ = (adjoint(CT3(ᶠu₃ʲ)) * ᶠu₃ʲ) / 2
-        @. ᶜtsʲ = TD.PhaseEquil_phq(thermo_params, ᶜp, ᶜmseʲ - ᶜΦ, ᶜq_totʲ)
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            @. ᶜtsʲ = TD.PhaseNonEquil_phq(
+                thermo_params,
+                ᶜp,
+                ᶜmseʲ - ᶜΦ,
+                TD.PhasePartition(
+                    ᶜq_totʲ,
+                    ᶜq_liqʲ + ᶜq_raiʲ,
+                    ᶜq_iceʲ + ᶜq_snoʲ,
+                ),
+            )
+        else
+            @. ᶜtsʲ = TD.PhaseEquil_phq(thermo_params, ᶜp, ᶜmseʲ - ᶜΦ, ᶜq_totʲ)
+        end
         @. ᶜρʲ = TD.air_density(thermo_params, ᶜtsʲ)
     end
     return nothing
@@ -117,6 +183,13 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
         ᶜtsʲ = ᶜtsʲs.:($j)
         ᶜmseʲ = Y.c.sgsʲs.:($j).mse
         ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            ᶜq_liqʲ = Y.c.sgsʲs.:($j).q_liq
+            ᶜq_iceʲ = Y.c.sgsʲs.:($j).q_ice
+            ᶜq_raiʲ = Y.c.sgsʲs.:($j).q_rai
+            ᶜq_snoʲ = Y.c.sgsʲs.:($j).q_sno
+        end
 
         # We need field_values everywhere because we are mixing
         # information from surface and first interior inside the
@@ -130,9 +203,11 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
         ᶜp_int_val = Fields.field_values(Fields.level(ᶜp, 1))
         (; ρ_flux_h_tot, ρ_flux_q_tot, ustar, obukhov_length) =
             p.precomputed.sfc_conditions
+
         buoyancy_flux_val = Fields.field_values(buoyancy_flux)
         ρ_flux_h_tot_val = Fields.field_values(ρ_flux_h_tot)
         ρ_flux_q_tot_val = Fields.field_values(ρ_flux_q_tot)
+
         ustar_val = Fields.field_values(ustar)
         obukhov_length_val = Fields.field_values(obukhov_length)
         sfc_local_geometry_val = Fields.field_values(
@@ -174,16 +249,53 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
             obukhov_length_val,
             sfc_local_geometry_val,
         )
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            # TODO - any better way to define the cloud and precip tracer flux?
+            ᶜq_liq_int_val =
+                Fields.field_values(Fields.level(ᶜspecific.q_liq, 1))
+            ᶜq_liqʲ_int_val = Fields.field_values(Fields.level(ᶜq_liqʲ, 1))
+            @. ᶜq_liqʲ_int_val = ᶜq_liq_int_val
+
+            ᶜq_ice_int_val =
+                Fields.field_values(Fields.level(ᶜspecific.q_ice, 1))
+            ᶜq_iceʲ_int_val = Fields.field_values(Fields.level(ᶜq_iceʲ, 1))
+            @. ᶜq_iceʲ_int_val = ᶜq_ice_int_val
+
+            ᶜq_rai_int_val =
+                Fields.field_values(Fields.level(ᶜspecific.q_rai, 1))
+            ᶜq_raiʲ_int_val = Fields.field_values(Fields.level(ᶜq_raiʲ, 1))
+            @. ᶜq_raiʲ_int_val = ᶜq_rai_int_val
+
+            ᶜq_sno_int_val =
+                Fields.field_values(Fields.level(ᶜspecific.q_sno, 1))
+            ᶜq_snoʲ_int_val = Fields.field_values(Fields.level(ᶜq_snoʲ, 1))
+            @. ᶜq_snoʲ_int_val = ᶜq_sno_int_val
+        end
 
         # Then overwrite the prognostic variables at first inetrior point.
         ᶜΦ_int_val = Fields.field_values(Fields.level(ᶜΦ, 1))
         ᶜtsʲ_int_val = Fields.field_values(Fields.level(ᶜtsʲ, 1))
-        @. ᶜtsʲ_int_val = TD.PhaseEquil_phq(
-            thermo_params,
-            ᶜp_int_val,
-            ᶜmseʲ_int_val - ᶜΦ_int_val,
-            ᶜq_totʲ_int_val,
-        )
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            @. ᶜtsʲ_int_val = TD.PhaseNonEquil_phq(
+                thermo_params,
+                ᶜp_int_val,
+                ᶜmseʲ_int_val - ᶜΦ_int_val,
+                TD.PhasePartition(
+                    ᶜq_totʲ_int_val,
+                    ᶜq_liqʲ_int_val + ᶜq_raiʲ_int_val,
+                    ᶜq_iceʲ_int_val + ᶜq_snoʲ_int_val,
+                ),
+            )
+        else
+            @. ᶜtsʲ_int_val = TD.PhaseEquil_phq(
+                thermo_params,
+                ᶜp_int_val,
+                ᶜmseʲ_int_val - ᶜΦ_int_val,
+                ᶜq_totʲ_int_val,
+            )
+        end
         sgsʲs_ρ_int_val = Fields.field_values(Fields.level(ᶜρʲs.:($j), 1))
         sgsʲs_ρa_int_val =
             Fields.field_values(Fields.level(Y.c.sgsʲs.:($j).ρa, 1))
@@ -313,7 +425,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_closures!(
     @. ᶜgradᵥ_q_tot⁰ = ᶜgradᵥ(ᶠinterp(ᶜq_tot⁰))                                        # ∂qt∂z_sat
     @. ᶜgradᵥ_θ_liq_ice⁰ =
         ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts⁰)))                    # ∂θl∂z_sat
-    @. ᶜlinear_buoygrad = buoyancy_gradients(
+    @. ᶜlinear_buoygrad = buoyancy_gradients( # TODO - do we need to modify buoyancy gradients based on NonEq + 1M tracers?
         BuoyGradMean(),
         thermo_params,
         moisture_model,
@@ -437,60 +549,100 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     p,
     ::Microphysics1Moment,
 )
-    error("Not implemented yet")
-    #@assert !(p.atmos.moisture_model isa DryModel)
+    @assert (p.atmos.moisture_model isa NonEquilMoistModel)
 
-    #(; params, dt) = p
-    #(; ᶜΦ,) = p.core
-    #thp = CAP.thermodynamics_params(params)
-    #cmp = CAP.microphysics_1m_params(params)
+    (; params, dt) = p
+    (; ᶜΦ,) = p.core
+    thp = CAP.thermodynamics_params(params)
+    cmp = CAP.microphysics_1m_params(params)
+    cmc = CAP.microphysics_cloud_params(params)
 
-    #(; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs, ᶜρʲs, ᶜtsʲs) = p.precomputed
-    #(; ᶜSeₜᵖ⁰, ᶜSqₜᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜρ⁰, ᶜts⁰) = p.precomputed
-    #(; ᶜqᵣ, ᶜqₛ) = p.precomputed
+    (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs, ᶜρʲs, ᶜtsʲs) = p.precomputed
+    (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜρ⁰, ᶜts⁰) = p.precomputed
+    (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
 
-    ## TODO - can I re-use them between js and env?
-    #ᶜSᵖ = p.scratch.ᶜtemp_scalar
-    #ᶜSᵖ_snow = p.scratch.ᶜtemp_scalar_2
+    # TODO - can I re-use them between js and env?
+    ᶜSᵖ = p.scratch.ᶜtemp_scalar
+    ᶜSᵖ_snow = p.scratch.ᶜtemp_scalar_2
 
-    #n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
 
-    ## Sources from the updrafts
-    #for j in 1:n
-    #    compute_precipitation_sources!(
-    #        ᶜSᵖ,
-    #        ᶜSᵖ_snow,
-    #        ᶜSqₜᵖʲs.:($j),
-    #        ᶜSqᵣᵖʲs.:($j),
-    #        ᶜSqₛᵖʲs.:($j),
-    #        ᶜSeₜᵖʲs.:($j),
-    #        ᶜρʲs.:($j),
-    #        ᶜqᵣ,
-    #        ᶜqₛ,
-    #        ᶜtsʲs.:($j),
-    #        ᶜΦ,
-    #        dt,
-    #        cmp,
-    #        thp,
-    #    )
-    #end
+    for j in 1:n
+        # Precipitation sources and sinks from the updrafts
+        compute_precipitation_sources!(
+            ᶜSᵖ,
+            ᶜSᵖ_snow,
+            ᶜSqₗᵖʲs.:($j),
+            ᶜSqᵢᵖʲs.:($j),
+            ᶜSqᵣᵖʲs.:($j),
+            ᶜSqₛᵖʲs.:($j),
+            ᶜρʲs.:($j),
+            Y.c.sgsʲs.:($j).q_rai,
+            Y.c.sgsʲs.:($j).q_sno,
+            ᶜtsʲs.:($j),
+            dt,
+            cmp,
+            thp,
+        )
+        compute_precipitation_sinks!(
+            ᶜSᵖ,
+            ᶜSqᵣᵖʲs.:($j),
+            ᶜSqₛᵖʲs.:($j),
+            ᶜρʲs.:($j),
+            Y.c.sgsʲs.:($j).q_rai,
+            Y.c.sgsʲs.:($j).q_sno,
+            ᶜtsʲs.:($j),
+            dt,
+            cmp,
+            thp,
+        )
+        # Cloud formation from the updrafts
+        @. ᶜSqₗᵖʲs.:($$j) += cloud_sources(
+            cmc.liquid,
+            thp,
+            ᶜtsʲs.:($$j),
+            Y.c.sgsʲs.:($$j).q_rai,
+            dt,
+        )
+        @. ᶜSqᵢᵖʲs.:($$j) += cloud_sources(
+            cmc.ice,
+            thp,
+            ᶜtsʲs.:($$j),
+            Y.c.sgsʲs.:($$j).q_sno,
+            dt,
+        )
+    end
 
-    ## Sources from the environment
-    #compute_precipitation_sources!(
-    #    ᶜSᵖ,
-    #    ᶜSᵖ_snow,
-    #    ᶜSqₜᵖ⁰,
-    #    ᶜSqᵣᵖ⁰,
-    #    ᶜSqₛᵖ⁰,
-    #    ᶜSeₜᵖ⁰,
-    #    ᶜρ⁰,
-    #    ᶜqᵣ,
-    #    ᶜqₛ,
-    #    ᶜts⁰,
-    #    ᶜΦ,
-    #    dt,
-    #    cmp,
-    #    thp,
-    #)
+    # Precipitation sources and sinks from the environment
+    compute_precipitation_sources!(
+        ᶜSᵖ,
+        ᶜSᵖ_snow,
+        ᶜSqₗᵖ⁰,
+        ᶜSqᵢᵖ⁰,
+        ᶜSqᵣᵖ⁰,
+        ᶜSqₛᵖ⁰,
+        ᶜρ⁰,
+        ᶜq_rai⁰,
+        ᶜq_sno⁰,
+        ᶜts⁰,
+        dt,
+        cmp,
+        thp,
+    )
+    compute_precipitation_sinks!(
+        ᶜSᵖ,
+        ᶜSqᵣᵖ⁰,
+        ᶜSqₛᵖ⁰,
+        ᶜρ⁰,
+        ᶜq_rai⁰,
+        ᶜq_sno⁰,
+        ᶜts⁰,
+        dt,
+        cmp,
+        thp,
+    )
+    # Cloud formation from the environment
+    @. ᶜSqₗᵖ⁰ += cloud_sources(cmc.liquid, thp, ᶜts⁰, ᶜq_rai⁰, dt)
+    @. ᶜSqᵢᵖ⁰ += cloud_sources(cmc.ice, thp, ᶜts⁰, ᶜq_sno⁰, dt)
     return nothing
 end

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -118,10 +118,6 @@ function precipitation_tendency!(
 
     #(; ᶜρaʲs) = p.precomputed
 
-    ## Populate the cache and precipitation surface fluxes
-    #compute_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    #compute_precipitation_surface_fluxes!(Y, p, precip_model)
-
     ## Update from environment precipitation sources
     ## and the grid mean precipitation sinks
     #@. Yₜ.c.ρ += Y.c.ρ * (ᶜSqₜᵖ⁰ + ᶜSqₜᵖ)
@@ -149,33 +145,23 @@ function precipitation_tendency!(
     precip_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
-    error("Not implemented yet")
-    ## Source terms from EDMFX environment
-    #(; ᶜSeₜᵖ⁰, ᶜSqₜᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜρa⁰) = p.precomputed
-    ## Source terms from EDMFX updrafts
-    #(; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
-    ## Grid mean precipitation sinks
-    #(; ᶜSqₜᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ, ᶜSeₜᵖ) = p.precipitation
+    # Source terms from EDMFX updrafts
+    (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
+    # Source terms from EDMFX environment
+    (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜρa⁰) = p.precomputed
 
-    ## Populate the cache and precipitation surface fluxes
-    #compute_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    #compute_precipitation_surface_fluxes!(Y, p, precip_model)
+    # Update from environment precipitation and cloud formation sources/sinks
+    @. Yₜ.c.ρq_liq += ᶜρa⁰ * ᶜSqₗᵖ⁰
+    @. Yₜ.c.ρq_ice += ᶜρa⁰ * ᶜSqᵢᵖ⁰
+    @. Yₜ.c.ρq_rai += ᶜρa⁰ * ᶜSqᵣᵖ⁰
+    @. Yₜ.c.ρq_sno += ᶜρa⁰ * ᶜSqₛᵖ⁰
 
-    ## Update from environment precipitation sources
-    ## and the grid mean precipitation sinks
-    #@. Yₜ.c.ρ += ᶜρa⁰ * ᶜSqₜᵖ⁰ + Y.c.ρ * ᶜSqₜᵖ
-    #@. Yₜ.c.ρq_tot += ᶜρa⁰ * ᶜSqₜᵖ⁰ + Y.c.ρ * ᶜSqₜᵖ
-    #@. Yₜ.c.ρe_tot += ᶜρa⁰ * ᶜSeₜᵖ⁰ + Y.c.ρ * ᶜSeₜᵖ
-    #@. Yₜ.c.ρq_rai += ᶜρa⁰ * ᶜSqᵣᵖ⁰ + Y.c.ρ * ᶜSqᵣᵖ
-    #@. Yₜ.c.ρq_sno += ᶜρa⁰ * ᶜSqₛᵖ⁰ + Y.c.ρ * ᶜSqₛᵖ
-
-    ## Update from the updraft precipitation sources
-    #n = n_mass_flux_subdomains(p.atmos.turbconv_model)
-    #for j in 1:n
-    #    @. Yₜ.c.ρ += Y.c.sgsʲs.:($$j).ρa * ᶜSqₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_tot += Y.c.sgsʲs.:($$j).ρa * ᶜSqₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρe_tot += Y.c.sgsʲs.:($$j).ρa * ᶜSeₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_rai += Y.c.sgsʲs.:($$j).ρa * ᶜSqᵣᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_sno += Y.c.sgsʲs.:($$j).ρa * ᶜSqₛᵖʲs.:($$j)
-    #end
+    # Update from the updraft precipitation sources
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    for j in 1:n
+        @. Yₜ.c.ρq_liq += Y.c.sgsʲs.:($$j).ρa * ᶜSqₗᵖʲs.:($$j)
+        @. Yₜ.c.ρq_ice += Y.c.sgsʲs.:($$j).ρa * ᶜSqᵢᵖʲs.:($$j)
+        @. Yₜ.c.ρq_rai += Y.c.sgsʲs.:($$j).ρa * ᶜSqᵣᵖʲs.:($$j)
+        @. Yₜ.c.ρq_sno += Y.c.sgsʲs.:($$j).ρa * ᶜSqₛᵖʲs.:($$j)
+    end
 end

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -65,6 +65,21 @@ NVTX.@annotate function horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
             @. Yₜ.c.sgsʲs.:($$j).q_tot -=
                 wdivₕ(Y.c.sgsʲs.:($$j).q_tot * ᶜuʲs.:($$j)) -
                 Y.c.sgsʲs.:($$j).q_tot * wdivₕ(ᶜuʲs.:($$j))
+            if p.atmos.moisture_model isa NonEquilMoistModel &&
+               p.atmos.precip_model isa Microphysics1Moment
+                @. Yₜ.c.sgsʲs.:($$j).q_liq -=
+                    wdivₕ(Y.c.sgsʲs.:($$j).q_liq * ᶜuʲs.:($$j)) -
+                    Y.c.sgsʲs.:($$j).q_liq * wdivₕ(ᶜuʲs.:($$j))
+                @. Yₜ.c.sgsʲs.:($$j).q_ice -=
+                    wdivₕ(Y.c.sgsʲs.:($$j).q_ice * ᶜuʲs.:($$j)) -
+                    Y.c.sgsʲs.:($$j).q_ice * wdivₕ(ᶜuʲs.:($$j))
+                @. Yₜ.c.sgsʲs.:($$j).q_rai -=
+                    wdivₕ(Y.c.sgsʲs.:($$j).q_rai * ᶜuʲs.:($$j)) -
+                    Y.c.sgsʲs.:($$j).q_rai * wdivₕ(ᶜuʲs.:($$j))
+                @. Yₜ.c.sgsʲs.:($$j).q_sno -=
+                    wdivₕ(Y.c.sgsʲs.:($$j).q_sno * ᶜuʲs.:($$j)) -
+                    Y.c.sgsʲs.:($$j).q_sno * wdivₕ(ᶜuʲs.:($$j))
+            end
         end
     end
     return nothing
@@ -235,5 +250,35 @@ function edmfx_sgs_vertical_advection_tendency!(
             edmfx_upwinding,
         )
         @. Yₜ.c.sgsʲs.:($$j).q_tot += va
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            # TODO - add precipitation terminal velocity
+            # TODO - add cloud sedimentation velocity
+            # TODO - add their contributions to mean energy and mass
+            va = vertical_advection(
+                ᶠu³ʲs.:($j),
+                Y.c.sgsʲs.:($j).q_liq,
+                edmfx_upwinding,
+            )
+            @. Yₜ.c.sgsʲs.:($$j).q_liq += va
+            va = vertical_advection(
+                ᶠu³ʲs.:($j),
+                Y.c.sgsʲs.:($j).q_ice,
+                edmfx_upwinding,
+            )
+            @. Yₜ.c.sgsʲs.:($$j).q_ice += va
+            va = vertical_advection(
+                ᶠu³ʲs.:($j),
+                Y.c.sgsʲs.:($j).q_rai,
+                edmfx_upwinding,
+            )
+            @. Yₜ.c.sgsʲs.:($$j).q_rai += va
+            va = vertical_advection(
+                ᶠu³ʲs.:($j),
+                Y.c.sgsʲs.:($j).q_sno,
+                edmfx_upwinding,
+            )
+            @. Yₜ.c.sgsʲs.:($$j).q_sno += va
+        end
     end
 end

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -365,6 +365,11 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
     (; ᶜturb_entrʲs, ᶜentrʲs, ᶜdetrʲs) = p.precomputed
     (; ᶜq_tot⁰, ᶜmse⁰, ᶠu₃⁰) = p.precomputed
 
+    if p.atmos.moisture_model isa NonEquilMoistModel &&
+       p.atmos.precip_model isa Microphysics1Moment
+        (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
+    end
+
     for j in 1:n
 
         @. Yₜ.c.sgsʲs.:($$j).ρa +=
@@ -377,6 +382,22 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
         @. Yₜ.c.sgsʲs.:($$j).q_tot +=
             (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
             (ᶜq_tot⁰ - Y.c.sgsʲs.:($$j).q_tot)
+
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            @. Yₜ.c.sgsʲs.:($$j).q_liq +=
+                (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
+                (ᶜq_liq⁰ - Y.c.sgsʲs.:($$j).q_liq)
+            @. Yₜ.c.sgsʲs.:($$j).q_ice +=
+                (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
+                (ᶜq_ice⁰ - Y.c.sgsʲs.:($$j).q_ice)
+            @. Yₜ.c.sgsʲs.:($$j).q_rai +=
+                (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
+                (ᶜq_rai⁰ - Y.c.sgsʲs.:($$j).q_rai)
+            @. Yₜ.c.sgsʲs.:($$j).q_sno +=
+                (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
+                (ᶜq_sno⁰ - Y.c.sgsʲs.:($$j).q_sno)
+        end
 
         @. Yₜ.f.sgsʲs.:($$j).u₃ +=
             (ᶠinterp(ᶜentrʲs.:($$j)) .+ ᶠinterp(ᶜturb_entrʲs.:($$j))) *

--- a/src/prognostic_equations/edmfx_precipitation.jl
+++ b/src/prognostic_equations/edmfx_precipitation.jl
@@ -46,20 +46,23 @@ function edmfx_precipitation_tendency!(
     precip_model::Microphysics1Moment,
 )
     n = n_mass_flux_subdomains(turbconv_model)
-    (; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜtsʲs) = p.precomputed
-    thp = CAP.thermodynamics_params(p.params)
-    (; ᶜΦ) = p.core
+
+    (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
+
+    # TODO what about the mass end energy outflow via bottom boundary?
 
     for j in 1:n
+        @. Yₜ.c.sgsʲs.:($$j).q_liq +=
+            ᶜSqₗᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_liq)
 
-        @. Yₜ.c.sgsʲs.:($$j).ρa += Y.c.sgsʲs.:($$j).ρa * ᶜSqₜᵖʲs.:($$j)
+        @. Yₜ.c.sgsʲs.:($$j).q_ice +=
+            ᶜSqᵢᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_ice)
 
-        @. Yₜ.c.sgsʲs.:($$j).mse +=
-            ᶜSeₜᵖʲs.:($$j) -
-            ᶜSqₜᵖʲs.:($$j) * TD.internal_energy(thp, ᶜtsʲs.:($$j))
+        @. Yₜ.c.sgsʲs.:($$j).q_rai +=
+            ᶜSqᵣᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_rai)
 
-        @. Yₜ.c.sgsʲs.:($$j).q_tot +=
-            ᶜSqₜᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_tot)
+        @. Yₜ.c.sgsʲs.:($$j).q_sno +=
+            ᶜSqₛᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_sno)
     end
     return nothing
 end

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -17,6 +17,12 @@ function edmfx_sgs_mass_flux_tendency!(
     (; ᶠu³, ᶜh_tot, ᶜspecific) = p.precomputed
     (; ᶠu³ʲs, ᶜKʲs, ᶜρʲs) = p.precomputed
     (; ᶜρa⁰, ᶜρ⁰, ᶠu³⁰, ᶜK⁰, ᶜmse⁰, ᶜq_tot⁰) = p.precomputed
+    if (
+        p.atmos.moisture_model isa NonEquilMoistModel &&
+        p.atmos.precip_model isa Microphysics1Moment
+    )
+        (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
+    end
     (; dt) = p
     ᶜJ = Fields.local_geometry_field(Y.c).J
 
@@ -76,10 +82,107 @@ function edmfx_sgs_mass_flux_tendency!(
             )
             @. Yₜ.c.ρq_tot += vtt
         end
+
+        if (
+            p.atmos.moisture_model isa NonEquilMoistModel &&
+            p.atmos.precip_model isa Microphysics1Moment
+        )
+            for j in 1:n
+                @. ᶠu³_diff = ᶠu³ʲs.:($$j) - ᶠu³
+
+                @. ᶜa_scalar =
+                    (Y.c.sgsʲs.:($$j).q_liq - ᶜspecific.q_liq) *
+                    draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))
+                vtt = vertical_transport(
+                    ᶜρʲs.:($j),
+                    ᶠu³_diff,
+                    ᶜa_scalar,
+                    dt,
+                    edmfx_sgsflux_upwinding,
+                )
+                @. Yₜ.c.ρq_liq += vtt
+
+                @. ᶜa_scalar =
+                    (Y.c.sgsʲs.:($$j).q_ice - ᶜspecific.q_ice) *
+                    draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))
+                vtt = vertical_transport(
+                    ᶜρʲs.:($j),
+                    ᶠu³_diff,
+                    ᶜa_scalar,
+                    dt,
+                    edmfx_sgsflux_upwinding,
+                )
+                @. Yₜ.c.ρq_ice += vtt
+
+                @. ᶜa_scalar =
+                    (Y.c.sgsʲs.:($$j).q_rai - ᶜspecific.q_rai) *
+                    draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))
+                vtt = vertical_transport(
+                    ᶜρʲs.:($j),
+                    ᶠu³_diff,
+                    ᶜa_scalar,
+                    dt,
+                    edmfx_sgsflux_upwinding,
+                )
+                @. Yₜ.c.ρq_rai += vtt
+
+                @. ᶜa_scalar =
+                    (Y.c.sgsʲs.:($$j).q_sno - ᶜspecific.q_sno) *
+                    draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))
+                vtt = vertical_transport(
+                    ᶜρʲs.:($j),
+                    ᶠu³_diff,
+                    ᶜa_scalar,
+                    dt,
+                    edmfx_sgsflux_upwinding,
+                )
+                @. Yₜ.c.ρq_sno += vtt
+            end
+            @. ᶠu³_diff = ᶠu³⁰ - ᶠu³
+
+            @. ᶜa_scalar = (ᶜq_liq⁰ - ᶜspecific.q_liq) * draft_area(ᶜρa⁰, ᶜρ⁰)
+            vtt = vertical_transport(
+                ᶜρ⁰,
+                ᶠu³_diff,
+                ᶜa_scalar,
+                dt,
+                edmfx_sgsflux_upwinding,
+            )
+            @. Yₜ.c.ρq_liq += vtt
+
+            @. ᶜa_scalar = (ᶜq_ice⁰ - ᶜspecific.q_ice) * draft_area(ᶜρa⁰, ᶜρ⁰)
+            vtt = vertical_transport(
+                ᶜρ⁰,
+                ᶠu³_diff,
+                ᶜa_scalar,
+                dt,
+                edmfx_sgsflux_upwinding,
+            )
+            @. Yₜ.c.ρq_ice += vtt
+
+            @. ᶜa_scalar = (ᶜq_rai⁰ - ᶜspecific.q_rai) * draft_area(ᶜρa⁰, ᶜρ⁰)
+            vtt = vertical_transport(
+                ᶜρ⁰,
+                ᶠu³_diff,
+                ᶜa_scalar,
+                dt,
+                edmfx_sgsflux_upwinding,
+            )
+            @. Yₜ.c.ρq_rai += vtt
+
+            @. ᶜa_scalar = (ᶜq_sno⁰ - ᶜspecific.q_sno) * draft_area(ᶜρa⁰, ᶜρ⁰)
+            vtt = vertical_transport(
+                ᶜρ⁰,
+                ᶠu³_diff,
+                ᶜa_scalar,
+                dt,
+                edmfx_sgsflux_upwinding,
+            )
+            @. Yₜ.c.ρq_sno += vtt
+        end
+        # TODO - compute sedimentation and terminal velocities
+        # TODO - add w q_tot, w h_tot terms
     end
-
-    # TODO: Add tracer flux
-
     return nothing
 end
 
@@ -158,9 +261,6 @@ function edmfx_sgs_mass_flux_tendency!(
             end
         end
     end
-
-    # TODO: Add tracer flux
-
     return nothing
 end
 
@@ -173,12 +273,17 @@ function edmfx_sgs_diffusive_flux_tendency!(
     t,
     turbconv_model::PrognosticEDMFX,
 )
-
     FT = Spaces.undertype(axes(Y.c))
     (; dt, params) = p
     turbconv_params = CAP.turbconv_params(params)
     c_d = CAP.tke_diss_coeff(turbconv_params)
     (; ᶜρa⁰, ᶜu⁰, ᶜK⁰, ᶜmse⁰, ᶜq_tot⁰, ᶜtke⁰, ᶜmixing_length) = p.precomputed
+    if (
+        p.atmos.moisture_model isa NonEquilMoistModel &&
+        p.atmos.precip_model isa Microphysics1Moment
+    )
+        (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
+    end
     (; ᶜK_u, ᶜK_h, ρatke_flux) = p.precomputed
     ᶠgradᵥ = Operators.GradientC2F()
 
@@ -221,6 +326,33 @@ function edmfx_sgs_diffusive_flux_tendency!(
             @. Yₜ.c.ρq_tot -= ᶜρχₜ_diffusion
             @. Yₜ.c.ρ -= ᶜρχₜ_diffusion
         end
+        if (
+            p.atmos.moisture_model isa NonEquilMoistModel &&
+            p.atmos.precip_model isa Microphysics1Moment
+        )
+            α_vert_diff_tracer = CAP.α_vert_diff_tracer(params)
+
+            ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
+            ᶜdivᵥ_ρq = Operators.DivergenceF2C(
+                top = Operators.SetValue(C3(FT(0))),
+                bottom = Operators.SetValue(C3(FT(0))),
+            )
+            @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρq(-(ᶠρaK_h * ᶠgradᵥ(ᶜq_liq⁰)))
+            @. Yₜ.c.ρq_liq -= ᶜρχₜ_diffusion
+
+            @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρq(-(ᶠρaK_h * ᶠgradᵥ(ᶜq_ice⁰)))
+            @. Yₜ.c.ρq_ice -= ᶜρχₜ_diffusion
+
+            # TODO - do I need to change anything in the implicit solver
+            # to include the α_vert_diff_tracer?
+            @. ᶜρχₜ_diffusion =
+                ᶜdivᵥ_ρq(-(ᶠρaK_h * α_vert_diff_tracer * ᶠgradᵥ(ᶜq_rai⁰)))
+            @. Yₜ.c.ρq_rai -= ᶜρχₜ_diffusion
+
+            @. ᶜρχₜ_diffusion =
+                ᶜdivᵥ_ρq(-(ᶠρaK_h * α_vert_diff_tracer * ᶠgradᵥ(ᶜq_sno⁰)))
+            @. Yₜ.c.ρq_sno -= ᶜρχₜ_diffusion
+        end
 
         # momentum
         ᶠstrain_rate = p.scratch.ᶠtemp_UVWxUVW
@@ -228,9 +360,6 @@ function edmfx_sgs_diffusive_flux_tendency!(
         @. ᶠstrain_rate = bc_strain_rate
         @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(-(2 * ᶠρaK_u * ᶠstrain_rate)) / Y.c.ρ)
     end
-
-    # TODO: Add tracer flux
-
     return nothing
 end
 

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -6,13 +6,24 @@ import ClimaCore.Geometry as Geometry
 import ClimaCore.Fields as Fields
 import ClimaCore.Spaces as Spaces
 
-hyperdiffusion_cache(Y, atmos) =
-    hyperdiffusion_cache(Y, atmos.hyperdiff, atmos.turbconv_model)
+hyperdiffusion_cache(Y, atmos) = hyperdiffusion_cache(
+    Y,
+    atmos.hyperdiff,
+    atmos.turbconv_model,
+    atmos.moisture_model,
+    atmos.precip_model,
+)
 
 # No hyperdiffiusion
-hyperdiffusion_cache(Y, hyperdiff::Nothing, _) = (;)
+hyperdiffusion_cache(Y, hyperdiff::Nothing, _, _, _) = (;)
 
-function hyperdiffusion_cache(Y, hyperdiff::ClimaHyperdiffusion, turbconv_model)
+function hyperdiffusion_cache(
+    Y,
+    hyperdiff::ClimaHyperdiffusion,
+    turbconv_model,
+    moisture_model,
+    precip_model,
+)
     quadrature_style =
         Spaces.quadrature_style(Spaces.horizontal_space(axes(Y.c)))
     FT = eltype(Y)
@@ -30,6 +41,16 @@ function hyperdiffusion_cache(Y, hyperdiff::ClimaHyperdiffusion, turbconv_model)
     ᶜ∇²uʲs =
         turbconv_model isa PrognosticEDMFX ? similar(Y.c, NTuple{n, C123{FT}}) :
         (;)
+    moisture_sgs_quantities =
+        turbconv_model isa PrognosticEDMFX &&
+        moisture_model isa NonEquilMoistModel &&
+        precip_model isa Microphysics1Moment ?
+        (;
+            ᶜ∇²q_liqʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜ∇²q_iceʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜ∇²q_raiʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜ∇²q_snoʲs = similar(Y.c, NTuple{n, FT}),
+        ) : (;)
     sgs_quantities =
         turbconv_model isa PrognosticEDMFX ?
         (;
@@ -37,6 +58,7 @@ function hyperdiffusion_cache(Y, hyperdiff::ClimaHyperdiffusion, turbconv_model)
             ᶜ∇²uᵥʲs = similar(Y.c, NTuple{n, C3{FT}}),
             ᶜ∇²mseʲs = similar(Y.c, NTuple{n, FT}),
             ᶜ∇²q_totʲs = similar(Y.c, NTuple{n, FT}),
+            moisture_sgs_quantities...,
         ) : (;)
     maybe_ᶜ∇²tke⁰ =
         use_prognostic_tke(turbconv_model) ? (; ᶜ∇²tke⁰ = similar(Y.c, FT)) :
@@ -196,7 +218,18 @@ function dss_hyperdiffusion_tendency_pairs(p)
     tc_tracer_pairs =
         turbconv_model isa PrognosticEDMFX ?
         (p.hyperdiff.ᶜ∇²q_totʲs => buffer.ᶜ∇²q_totʲs,) : ()
-    tracer_pairs = (core_tracer_pairs..., tc_tracer_pairs...)
+    tc_moisture_pairs =
+        turbconv_model isa PrognosticEDMFX &&
+        p.atmos.moisture_model isa NonEquilMoistModel &&
+        p.atmos.precip_model isa Microphysics1Moment ?
+        (
+            p.hyperdiff.ᶜ∇²q_liqʲs => buffer.ᶜ∇²q_liqʲs,
+            p.hyperdiff.ᶜ∇²q_iceʲs => buffer.ᶜ∇²q_iceʲs,
+            p.hyperdiff.ᶜ∇²q_raiʲs => buffer.ᶜ∇²q_raiʲs,
+            p.hyperdiff.ᶜ∇²q_snoʲs => buffer.ᶜ∇²q_snoʲs,
+        ) : ()
+    tracer_pairs =
+        (core_tracer_pairs..., tc_tracer_pairs..., tc_moisture_pairs...)
     return (dynamics_pairs..., tracer_pairs...)
 end
 
@@ -219,6 +252,17 @@ NVTX.@annotate function prep_tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
         for j in 1:n
             # Note: It is more correct to have ρa inside and outside the divergence
             @. ᶜ∇²q_totʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_tot))
+        end
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            (; ᶜ∇²q_liqʲs, ᶜ∇²q_iceʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs) = p.hyperdiff
+            for j in 1:n
+                # Note: It is more correct to have ρa inside and outside the divergence
+                @. ᶜ∇²q_liqʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_liq))
+                @. ᶜ∇²q_iceʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_ice))
+                @. ᶜ∇²q_raiʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_rai))
+                @. ᶜ∇²q_snoʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_sno))
+            end
         end
     end
     return nothing
@@ -255,12 +299,31 @@ NVTX.@annotate function apply_tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
     end
     if turbconv_model isa PrognosticEDMFX
         (; ᶜ∇²q_totʲs) = p.hyperdiff
+        if p.atmos.moisture_model isa NonEquilMoistModel &&
+           p.atmos.precip_model isa Microphysics1Moment
+            (; ᶜ∇²q_liqʲs, ᶜ∇²q_iceʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs) = p.hyperdiff
+        end
         for j in 1:n
             @. Yₜ.c.sgsʲs.:($$j).ρa -=
                 ν₄_scalar *
                 wdivₕ(Y.c.sgsʲs.:($$j).ρa * gradₕ(ᶜ∇²q_totʲs.:($$j)))
             @. Yₜ.c.sgsʲs.:($$j).q_tot -=
                 ν₄_scalar * wdivₕ(gradₕ(ᶜ∇²q_totʲs.:($$j)))
+            if p.atmos.moisture_model isa NonEquilMoistModel &&
+               p.atmos.precip_model isa Microphysics1Moment
+                @. Yₜ.c.sgsʲs.:($$j).q_liq -=
+                    ν₄_scalar * wdivₕ(gradₕ(ᶜ∇²q_liqʲs.:($$j)))
+                @. Yₜ.c.sgsʲs.:($$j).q_ice -=
+                    ν₄_scalar * wdivₕ(gradₕ(ᶜ∇²q_iceʲs.:($$j)))
+                @. Yₜ.c.sgsʲs.:($$j).q_rai -=
+                    α_hyperdiff_tracer *
+                    ν₄_scalar *
+                    wdivₕ(gradₕ(ᶜ∇²q_raiʲs.:($$j)))
+                @. Yₜ.c.sgsʲs.:($$j).q_sno -=
+                    α_hyperdiff_tracer *
+                    ν₄_scalar *
+                    wdivₕ(gradₕ(ᶜ∇²q_snoʲs.:($$j)))
+            end
         end
     end
     return nothing

--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -267,18 +267,26 @@ function ImplicitEquationJacobian(
 
     end
 
+    sgs_scalar_names = (
+        @name(c.sgsʲs.:(1).q_tot),
+        @name(c.sgsʲs.:(1).q_liq),
+        @name(c.sgsʲs.:(1).q_ice),
+        @name(c.sgsʲs.:(1).q_rai),
+        @name(c.sgsʲs.:(1).q_sno),
+        @name(c.sgsʲs.:(1).mse),
+        @name(c.sgsʲs.:(1).ρa)
+    )
+    available_sgs_scalar_names =
+        MatrixFields.unrolled_filter(is_in_Y, sgs_scalar_names)
+
     sgs_advection_blocks = if atmos.turbconv_model isa PrognosticEDMFX
         @assert n_prognostic_mass_flux_subdomains(atmos.turbconv_model) == 1
-        sgs_scalar_names = (
-            @name(c.sgsʲs.:(1).q_tot),
-            @name(c.sgsʲs.:(1).mse),
-            @name(c.sgsʲs.:(1).ρa)
-        )
+
         if use_derivative(sgs_advection_flag)
             (
                 MatrixFields.unrolled_map(
                     name -> (name, name) => similar(Y.c, TridiagonalRow),
-                    sgs_scalar_names,
+                    available_sgs_scalar_names,
                 )...,
                 (@name(c.sgsʲs.:(1).mse), @name(c.ρ)) =>
                     similar(Y.c, DiagonalRow),
@@ -301,7 +309,7 @@ function ImplicitEquationJacobian(
             (
                 MatrixFields.unrolled_map(
                     name -> (name, name) => FT(-1) * I,
-                    sgs_scalar_names,
+                    available_sgs_scalar_names,
                 )...,
                 (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) =>
                     !isnothing(atmos.rayleigh_sponge) ?
@@ -336,22 +344,19 @@ function ImplicitEquationJacobian(
         sgs_massflux_blocks...,
     )
 
-    sgs_names_if_available = if atmos.turbconv_model isa PrognosticEDMFX
-        (
-            @name(c.sgsʲs.:(1).q_tot),
-            @name(c.sgsʲs.:(1).mse),
-            @name(c.sgsʲs.:(1).ρa),
-            @name(f.sgsʲs.:(1).u₃),
-        )
+    sgs_u³_names_if_available = if atmos.turbconv_model isa PrognosticEDMFX
+        (@name(f.sgsʲs.:(1).u₃),)
     else
         ()
     end
+
     names₁_group₁ = (@name(c.ρ), sfc_if_available...)
     names₁_group₂ = (available_tracer_names..., ρatke_if_available...)
     names₁_group₃ = (@name(c.ρe_tot),)
     names₁ = (
         names₁_group₁...,
-        sgs_names_if_available...,
+        available_sgs_scalar_names...,
+        sgs_u³_names_if_available...,
         names₁_group₂...,
         names₁_group₃...,
     )
@@ -373,6 +378,7 @@ function ImplicitEquationJacobian(
                         ) : (;)
                     (;
                         alg₂ = MatrixFields.BlockLowerTriangularSolve(
+                            # TODO: What needs to be changed here for 1M?
                             @name(c.sgsʲs.:(1).q_tot);
                             alg₂ = MatrixFields.BlockLowerTriangularSolve(
                                 @name(c.sgsʲs.:(1).mse);

--- a/src/utils/variable_manipulations.jl
+++ b/src/utils/variable_manipulations.jl
@@ -212,6 +212,38 @@ mass-flux subdomain states are stored in `sgsʲs`.
 ρaq_tot⁺(sgsʲs) = mapreduce_with_init(sgsʲ -> sgsʲ.ρa * sgsʲ.q_tot, +, sgsʲs)
 
 """
+    ρaq_liq⁺(sgsʲs)
+
+Computes the liquid water mass-flux subdomain area-weighted ρq_liq, assuming that the
+mass-flux subdomain states are stored in `sgsʲs`.
+"""
+ρaq_liq⁺(sgsʲs) = mapreduce_with_init(sgsʲ -> sgsʲ.ρa * sgsʲ.q_liq, +, sgsʲs)
+
+"""
+    ρaq_ice⁺(sgsʲs)
+
+Computes the ice water  mass-flux subdomain area-weighted ρq_ice, assuming that the
+mass-flux subdomain states are stored in `sgsʲs`.
+"""
+ρaq_ice⁺(sgsʲs) = mapreduce_with_init(sgsʲ -> sgsʲ.ρa * sgsʲ.q_ice, +, sgsʲs)
+
+"""
+    ρaq_rai⁺(sgsʲs)
+
+Computes the rain mass-flux subdomain area-weighted ρq_rai, assuming that the
+mass-flux subdomain states are stored in `sgsʲs`.
+"""
+ρaq_rai⁺(sgsʲs) = mapreduce_with_init(sgsʲ -> sgsʲ.ρa * sgsʲ.q_rai, +, sgsʲs)
+
+"""
+    ρaq_sno⁺(sgsʲs)
+
+Computes the snow mass-flux subdomain area-weighted ρq_sno, assuming that the
+mass-flux subdomain states are stored in `sgsʲs`.
+"""
+ρaq_sno⁺(sgsʲs) = mapreduce_with_init(sgsʲ -> sgsʲ.ρa * sgsʲ.q_sno, +, sgsʲs)
+
+"""
     ρa⁰(gs)
 
 Computes the environment area-weighted density, assuming that the mass-flux
@@ -220,7 +252,7 @@ subdomain states are stored in `gs.sgsʲs`.
 ρa⁰(gs) = gs.ρ - mapreduce_with_init(sgsʲ -> sgsʲ.ρa, +, gs.sgsʲs)
 
 """
-    u₃⁺(ρaʲs, u₃ʲs, ρ, u₃, turbconv_model) 
+    u₃⁺(ρaʲs, u₃ʲs, ρ, u₃, turbconv_model)
 
 Computes the average mass-flux subdomain vertical velocity `u₃⁺` by dividing the
 total momentum `ρaw⁺` by the total area-weighted density `ρa⁺`, both of which


### PR DESCRIPTION
@szy21 - This is the code that I have right now that tries to add precipitation to edmf updrafts.

Included:
- Remove `xfail` from EDMF +1M Rico SCM case. Make that case use explicit diffusion for now. Add cloud condensate non-equil and precipitation in the updrafts/environment to diagnostics and CI plots.
- Add additional cached sgs variables:
       - environmental cloud condensate and precipitation: `ᶜq_liq⁰`, `ᶜq_ice⁰`, `ᶜq_rai⁰`, `ᶜq_sno⁰`
       - cloud and precipitation sources in the updrafts and environment: `ᶜSqₗᵖʲs`, `ᶜSqᵢᵖʲs`, `ᶜSqᵣᵖʲs`, `ᶜSqₛᵖʲs`, `ᶜSqₗᵖ⁰`, `ᶜSqᵢᵖ⁰`, `ᶜSqᵣᵖ⁰`, `ᶜSqₛᵖ⁰`
- Create a `TD.PhaseNonEquil_phq` state in the updraft and environment
- Set the `ᶜq_liqʲ_int_val` etc to the grid mean value. (Hacky?)
- Compute `compute_precipitation_sources!`, `compute_precipitation_sinks!`, `cloud_sources` in the updraft and environment.
-  Add `q_tot`, `q_liq`, `q_ice`, `q_rai`, `q_sno` to prognostic EDMF initial conditions.
- Add contributions from updraft and environment to the grid mean cloud and precipitation.
- Add tendencies to `Yₜ.c.sgsʲs.:($$j).q_liq`, `Yₜ.c.sgsʲs.:($$j).q_ice`, `Yₜ.c.sgsʲs.:($$j).q_rai`, `Yₜ.c.sgsʲs.:($$j).q_sno` from:
        - horizontal advection with the mean flow
        - vertical advection with updrafts
        - entrainment/detrainment
        - cloud and precipitation formation
        - diffusion and hyperdiffusion (with the corresponding multiplier for precip tracers to be able to switch it off)
- Add ED and MF contributions to `Yₜ.c.ρq_liq`, `Yₜ.c.ρq_ice`, `Yₜ.c.ρq_rai`, `Yₜ.c.ρq_sno`

Things left to do in the next PR:
- Add cloud and precipitation sedimentation
- Working TRMM SCM
- Add `∂ᶜqʲ_err_∂ᶜqʲ` to implicit solver Jacobian, following what was done for `c.sgsʲs.:(1).q_tot` for vertical advection and entrainment/detrainment. More terms?
