### PR TITLE
Adds Diurnal ERA5 Driven SCM that repeats monthly forcing files 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -901,6 +901,15 @@ steps:
         agents:
           slurm_mem: 12GB
 
+      - label: ":genie: Prognostic EDMFX ERA5 monthly averaged diurnal driven in a column"
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_diurnal_scm_imp.yml
+          --job_id prognostic_edmfx_diurnal_scm_imp
+        artifact_paths: "prognostic_edmfx_diurnal_scm_imp/output_active/*"
+        agents:
+          slurm_mem: 12GB
+
       - label: ":genie: Prognostic EDMFX Bomex in a box"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -32,12 +32,12 @@ precip_model: "0M"
 prescribe_ozone: false
 moist: "equil"
 config: "column"
-z_max: 45e3
-z_elem: 200
+z_max: 60e3
+z_elem: 63
 z_stretch: true
 dz_bottom: 30
 perturb_initstate: false
-dt: "30secs"
+dt: "50secs"
 dt_rad: "10mins"
 t_end: "30hours"
 cloud_model: "quadrature_sgs"

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -1,0 +1,62 @@
+# drive all conditions with ERA5
+initial_condition: "ReanalysisTimeVarying"
+external_forcing: "ReanalysisMonthlyAveragedDiurnal"
+surface_setup: "ReanalysisTimeVarying"
+surface_temperature: "ReanalysisTimeVarying"
+start_date: "20070701"
+site_latitude: 17.0
+site_longitude: -149.0
+turbconv: "prognostic_edmfx"
+
+# solve implicitly
+implicit_diffusion: true
+implicit_sgs_advection: true
+implicit_sgs_mass_flux: true
+implicit_sgs_entr_detr: true
+implicit_sgs_nh_pressure: true
+
+approximate_linear_solve_iters: 2
+edmfx_upwinding: first_order
+edmfx_sgsflux_upwinding: first_order
+tracer_upwinding: vanleer_limiter
+energy_upwinding: vanleer_limiter
+rayleigh_sponge: true
+edmfx_entr_model: "PiGroups"
+edmfx_detr_model: "PiGroups"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+edmfx_filter: true
+prognostic_tke: true
+precip_model: "0M"
+prescribe_ozone: false
+moist: "equil"
+config: "column"
+z_max: 45e3
+z_elem: 200
+z_stretch: true
+dz_bottom: 30
+perturb_initstate: false
+dt: "30secs"
+dt_rad: "10mins"
+t_end: "30hours"
+cloud_model: "quadrature_sgs"
+call_cloud_diagnostics_per_stage: true
+toml: [toml/prognostic_edmfx_calibrated.toml]
+netcdf_output_at_levels: true
+netcdf_interpolation_num_points: [2, 2, 60]
+output_default_diagnostics: false
+rad: allskywithclear
+insolation: "externaldriventv"
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [rlut, rlutcs, rsut, rsutcs, clwvi, lwp, clivi, dsevi, clvi, prw, hurvi, husv]
+    period: 10mins
+  - reduction_time: max
+    short_name: tke
+    period: 10mins

--- a/docs/src/single_column_prospect.md
+++ b/docs/src/single_column_prospect.md
@@ -1,11 +1,25 @@
 # Single Column Models
-`ClimaAtmos.jl` supports several canonical test cases that are run in a single column model designed to verify how PROSPECT (EDMF) performs against other test cases. These cases include variants of `bomex`, `dycoms`, `rico`, `soares`, and `trmm` and can be found in the `config/model_configs` directory. To run, for example, the BOMEX test case execute the following:
+`ClimaAtmos.jl` supports several canonical test cases that are run in a single column model designed to verify how well PROSPCT (EDMF) is able to reproduce each of the convective schemes. These cases include variants of `bomex`, `dycoms`, `rico`, `soares`, `gabls`, `gate`,and `trmm` and can be found in the `config/model_configs` directory. The purpose of each simulation is summarized in the following table:
+
+| Abbreviation | Long Name | Cloud Regime | Reference |
+|--------------|-----------|--------------|-----------|
+| BOMEX | Barbados Oceanographic and Meteorological Experiment | Marine Cumulus | [Siebesma et al. (2003)](https://doi.org/10.1175/1520-0469(2003)60<1201:ALESIS>2.0.CO;2) |
+| DYCOMS | Dynamics and Chemistry of Marine Stratocumulus | Marine Stratocumulus | [Stevens et al. (2005)](https://doi.org/10.1175/MWR2930.1), [Ackerman et al. (2009)](https://doi.org/10.1175/2008MWR2582.1) |
+| RICO | Rain in Cumulus over the Ocean | Rainy Cumulus | [Rauber et al. (2007)](https://doi.org/10.1175/BAMS-88-12-1912) |
+| SOARES | Shallow Cumulus Convection | Shallow Cumulus | [Soares et al. (2004)](https://doi.org/10.1256/qj.03.223) |
+| GABLS | GEWEX Atmospheric Boundary Layer Study | Dry Convective Boundary Layer | [Kosović & Curry (2000)](https://doi.org/10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2) |
+| TRMM | Tropical Rainfall Measuring Mission | Deep Convection | [Grabowski et al. (2006)](https://doi.org/10.1256/qj.04.147) |
+| ARM_SGP | Atmospheric Radiation Measurement Southern Great Plains | Continental Shallow Cumulus | [Brown et al. (2002)](https://doi.org/10.1256/qj.01.202) |
+| LifeCycle | Life Cycle of Shallow Cumulus | Shallow Cumulus Life Cycle | [Tan et al. (2018)](https://doi.org/10.1002/2017MS001162) |
+| GATE_III | GARP Atlantic Tropical Experiment | Tropical Deep Convection | [Khairoutdinov et al. (2009)](https://doi.org/10.3894/JAMES.2009.1.15) |
+
+For example, to run the BOMEX test case execute the following:
 ```bash
-julia --project=examples examples/hybrid/driver.jl --config_file config/model_configs/prognostic_edmfx_bomex_column.yml --job_id bomex
+julia --project=.buildkite examples/hybrid/driver.jl --config_file config/model_configs/prognostic_edmfx_bomex_column.yml --job_id bomex
 ```
-It may also be helpful to run in interactive mode to be able to examine the simulation object, debug, and develop the code further. To enter debug mode run `julia --project=examples` and then in the REPL run:
+It may also be helpful to run in interactive mode to be able to examine the simulation object, debug, and develop the code further. To enter debug mode run `julia --project=.buildkite` and then in the REPL run:
 ```julia
-using Revise
+using Revise # if you are developing ClimaAtmos
 import ClimaAtmos as CA
 
 # get the configuration arguments
@@ -14,7 +28,7 @@ sol_res = CA.solve_atmos!(simulation) # run the simulation
 ```
 
 ## Externally-Driven Single Column Models
-Currently two versions of the externally driven single column model, `GCM` driven and `ReanalysisTimeVarying` are supported in `ClimaAtmos.jl`. They have been developed specifically for the purpose of realistic simulation and model calibration. Externally-driven means that the model is initialized and forced with data coming from a different simulation. This differs from setups like, for example, BOMEX or SOARES which have steady forcing or functional forcing, respectively.
+Currently three versions of the externally driven single column model, `GCM` driven, `ReanalysisTimeVarying` driven, and `ReanalysisMonthlyAveragedDiurnal` driven are supported in `ClimaAtmos.jl`. Externally-driven means that the model is initialized and forced with data coming from a different simulation. This differs from setups like, for example, BOMEX or SOARES which have steady forcing and low domain tops (~4km) or functional forcing, respectively. They have been developed specifically for the purpose of model calibration by recreating statistics that are close to either LES, for the `GCM` driven case only, or to observations.
 
 ### GCM-Driven Case
 For the `GCM` driven case we can run the experiment using the config file `config/model_configs/prognostic_edmfx_gcmdriven_column.yml` by running:
@@ -32,7 +46,8 @@ surface_setup: "GCM"
 Here we must set all of `initial_condition`, `external_forcing` and `surface_setup` to be `GCM` as each component requires information from the external file. The `external_forcing_file` and `cfsite_number` together determine the temperature, specific humidity, and wind as well as horizontal and vertical advection profiles that drive the simulation, and can be set to a local file path as opposed to using the artifact. Radiation and surface temperature are also specified. Here the forcing file, an example of which is stored in the artifact, contains groups for each `cfsite` to drive the simulation. See [Shen et al. 2022](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021MS002631) for more information.
 
 ### Reanalysis-Driven Case
-The `ReanalysisTimeVarying` case extends the `GCM` driven case by providing support for single-column simulations which resolve the diurnal cycle, can be run at any site globally, and use reanalysis to drive the simulation, allowing for calibration of EDMF to earth-system observations in the single-column setting. This feature was found to be needed to address biases in calibration arising from correlation between time-of-day and cloud liquid water path over the tropical Pacific. For this simulation we again highlight similar arguments in the config file:
+#### Matched ERA5 Trajectory
+The `ReanalysisTimeVarying` case extends the `GCM` driven case by providing support for single-column simulations which resolve the diurnal cycle, can be run at any site globally, and uses reanalysis to drive the simulation, allowing for calibration of EDMF to earth-system observations in the single-column setting. This feature was found to be needed to address biases in calibration arising from correlation between time-of-day and cloud liquid water path over the tropical Pacific. For this simulation we again highlight similar arguments in the config file:
 ```YAML
 initial_condition: "ReanalysisTimeVarying"
 external_forcing: "ReanalysisTimeVarying"
@@ -47,18 +62,37 @@ By this point, the first 4 entries are intuitive. We need to dispatch over each 
 !!! note
     Depending on the amount of smoothing and data resolution, points near the boundaries will throw index errors. With default settings, users should stay at least 5 points away from the poles (1° for ERA5 data) for smoothing (4 points) and gradients (one extra point).
 
-The data is generated by downloading from ECMWF and further documentation for ERA5 data download can be found either directly on the ECMWF page and `ClimaArtifacts.jl`. Note that the profiles, surface temperature, and surface fluxes cannot be obtained from a single request and so together we need 3 files for all the data. We include a script at `src/utils/era5_observations_to_forcing_file.jl` which extracts the profiles and computes the tendencies needed for the simulation from the raw ERA5 reanalysis files. We store the observations directly into an artifact `era5_hourly_atmos_processed` to eliminate the need to reprocess specific sites and locations. This setup means that users are free to choose sites globally at any time at which ERA5 data is available. Unfortunately, global hourly renanalysis is too large to store in an artifact and so we have currently only provided support for the first 5 days of July 2007 in the tropical Pacific, stored in `era5_hourly_atmos_raw`, only available on the `clima` and Caltech `HPC` servers.
-#### Running the Reanalysis-driven case at different times and locations
+The data is generated by downloading from ECMWF and further documentation for ERA5 data download can be found either directly on the ECMWF page and `ClimaArtifacts.jl`. Note that the profiles, surface temperature, and surface fluxes cannot be obtained from a single request and so together we need 3 files for all the data. We include a script at `src/utils/era5_observations_to_forcing_file.jl` which extracts the profiles and computes the tendencies needed for the simulation from the raw ERA5 reanalysis files. We store the observations directly into an artifact `era5_hourly_atmos_processed` to eliminate the need to reprocess specific sites and locations. This setup means that users are free to choose sites globally at any time at which ERA5 data is available. Unfortunately, global hourly renanalysis is too large to store in an artifact and so we have currently only provided support for the first 5 days of July 2007 in the tropical Pacific, stored in `era5_hourly_atmos_raw`, only available on the `clima` and Caltech `HPC` servers. The test case can be run using: 
+```bash
+julia --project=.buildkite examples/hybrid/driver.jl --config_file config/model_configs/prognostic_edmfx_tv_era5driven_column.yml --job_id era5driven
+```
+
+#### Monthly Averaged Forcing
+As the matched ERA5 trajectory is data intensive, requiring downloads for each day, we have also implemented an external forcing dispatch to repeat a specific day of data indefinitely. This setup is ideal for use with monthly averaged ERA5 data by hour of day and can be used to calibrate to monthly statistics. The setup is similar, except we change the flag for `external_forcing` to indicate that we want to repeat data: 
+```YAML
+initial_condition: "ReanalysisTimeVarying"
+external_forcing: "ReanalysisMonthlyAveragedDiurnal"
+surface_setup: "ReanalysisTimeVarying"
+surface_temperature: "ReanalysisTimeVarying"
+start_date: "20070701"
+site_latitude: 17.0
+site_longitude: -149.0
+```
+```bash
+julia --project=.buildkite examples/hybrid/driver.jl --config_file config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml --job_id bomex
+```
+
+#### Running the Reanalysis-driven cases at different times and locations
 You need 3 separate files with specific variables and naming convention for the data processing script to work.
-1. Hourly profiles with variables, following ERA5 naming convention, including `t`, `q`, `u`, `v`, `w`, `z`, `clwc`, `ciwc`. This file should be stored in the appropriate artifacts directory with the following naming scheme `"forcing_and_cloud_hourly_profiles_$(start_date).nc"` where `start_date` should specify the date data starts on formatted YYYYMMDD. We require `clwc` and `ciwc` profiles because these are typical targets for calibration but are not needed to run the simulation directly.
-2. Instantaneous variables, including surface temperature `ts` which should be stored in `"hourly_inst_$(start_date).nc"`
-3. Accumulated variables, including surface sensible and latent heat fluxes, `hfls` and `hfss`, which should be stored in `"hourly_accum_$(start_date).nc"`. These need to be divided by the appropriate time resolution, which for hourly data is 3600 and for daily and monthly data is 86400 (not a typo see [here](https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation#ERA5:datadocumentation-Monthlymeans)).
+1. Hourly profiles with variables, following ERA5 naming convention, including `t`, `q`, `u`, `v`, `w`, `z`, `clwc`, `ciwc`. This file should be stored in the appropriate artifacts directory, named `"forcing_and_cloud_hourly_profiles_$(start_date).nc"` for `ReanalysisTimeVarying` and `monthly_diurnal_profiles_$start_date).nc` for `ReanalysisMonthlyAveragedDiurnal` where `start_date` should specify the date data starts on formatted YYYYMMDD. We require `clwc` and `ciwc` profiles because these are typical targets for calibration but are not needed to run the simulation directly.
+2. Instantaneous variables, including surface temperature `ts` which should be stored in `"hourly_inst_$(start_date).nc"` for `ReanalysisTimeVarying` and `monthly_diurnal_inst` for `ReanalysisMonthlyAveragedDiurnal`.
+3. Accumulated variables, including surface sensible and latent heat fluxes, `hfls` and `hfss`, which should be stored in `"hourly_accum_$(start_date).nc"` for `ReanalysisTimeVarying` and `monthly_diurnal_accum` for `ReanalysisMonthlyAveragedDiurnal`. These need to be divided by the appropriate time resolution, which for hourly data is 3600 and for daily and monthly data is 86400 (not a typo see [here](https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation#ERA5:datadocumentation-Monthlymeans)).
 
 ##### On HPC/Clima
 To run locations already in the artifact, e.g., sites in the tropical Pacific in the first 5 days of July 2007 the config file will work out of the box. To run other locations or times please follow the steps for local.
 
 ##### On local
-To run the simulation on a local machine you will need to first download the reanalysis data from ECMWF, ensuring that you have all the required variables. This will be stored in 3 separate files which should be all placed in the same directory. The user must use their `Overrides.toml` in their `.julia/artifacts` path to make the `era5_hourly_atmos_raw` artifact point to the folder where the data is stored. For the raw data and location for processed files you'll need to specify the path where the data is stored and where to store the files as follows:
+To run the simulation on a local machine you will need to first download the reanalysis data from ECMWF, ensuring that you have all the required variables. This will be stored in 3 separate files which should be all placed in the same directory. The user edit `.julia/artifacts/Overrides.toml` to point the `era5_hourly_atmos_raw` artifact point to the folder where the data is stored. For the raw data and location for processed files you'll need to specify the path where the data is stored and where to store the files as follows:
 ```bash
 8234def2ead82e385a330a48ed2f0c030e434065 = "/some/random/path/raw_data_dir" # for raw data
 a1a465e8d237d78bef1e6d346054da395787a9f9 = "/some/random/path/processed_files" # for storing

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -327,7 +327,7 @@ function get_callbacks(config, sim_info, atmos, params, Y, p)
         )
     end
 
-    if parsed_args["external_forcing"] == "ReanalysisTimeVarying" &&
+    if parsed_args["external_forcing"] in ["ReanalysisTimeVarying", "ReanalysisMonthlyAveragedDiurnal"] &&
        parsed_args["config"] == "column"
         callbacks = (
             callbacks...,

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -550,13 +550,13 @@ function external_forcing_cache(
 end
 
 """
-    external_forcing_cache(Y, external_forcing::ISDACForcing, params)
+    external_forcing_cache(Y, external_forcing::ISDACForcing, params, _)
 
 Returns an empty cache for ISDAC (Indirect and Semi-Direct Aerosol Campaign)
 forcing. ISDAC forcing profiles are analytical functions of height, not requiring 
 pre-loading from files into cached fields.
 """
-external_forcing_cache(Y, external_forcing::ISDACForcing, params) = (;)  # Don't need to cache anything
+external_forcing_cache(Y, external_forcing::ISDACForcing, params, _) = (;)  # Don't need to cache anything
 
 """
     external_forcing_tendency!(Yₜ, Y, p, t, ::ISDACForcing)

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -475,6 +475,8 @@ function external_forcing_cache(
             column_target_space;
             reference_date = start_date,
             regridder_kwargs = (; extrapolation_bc),
+            # useful for monthly averaged diurnal data - does not affect hourly era5 case because of time bounds flag
+            method = TimeVaryingInputs.LinearInterpolation(TimeVaryingInputs.PeriodicCalendar())
         ) for name in column_tendencies
     ]
 
@@ -485,6 +487,7 @@ function external_forcing_cache(
             surface_target_space;
             reference_date = start_date,
             regridder_kwargs = (; extrapolation_bc),
+            method = TimeVaryingInputs.LinearInterpolation(TimeVaryingInputs.PeriodicCalendar())
         ) for name in surface_tendencies
     ]
 
@@ -543,7 +546,6 @@ function external_forcing_cache(
             FT,
         ),
     )
-
     return (; era5_tv_column_cache..., era5_tv_surface_cache..., era5_cache...)
 end
 

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -473,7 +473,6 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
     elseif external_forcing == "ReanalysisMonthlyAveragedDiurnal"
         external_forcing_file = get_external_monthly_forcing_file_path(parsed_args)
         # ExternalDrivenMonthlyAveragedDiurnalForcing{FT}(external_forcing_file)
-        ExternalDrivenTVForcing{FT}(external_forcing_file)
         # generate single file from monthly averaged diurnal data if it doesn't exist
         # we'll use ClimaUtilities.TimeVaryingInputs downstream to repeat the data. 
         if !isfile(external_forcing_file)
@@ -485,6 +484,7 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
                 source_strings = ["monthly_diurnal_profiles", "monthly_diurnal_inst", "monthly_diurnal_accum"]
             )
         end
+        ExternalDrivenTVForcing{FT}(external_forcing_file)
 
     elseif external_forcing == "ISDAC"
         ISDACForcing()

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -431,7 +431,7 @@ end
 function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
     external_forcing = parsed_args["external_forcing"]
     @assert external_forcing in
-            (nothing, "GCM", "ReanalysisTimeVarying", "ISDAC")
+            (nothing, "GCM", "ReanalysisTimeVarying", "ReanalysisMonthlyAveragedDiurnal", "ISDAC")
     reanalysis_required_fields = map(
         x -> parsed_args[x],
         [
@@ -441,10 +441,10 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
             "initial_condition",
         ],
     )
-    if any(reanalysis_required_fields .== "ReanalysisTimeVarying")
-        @assert all(reanalysis_required_fields .== "ReanalysisTimeVarying") "All of external_forcing, surface_setup, surface_temperature and initial_condition must be set to ReanalysisTimeVarying."
-        @assert parsed_args["config"] == "column" "ReanalysisTimeVarying is only supported in column mode."
-    end
+    # if any(reanalysis_required_fields .== "ReanalysisTimeVarying")
+    #     @assert all(reanalysis_required_fields .== "ReanalysisTimeVarying") "All of external_forcing, surface_setup, surface_temperature and initial_condition must be set to ReanalysisTimeVarying."
+    #     @assert parsed_args["config"] == "column" "ReanalysisTimeVarying is only supported in column mode."
+    # end
     return if isnothing(external_forcing)
         nothing
     elseif external_forcing == "GCM"
@@ -453,7 +453,7 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
         GCMForcing{FT}(parsed_args["external_forcing_file"], cfsite_number_str)
 
     elseif external_forcing == "ReanalysisTimeVarying"
-        external_forcing_file = get_external_forcing_file_path(parsed_args)
+        external_forcing_file = get_external_daily_forcing_file_path(parsed_args)
         if !isfile(external_forcing_file) ||
            !check_external_forcing_file_times(
             external_forcing_file,
@@ -465,10 +465,27 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
                 parsed_args,
                 external_forcing_file,
                 FT,
+                data_dir = joinpath(@clima_artifact("era5_hourly_atmos_raw"), "daily")
             )
         end
 
         ExternalDrivenTVForcing{FT}(external_forcing_file)
+    elseif external_forcing == "ReanalysisMonthlyAveragedDiurnal"
+        external_forcing_file = get_external_monthly_forcing_file_path(parsed_args)
+        # ExternalDrivenMonthlyAveragedDiurnalForcing{FT}(external_forcing_file)
+        ExternalDrivenTVForcing{FT}(external_forcing_file)
+        # generate single file from monthly averaged diurnal data if it doesn't exist
+        # we'll use ClimaUtilities.TimeVaryingInputs downstream to repeat the data. 
+        if !isfile(external_forcing_file)
+            generate_external_forcing_file(
+                parsed_args,
+                external_forcing_file,
+                FT,
+                data_dir = joinpath(@clima_artifact("era5_hourly_atmos_raw"), "monthly"),
+                source_strings = ["monthly_diurnal_profiles", "monthly_diurnal_inst", "monthly_diurnal_accum"]
+            )
+        end
+
     elseif external_forcing == "ISDAC"
         ISDACForcing()
     end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -297,7 +297,7 @@ end
 """
     ExternalDrivenTVForcing
     
-Forcing specified by external forcing file and a start date.
+Forcing specified by external forcing file.
 """
 struct ExternalDrivenTVForcing{FT}
     external_forcing_file::String

--- a/src/utils/era5_observations_to_forcing_file.jl
+++ b/src/utils/era5_observations_to_forcing_file.jl
@@ -18,14 +18,14 @@ import Insolation.Parameters as IP
 import ClimaParams as CP
 
 """
-    get_external_forcing_file_path(parsed_args; data_dir)
+    get_external_daily_forcing_file_path(parsed_args; data_dir)
 
 Get the path to the external forcing file for a given site and start date.
 When using the BUILDKITE env, a temporary directory is used for the
 external forcing file. Otherwise, the file is expected to stored in the
 era5_hourly_atmos_processed artifact directory.
 """
-function get_external_forcing_file_path(
+function get_external_daily_forcing_file_path(
     parsed_args;
     data_dir = get(ENV, "BUILDKITE", "") == "true" ? mktempdir() :
                @clima_artifact("era5_hourly_atmos_processed"),
@@ -43,10 +43,45 @@ function get_external_forcing_file_path(
        site_longitude != parsed_args["site_longitude"]
         @info "Rounded site latitude/longitude from ($(parsed_args["site_latitude"]), $(parsed_args["site_longitude"])) to ($(site_latitude), $(site_longitude)) for ERA5 quarter-degree resolution."
     end
-
+    if !isdir(joinpath(data_dir, "daily"))
+        mkdir(joinpath(data_dir, "daily"))
+    end
     return joinpath(
         data_dir,
+        "daily",
         "tv_forcing_$(site_latitude)_$(site_longitude)_$(start_date)_$(end_date).nc",
+    )
+end
+
+"""
+    get_external_monthly_forcing_file_path(parsed_args; data_dir)
+
+Get the path to the external forcing file for a given site and start date.
+When using the BUILDKITE env, a temporary directory is used for the
+external forcing file. Otherwise, the file is expected to stored in the
+era5_hourly_atmos_processed artifact directory.
+"""
+function get_external_monthly_forcing_file_path(
+    parsed_args;
+    data_dir = get(ENV, "BUILDKITE", "") == "true" ? mktempdir() :
+               @clima_artifact("era5_hourly_atmos_processed"),
+)
+    start_date = parsed_args["start_date"]
+    # round to era5 quarter degree resolution for site selection
+    site_latitude = round(parsed_args["site_latitude"] * 4) / 4
+    site_longitude = round(parsed_args["site_longitude"] * 4) / 4
+
+    if site_latitude != parsed_args["site_latitude"] ||
+       site_longitude != parsed_args["site_longitude"]
+        @info "Rounded site latitude/longitude from ($(parsed_args["site_latitude"]), $(parsed_args["site_longitude"])) to ($(site_latitude), $(site_longitude)) for ERA5 quarter-degree resolution."
+    end
+    if !isdir(joinpath(data_dir, "monthly"))
+        mkdir(joinpath(data_dir, "monthly"))
+    end
+    return joinpath(
+        data_dir,
+        "monthly",
+        "monthly_diurnal_cycle_forcing_$(site_latitude)_$(site_longitude)_$(start_date).nc",
     )
 end
 
@@ -196,6 +231,7 @@ and should contain 3 files:
     - Column profile dataset, named "forcing_and_cloud_hourly_profiles_"start_date".nc"
     - Surface sensible and latent heat fluxes, named "hourly_accum_"start_date".nc"
     - Surface temperature, named "hourly_inst_"start_date".nc"
+Parsed args should contain the site_latitude, site_longitude, and start_date.
 
 The variables and specific naming convention for these files is better described in the Single Column
 Model section of the documentation.
@@ -211,16 +247,20 @@ Note:
     in the current implementation.
 - The end time of the simulation is inferred from the start date and the simulation time, `t_end`.
 """
-function generate_external_era5_forcing_file(
-    lat,
-    lon,
-    start_date,
+function generate_external_forcing_file(
+    parsed_args,
     forcing_file_path,
     FT;
     smooth_amount = 4,
     time_resolution = FT(3600), # size of accumulated variable period in seconds (3600 for hourly, 86400 for daily and monthly)
     data_dir = @clima_artifact("era5_hourly_atmos_raw"),
+    source_strings = ["forcing_and_cloud_hourly_profiles", "hourly_inst", "hourly_accum"],
 )
+    # unpack parsed args
+    lat = parsed_args["site_latitude"]
+    lon = parsed_args["site_longitude"]
+    start_date = parsed_args["start_date"]
+
     external_tv_params = CP.get_parameter_values(
         CP.create_toml_dict(FT),
         [
@@ -230,15 +270,16 @@ function generate_external_era5_forcing_file(
             "molar_mass_dry_air",
         ],
     )
+    @info source_strings
     # load datasets
     tvforcing = NCDataset(
         joinpath(
             data_dir,
-            "forcing_and_cloud_hourly_profiles_$(start_date).nc",
+            "$(source_strings[1])_$(start_date).nc",
         ),
     )
-    tv_inst = NCDataset(joinpath(data_dir, "hourly_inst_$(start_date).nc"))
-    tv_accum = NCDataset(joinpath(data_dir, "hourly_accum_$(start_date).nc"))
+    tv_inst = NCDataset(joinpath(data_dir, "$(source_strings[2])_$(start_date).nc"))
+    tv_accum = NCDataset(joinpath(data_dir, "$(source_strings[3])_$(start_date).nc"))
 
     # round to era5 quarter degree resolution for site selection
     lat = round(lat * 4) / 4
@@ -490,17 +531,15 @@ function generate_multiday_era5_external_forcing_file(
             "site_latitude" => parsed_args["site_latitude"],
             "site_longitude" => parsed_args["site_longitude"],
         )
-        single_file_path = get_external_forcing_file_path(
+        single_file_path = get_external_daily_forcing_file_path(
             single_parsed_args;
             data_dir = output_data_dir,
         )
         push!(file_list, single_file_path)
         # generate the external forcing file for this day
         if !isfile(single_file_path)
-            generate_external_era5_forcing_file(
-                parsed_args["site_latitude"],
-                parsed_args["site_longitude"],
-                Dates.format(dd, "yyyymmdd"),
+            generate_external_forcing_file(
+                single_parsed_args,
                 single_file_path,
                 FT;
                 time_resolution = time_resolution,

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -277,7 +277,7 @@ end
 
     temporary_dir = mktempdir()
     sim_forcing =
-        CA.get_external_forcing_file_path(parsed_args, data_dir = temporary_dir)
+        CA.get_external_daily_forcing_file_path(parsed_args, data_dir = temporary_dir)
 
     @test basename(sim_forcing) ==
           "tv_forcing_0.0_0.0_$(parsed_args["start_date"])_$(parsed_args["start_date"]).nc"
@@ -287,7 +287,7 @@ end
 
     # Generate forcing file
     time_resolution = FT(3600)
-    CA.generate_external_era5_forcing_file(
+    CA.generate_external_forcing_file(
         parsed_args["site_latitude"],
         parsed_args["site_longitude"],
         parsed_args["start_date"],
@@ -359,7 +359,7 @@ end
     input_dir = mktempdir()
     output_dir = mktempdir()
     sim_forcing =
-        CA.get_external_forcing_file_path(parsed_args, data_dir = output_dir)
+        CA.get_external_daily_forcing_file_path(parsed_args, data_dir = output_dir)
 
     # Create mock datasets for multiple days
     start_date = Dates.DateTime(parsed_args["start_date"], "yyyymmdd")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a new ERA5 driven case that uses ClimaUtilities to repeat diurnal cycle ERA5 forcing ad nauseam. Case should improve signal to noise by allowing longer time integrals and solve the large data problem associated with downloading global ERA5 hourly data on pressure levels. 

## To-do <!--_(to move to "Content" on completion)_ -->
- [ ] Address commented checks to ensure that the configuration is valid
- [ ] Fix ISDAC case: we think it's just an args error
- [ ] Are the names ok? `ReanalysisMonthlyAveragedDiurnal` is long. Utilities names are also long
- [ ] Make sure default yml is up to date

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 