### PR TITLE
Add updraft rho*a and u_3  jacobian terms in implicit solver

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-225
+226
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+
+226
+- Add updraft rho*a and u_{3,m} jacobian terms
 
 225
 - Move nonhydrostatic pressure drag calculation to precomputed quantities and 


### PR DESCRIPTION
Add leading jacobian contributions from updraft  rho*a and u_{3} to grid-mean ρe_tot and ρq_tot