### PR TITLE
use lazy broadcasting instead of temp scalar in implicit solver

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-231
+232
 
 # **README**
 #
@@ -20,6 +20,11 @@
 
 
 #=
+
+232
+- Use lazy broadcasting instead of temp scalar in implicit solver for kappa_m vars,
+  which fixes a bug that the temp scalar is updated before it is reused.
+
 231
 - Add mass flux derivatives with respect to grid-mean u_3
 

--- a/src/prognostic_equations/implicit/implicit_solver.jl
+++ b/src/prognostic_equations/implicit/implicit_solver.jl
@@ -621,9 +621,9 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, t)
     ᶠgⁱʲ = Fields.local_geometry_field(Y.f).gⁱʲ
     ᶠlg = Fields.local_geometry_field(Y.f)
 
-    ᶜkappa_m = p.ᶜtemp_scalar
-    @. ᶜkappa_m =
-        TD.gas_constant_air(thermo_params, ᶜts) / TD.cv_m(thermo_params, ᶜts)
+    ᶜkappa_m = @. lazy(
+        TD.gas_constant_air(thermo_params, ᶜts) / TD.cv_m(thermo_params, ᶜts),
+    )
 
     if use_derivative(topography_flag)
         @. ∂ᶜK_∂ᶜuₕ = DiagonalMatrixRow(
@@ -899,10 +899,10 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, t)
             ) # Need to wrap ᶠupwind_matrix in this for well-defined boundaries.
 
             ᶠu³ʲ_data = ᶠu³ʲs.:(1).components.data.:1
-            ᶜkappa_mʲ = p.ᶜtemp_scalar
-            @. ᶜkappa_mʲ =
+            ᶜkappa_mʲ = @. lazy(
                 TD.gas_constant_air(thermo_params, ᶜtsʲs.:(1)) /
-                TD.cv_m(thermo_params, ᶜtsʲs.:(1))
+                TD.cv_m(thermo_params, ᶜtsʲs.:(1)),
+            )
 
             ∂ᶜq_totʲ_err_∂ᶜq_totʲ =
                 matrix[@name(c.sgsʲs.:(1).q_tot), @name(c.sgsʲs.:(1).q_tot)]
@@ -1131,11 +1131,6 @@ function update_implicit_equation_jacobian!(A, Y, p, dtγ, t)
                     is_third_order ? QuaddiagonalMatrixRow : BidiagonalMatrixRow
                 ᶠupwind_matrix =
                     is_third_order ? ᶠupwind3_matrix : ᶠupwind1_matrix
-
-                ᶜkappa_mʲ = p.ᶜtemp_scalar
-                @. ᶜkappa_mʲ =
-                    TD.gas_constant_air(thermo_params, ᶜtsʲs.:(1)) /
-                    TD.cv_m(thermo_params, ᶜtsʲs.:(1))
 
                 # Jacobian contributions of updraft massflux to grid-mean
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This also fixes a bug because `temp_scalar` is updated to `ᶜkappa_mʲ`, but `ᶜkappa_m` is reused later.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Adjusted an internal reference metric to maintain system consistency.

- **Refactor**
  - Optimized internal computations with a deferred evaluation strategy to enhance processing efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->