### PR TITLE
Remove dt_save_to_sol

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaAtmos.jl Release Notes
 main
 -------
 
+### Remove `dt_save_to_sol`
+
+The option to save the solution to the integrator object (`dt_save_to_sol`) was
+removed from the configurable options.
+
 v0.29.1
 -------
 

--- a/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
@@ -31,7 +31,6 @@ perturb_initstate: false
 dt: "10secs"
 dt_rad: "30mins"
 t_end: "72hours"
-dt_save_to_disk: "10mins"
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage : true
 toml: [scm_tomls/prognostic_edmfx.toml]

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -166,9 +166,6 @@ test_dycore_consistency:
 dt_save_state_to_disk:
   help: "Time between saving the state to disk. Examples: [`10secs`, `1hours`, `1months`, `Inf` (do not save)]"
   value: "Inf"
-dt_save_to_sol:
-  help: "Time between saving solution. Examples: [`10days`, `1hours`, `Inf` (do not save)]"
-  value: "1days"
 moist:
   help: "Moisture model [`dry` (default), `equil`, `nonequil`]"
   value: "dry"

--- a/config/gpu_configs/baroclinic_wave_helem30.yml
+++ b/config/gpu_configs/baroclinic_wave_helem30.yml
@@ -4,7 +4,6 @@ dz_bottom: 30.0
 t_end: "1days"
 dt: "90secs"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false
 initial_condition: "DryBaroclinicWave"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: 12hours
-dt_save_to_sol: 12hours
 h_elem: 30
 z_max: 60000.0
 z_elem: 63

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 30
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 h_elem: 16
 z_max: 60000.0
 z_elem: 63

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 30
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 42
 z_max: 60000.0

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -1,5 +1,4 @@
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 h_elem: 60
 z_max: 60000.0

--- a/config/gpu_configs/held_suarez_equil_helem30.yml
+++ b/config/gpu_configs/held_suarez_equil_helem30.yml
@@ -7,7 +7,6 @@ viscous_sponge: true
 dt: "90secs"
 t_end: "1days"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 output_default_diagnostics: false
 moist: "equil"
 vert_diff: true

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ss.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_120_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_170_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_170_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ss.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_240_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ss.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_30_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_340_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_340_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_42_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_42_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_480_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_480_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ss.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ss.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_60_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/mbw_scaling_configs/moist_baroclinic_wave_helem_84_0M_ws.yml
+++ b/config/mbw_scaling_configs/moist_baroclinic_wave_helem_84_0M_ws.yml
@@ -8,6 +8,5 @@ initial_condition: "MoistBaroclinicWave"
 moist: "equil"
 precip_model: "0M"
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 disable_surface_flux_tendency: true
 output_default_diagnostics: false

--- a/config/model_configs/single_column_hydrostatic_balance_ft64.yml
+++ b/config/model_configs/single_column_hydrostatic_balance_ft64.yml
@@ -9,4 +9,3 @@ disable_surface_flux_tendency: true
 dt: "3hours"
 FLOAT_TYPE: "Float64"
 reproducibility_test: true
-dt_save_to_sol: "3hours"

--- a/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_allsky_idealized_clouds.yml
@@ -11,7 +11,6 @@ t_end: "654days"
 idealized_clouds: true
 config: "column"
 insolation: "timevarying"
-dt_save_to_sol: "30hours"
 disable_surface_flux_tendency: true
 rad: "allskywithclear"
 diagnostics:

--- a/config/model_configs/single_column_radiative_equilibrium_clearsky.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_clearsky.yml
@@ -9,6 +9,5 @@ dt_rad: "3hours"
 idealized_h2o: true
 t_end: "654days"
 config: "column"
-dt_save_to_sol: "30hours"
 disable_surface_flux_tendency: true
 rad: "clearsky"

--- a/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
@@ -9,7 +9,6 @@ initial_condition: "IsothermalProfile"
 t_end: "654days"
 dt: "3hours"
 dt_rad: "3hours"
-dt_save_to_sol: "30hours"
 dt_save_state_to_disk: "100days"
 disable_surface_flux_tendency: true
 prognostic_surface: true

--- a/config/model_configs/single_column_radiative_equilibrium_gray.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_gray.yml
@@ -9,7 +9,6 @@ dt_rad: "3hours"
 t_end: "654days"
 dz_bottom: 30.0
 config: "column"
-dt_save_to_sol: "30hours"
 disable_surface_flux_tendency: true
 rad: "gray"
 # [2, 2, 80] instead of [1, 1, 80] because Julia ranges are inclusive of the

--- a/config/model_configs/test_env.yml
+++ b/config/model_configs/test_env.yml
@@ -5,7 +5,6 @@ rad: "allskywithclear"
 precip_model: "0M"
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 z_elem: 20
 h_elem: 8
 dt_rad: "5secs"

--- a/config/perf_configs/bm_aquaplanet_diagedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_diagedmf.yml
@@ -3,7 +3,6 @@ z_elem: 25
 dt: 90secs
 t_end: 61mins
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 log_progress: false
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -3,7 +3,6 @@ z_elem: 25
 dt: 10secs
 t_end: 61mins
 dt_save_state_to_disk: "Inf"
-dt_save_to_sol: "Inf"
 log_progress: false
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/perf_configs/bm_baroclinic_wave_moist.yml
+++ b/config/perf_configs/bm_baroclinic_wave_moist.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "1mins"
-dt_save_to_sol: "Inf"
 log_progress: false
 moist: "equil"
 initial_condition: "MoistBaroclinicWave"

--- a/config/perf_configs/bm_callbacks.yml
+++ b/config/perf_configs/bm_callbacks.yml
@@ -5,7 +5,6 @@ dt: "1secs"
 dt_rad: "1secs"
 dt_cloud_fraction: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 dt_save_state_to_disk: "1secs"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_default.yml
+++ b/config/perf_configs/bm_default.yml
@@ -2,7 +2,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_default_1m.yml
+++ b/config/perf_configs/bm_default_1m.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_diagnostics.yml
+++ b/config/perf_configs/bm_diagnostics.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_diffusion.yml
+++ b/config/perf_configs/bm_diffusion.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/perf_configs/bm_gravity_wave.yml
+++ b/config/perf_configs/bm_gravity_wave.yml
@@ -3,7 +3,6 @@ h_elem: 12
 z_elem: 25
 dt: "1secs"
 t_end: "10secs"
-dt_save_to_sol: "Inf"
 log_progress: false
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/docs/src/radiative_equilibrium.md
+++ b/docs/src/radiative_equilibrium.md
@@ -21,7 +21,6 @@ z_elem: 70
 dz_bottom: 100 
 t_end: "654days" 
 dt: "3hours" 
-dt_save_to_sol: "30hours" 
 dt_save_state_to_disk: "100days" 
 prognostic_surface: true
 job_id: "single_column_radiative_equilibrium_clearsky_prognostic_surface_temp"


### PR DESCRIPTION
`dt_save_to_sol` copies the state to `integrator.sol`. For long simulations, this can be an expensive and unnecessary operation.

This used to be more useful in the past (before diagnostics were a thing), but now it is only used for conservation checks.

This commit removes the option from the configurable options.

This is a breaking change.

Closes #3704 