### PR TITLE
Add option to restart from a non zero t and bump to 0.29.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,15 @@ ClimaAtmos.jl Release Notes
 main
 -------
 
+v0.29.1
+-------
+
+### Add support for non-zero `t_start`
+
+Passing a non zero `t_start` is useful in conditions where one wants to have a
+specific `start_date`, but start the simulation from a different point. This is
+used by `ClimaCoupler` to restart simulations.
+
 v0.29.0
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.29.0"
+version = "0.29.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -123,6 +123,9 @@ FLOAT_TYPE:
 dt:
   help: "Simulation time step. Examples: [`10secs`, `1hours`]"
   value: "600secs"
+t_start:
+  help: "Simulation start time. This is typically useful in the context of manually restarting a simulation (e.g., but reinitializing the initial state). It is overwritten when the simulation is restarted with the checkpointing system. Examples: [`0secs`, `40secs`]"
+  value: "0secs"
 t_end:
   help: "Simulation end time. Examples: [`1200days`, `40secs`]"
   value: "10days"

--- a/docs/src/restarts.md
+++ b/docs/src/restarts.md
@@ -47,6 +47,12 @@ is started.
 If is also possible to manually specify a restart file. In this case, this will
 override any file automatically detected.
 
+`ClimaAtmos` also comes with a configuration,` t_start`, to change the initial
+time of the simulation without changing the start date. This option can be
+useful manually restarting a simulation (e.g., by overwriting the initial
+conditions). When a simulation is restarted from a checkpoint, this option
+becomes redundant.
+
 ### Accumulated Diagnostics
 
 At the moment, `ClimaAtmos` does not support working with accumulated

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -290,7 +290,7 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
 
     set_surface_albedo!(Y, p, t, p.atmos.surface_albedo)
 
-    RRTMGPI.update_fluxes!(rrtmgp_model, UInt32(t / integrator.p.dt))
+    RRTMGPI.update_fluxes!(rrtmgp_model, UInt32(floor(t / integrator.p.dt)))
     Fields.field2array(ᶠradiation_flux) .= rrtmgp_model.face_flux
     return nothing
 end

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -1,14 +1,6 @@
-function get_diagnostics(
-    parsed_args,
-    atmos_model,
-    Y,
-    p,
-    sim_info,
-    t_start,
-    output_dir,
-)
+function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, output_dir)
 
-    (; dt, start_date) = sim_info
+    (; dt, t_start, start_date) = sim_info
 
     FT = Spaces.undertype(axes(Y.c))
     context = ClimaComms.context(axes(Y.c))
@@ -249,16 +241,16 @@ function checkpoint_frequency_from_parsed_args(dt_save_state_to_disk::String)
 end
 
 
-function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
+function get_callbacks(config, sim_info, atmos, params, Y, p)
     (; parsed_args, comms_ctx) = config
     FT = eltype(params)
-    (; dt, output_dir, start_date) = sim_info
+    (; dt, output_dir, start_date, t_start, t_end) = sim_info
 
     callbacks = ()
     if parsed_args["log_progress"]
         @info "Progress logging enabled"
         walltime_info = WallTimeInfo()
-        tot_steps = ceil(Int, (sim_info.t_end - t_start) / dt)
+        tot_steps = ceil(Int, (t_end - t_start) / dt)
         five_percent_steps = ceil(Int, 0.05 * tot_steps)
         cond = let schedule = CappedGeometricSeriesSchedule(five_percent_steps)
             (u, t, integrator) -> schedule(integrator)
@@ -340,7 +332,7 @@ function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
             dt isa ITime ?
             ITime(time_to_seconds(parsed_args["dt_cloud_fraction"])) :
             FT(time_to_seconds(parsed_args["dt_cloud_fraction"]))
-        dt_cf, _, _, _ = promote(dt_cf, t_start, dt, sim_info.t_end)
+        dt_cf, _, _, _ = promote(dt_cf, t_start, dt, t_end)
         callbacks =
             (callbacks..., call_every_dt(cloud_fraction_model_callback!, dt_cf))
     end
@@ -349,7 +341,7 @@ function get_callbacks(config, sim_info, atmos, params, Y, p, t_start)
         dt_rad =
             dt isa ITime ? ITime(time_to_seconds(parsed_args["dt_rad"])) :
             FT(time_to_seconds(parsed_args["dt_rad"]))
-        dt_rad, _, _, _ = promote(dt_rad, t_start, dt, sim_info.t_end)
+        dt_rad, _, _, _ = promote(dt_rad, t_start, dt, t_end)
         # We use Millisecond to support fractional seconds, eg. 0.1
         dt_rad_ms = Dates.Millisecond(1_000 * float(dt_rad))
         if parsed_args["dt_save_state_to_disk"] != "Inf" &&

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -213,6 +213,8 @@ end
     # Verify that using PrescribedSurface does not break the initialization of
     # RRTMGP or diagnostic EDMF. We currently need a moisture model in order to
     # use diagnostic EDMF.
+    #
+    # Also verify we can start with a different t_start than 0
     config = CA.AtmosConfig(
         Dict(
             "surface_setup" => "PrescribedSurface",
@@ -225,6 +227,7 @@ end
             # remove the following line and check that the test runs in less than a few
             # minutes on GitHub
             "output_default_diagnostics" => false,
+            "t_start" => "1secs",
         );
         job_id = "coupler_compatibility3",
     )


### PR DESCRIPTION
ClimaCoupler handles restarts in its own way, but it was not possible to start a simulation from a `t_start` that is not zero without using the ClimaAtmos restart system. This commit adds this option and moves `t_start` inside `sim_info` for symmetry with `t_end` and `dt`.
