### PR TITLE
Use space instead of field, improve docs

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -283,7 +283,7 @@ end
 function surface_velocity(ᶠu₃, ᶠuₕ³)
     sfc_u₃ = Fields.level(ᶠu₃.components.data.:1, half)
     sfc_uₕ³ = Fields.level(ᶠuₕ³.components.data.:1, half)
-    sfc_g³³ = g³³_field(sfc_u₃)
+    sfc_g³³ = g³³_field(axes(sfc_u₃))
     return @. lazy(-sfc_uₕ³ / sfc_g³³) # u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³
 end
 

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -117,12 +117,13 @@ function compute_strain_rate_face(u::Fields.Field)
 end
 
 """
-    g³³_field(field)
+    g³³_field(space)
 
-Extracts the value of `g³³` from `Fields.local_geometry_field(field)`.
+Extracts the value of `g³³`, the 3rd component of the metric terms that convert
+Covariant AxisTensors to Contravariant AxisTensors, from the given space.
 """
-function g³³_field(field)
-    g_field = Fields.local_geometry_field(field).gⁱʲ.components.data
+function g³³_field(space)
+    g_field = Fields.local_geometry_field(space).gⁱʲ.components.data
     end_index = fieldcount(eltype(g_field)) # This will be 4 in 2D and 9 in 3D.
     return g_field.:($end_index) # For both 2D and 3D spaces, g³³ = g[end].
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -166,9 +166,8 @@ end
     (; cent_space, face_space) = get_cartesian_spaces()
     lg_gⁱʲ = cent_space.grid.center_local_geometry.gⁱʲ
     lg_g³³ = lg_gⁱʲ.components.data.:9
-    @test Fields.field_values(
-        CA.g³³_field(Fields.coordinate_field(cent_space).x),
-    ) == lg_g³³
+    (; x) = Fields.coordinate_field(cent_space)
+    @test Fields.field_values(CA.g³³_field(axes(x))) == lg_g³³
     @test maximum(abs.(lg_g³³ .- CA.g³³.(lg_gⁱʲ).components.data.:1)) == 0
     @test maximum(abs.(CA.g³ʰ.(lg_gⁱʲ).components.data.:1)) == 0
     @test maximum(abs.(CA.g³ʰ.(lg_gⁱʲ).components.data.:2)) == 0


### PR DESCRIPTION
This PR changes `g³³_field` to accept a space instead of a field (it will still work as a field, but a field is not necessary), and updates the doc string.

This peels off a part of from #3603.