### PR TITLE
modify the derivative of p and \rho with respect to qt

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -816,7 +816,6 @@ steps:
         artifact_paths: "prognostic_edmfx_trmm_column/output_active/*"
         agents:
           slurm_mem: 20GB
-        soft_fail: true
 
       - label: ":genie: Prognostic EDMFX TRMM with 0-moment in a column"
         command: >

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-232
+233
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+
+233
+- modify the derivative of p and \rho with respect to qt
 
 232
 - Use lazy broadcasting instead of temp scalar in implicit solver for kappa_m vars,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Take into account the derivative of R_m and cv_m with respect to qt in the Jacobians.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the numerical solver with refined calculations, improving simulation dynamics and overall performance.
- **Chores**
  - Revised the build process error handling so that failures are caught immediately, ensuring higher pipeline reliability.
- **Tests**
  - Updated reproducibility checks and reference tracking to deliver more consistent test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->