### PR TITLE
Make ᶜspecific lazy and remove matching_subfields

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -42,7 +42,7 @@ function implicit_precomputed_quantities(Y, atmos)
     TST = thermo_state_type(moisture_model, FT)
     n = n_mass_flux_subdomains(turbconv_model)
     gs_quantities = (;
-        ᶜspecific = specific_gs.(Y.c),
+        ᶜspecific = Base.materialize(ᶜspecific_gs_tracers(Y)),
         ᶜu = similar(Y.c, C123{FT}),
         ᶠu³ = similar(Y.f, CT3{FT}),
         ᶠu = similar(Y.f, CT123{FT}),
@@ -461,7 +461,7 @@ NVTX.@annotate function set_implicit_precomputed_quantities!(Y, p, t)
     thermo_params = CAP.thermodynamics_params(p.params)
     thermo_args = (thermo_params, moisture_model, precip_model)
 
-    @. ᶜspecific = specific_gs(Y.c)
+    ᶜspecific .= ᶜspecific_gs_tracers(Y)
     @. ᶠuₕ³ = $compute_ᶠuₕ³(Y.c.uₕ, Y.c.ρ)
 
     # TODO: We might want to move this to dss! (and rename dss! to something


### PR DESCRIPTION
This PR extends `foreach_gs_tracer` to handle specific tracer variables (like the ones in `ᶜ∇²specific_tracers`), and uses it to replace the for-loop over `matching_subfields` in the hyperdiffusion tendency. It also replaces `specific_gs.(Y.c)` with the lazy function `ᶜspecific_gs_tracers(Y)`, which we can use to remove `ᶜspecific` from the cache in a future PR. Since `matching_subfields`, `specific_gs`, and some related functions are no longer needed, their definitions are removed.

This PR also fixes a minor bug and updates an inaccurate code comment in the hyperdiffusion tendency for precipitating species. Details can be found in the [comment](https://github.com/CliMA/ClimaAtmos.jl/pull/3857#issuecomment-3010751311) below.