### PR TITLE
add reproducibility test for prognostic edmf

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -785,9 +785,14 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_implicit_column.yml
           --job_id prognostic_edmfx_bomex_column_implicit
+
+          julia --color=yes --project=.buildkite reproducibility_tests/test_mse.jl
+          --job_id prognostic_edmfx_bomex_column_implicit
+          --out_dir prognostic_edmfx_bomex_column_implicit/output_active
         artifact_paths: "prognostic_edmfx_bomex_column_implicit/output_active/*"
         agents:
           slurm_mem: 20GB
+          slurm_constraint: icelake|cascadelake|skylake|epyc
 
       - label: ":genie: Prognostic EDMFX Dycoms RF01 in a column"
         command: >
@@ -851,9 +856,14 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/prognostic_edmfx_aquaplanet.yml
           --job_id prognostic_edmfx_aquaplanet
+
+          julia --color=yes --project=.buildkite reproducibility_tests/test_mse.jl
+          --job_id prognostic_edmfx_aquaplanet
+          --out_dir prognostic_edmfx_aquaplanet/output_active
         artifact_paths: "prognostic_edmfx_aquaplanet/output_active/*"
         agents:
           slurm_mem: 20GB
+          slurm_constraint: icelake|cascadelake|skylake|epyc
 
   - group: "GPU"
     steps:

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -1,4 +1,4 @@
-# This jobs takes too long so we use a lower top and coarser vertical resolution
+# This job takes too long so we use a lower top and coarser vertical resolution
 # z_max: 60000.0
 # z_elem: 31
 # dz_bottom: 50.0
@@ -15,6 +15,14 @@ edmfx_nh_pressure: true
 edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
+implicit_diffusion: true
+implicit_sgs_advection: true
+# This job crashes when setting the following to true. There is potentially a bug.
+# implicit_sgs_entr_detr: true
+# implicit_sgs_nh_pressure: true
+# implicit_sgs_mass_flux: true
+approximate_linear_solve_iters: 2
+max_newton_iters_ode: 3
 moist: equil
 cloud_model: "quadrature_sgs"
 precip_model: 0M
@@ -23,6 +31,7 @@ t_end: 1hours
 dt_save_state_to_disk: 600secs
 toml: [toml/prognostic_edmfx.toml]
 output_default_diagnostics: false
+reproducibility_test: true
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
     reduction_time: average

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -31,6 +31,7 @@ perturb_initstate: false
 dt: "50secs"
 t_end: "6hours"
 dt_save_state_to_disk: "10mins"
+reproducibility_test: true
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
 diagnostics:

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-222
+223
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+
+223
+- Add some more jobs for reproductibility tests
+
 222
 - We don't know why, but aquaplanet_nonequil_allsky_gw_res and aquaplanet_equil_allsky_gw_raw_zonalasym
   seemed to not produce the same result between the merge-queue branch and the main branch.

--- a/reproducibility_tests/reproducibility_test_job_ids.jl
+++ b/reproducibility_tests/reproducibility_test_job_ids.jl
@@ -5,4 +5,6 @@ reproducibility_test_job_ids() = [
     "aquaplanet_equil_allsky_gw_raw_zonalasym",
     "diagnostic_edmfx_aquaplanet",
     "single_column_hydrostatic_balance_ft64",
+    "prognostic_edmfx_bomex_column_implicit",
+    "prognostic_edmfx_aquaplanet",
 ]

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -519,6 +519,7 @@ Base.@kwdef struct AtmosModel{
     DM,
     SAM,
     SEDM,
+    SNPM,
     SMM,
     VS,
     SL,
@@ -559,7 +560,7 @@ Base.@kwdef struct AtmosModel{
     """sgs_entr_detr_mode == Implicit() only works if sgs_adv_mode == Implicit()"""
     sgs_entr_detr_mode::SEDM = nothing
     """sgs_nh_pressure_mode == Implicit() only works if sgs_adv_mode == Implicit()"""
-    sgs_nh_pressure_mode::SEDM = nothing
+    sgs_nh_pressure_mode::SNPM = nothing
     """sgs_mf_mode == Implicit() only works if sgs_adv_mode == Implicit() and diff_mode == Implicit()"""
     sgs_mf_mode::SMM = nothing
     viscous_sponge::VS = nothing

--- a/toml/prognostic_edmfx.toml
+++ b/toml/prognostic_edmfx.toml
@@ -44,4 +44,4 @@ value = 0
 value = 40.0
 
 [precipitation_timescale]
-value = 10
+value = 100


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I added two prognostic edmf jobs to reproducibility tests because the aquaplanet one crashes when setting everything implicit. Therefore I added implicit bomex and explicit aquaplanet. I think there is a bug somewhere and I will look into it.

Also fixes a typo in the type of `sgs_nh_pressure_mode`

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
