### PR TITLE
Separate buoyancy and drag terms in edmf pressure closure

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -319,7 +319,8 @@ implicit_sgs_entr_detr:
   help: "Whether to treat the subgrid-scale entrainment and detrainment tendency implicitly [`false` (default), `true`]. Setting it to true only works if implicit_sgs_advection is set to true."
   value: false
 implicit_sgs_nh_pressure:
-  help: "Whether to treat the subgrid-scale nonhydrostatic pressure drag tendency implicitly [`false` (default), `true`]. Setting it to true only works if implicit_sgs_advection is set to true."
+  help: "Whether to treat the subgrid-scale nonhydrostatic pressure closure implicitly [`false` (default), `true`]. Setting it to true only works if implicit_sgs_advection is set to true.
+  This flag only controls whether the drag term in the pressure closure is treated implicitly. The buoyancy term is always treated explicitly."
   value: false
 implicit_sgs_mass_flux:
   help: "Whether to treat the subgrid-scale mass flux tendency implicitly or explicitly in grid-mean equations. Currently updraft only with Jacobian terms 0. [`false` (default), `true`]. Setting it to true only works if both implicit_sgs_advection and implicit_diffusion are set to true."

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-227
+228
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+
+228
+- Only treat the drag term in edmf pressure closure implicitly
 
 227
 - Move nonhydrostatic pressure drag calculation to implicit precomputed quantities

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -83,7 +83,7 @@ function implicit_precomputed_quantities(Y, atmos)
             ᶠKᵥʲs = similar(Y.f, NTuple{n, FT}),
             ᶜtsʲs = similar(Y.c, NTuple{n, TST}),
             ᶜρʲs = similar(Y.c, NTuple{n, FT}),
-            ᶠnh_pressure₃ʲs = similar(Y.f, NTuple{n, C3{FT}}),
+            ᶠnh_pressure₃_dragʲs = similar(Y.f, NTuple{n, C3{FT}}),
             moisture_sgs_quantities...,
         ) : (;)
     return (; gs_quantities..., sgs_quantities..., prognostic_sgs_quantities...)
@@ -172,6 +172,7 @@ function precomputed_quantities(Y, atmos)
             ᶜgradᵥ_θ_virt⁰ = Fields.Field(C3{FT}, cspace),
             ᶜgradᵥ_q_tot⁰ = Fields.Field(C3{FT}, cspace),
             ᶜgradᵥ_θ_liq_ice⁰ = Fields.Field(C3{FT}, cspace),
+            ᶠnh_pressure₃_buoyʲs = similar(Y.f, NTuple{n, C3{FT}}),
             precipitation_sgs_quantities...,
         ) : (;)
 
@@ -205,7 +206,8 @@ function precomputed_quantities(Y, atmos)
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜturb_entrʲs = similar(Y.c, NTuple{n, FT}),
-            ᶠnh_pressure³ʲs = similar(Y.f, NTuple{n, CT3{FT}}),
+            ᶠnh_pressure³_buoyʲs = similar(Y.f, NTuple{n, CT3{FT}}),
+            ᶠnh_pressure³_dragʲs = similar(Y.f, NTuple{n, CT3{FT}}),
             ᶠu³⁰ = similar(Y.f, CT3{FT}),
             ᶜu⁰ = similar(Y.c, C123{FT}),
             ᶜK⁰ = similar(Y.c, FT),

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -325,26 +325,22 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_implicit_clos
     (; params) = p
     n = n_mass_flux_subdomains(turbconv_model)
 
-    (; ᶠgradᵥ_ᶜΦ) = p.core
-    (; ᶠu₃⁰, ᶜρʲs, ᶠnh_pressure₃ʲs) = p.precomputed
+    (; ᶠu₃⁰, ᶠnh_pressure₃_dragʲs) = p.precomputed
     ᶠlg = Fields.local_geometry_field(Y.f)
 
     scale_height = CAP.R_d(params) * CAP.T_surf_ref(params) / CAP.grav(params)
+    # nonhydrostatic pressure closure drag term
     for j in 1:n
-        # nonhydrostatic pressure drag
-        for j in 1:n
-            if p.atmos.edmfx_model.nh_pressure isa Val{true}
-                @. ᶠnh_pressure₃ʲs.:($$j) = ᶠupdraft_nh_pressure(
-                    params,
-                    ᶠlg,
-                    ᶠbuoyancy(ᶠinterp(Y.c.ρ), ᶠinterp(ᶜρʲs.:($$j)), ᶠgradᵥ_ᶜΦ),
-                    Y.f.sgsʲs.:($$j).u₃,
-                    ᶠu₃⁰,
-                    scale_height,
-                )
-            else
-                @. ᶠnh_pressure₃ʲs.:($$j) = C3(0)
-            end
+        if p.atmos.edmfx_model.nh_pressure isa Val{true}
+            @. ᶠnh_pressure₃_dragʲs.:($$j) = ᶠupdraft_nh_pressure_drag(
+                params,
+                ᶠlg,
+                Y.f.sgsʲs.:($$j).u₃,
+                ᶠu₃⁰,
+                scale_height,
+            )
+        else
+            @. ᶠnh_pressure₃_dragʲs.:($$j) = C3(0)
         end
     end
 
@@ -367,6 +363,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
 
     (; params) = p
     (; dt) = p
+    (; ᶠgradᵥ_ᶜΦ) = p.core
     thermo_params = CAP.thermodynamics_params(params)
     turbconv_params = CAP.turbconv_params(params)
 
@@ -383,7 +380,16 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
         ᶜK_h,
         ρatke_flux,
     ) = p.precomputed
-    (; ᶜuʲs, ᶜtsʲs, ᶠu³ʲs, ᶜρʲs, ᶜentrʲs, ᶜdetrʲs, ᶜturb_entrʲs) = p.precomputed
+    (;
+        ᶜuʲs,
+        ᶜtsʲs,
+        ᶠu³ʲs,
+        ᶜρʲs,
+        ᶜentrʲs,
+        ᶜdetrʲs,
+        ᶜturb_entrʲs,
+        ᶠnh_pressure₃_buoyʲs,
+    ) = p.precomputed
     (; ustar, obukhov_length) = p.precomputed.sfc_conditions
 
     ᶜz = Fields.coordinate_field(Y.c).z
@@ -461,6 +467,16 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
             dt,
         )
+
+        # nonhydrostatic pressure closure buoyancy term
+        if p.atmos.edmfx_model.nh_pressure isa Val{true}
+            @. ᶠnh_pressure₃_buoyʲs.:($$j) = ᶠupdraft_nh_pressure_buoyancy(
+                params,
+                ᶠbuoyancy(ᶠinterp(Y.c.ρ), ᶠinterp(ᶜρʲs.:($$j)), ᶠgradᵥ_ᶜΦ),
+            )
+        else
+            @. ᶠnh_pressure₃_buoyʲs.:($$j) = C3(0)
+        end
     end
 
     (; ᶜgradᵥ_θ_virt⁰, ᶜgradᵥ_q_tot⁰, ᶜgradᵥ_θ_liq_ice⁰) = p.precomputed

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -26,9 +26,12 @@ function edmfx_tke_tendency!(
     (; ᶠu³⁰, ᶠu³, ᶜstrain_rate_norm, ᶜlinear_buoygrad, ᶜtke⁰) = p.precomputed
     (; ᶜK_u, ᶜK_h) = p.precomputed
     ᶜρa⁰ = turbconv_model isa PrognosticEDMFX ? p.precomputed.ᶜρa⁰ : Y.c.ρ
-    nh_pressure3ʲs =
-        turbconv_model isa PrognosticEDMFX ? p.precomputed.ᶠnh_pressure₃ʲs :
-        p.precomputed.ᶠnh_pressure³ʲs
+    nh_pressure3_buoyʲs =
+        turbconv_model isa PrognosticEDMFX ?
+        p.precomputed.ᶠnh_pressure₃_buoyʲs : p.precomputed.ᶠnh_pressure³_buoyʲs
+    nh_pressure3_dragʲs =
+        turbconv_model isa PrognosticEDMFX ?
+        p.precomputed.ᶠnh_pressure₃_dragʲs : p.precomputed.ᶠnh_pressure³_dragʲs
     ᶜtke_press = p.scratch.ᶜtemp_scalar
     @. ᶜtke_press = 0
     for j in 1:n
@@ -38,7 +41,9 @@ function edmfx_tke_tendency!(
         @. ᶜtke_press +=
             ᶜρaʲ *
             adjoint(ᶜinterp.(ᶠu³ʲs.:($$j) - ᶠu³⁰)) *
-            ᶜinterp(C3(nh_pressure3ʲs.:($$j)))
+            ᶜinterp(
+                C3((nh_pressure3_buoyʲs.:($$j)) + nh_pressure3_dragʲs.:($$j)),
+            )
     end
 
     if use_prognostic_tke(turbconv_model)

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -40,7 +40,7 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
     end
 
     if p.atmos.sgs_nh_pressure_mode == Implicit()
-        edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+        edmfx_nh_pressure_drag_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
 
     # NOTE: All ρa tendencies should be applied before calling this function

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -118,8 +118,9 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     if p.atmos.sgs_mf_mode == Explicit()
         edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
+    edmfx_nh_pressure_buoyancy_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     if p.atmos.sgs_nh_pressure_mode == Explicit()
-        edmfx_nh_pressure_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+        edmfx_nh_pressure_drag_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
     edmfx_filter_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     edmfx_tke_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -411,12 +411,10 @@ if MANYTESTS
                             "enable_diagnostics" => false,
                             "output_dir" => joinpath(output_loc, job_id),
                         )
-                        more_ignore = Symbol[]
-
-                        if turbconv_mode == "prognostic_edmf"
-                            more_ignore = [:ᶠnh_pressure₃ʲs]
-                        end
-                        push!(TESTING, (; test_dict, job_id, more_ignore))
+                        push!(
+                            TESTING,
+                            (; test_dict, job_id, more_ignore = Symbol[]),
+                        )
                     end
                 end
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Right now we only take the Jacobians of the drag term in the edmf pressure closure, not the buoyancy (virtual mass) term. This PR separates the two terms in the pressure closure, so we can apply the tendencies separately and control whether to treat them implicitly. To be consistent with the Jacobians, we treat the tendency from the buoyancy term explicitly but the tendency from the drag term implicitly.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
