### PR TITLE
specific contents jargon clarifications (to avoid humidity of snow, ice, rain, ...)

### DIFF
--- a/docs/src/diagnostic_edmf_equations.md
+++ b/docs/src/diagnostic_edmf_equations.md
@@ -8,7 +8,7 @@ This describes the diagnostic EDMF scheme equations and its discretizations. Whe
 * ``\rho``: _density_ in kg/m³, discretized at cell centers.
 * ``u^3``: the contravariant 3 component of velocity, discretized at cell faces.
 * ``h_{\mathrm{s}}``: moist static energy in J/kg, discretized at cell centers.
-* ``q_t``: total specific humidity in kg/kg, discretized at cell centers.
+* ``q_t``: total water specific content in kg/kg, discretized at cell centers.
 * ``\Phi = g z``: geopotential in m²/s², where ``g`` is the gravitational acceleration rate and ``z`` is altitude above the mean sea level, discretized at cell centers.
 * ``(\nabla \Phi)^3``: the contravariant 3 component of the gradient of geopotential, reconstructed at cell centers.
 * ``p``: air pressure, reconstructed at cell centers.
@@ -22,7 +22,7 @@ This describes the diagnostic EDMF scheme equations and its discretizations. Whe
   ```
 * ``u^{j,3}``: the contravariant 3 component of velocity, discretized at cell faces.
 * ``h_{\mathrm{s}}^j``: moist static energy, discretized at cell centers.
-* ``q_t^j``: total specific humidity of the sub-domain j, discretized at cell centers.
+* ``q_t^j``: total water specific content of the sub-domain j, discretized at cell centers.
 * ``u^{0,3}``: the contravariant 3 component of the environmental velocity, obtained as the residual:
   ```math
   \rho u^{0, 3} = \rho u^3 -  \sum_{j\ne 0} \hat\rho^j u^{j, 3}.

--- a/docs/src/edmf_equations.md
+++ b/docs/src/edmf_equations.md
@@ -22,7 +22,7 @@ This describes the EDMF scheme equations and its discretizations. Where possible
 * ``\boldsymbol{u}^j`` _velocity_, a vector in m/s. This is discretized via ``\boldsymbol{u}^j = \boldsymbol{u}_h + \boldsymbol{u}_v^j`` where
   - ``\boldsymbol{u}_v^j = u_3^j \boldsymbol{e}^3`` is the projection onto the vertical covariant components, stored at cell faces.
 * ``\hat{\rho}^j e^j``: _total energy_ in J/m³. This is discretized at cell centers.
-* ``\hat{\rho}^j q^j``: moisture tracers. ``q^j`` stands for the sub-domain total (liquid, ice, rain, snow) specific humidity in kg/kg. This is stored at cell centers.
+* ``\hat{\rho}^j q^j``: moisture tracers. ``q^j`` stands for the sub-domain total condensate (liquid, ice, rain, snow) specific content in kg/kg. This is stored at cell centers.
 * ``\hat{\rho}^j \chi^j``: other tracers (aerosol, ...), again stored at cell centers.
 
 ## Operators

--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -283,7 +283,7 @@ Sources from cloud microphysics ``\mathcal{S}`` represent the transfer of mass
 
 The scalars ``\rho q_{rai}`` and ``\rho q_{sno}`` are part of the state vector
   when running simulations with 1-moment microphysics scheme,
-  and represent the specific humidity of liquid and solid precipitation
+  and represent the specific content of liquid and solid precipitation
   (i.e. rain and snow).
 
 ```math
@@ -391,7 +391,7 @@ The corresponding energy sink associated with heat transfer
 ```math
 \frac{d}{dt} \rho e = - \rho q_p (\boldsymbol{u} - v_p) c_p \nabla T_a
 ```
-where ``q_p``, ``\boldsymbol{u}``, ``v_p``, ``c_p `` are the precipitation specific humidity,
+where ``q_p``, ``\boldsymbol{u}``, ``v_p``, ``c_p `` are the precipitation specific content,
 air velocity, precipitation terminal velocity assumed to be along the gravity axis,
 specific heat of precipitating species.
 
@@ -402,7 +402,7 @@ specific heat of precipitating species.
 ### Stability and positivity
 
 All source terms are individually limited such that they don't exceed the
-  available tracer specific humidity divided by a coefficient ``a``.
+  available tracer specific content divided by a coefficient ``a``.
 ```math
 \mathcal{S}_{x \rightarrow y} = min(\mathcal{S}_{x \rightarrow y}, \frac{q_{x}}{a \; dt})
 ```
@@ -410,7 +410,7 @@ This will not ensure positivity because the sum of all source terms,
   combined with the advection tendency,
   could still drive the solution to negative numbers.
 It should however help mitigate some of the problems.
-The source terms functions treat negative specific humidities as zeros,
+The source terms functions treat negative specific contents as zeros,
   so the simulations should be stable even with small negative numbers.
 
 We do not apply hyperdiffusion for precipitation tracers.

--- a/src/cache/cloud_fraction.jl
+++ b/src/cache/cloud_fraction.jl
@@ -49,7 +49,7 @@ NVTX.@annotate function set_cloud_fraction!(
             @. ᶜgradᵥ_θ_virt =
                 ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts)))
             @. ᶜgradᵥ_q_tot =
-                ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts)))
+                ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts)))  # TODO: rename to "total_water_specific_content"
             @. ᶜgradᵥ_θ_liq_ice =
                 ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts)))
         end
@@ -95,7 +95,7 @@ NVTX.@annotate function set_cloud_fraction!(
             @. ᶜgradᵥ_θ_virt =
                 ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts)))
             @. ᶜgradᵥ_q_tot =
-                ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts)))
+                ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts)))  # TODO: rename to "total_water_specific_content"
             @. ᶜgradᵥ_θ_liq_ice =
                 ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts)))
         end
@@ -265,7 +265,7 @@ function quad_loop(
     thermo_params,
 )
     p_c = TD.air_pressure(thermo_params, ts)
-    q_mean = TD.total_specific_humidity(thermo_params, ts)
+    q_mean = TD.total_specific_humidity(thermo_params, ts)  # TODO: rename to "total_water_specific_content"
     θ_mean = TD.liquid_ice_pottemp(thermo_params, ts)
     # Returns the physical values based on quadrature sampling points
     # and limited covarainces
@@ -325,7 +325,7 @@ end
    that approximate the sub-grid scale variability of θ and q.
 
    θ - liquid ice potential temperature
-   q - total water specific humidity
+   q - total water specific content
 """
 function quad(f::F, get_x_hat::F1, quad) where {F <: Function, F1 <: Function}
     χ = quad.a

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -28,7 +28,7 @@ In addition, there are several other SGS quantities for `PrognosticEDMFX`:
     - `ᶜtke⁰`: turbulent kinetic energy of the environment on cell centers
     - `ᶜρa⁰`: area-weighted air density of the environment on cell centers
     - `ᶜmse⁰`: moist static energy of the environment on cell centers
-    - `ᶜq_tot⁰`: total specific humidity of the environment on cell centers
+    - `ᶜq_tot⁰`: total water specific content of the environment on cell centers
     - `ᶜρ⁰`: air density of the environment on cell centers
     - `ᶜρʲs`: a tuple of the air densities of the mass-flux subdomains on cell
         centers
@@ -516,7 +516,7 @@ NVTX.@annotate function set_explicit_precomputed_quantities!(Y, p, t)
         @. p.precomputed.ᶜgradᵥ_θ_virt =
             ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts)))
         @. p.precomputed.ᶜgradᵥ_q_tot =
-            ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts)))
+            ᶜgradᵥ(ᶠinterp(TD.total_specific_humidity(thermo_params, ᶜts))) # TODO: rename to "total_water_specific_content"
         @. p.precomputed.ᶜgradᵥ_θ_liq_ice =
             ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts)))
     end

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -346,7 +346,7 @@ add_diagnostic_variable!(
 )
 
 ###
-# Total specific humidity (3d)
+# Total water specific content (3d)
 ###
 compute_hus!(out, state, cache, time) =
     compute_hus!(out, state, cache, time, cache.atmos.moisture_model)
@@ -369,15 +369,15 @@ end
 
 add_diagnostic_variable!(
     short_name = "hus",
-    long_name = "Specific Humidity",
-    standard_name = "specific_humidity",
+    long_name = "Specific Humidity",  # TODO: rename to "Total Water Specific Content"
+    standard_name = "specific_humidity",  # TODO: rename to total_water_specific_content
     units = "kg kg^-1",
     comments = "Mass of all water phases per mass of air",
     compute! = compute_hus!,
 )
 
 ###
-# Liquid water specific humidity (3d)
+# Liquid water specific content (3d)
 ###
 compute_clw!(out, state, cache, time) =
     compute_clw!(out, state, cache, time, cache.atmos.moisture_model)
@@ -413,7 +413,7 @@ add_diagnostic_variable!(
 )
 
 ###
-# Ice water specific humidity (3d)
+# Ice water specific content (3d)
 ###
 compute_cli!(out, state, cache, time) =
     compute_cli!(out, state, cache, time, cache.atmos.moisture_model)
@@ -449,7 +449,7 @@ add_diagnostic_variable!(
 )
 
 ###
-# Surface specific humidity (2d)
+# Surface total water specific content (2d)
 ###
 compute_hussfc!(out, state, cache, time) =
     compute_hussfc!(out, state, cache, time, cache.atmos.moisture_model)
@@ -465,13 +465,13 @@ function compute_hussfc!(
 ) where {T <: Union{EquilMoistModel, NonEquilMoistModel}}
     thermo_params = CAP.thermodynamics_params(cache.params)
     if isnothing(out)
-        return TD.total_specific_humidity.(
+        return TD.total_specific_humidity.(  # TODO: rename to "total_water_specific_content"
             thermo_params,
             cache.precomputed.sfc_conditions.ts,
         )
     else
         out .=
-            TD.total_specific_humidity.(
+            TD.total_specific_humidity.(  # TODO: rename to total_water_specific_content
                 thermo_params,
                 cache.precomputed.sfc_conditions.ts,
             )
@@ -480,8 +480,8 @@ end
 
 add_diagnostic_variable!(
     short_name = "hussfc",
-    long_name = "Surface Specific Humidity",
-    standard_name = "specific_humidity",
+    long_name = "Surface Specific Humidity",  # TODO: rename to "Surface Total Water Spefici Content"
+    standard_name = "specific_humidity",  # TODO: rename to "total_water_specific_content"
     units = "kg kg^-1",
     comments = "Mass of all water phases per mass of air in the layer infinitely close to the surface",
     compute! = compute_hussfc!,
@@ -1239,7 +1239,7 @@ end
 
 add_diagnostic_variable!(
     short_name = "husv",
-    long_name = "Vapor Specific Humidity",
+    long_name = "Vapor Specific Humidity",  # TODO: rename to "Specific Humidity"?
     units = "kg kg^-1",
     comments = "Mass of water vapor per mass of air",
     compute! = compute_husv!,

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -353,7 +353,7 @@ levels assuming hydrostatic balance, given the surface pressure.
 We expect the file to contain the following variables:
 - `p`, for pressure,
 - `t`, for temperature,
-- `q`, for humidity,
+- `q`, for specific humidity,
 - `u, v, w`, for velocity,
 - `cswc, crwc` for snow and rain water content (for 1 moment microphysics).
 """

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -39,7 +39,7 @@ end
 
  - cmc - a struct with cloud and aerosol parameters
  - c_dust, c_seasalt, c_SO4 - dust, seasalt and ammonium sulfate mass concentrations [kg/kg]
- - q_liq - liquid water specific humidity
+ - q_liq - liquid water specific content
 
 Returns the liquid cloud droplet number concentration diagnosed based on the
 aerosol loading and cloud liquid water.
@@ -110,7 +110,7 @@ end
 
  - thp, cmp - structs with thermodynamic and microphysics parameters
  - dt - model time step
- - qₜ - total water specific humidity
+ - qₜ - total water specific content
  - ts - thermodynamic state (see Thermodynamics.jl package for details)
 
 Returns the qₜ source term due to precipitation formation
@@ -148,13 +148,13 @@ end
  - Sᵖ, Sᵖ_snow - temporary containters to help compute precipitation source terms
  - Sqₗᵖ, Sqᵢᵖ, Sqᵣᵖ, Sqₛᵖ - cached storage for precipitation source terms
  - ρ - air density
- - qᵣ, qₛ - precipitation (rain and snow) specific humidity
+ - qᵣ, qₛ - precipitation (rain and snow) specific content
  - ts - thermodynamic state (see td package for details)
  - dt - model time step
  - thp, cmp - structs with thermodynamic and microphysics parameters
 
 Returns the q source terms due to precipitation formation from the 1-moment scheme.
-The specific humidity source terms are defined as defined as Δmᵢ / (m_dry + m_tot)
+The water specific content source terms are defined as Δmᵢ / (m_dry + m_tot)
 where i stands for total, rain or snow.
 Also returns the total energy source term due to the microphysics processes.
 """
@@ -272,13 +272,13 @@ end
  - Sᵖ - a temporary containter to help compute precipitation source terms
  - Sqᵣᵖ, Sqₛᵖ - cached storage for precipitation source terms
  - ρ - air density
- - qᵣ, qₛ - precipitation (rain and snow) specific humidities
+ - qᵣ, qₛ - precipitation (rain and snow) specific contents
  - ts - thermodynamic state (see td package for details)
  - dt - model time step
  - thp, cmp - structs with thermodynamic and microphysics parameters
 
 Returns the q source terms due to precipitation sinks from the 1-moment scheme.
-The specific humidity source terms are defined as defined as Δmᵢ / (m_dry + m_tot)
+The water specific content source terms are defined as Δmᵢ / (m_dry + m_tot)
 where i stands for total, rain or snow.
 Also returns the total energy source term due to the microphysics processes.
 """

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -56,7 +56,7 @@ function edmfx_sgs_mass_flux_tendency!(
         @. Yₜ.c.ρe_tot += vtt
 
         if !(p.atmos.moisture_model isa DryModel)
-            # specific humidity
+            # total water specific content
             for j in 1:n
                 @. ᶠu³_diff = ᶠu³ʲs.:($$j) - ᶠu³
                 @. ᶜa_scalar =
@@ -233,7 +233,7 @@ function edmfx_sgs_mass_flux_tendency!(
         end
 
         if !(p.atmos.moisture_model isa DryModel)
-            # specific humidity
+            # total water specific content
             for j in 1:n
                 @. ᶠu³_diff = ᶠu³ʲs.:($$j) - ᶠu³
                 # @. ᶜa_scalar =
@@ -316,7 +316,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
                 )
         end
         if !(p.atmos.moisture_model isa DryModel)
-            # specific humidity
+            # total water specific content
             ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
             ᶜdivᵥ_ρq_tot = Operators.DivergenceF2C(
                 top = Operators.SetValue(C3(FT(0))),
@@ -405,7 +405,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
         end
 
         if !(p.atmos.moisture_model isa DryModel)
-            # specific humidity
+            # total water specific content
             ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
             ᶜdivᵥ_ρq_tot = Operators.DivergenceF2C(
                 top = Operators.SetValue(C3(FT(0))),

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -210,7 +210,7 @@ function external_forcing_tendency!(Yₜ, Y, p, t, ::GCMForcing)
                 R_v * T_0
             ) * ᶜdqtdt_sum
         )
-    # total specific humidity
+    # total water specific content
     @. Yₜ.c.ρq_tot += Y.c.ρ * ᶜdqtdt_sum
 
     ## subsidence -->
@@ -294,6 +294,6 @@ function external_forcing_tendency!(Yₜ, Y, p, t, ::ISDACForcing)
             ) * ᶜdqtdt_nudging
         )
 
-    # total specific humidity
+    # total water specific content
     @. Yₜ.c.ρq_tot += Y.c.ρ * ᶜdqtdt_nudging
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Avoid misleading jargon featuring humidities of snow, humidities of water, etc by reserving the term "humidity" for humidity, and using specific contents for all other solid and liquid phase per-mass water contents. See related https://github.com/CliMA/CloudMicrophysics.jl/pull/540 

## To-do
- the PR corrects only docstrings and code comments, code changes for now just marked with TODO comments (likely need to be coordinated with Thermodynamics.jl PR: https://github.com/search?q=repo%3ACliMA%2FThermodynamics.jl%20specific%20humidity&type=code)

## Content
jargon changes in docs and code comments

