### PR TITLE
Surface cloud sedimentation included in precipitation fluxes

### DIFF
--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -334,7 +334,7 @@ function set_precipitation_surface_fluxes!(
 )
     (; surface_rain_flux, surface_snow_flux) = p.precomputed
     (; col_integrated_precip_energy_tendency,) = p.conservation_check
-    (; ᶜwᵣ, ᶜwₛ, ᶜspecific) = p.precomputed
+    (; ᶜwᵣ, ᶜwₛ, ᶜwₗ, ᶜwᵢ, ᶜspecific) = p.precomputed
     ᶜJ = Fields.local_geometry_field(Y.c).J
     ᶠJ = Fields.local_geometry_field(Y.f).J
     sfc_J = Fields.level(ᶠJ, Fields.half)
@@ -355,10 +355,20 @@ function set_precipitation_surface_fluxes!(
         Fields.field_values(Fields.level(ᶜspecific.q_sno, 1)),
         sfc_space,
     )
+    sfc_qₗ = Fields.Field(
+        Fields.field_values(Fields.level(ᶜspecific.q_liq, 1)),
+        sfc_space,
+    )
+    sfc_qᵢ = Fields.Field(
+        Fields.field_values(Fields.level(ᶜspecific.q_ice, 1)),
+        sfc_space,
+    )
     sfc_wᵣ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵣ, 1)), sfc_space)
     sfc_wₛ = Fields.Field(Fields.field_values(Fields.level(ᶜwₛ, 1)), sfc_space)
+    sfc_wₗ = Fields.Field(Fields.field_values(Fields.level(ᶜwₗ, 1)), sfc_space)
+    sfc_wᵢ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵢ, 1)), sfc_space)
 
-    @. surface_rain_flux = sfc_ρ * sfc_qᵣ * (-sfc_wᵣ)
-    @. surface_snow_flux = sfc_ρ * sfc_qₛ * (-sfc_wₛ)
+    @. surface_rain_flux = sfc_ρ * (sfc_qᵣ * (-sfc_wᵣ) + sfc_qₗ * (-sfc_wₗ))
+    @. surface_snow_flux = sfc_ρ * (sfc_qₛ * (-sfc_wₛ) + sfc_qᵢ * (-sfc_wᵢ))
     return nothing
 end


### PR DESCRIPTION
This PR:
- adds the contribution from sedimenting cloud condensate to `surface_rain_flux` and `surface_snow_flux` for the 1M microphysics. I would prefer to keep the names the same even though now they contain both precipitation and cloud fluxes. It's a slow process to change it in both Coupler and Atmos.
