### PR TITLE
Check for equality with float(t) instead of t

### DIFF
--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -110,7 +110,7 @@ so the initial callback initialization doesn't lead to NaNs in the radiation mod
 Subsequently, the surface albedo will be updated by the coupler.
 """
 function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
-    if t == 0
+    if float(t) == 0
         FT = eltype(Y)
         # set initial insolation initial conditions
         !(p.atmos.insolation isa IdealizedInsolation) &&


### PR DESCRIPTION
This fixed the bug that resulted in `NaN`s in the first time slice of any radiation-related diagnostics.

Related PR: https://github.com/CliMA/ClimaCoupler.jl/pull/1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numerical comparison logic in surface property calculations to ensure consistent and reliable performance during evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->