### PR TITLE
Add `assert_eltype` helper

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -284,15 +284,11 @@ end
 function surface_velocity(ᶠu₃, ᶠuₕ³)
     assert_eltype(ᶠu₃, Geometry.Covariant3Vector)
     assert_eltype(ᶠuₕ³, Geometry.Contravariant3Vector)
+    ᶠlg = Fields.local_geometry_field(axes(ᶠu₃))
     sfc_u₃ = Fields.level(ᶠu₃.components.data.:1, half)
     sfc_uₕ³ = Fields.level(ᶠuₕ³.components.data.:1, half)
     sfc_g³³ = g³³_field(sfc_u₃)
-    w₃ = @. lazy(-sfc_uₕ³ / sfc_g³³) # u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³
-
-    # sfc_u₃ = Fields.level(ᶠu₃, half)
-    # sfc_uₕ³ = Fields.level(ᶠuₕ³, half)
-    # w₃ = @. lazy(-sfc_uₕ³ / sfc_u₃) # are metric terms automatically applied here?
-
+    w₃ = @. lazy(-C3(sfc_uₕ³ / sfc_g³³, ᶠlg)) # u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³
     assert_eltype(w₃, Geometry.Covariant3Vector)
     return w₃
 end

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -493,3 +493,26 @@ function issphere(space)
     return Meshes.domain(Spaces.topology(Spaces.horizontal_space(space))) isa
            Domains.SphereDomain
 end
+
+import ClimaCore.DataLayouts
+
+"""
+    assert_eltype(x, ::Type{T}) where {T}
+
+Assert that the eltype of `x` is of type `T`
+"""
+function assert_eltype end
+
+assert_eltype(bc::Base.AbstractBroadcasted, ::Type{T}) where {T} =
+    assert_eltype(eltype(bc), T)
+assert_eltype(f::Fields.Field, ::Type{T}) where {T} =
+    assert_eltype(Fields.field_values(f), T)
+assert_eltype(data::DataLayouts.AbstractData, ::Type{T}) where {T} =
+    assert_eltype(eltype(data), T)
+
+function assert_eltype(::Type{S}, ::Type{T}) where {S, T}
+    if !(S <: T)
+        error("Type $S should be a subtype of $T")
+    end
+    return nothing
+end


### PR DESCRIPTION
When working on #3817, I found some things that surprised me a bit. In particular, with the new helper (added in this PR), I believe that this will fail (let's see what CI says):

```julia
function surface_velocity(ᶠu₃, ᶠuₕ³)
    assert_eltype(ᶠu₃, Geometry.Covariant3Vector)
    assert_eltype(ᶠuₕ³, Geometry.Contravariant3Vector)
    sfc_u₃ = Fields.level(ᶠu₃.components.data.:1, half)
    sfc_uₕ³ = Fields.level(ᶠuₕ³.components.data.:1, half)
    sfc_g³³ = g³³_field(sfc_u₃)
    w₃ = @. lazy(-sfc_uₕ³ / sfc_g³³) # u³ = uₕ³ + w³ = uₕ³ + w₃ * g³³
    assert_eltype(w₃, Geometry.Covariant3Vector)
    return w₃
end
```
despite, where this function is called looks like `sfc_u₃ .= surface_velocity(Y.f.u₃, ᶠuₕ³)`. The variable being assigned appears to be a `Covariant3Vector`, however, the RHS of that expression doesn't seem to be.

I think the reason is because we reach into the components to get floats, and then the type of the output is actually a `Contravariant3Vector`, as it adopts the type of `g³³`.

This doesn't error, however, because ClimaCore has conversion methods for this sort of thing. I'm not sure if this is intended behavior, or if this will yield the intended result or not.

Assuming ClimaCore does this automatically, I'm actually surprised that this method isn't simply written as

```julia
function surface_velocity(ᶠu₃, ᶠuₕ³)
    assert_eltype(ᶠu₃, Geometry.Covariant3Vector)
    assert_eltype(ᶠuₕ³, Geometry.Contravariant3Vector)
    sfc_u₃ = Fields.level(ᶠu₃, half)
    sfc_uₕ³ = Fields.level(ᶠuₕ³, half)
    w₃ = @. lazy(-sfc_uₕ³ / sfc_u₃)
    assert_eltype(w₃, Geometry.Covariant3Vector)
    return w₃
end
```

Also, the `assert_eltype` should work for DataLayouts, Fields, and Broadcasted objects, so we can safely remove some of the other type assertions, which currently prevents some of the lazy machinery from working.