### PR TITLE
Unconditionally update insolation tuple

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -223,10 +223,7 @@ NVTX.@annotate function rrtmgp_model_callback!(integrator)
         end
     end
 
-    if p.atmos.insolation isa IdealizedInsolation ||
-       !(p.atmos.surface_albedo isa CouplerAlbedo)
-        set_insolation_variables!(Y, p, t, p.atmos.insolation)
-    end
+    set_insolation_variables!(Y, p, t, p.atmos.insolation)
 
     if radiation_mode isa RRTMGPI.AllSkyRadiation ||
        radiation_mode isa RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics


### PR DESCRIPTION
I am not sure why insolation was set to not be updated with `CouplerAlbedo`, but I don't think this is currently necessary.

The function `set_insolation_variables!` was manually called by ClimaCoupler as part of the coupling loop

https://github.com/CliMA/ClimaCoupler.jl/blob/a3b32d169137f7dad2edf33fd2f5e29ebd6d5356/experiments/ClimaEarth/components/atmosphere/climaatmos.jl#L394

My guess is that this is because we wanted to update it more frequently than a radiation timestep.

Maybe the point was to obtain `cos_zenith_angle`?

In this commit, I unconditionally update the insolation_tuple. I will also change ClimaCoupler to update it as it used to do, but I think that won't be needed after we remove `cos_zenith_angle` as an exchange field.
