### PR TITLE
Make nogw_callback no-op when there's no GW

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -407,7 +407,11 @@ NVTX.@annotate function nogw_model_callback!(integrator)
     Y = integrator.u
     p = integrator.p
 
-    non_orographic_gravity_wave_compute_tendency!(Y, p)
+    non_orographic_gravity_wave_compute_tendency!(
+        Y,
+        p,
+        p.atmos.non_orographic_gravity_wave,
+    )
     return nothing
 end
 

--- a/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
@@ -131,7 +131,13 @@ function non_orographic_gravity_wave_cache(Y, gw::NonOrographicGravityWave)
     end
 end
 
-function non_orographic_gravity_wave_compute_tendency!(Y, p)
+non_orographic_gravity_wave_compute_tendency!(Y, p, ::Nothing) = nothing
+
+function non_orographic_gravity_wave_compute_tendency!(
+    Y,
+    p,
+    ::NonOrographicGravityWave,
+)
     #unpack
     ᶜT = p.scratch.ᶜtemp_scalar
     (; ᶜts) = p.precomputed


### PR DESCRIPTION
The code crashes when one calls `nogw_model_callback` without turning on gravity waves. This commit changes it so that it will just be a no-op.