### PR TITLE
Fix Jacobian for zero_velocity_tendency

### DIFF
--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -550,10 +550,10 @@ NVTX.@annotate function Wfact!(A, Y, p, dtγ, t)
     dtγ′ = FT(float(dtγ))
 
     A.dtγ_ref[] = dtγ′
-    update_implicit_equation_jacobian!(A, Y, p′, dtγ′)
+    update_implicit_equation_jacobian!(A, Y, p′, dtγ′, t)
 end
 
-function update_implicit_equation_jacobian!(A, Y, p, dtγ)
+function update_implicit_equation_jacobian!(A, Y, p, dtγ, t)
     dtγ = float(dtγ)
     (;
         matrix,
@@ -1148,4 +1148,7 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ)
                 ) - (I_u₃,)
         end
     end
+
+    # NOTE: All velocity tendency derivatives should be set BEFORE this call.
+    zero_velocity_jacobian!(matrix, Y, p, t)
 end

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -46,7 +46,7 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
     # NOTE: All ρa tendencies should be applied before calling this function
     pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
-    # NOTE: This will zero out all monmentum tendencies in the edmfx advection test
+    # NOTE: This will zero out all momentum tendencies in the edmfx advection test
     # please DO NOT add additional velocity tendencies after this function
     zero_velocity_tendency!(Yₜ, Y, p, t)
 

--- a/src/prognostic_equations/zero_velocity.jl
+++ b/src/prognostic_equations/zero_velocity.jl
@@ -1,20 +1,49 @@
+import ClimaCore: MatrixFields
+import LinearAlgebra: UniformScaling
+
 ###
 ### edmfx advection test 
 ###
 
+# Turn off all momentum tendencies in the advection test.
 function zero_velocity_tendency!(Yₜ, Y, p, t)
-    # turn off all monmentum tendencies in the advection test
-    if p.atmos.advection_test
-        FT = eltype(Y)
-        n = n_mass_flux_subdomains(p.atmos.turbconv_model)
-
-        @. Yₜ.c.uₕ = C12(FT(0), FT(0))
-        @. Yₜ.f.u₃ = Geometry.Covariant3Vector(FT(0))
-        if p.atmos.turbconv_model isa PrognosticEDMFX
-            for j in 1:n
-                @. Yₜ.f.sgsʲs.:($$j).u₃ = Geometry.Covariant3Vector(FT(0))
-            end
+    p.atmos.advection_test || return nothing
+    @. Yₜ.c.uₕ = C12(0, 0)
+    @. Yₜ.f.u₃ = C3(0)
+    if p.atmos.turbconv_model isa PrognosticEDMFX
+        for j in 1:n_mass_flux_subdomains(p.atmos.turbconv_model)
+            @. Yₜ.f.sgsʲs.:($$j).u₃ = C3(0)
         end
     end
     return nothing
+end
+
+# Turn off all momentum tendency derivatives in the advection test.
+function zero_velocity_jacobian!(∂Yₜ_err_∂Y, Y, p, t)
+    p.atmos.advection_test || return nothing
+    for ((row_name, col_name), matrix_entry) in pairs(∂Yₜ_err_∂Y)
+        matrix_entry isa Fields.Field || continue
+        if row_name in (MatrixFields.@name(c.uₕ), MatrixFields.@name(f.u₃))
+            set_identity_matrix_entry!(matrix_entry, row_name, col_name)
+        end
+        if p.atmos.turbconv_model isa PrognosticEDMFX
+            for j in 1:n_mass_flux_subdomains(p.atmos.turbconv_model)
+                if row_name == MatrixFields.FieldName(:f, :sgsʲs, j, :u₃)
+                    set_identity_matrix_entry!(matrix_entry, row_name, col_name)
+                end
+            end
+        end
+    end
+end
+
+function set_identity_matrix_entry!(matrix_entry, row_name, col_name)
+    identity_matrix_entry_value = if row_name == col_name
+        # TODO: Add a method for one(::Axis2Tensor) to simplify this.
+        T = eltype(eltype(matrix_entry))
+        tensor_data = UniformScaling(one(eltype(T)))
+        -DiagonalMatrixRow(Geometry.AxisTensor(axes(T), tensor_data))
+    else
+        zero(eltype(matrix_entry))
+    end
+    matrix_entry .= (identity_matrix_entry_value,)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
We are currently using `zero_velocity_tendency!` in the EDMFX (prospct) advection test's tendency, but we are not making any corresponding update to the Jacobian. This PR adds a `zero_velocity_jacobian!` function that zeros out the corresponding Jacobian blocks.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
