### PR TITLE
change tracer_vertical_diffusion_factor to 0 in 1M jobs

### DIFF
--- a/toml/les_isdac.toml
+++ b/toml/les_isdac.toml
@@ -4,3 +4,6 @@ value = 2000.0
 [mixing_length_Prandtl_number_0]
 value = 0.33333
 type = "float"
+
+[tracer_vertical_diffusion_factor]
+value = 0

--- a/toml/longrun_aquaplanet_1M.toml
+++ b/toml/longrun_aquaplanet_1M.toml
@@ -1,3 +1,6 @@
+[tracer_vertical_diffusion_factor]
+value = 0
+
 [condensation_evaporation_timescale]
 value = 150
 

--- a/toml/longrun_baroclinic_wave_1M.toml
+++ b/toml/longrun_baroclinic_wave_1M.toml
@@ -1,3 +1,6 @@
+[tracer_vertical_diffusion_factor]
+value = 0
+
 [condensation_evaporation_timescale]
 value = 100
 

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -43,6 +43,9 @@ value = 0
 [pressure_normalmode_drag_coeff]
 value = 40.0
 
+[tracer_vertical_diffusion_factor]
+value = 0
+
 [condensation_evaporation_timescale]
 value = 100
 

--- a/toml/single_column_precipitation_test.toml
+++ b/toml/single_column_precipitation_test.toml
@@ -7,5 +7,8 @@ value = 100
 [C_H]
 value = 0.0
 
+[tracer_vertical_diffusion_factor]
+value = 0
+
 [prescribed_cloud_droplet_number_concentration]
 value = 0.0

--- a/toml/sphere_aquaplanet_1M.toml
+++ b/toml/sphere_aquaplanet_1M.toml
@@ -1,3 +1,6 @@
+[tracer_vertical_diffusion_factor]
+value = 0
+
 [condensation_evaporation_timescale]
 value = 400
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Based on our discussion today, it is preferred to have no vertical diffusion on precipitation. This PR sets `tracer_vertical_diffusion_factor` in all the 1M tomls. If we are sure this is what we want in the future we can change the default in ClimaParameters.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
