### PR TITLE
add a config file for gpu prognostic_edmfx_aquaplanet

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -973,7 +973,7 @@ steps:
       - label: "GPU: Prognostic EDMFX aquaplanet"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
-          --config_file $CONFIG_PATH/prognostic_edmfx_aquaplanet.yml
+          --config_file $CONFIG_PATH/prognostic_edmfx_aquaplanet_gpu.yml
           --job_id prognostic_edmfx_aquaplanet_gpu
         artifact_paths: "prognostic_edmfx_aquaplanet_gpu/output_active/*"
         env:

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -1,0 +1,41 @@
+# This job takes too long so we use a lower top and coarser vertical resolution
+# z_max: 60000.0
+# z_elem: 31
+# dz_bottom: 50.0
+# rayleigh_sponge: true
+surface_setup: DefaultMoninObukhov
+rad: clearsky
+co2_model: fixed
+turbconv: prognostic_edmfx
+prognostic_tke: true
+edmfx_upwinding: first_order
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_nh_pressure: true
+edmfx_filter: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+implicit_diffusion: true
+implicit_sgs_advection: true
+# This job crashes when setting the following to true. There is potentially a bug.
+# implicit_sgs_entr_detr: true
+# implicit_sgs_nh_pressure: true
+# implicit_sgs_mass_flux: true
+approximate_linear_solve_iters: 2
+max_newton_iters_ode: 3
+moist: equil
+cloud_model: "quadrature_sgs"
+precip_model: 0M
+dt: 10secs
+t_end: 1hours
+dt_save_state_to_disk: 600secs
+toml: [toml/prognostic_edmfx.toml]
+output_default_diagnostics: false
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hfes, hur, hus, cl, clw, cli, evspsbl, pr, rsd, rsu, rld, rlu]
+    reduction_time: average
+    period: 1hours
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+    reduction_time: average
+    period: 1hours
+use_itime: true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
GPU and CPU prognostic_edmfx_aquaplanet used the same config before, but I added the reproducibility test for CPU in #3729. This causes issues in the GPU test: https://buildkite.com/clima/climaatmos-ci/builds/23586#0195b82f-5cc0-4b5c-af3e-8b7b266c1ce0, so I add a separate config file for the GPU one.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
