### PR TITLE
Fix broken downgrade test

### DIFF
--- a/config/model_configs/single_column_precipitation_test.yml
+++ b/config/model_configs/single_column_precipitation_test.yml
@@ -19,5 +19,5 @@ toml: [toml/single_column_precipitation_test.toml]
 diagnostics:
   - short_name: [hus, clw, cli, husra, hussn, ta, wa]
     period: 500secs
-  - short_name: [pr, ]
+  - short_name: [pr]
     period: 10secs


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fixes the [broken downgrade test](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/13974091895/job/39123240375). 
## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
This was caused by a trailing comma in a YAML file `[pr, ]` which resulted in an error on an old version of YAML.jl (v0.4.0).
Maybe we should add a YAML formatter/linter.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
