### PR TITLE
Fix name identifier for scaled diff in implicit solver

### DIFF
--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -781,7 +781,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
             ∂ᶜρq_err_∂ᶜρ = matrix[ρq_name, @name(c.ρ)]
             ∂ᶜρq_err_∂ᶜρq = matrix[ρq_name, ρq_name]
             ᶜtridiagonal_matrix_scalar = ifelse(
-                q_name in (:q_rai, :q_sno),
+                q_name in (@name(q_rai), @name(q_sno)),
                 ᶜdiffusion_h_matrix_scaled,
                 ᶜdiffusion_h_matrix,
             )

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -52,7 +52,7 @@ function vertical_diffusion_boundary_layer_tendency!(
             bottom = Operators.SetValue(C3(FT(0))),
         )
         @. ᶜρχₜ_diffusion =
-            ᶜdivᵥ_ρχ(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜχ)))
+            ᶜdivᵥ_ρχ(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h_scaled) * ᶠgradᵥ(ᶜχ)))
         @. ᶜρχₜ -= ᶜρχₜ_diffusion
         @. Yₜ.c.ρ -= ᶜρχₜ_diffusion
     end


### PR DESCRIPTION
Uses `@name` to get identifiers for tracers when scaling diffusion. 

Also, fixes usage of scaled coeff in vertical boundary layer diffusion tendency (Thanks @trontrytel !). 


