### PR TITLE
Remove Aqua.jl tests from downgrade action

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,13 @@ using Test
 include("download_artifacts.jl")
 
 #! format: off
-@safetestset "Aqua" begin @time include("aqua.jl") end
+
+# Skip Aqua tests due to precompilation failures in old versions of SciMLBase
+import SciMLBase
+if pkgversion(SciMLBase) > v"2.12.1"
+    @safetestset "Aqua" begin @time include("aqua.jl") end
+end
+
 @safetestset "Dependencies" begin @time include("dependencies.jl") end
 @safetestset "Callbacks" begin @time include("callbacks.jl") end
 @safetestset "Utilities" begin @time include("utilities.jl") end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes the broken downgrade test. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
One of the Aqua.jl tests fail when precompilation fails, so I disabled Aqua tests in the downgrade action.
Precompilation fails in the downgrade test due to method overwriting between SciMLBase and SciMLOperators:
```
WARNING: Method definition islinear(Any) in module SciMLOperators at /home/runner/.julia/packages/SciMLOperators/2UPBq/src/interface.jl:311 overwritten in module SciMLBase at /home/runner/.julia/packages/SciMLBase/cL99i/src/operators/operators.jl:7.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
```


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
