### PR TITLE
Add preliminary implicit solver interface and documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -35,6 +35,7 @@ makedocs(;
         "Ocean Surface Albedo Parameterization" => "surface_albedo.md",
         "Topography Representation" => "topography.md",
         "Tracers" => "tracers.md",
+        "Implicit Solver" => "implicit_solver.md",
         "Radiative Equilibrium" => "radiative_equilibrium.md",
         "Single Column Model" => "single_column_prospect.md",
         "Restarts and checkpoints" => "restarts.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,10 +43,12 @@ ClimaAtmos.InitialConditions.Bomex
 ClimaAtmos.InitialConditions.Soares
 ```
 
-### Implicit Solver
+### Jacobian
 
 ```@docs
-ClimaAtmos.ImplicitEquationJacobian
+ClimaAtmos.Jacobian
+ClimaAtmos.JacobianAlgorithm
+ClimaAtmos.ManualSparseJacobian
 ```
 
 ### Helper

--- a/docs/src/implicit_solver.md
+++ b/docs/src/implicit_solver.md
@@ -1,0 +1,57 @@
+# Implicit Solver
+
+When we use an implicit or split implicit-explicit (IMEX) timestepping scheme,
+we end up with a nonlinear equation of the form ``R(Y) = 0``, where
+```math
+    R(Y) = Y_{imp}(Y) - Y = Y_{prev} + Δt * T_{imp}(Y) - Y.
+```
+In this expression, ``Y_{imp}(Y)`` denotes the state at some time ``t + Δt``.
+This can be expressed as the sum of ``Y_{prev}``, the contribution from the
+state at time ``t`` (and possibly also at earlier times, depending on the order
+of the timestepping scheme), and ``Δt * T_{imp}(Y)``, the contribution from the
+implicit tendency ``T_{imp}`` between times ``t`` and ``t + Δt``. The new state
+at the end of each implicit step in the timestepping scheme is the value of
+``Y`` that solves this equation, i.e., the value of ``Y`` that is consistent
+with the state ``Y_{imp}(Y)`` predicted by the implicit step.
+
+Note: When we use a higher-order timestepping scheme, the full step ``Δt`` is
+divided into several sub-steps or "stages", where the duration of stage ``i`` is
+``Δt * γ_i`` for some constant ``γ_i`` between 0 and 1.
+
+In order to solve this equation using Newton's method, we must specify the
+derivative ``∂R/∂Y``. Since ``Y_{prev}`` does not depend on ``Y`` (it is only a
+function of the state at or before time ``t``), this derivative is
+```math
+    R'(Y) = Δt * T_{imp}'(Y) - I.
+```
+In addition, we must specify how to divide ``R(Y)`` by this derivative, i.e.,
+how to solve the linear equation
+```math
+    R'(Y) * ΔY = R(Y).
+```
+
+Note: This equation comes from assuming that there is some ``ΔY`` such that
+``R(Y - ΔY) = 0`` and making the first-order approximation
+```math
+    R(Y - ΔY) \approx R(Y) - R'(Y) * ΔY.
+```
+
+After initializing ``Y`` to ``Y[0] = Y_{prev}``, Newton's method executes the
+following steps:
+- Compute the derivative ``R'(Y[0])``.
+- Compute the implicit tendency ``T_{imp}(Y[0])`` and use it to get ``R(Y[0])``.
+- Solve the linear equation ``R'(Y[0]) * ΔY[0] = R(Y[0])`` for ``ΔY[0]``.
+- Update ``Y`` to ``Y[1] = Y[0] - ΔY[0]``.
+
+If the number of Newton iterations is limited to 1, this new value of ``Y`` is
+taken to be the solution of the implicit equation. Otherwise, this sequence of
+steps is repeated, i.e., ``ΔY[1]`` is computed and used to update ``Y`` to
+``Y[2] = Y[1] - ΔY[1]``, then ``ΔY[2]`` is computed and used to update ``Y`` to
+``Y[3] = Y[2] - ΔY[2]``, and so on. The iterative process is terminated either
+when the residual ``R(Y)`` is sufficiently close to 0 (according to the
+convergence condition passed to Newton's method), or when the maximum number of
+iterations is reached.
+
+In ClimaAtmos, the derivative ``∂R/∂Y`` is represented as a
+[`ClimaAtmos.Jacobian`](@ref), and the method for computing it is given by a
+[`ClimaAtmos.JacobianAlgorithm`](@ref).

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -2,6 +2,7 @@ module ClimaAtmos
 
 using NVTX
 import Adapt
+import LinearAlgebra
 import NullBroadcasts: NullBroadcasted
 import LazyBroadcast
 import LazyBroadcast: lazy
@@ -55,7 +56,9 @@ include(joinpath("prognostic_equations", "pressure_work.jl"))
 include(joinpath("prognostic_equations", "zero_velocity.jl"))
 
 include(joinpath("prognostic_equations", "implicit", "implicit_tendency.jl"))
-include(joinpath("prognostic_equations", "implicit", "implicit_solver.jl"))
+include(
+    joinpath("prognostic_equations", "implicit", "manual_sparse_jacobian.jl"),
+)
 
 include(joinpath("prognostic_equations", "water_advection.jl"))
 include(joinpath("prognostic_equations", "remaining_tendency.jl"))

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -6,7 +6,6 @@ import ClimaUtilities.OutputPathGenerator
 import ClimaCore: InputOutput, Meshes, Spaces, Quadratures
 import ClimaAtmos.RRTMGPInterface as RRTMGPI
 import ClimaAtmos as CA
-import LinearAlgebra
 import ClimaCore.Fields
 import ClimaTimeSteppers as CTS
 import Logging
@@ -427,55 +426,22 @@ function get_surface_setup(parsed_args)
     return getproperty(SurfaceConditions, Symbol(parsed_args["surface_setup"]))()
 end
 
-is_explicit_CTS_algo_type(alg_or_tableau) =
-    alg_or_tableau <: CTS.ERKAlgorithmName
-
-is_imex_CTS_algo_type(alg_or_tableau) =
-    alg_or_tableau <: CTS.IMEXARKAlgorithmName
-
-is_implicit_type(alg_or_tableau) = is_imex_CTS_algo_type(alg_or_tableau)
-
-is_imex_CTS_algo(::CTS.IMEXAlgorithm) = true
-is_imex_CTS_algo(::CTS.RosenbrockAlgorithm) = true
-is_imex_CTS_algo(::SciMLBase.AbstractODEAlgorithm) = false
-
-is_implicit(ode_algo) = is_imex_CTS_algo(ode_algo)
-
-is_rosenbrock(::SciMLBase.AbstractODEAlgorithm) = false
-use_transform(ode_algo) =
-    !(is_imex_CTS_algo(ode_algo) || is_rosenbrock(ode_algo))
-
-additional_integrator_kwargs(::SciMLBase.AbstractODEAlgorithm) = (;
-    adaptive = false,
-    progress = isinteractive(),
-    progress_steps = isinteractive() ? 1 : 1000,
-)
-additional_integrator_kwargs(::CTS.DistributedODEAlgorithm) = (;
-    kwargshandle = CTS.DiffEqBase.KeywordArgSilent, # allow custom kwargs
-    adjustfinal = true,
-    # TODO: enable progress bars in ClimaTimeSteppers
-)
-
-is_cts_algo(::SciMLBase.AbstractODEAlgorithm) = false
-is_cts_algo(::CTS.DistributedODEAlgorithm) = true
-
-function jac_kwargs(ode_algo, Y, atmos, parsed_args)
-    if is_implicit(ode_algo)
-        A = ImplicitEquationJacobian(
-            Y,
-            atmos;
-            approximate_solve_iters = parsed_args["approximate_linear_solve_iters"],
-            transform_flag = use_transform(ode_algo),
+get_jacobian(ode_algo, Y, atmos, parsed_args) =
+    if ode_algo isa Union{CTS.IMEXAlgorithm, CTS.RosenbrockAlgorithm}
+        jacobian_algorithm = ManualSparseJacobian(
+            DerivativeFlag(has_topography(axes(Y.c))),
+            DerivativeFlag(atmos.diff_mode),
+            DerivativeFlag(atmos.sgs_adv_mode),
+            DerivativeFlag(atmos.sgs_entr_detr_mode),
+            DerivativeFlag(atmos.sgs_mf_mode),
+            DerivativeFlag(atmos.sgs_nh_pressure_mode),
+            parsed_args["approximate_linear_solve_iters"],
         )
-        if use_transform(ode_algo)
-            return (; jac_prototype = A, Wfact_t = Wfact!)
-        else
-            return (; jac_prototype = A, Wfact = Wfact!)
-        end
+        @info "Jacobian algorithm: $(summary_string(jacobian_algorithm))"
+        Jacobian(jacobian_algorithm, Y, atmos)
     else
-        return NamedTuple()
+        nothing
     end
-end
 
 #=
     ode_configuration(Y, parsed_args)
@@ -484,17 +450,14 @@ Returns the ode algorithm
 =#
 function ode_configuration(::Type{FT}, parsed_args) where {FT}
     ode_name = parsed_args["ode_algo"]
-    alg_or_tableau = getproperty(CTS, Symbol(ode_name))
-    @info "Using ODE config: `$alg_or_tableau`"
-    if ode_name == "SSPKnoth"
-        return CTS.RosenbrockAlgorithm(CTS.tableau(CTS.SSPKnoth()))
-    end
-
-    if is_explicit_CTS_algo_type(alg_or_tableau)
-        return CTS.ExplicitAlgorithm(alg_or_tableau())
-    elseif !is_implicit_type(alg_or_tableau)
-        return alg_or_tableau()
-    elseif is_imex_CTS_algo_type(alg_or_tableau)
+    ode_algo_name = getproperty(CTS, Symbol(ode_name))
+    @info "Using ODE config: `$ode_algo_name`"
+    return if ode_algo_name <: CTS.RosenbrockAlgorithmName
+        CTS.RosenbrockAlgorithm(CTS.tableau(ode_algo_name()))
+    elseif ode_algo_name <: CTS.ERKAlgorithmName
+        CTS.ExplicitAlgorithm(ode_algo_name())
+    else
+        @assert ode_algo_name <: CTS.IMEXARKAlgorithmName
         newtons_method = CTS.NewtonsMethod(;
             max_iters = parsed_args["max_newton_iters_ode"],
             krylov_method = if parsed_args["use_krylov_method"]
@@ -523,9 +486,7 @@ function ode_configuration(::Type{FT}, parsed_args) where {FT}
                 nothing
             end,
         )
-        return CTS.IMEXAlgorithm(alg_or_tableau(), newtons_method)
-    else
-        return alg_or_tableau(; linsolve = linsolve!)
+        CTS.IMEXAlgorithm(ode_algo_name(), newtons_method)
     end
 end
 
@@ -670,38 +631,30 @@ end
 
 function args_integrator(parsed_args, Y, p, tspan, ode_algo, callback)
     (; atmos, dt) = p
-
     s = @timed_str begin
-        func = if parsed_args["split_ode"]
-            implicit_func = SciMLBase.ODEFunction(
-                implicit_tendency!;
-                jac_kwargs(ode_algo, Y, atmos, parsed_args)...,
-                tgrad = (∂Y∂t, Y, p, t) -> (∂Y∂t .= 0),
-            )
-            if is_cts_algo(ode_algo)
-                CTS.ClimaODEFunction(;
-                    T_exp_T_lim! = remaining_tendency!,
-                    T_imp! = implicit_func,
-                    # Can we just pass implicit_tendency! and jac_prototype etc.?
-                    lim! = limiters_func!,
-                    dss!,
-                    cache! = set_precomputed_quantities!,
-                    cache_imp! = set_implicit_precomputed_quantities!,
-                )
-            else
-                SciMLBase.SplitFunction(implicit_func, remaining_tendency!)
-            end
-        else
-            remaining_tendency! # should be total_tendency!
-        end
+        T_imp! = SciMLBase.ODEFunction(
+            implicit_tendency!;
+            jac_prototype = get_jacobian(ode_algo, Y, atmos, parsed_args),
+            Wfact = update_jacobian!,
+        )
+        tendency_function = CTS.ClimaODEFunction(;
+            T_exp_T_lim! = remaining_tendency!,
+            T_imp!,
+            lim! = limiters_func!,
+            dss!,
+            cache! = set_precomputed_quantities!,
+            cache_imp! = set_implicit_precomputed_quantities!,
+        )
     end
     @info "Define ode function: $s"
-    problem = SciMLBase.ODEProblem(func, Y, tspan, p)
+    problem = SciMLBase.ODEProblem(tendency_function, Y, tspan, p)
     t_begin, t_end, _ = promote(tspan[1], tspan[2], p.dt)
     # Save solution to integrator.sol at the beginning and end
     saveat = [t_begin, t_end]
     args = (problem, ode_algo)
-    kwargs = (; saveat, callback, dt, additional_integrator_kwargs(ode_algo)...)
+    allow_custom_kwargs = (; kwargshandle = CTS.DiffEqBase.KeywordArgSilent)
+    kwargs =
+        (; saveat, callback, dt, adjustfinal = true, allow_custom_kwargs...)
     return (args, kwargs)
 end
 

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -272,6 +272,24 @@ using ClimaComms
 is_distributed(::ClimaComms.SingletonCommsContext) = false
 is_distributed(::ClimaComms.MPICommsContext) = true
 
+"""
+    summary_string(x)
+
+Returns a string that is similar to the output of `dump(x)`, but without any
+type parameters.
+"""
+summary_string(x) = summary_string(x, 0)
+summary_string(x, depth) =
+    fieldcount(typeof(x)) == 0 ? repr(x) :
+    (string(nameof(typeof(x))) * '(') *
+    mapreduce(*, 1:fieldcount(typeof(x))) do i
+        field =
+            x isa Tuple ? ':' * string(i) : string(fieldname(typeof(x), i))
+        ('\n' * "  "^(depth + 1) * field * " = ") *
+        (summary_string(getfield(x, i), depth + 1) * ',')
+    end *
+    ('\n' * "  "^depth * ')')
+
 # From BenchmarkTools
 function prettytime(t)
     if t < 1e3


### PR DESCRIPTION
## Purpose

This PR is split off from #2730. It contains some preliminary setup for the new implicit solver interface, as well as documentation improvements and some code simplifications.

## Content

- Replace the `ImplicitEquationJacobian` with a more general `JacobianAlgorithm` that can be wrapped in a `Jacobian`. For now, the only available `JacobianAlgorithm` is `ManualSparseJacobian`, but I will also add `AutoDenseJacobian`, `AutoSparseJacobian`, and `DebugJacobian` in future PRs.
- Rename `implicit_solver.jl` to `manual_sparse_jacobian.jl`. The first part of this file, which now deals with the `JacobianAlgorithm` interface, will be moved into a separate file called `jacobian.jl` in another PR. Keeping everything in one file for now ensures that the Git history of the manual Jacobian approximation will be preserved.
- Add docstrings for `Jacobian` and `JacobianAlgorithm`, and move some of the original docstring for `ImplicitEquationJacobian` into a new documentation page for the implicit solver.
- Get rid of outdated code that drops unnecessary values from `p` for the Jacobian approximation, since this was only needed when we used `bycolumn`.
- Rearrange and remove some code from the Jacobian approximation to avoid inconsistent formatting and code duplication.
- Remove extraneous function definitions related to the ODE solver from `type_getters.jl`.
- Add a utility function that summarizes arbitrary data structures, and use it to print info about the `JacobianAlgorithm`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
