### PR TITLE
Rename variable after AtmosModel refactor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaAtmos.jl Release Notes
 main
 -------
 
+PR [#3886](https://github.com/CliMA/ClimaAtmos.jl/pull/3886) renames `PrognosticSurfaceTemperature` -> `SlabOceanSST`, `PrescribedSurfaceTemperature` -> `PrescribedSST` and deprecates the `prognostic_surface = "Prognostic/PrescribedSurfaceTemperature"` config argument
+
 PR [#3883](https://github.com/CliMA/ClimaAtmos.jl/pull/3883) adds atmosphere initial condition for WeatherQuest from ERA5
 
 PR [#3870](https://github.com/CliMA/ClimaAtmos.jl/pull/3870) adds externally driven SCM models forced by monthly-averaged ERA5
@@ -12,7 +14,6 @@ factor speedup. The associated documentation section, "Single Column Model", was
 
 v0.30.4
 -------
-
 PR [#3856](https://github.com/CliMA/ClimaAtmos.jl/pull/3856) adds number adjustment tendencies to the two-moment microphysics scheme.
 
 v0.30.3

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -272,7 +272,7 @@ prognostic_tke:
   help: "A flag for prognostic TKE [`false` (default), `true`]"
   value: false
 prognostic_surface:
-  help: "Determines if surface temperature is prognostic [`false` (default), , `true`, `PrognosticSurfaceTemperature`, `PrescribedSurfaceTemperature`]"
+  help: "Determines if surface temperature is prognostic [`false` (default), , `true`, `SlabOceanSST`, `PrescribedSST`]"
   value: false
 albedo_model:
   help: "Variable surface albedo [`ConstantAlbedo` (default), `RegressionFunctionAlbedo`, `CouplerAlbedo`]"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
@@ -11,7 +11,7 @@ t_end: "360days"
 dt_save_state_to_disk: "30days"
 check_conservation: true
 moist: "equil"
-prognostic_surface: "PrognosticSurfaceTemperature"
+prognostic_surface: "SlabOceanSST"
 albedo_model: "RegressionFunctionAlbedo"
 surface_setup: "DefaultMoninObukhov"
 vert_diff: "DecayWithHeightDiffusion"

--- a/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean.yml
+++ b/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean.yml
@@ -10,5 +10,5 @@ approximate_linear_solve_iters: 2
 rad: "clearsky"
 insolation: "timevarying"
 dt_rad: "1hours"
-prognostic_surface: "PrognosticSurfaceTemperature"
+prognostic_surface: "SlabOceanSST"
 check_conservation: true

--- a/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
+++ b/config/model_configs/aquaplanet_equil_clearsky_tvinsol_0M_slabocean_ft64.yml
@@ -10,5 +10,5 @@ approximate_linear_solve_iters: 2
 rad: "clearsky"
 insolation: "timevarying"
 dt_rad: "1hours"
-prognostic_surface: "PrognosticSurfaceTemperature"
+prognostic_surface: "SlabOceanSST"
 check_conservation: true

--- a/config/model_configs/baroclinic_wave_equil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_equil_conservation_source.yml
@@ -3,7 +3,7 @@ dt: "400secs"
 t_end: "10days"
 moist: "equil"
 surface_setup: DefaultMoninObukhov
-prognostic_surface: "PrognosticSurfaceTemperature"
+prognostic_surface: "SlabOceanSST"
 rad: "clearsky"
 precip_model: "0M"
 vert_diff: true

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -111,7 +111,7 @@ function build_cache(
     net_energy_flux_sfc = [Geometry.WVector(FT(0))]
 
     conservation_check =
-        !(atmos.precip_model isa NoPrecipitation) ?
+        !(atmos.microphysics_model isa NoPrecipitation) ?
         (;
             col_integrated_precip_energy_tendency = zeros(
                 axes(Fields.level(Geometry.WVector.(Y.f.u₃), half)),

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -272,7 +272,7 @@ function compute_ρaʲu³ʲ(
     detrʲ_prev_level,
     u³ʲ_data_prev_halflevel,
     S_q_totʲ_prev_level,
-    precip_model,
+    microphysics_model,
 )
 
     ρaʲu³ʲ_data =
@@ -282,7 +282,7 @@ function compute_ρaʲu³ʲ(
     ρaʲu³ʲ_data +=
         (1 / J_halflevel) *
         (J_prev_level * ρaʲ_prev_level * (entrʲ_prev_level - detrʲ_prev_level))
-    if precip_model isa Union{Microphysics0Moment, Microphysics1Moment}
+    if microphysics_model isa Union{Microphysics0Moment, Microphysics1Moment}
         ρaʲu³ʲ_data +=
             (1 / J_halflevel) *
             (J_prev_level * ρaʲ_prev_level * S_q_totʲ_prev_level)
@@ -295,7 +295,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     p,
     t,
 )
-    (; turbconv_model, precip_model) = p.atmos
+    (; turbconv_model, microphysics_model) = p.atmos
     FT = eltype(Y)
     n = n_mass_flux_subdomains(turbconv_model)
     ᶜz = Fields.coordinate_field(Y.c).z
@@ -323,7 +323,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     ) = p.precomputed
     (; ᶠu³⁰, ᶜK⁰, ᶜtke⁰) = p.precomputed
 
-    if precip_model isa Microphysics1Moment
+    if microphysics_model isa Microphysics1Moment
         ᶜq_liqʲs = p.precomputed.ᶜq_liqʲs
         ᶜq_iceʲs = p.precomputed.ᶜq_iceʲs
         q_rai = p.precomputed.ᶜqᵣ
@@ -384,7 +384,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
         z_prev_level = Fields.field_values(Fields.level(ᶜz, i - 1))
         dz_prev_level = Fields.field_values(Fields.level(ᶜdz, i - 1))
 
-        if precip_model isa Microphysics1Moment
+        if microphysics_model isa Microphysics1Moment
             q_rai_prev_level = Fields.field_values(Fields.level(q_rai, i - 1))
             q_sno_prev_level = Fields.field_values(Fields.level(q_sno, i - 1))
         end
@@ -409,10 +409,11 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
             ᶠnh_pressure³_buoyʲ = ᶠnh_pressure³_buoyʲs.:($j)
             ᶠnh_pressure³_dragʲ = ᶠnh_pressure³_dragʲs.:($j)
 
-            if precip_model isa Union{Microphysics0Moment, Microphysics1Moment}
+            if microphysics_model isa
+               Union{Microphysics0Moment, Microphysics1Moment}
                 ᶜS_q_totʲ = p.precomputed.ᶜSqₜᵖʲs.:($j)
             end
-            if precip_model isa Microphysics1Moment
+            if microphysics_model isa Microphysics1Moment
                 ᶜS_q_raiʲ = p.precomputed.ᶜSqᵣᵖʲs.:($j)
                 ᶜS_q_snoʲ = p.precomputed.ᶜSqₛᵖʲs.:($j)
                 ᶜS_e_totʲ = p.precomputed.ᶜSeₜᵖʲs.:($j)
@@ -455,13 +456,13 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                 CAP.R_d(params) * CAP.T_surf_ref(params) / CAP.grav(params)
 
             S_q_totʲ_prev_level =
-                if precip_model isa
+                if microphysics_model isa
                    Union{Microphysics0Moment, Microphysics1Moment}
                     Fields.field_values(Fields.level(ᶜS_q_totʲ, i - 1))
                 else
                     Ref(nothing)
                 end
-            if precip_model isa Microphysics1Moment
+            if microphysics_model isa Microphysics1Moment
                 S_q_raiʲ_prev_level =
                     Fields.field_values(Fields.level(ᶜS_q_raiʲ, i - 1))
                 S_q_snoʲ_prev_level =
@@ -571,7 +572,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
             # Updraft q_tot sources from precipitation formation
             # To be applied in updraft continuity, moisture and energy
             # for updrafts and grid mean
-            if precip_model isa Microphysics0Moment
+            if microphysics_model isa Microphysics0Moment
                 @. S_q_totʲ_prev_level = q_tot_0M_precipitation_sources(
                     thermo_params,
                     microphys_0m_params,
@@ -579,7 +580,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                     q_totʲ_prev_level,
                     tsʲ_prev_level,
                 )
-            elseif precip_model isa Microphysics1Moment
+            elseif microphysics_model isa Microphysics1Moment
                 compute_precipitation_sources!(
                     Sᵖ_prev_level,
                     Sᵖ_snow_prev_level,
@@ -689,7 +690,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                 detrʲ_prev_level,
                 u³ʲ_data_prev_halflevel,
                 S_q_totʲ_prev_level,
-                precip_model,
+                microphysics_model,
             )
 
             @. u³ʲ_halflevel = ifelse(
@@ -733,7 +734,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                         mseʲ_prev_level
                     )
                 )
-            if precip_model isa Microphysics0Moment
+            if microphysics_model isa Microphysics0Moment
                 @. ρaʲu³ʲ_datamse +=
                     (1 / local_geometry_halflevel.J) * (
                         local_geometry_prev_level.J *
@@ -747,7 +748,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                             )
                         )
                     )
-            elseif precip_model isa Microphysics1Moment
+            elseif microphysics_model isa Microphysics1Moment
                 @. ρaʲu³ʲ_datamse +=
                     (1 / local_geometry_halflevel.J) * (
                         local_geometry_prev_level.J *
@@ -782,7 +783,8 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                         q_totʲ_prev_level
                     )
                 )
-            if precip_model isa Union{Microphysics0Moment, Microphysics1Moment}
+            if microphysics_model isa
+               Union{Microphysics0Moment, Microphysics1Moment}
                 @. ρaʲu³ʲ_dataq_tot +=
                     (1 / local_geometry_halflevel.J) * (
                         local_geometry_prev_level.J *
@@ -885,7 +887,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_top_bc!(
     (; ᶜentrʲs, ᶜdetrʲs, ᶜturb_entrʲs) = p.precomputed
     (; ᶠu³⁰, ᶠu³ʲs, ᶜuʲs, ᶠnh_pressure³_buoyʲs, ᶠnh_pressure³_dragʲs) =
         p.precomputed
-    (; precip_model) = p.atmos
+    (; microphysics_model) = p.atmos
 
     # set values for the top level
     i_top = Spaces.nlevels(axes(Y.c))
@@ -924,12 +926,13 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_top_bc!(
         fill!(turb_entrʲ_level, RecursiveApply.rzero(eltype(turb_entrʲ_level)))
         @. ᶜuʲ = C123(Y.c.uₕ) + ᶜinterp(C123(ᶠu³ʲ))
 
-        if precip_model isa Union{Microphysics0Moment, Microphysics1Moment}
+        if microphysics_model isa
+           Union{Microphysics0Moment, Microphysics1Moment}
             ᶜS_q_totʲ = p.precomputed.ᶜSqₜᵖʲs.:($j)
             S_q_totʲ_level = Fields.field_values(Fields.level(ᶜS_q_totʲ, i_top))
             @. S_q_totʲ_level = 0
         end
-        if precip_model isa Microphysics1Moment
+        if microphysics_model isa Microphysics1Moment
             ᶜS_q_raiʲ = p.precomputed.ᶜSqᵣᵖʲs.:($j)
             ᶜS_q_snoʲ = p.precomputed.ᶜSqₛᵖʲs.:($j)
             ᶜS_e_totʲ = p.precomputed.ᶜSeₜᵖʲs.:($j)
@@ -954,7 +957,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
     p,
     t,
 )
-    (; moisture_model, turbconv_model, precip_model) = p.atmos
+    (; moisture_model, turbconv_model, microphysics_model) = p.atmos
     n = n_mass_flux_subdomains(turbconv_model)
     ᶜz = Fields.coordinate_field(Y.c).z
     ᶜdz = Fields.Δz_field(axes(Y.c))
@@ -1072,7 +1075,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
     Y,
     p,
     t,
-    precip_model::Microphysics0Moment,
+    microphysics_model::Microphysics0Moment,
 )
     thermo_params = CAP.thermodynamics_params(p.params)
     microphys_0m_params = CAP.microphysics_0m_params(p.params)
@@ -1093,7 +1096,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_precipita
     Y,
     p,
     t,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
 )
     error("Not implemented yet")
     #thermo_params = CAP.thermodynamics_params(p.params)

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -31,7 +31,7 @@ function Kin(ᶜw_precip, ᶜu_air)
 end
 
 """
-    set_precipitation_velocities!(Y, p, moisture_model, precip_model)
+    set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
 
 Updates the precipitation terminal velocity, cloud sedimentation velocity,
 and their contribution to total water and energy advection.
@@ -46,7 +46,7 @@ function set_precipitation_velocities!(
     Y,
     p,
     moisture_model::NonEquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
 )
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ, ᶜts, ᶜu) = p.precomputed
     (; ᶜΦ) = p.core
@@ -102,7 +102,7 @@ function set_precipitation_velocities!(
     Y,
     p,
     moisture_model::NonEquilMoistModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
 )
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwnₗ, ᶜwnᵣ, ᶜwₜqₜ, ᶜwₕhₜ, ᶜts, ᶜu) = p.precomputed
     (; ᶜΦ) = p.core
@@ -182,7 +182,7 @@ function set_precipitation_velocities!(
 end
 
 """
-    set_precipitation_cache!(Y, p, precip_model, turbconv_model)
+    set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
 
 Computes the cache needed for precipitation tendencies. When run without edmf
 model this involves computing precipitation sources based on the grid mean
@@ -423,7 +423,7 @@ set_precipitation_surface_fluxes!(Y, p, _) = nothing
 function set_precipitation_surface_fluxes!(
     Y,
     p,
-    precip_model::Microphysics0Moment,
+    microphysics_model::Microphysics0Moment,
 )
     ᶜT = p.scratch.ᶜtemp_scalar
     (; ᶜts) = p.precomputed  # assume ᶜts has been updated
@@ -450,7 +450,7 @@ end
 function set_precipitation_surface_fluxes!(
     Y,
     p,
-    precip_model::Union{Microphysics1Moment, Microphysics2Moment},
+    microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
 )
     (; surface_rain_flux, surface_snow_flux) = p.precomputed
     (; col_integrated_precip_energy_tendency,) = p.conservation_check

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -25,7 +25,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     (; ᶜtke⁰, ᶜρa⁰, ᶠu₃⁰, ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜρ⁰, ᶜmse⁰, ᶜq_tot⁰) =
         p.precomputed
     if p.atmos.moisture_model isa NonEquilMoistModel &&
-       p.atmos.precip_model isa Microphysics1Moment
+       p.atmos.microphysics_model isa Microphysics1Moment
         (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
     end
 
@@ -46,7 +46,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
         turbconv_model,
     )
     if p.atmos.moisture_model isa NonEquilMoistModel &&
-       p.atmos.precip_model isa Microphysics1Moment
+       p.atmos.microphysics_model isa Microphysics1Moment
         @. ᶜq_liq⁰ = divide_by_ρa(
             Y.c.ρq_liq - ρaq_liq⁺(Y.c.sgsʲs),
             ᶜρa⁰,
@@ -80,7 +80,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.uₕ, ᶠuₕ³)
     # @. ᶜK⁰ += ᶜtke⁰
     if p.atmos.moisture_model isa NonEquilMoistModel &&
-       p.atmos.precip_model isa Microphysics1Moment
+       p.atmos.microphysics_model isa Microphysics1Moment
         @. ᶜts⁰ = TD.PhaseNonEquil_phq(
             thermo_params,
             ᶜp,
@@ -125,7 +125,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
         ᶜmseʲ = Y.c.sgsʲs.:($j).mse
         ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             ᶜq_liqʲ = Y.c.sgsʲs.:($j).q_liq
             ᶜq_iceʲ = Y.c.sgsʲs.:($j).q_ice
             ᶜq_raiʲ = Y.c.sgsʲs.:($j).q_rai
@@ -135,7 +135,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
         set_velocity_quantities!(ᶜuʲ, ᶠu³ʲ, ᶜKʲ, ᶠu₃ʲ, Y.c.uₕ, ᶠuₕ³)
         @. ᶠKᵥʲ = (adjoint(CT3(ᶠu₃ʲ)) * ᶠu₃ʲ) / 2
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             @. ᶜtsʲ = TD.PhaseNonEquil_phq(
                 thermo_params,
                 ᶜp,
@@ -181,7 +181,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
         ᶜmseʲ = Y.c.sgsʲs.:($j).mse
         ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             ᶜq_liqʲ = Y.c.sgsʲs.:($j).q_liq
             ᶜq_iceʲ = Y.c.sgsʲs.:($j).q_ice
             ᶜq_raiʲ = Y.c.sgsʲs.:($j).q_rai
@@ -247,7 +247,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
             sfc_local_geometry_val,
         )
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             # TODO - any better way to define the cloud and precip tracer flux?
             ᶜq_liq_int_val =
                 Fields.field_values(Fields.level(ᶜspecific.q_liq, 1))
@@ -274,7 +274,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_bottom_bc!(
         ᶜΦ_int_val = Fields.field_values(Fields.level(ᶜΦ, 1))
         ᶜtsʲ_int_val = Fields.field_values(Fields.level(ᶜtsʲ, 1))
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             @. ᶜtsʲ_int_val = TD.PhaseNonEquil_phq(
                 thermo_params,
                 ᶜp_int_val,
@@ -553,7 +553,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
 end
 
 """
-    set_prognostic_edmf_precomputed_quantities_precipitation!(Y, p, precip_model)
+    set_prognostic_edmf_precomputed_quantities_precipitation!(Y, p, microphysics_model)
 
 Updates the precomputed quantities stored in `p` for edmfx precipitation sources.
 """

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -30,7 +30,7 @@ function flux_accumulation!(integrator)
         net_energy_flux_toa[] +=
             horizontal_integral_at_boundary(ᶠradiation_flux, nlevels + half) *
             float(Δt)
-        if p.atmos.surface_model isa PrescribedSurfaceTemperature
+        if p.atmos.surface_model isa PrescribedSST
             net_energy_flux_sfc[] +=
                 horizontal_integral_at_boundary(ᶠradiation_flux, half) *
                 float(Δt)

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -29,7 +29,7 @@ import ..DryModel
 import ..EquilMoistModel
 import ..NonEquilMoistModel
 
-# precip_model
+# microphysics_model
 import ..NoPrecipitation
 import ..Microphysics0Moment
 import ..Microphysics1Moment
@@ -52,7 +52,7 @@ import ..NonOrographicGravityWave
 import ..OrographicGravityWave
 
 # surface_model
-import ..PrognosticSurfaceTemperature
+import ..SlabOceanSST
 
 # functions used to calculate diagnostics
 import ..draft_area

--- a/src/diagnostics/conservation_diagnostics.jl
+++ b/src/diagnostics/conservation_diagnostics.jl
@@ -80,7 +80,7 @@ function compute_energyo!(
     cache,
     time,
     surface_model::T,
-) where {T <: PrognosticSurfaceTemperature}
+) where {T <: SlabOceanSST}
     sfc_cρh =
         surface_model.ρ_ocean *
         surface_model.cp_ocean *
@@ -118,7 +118,7 @@ compute_watero!(
     moisture_model::T1,
     surface_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
-    "Can only compute total water of the ocean with a moist model and with PrognosticSurfaceTemperature",
+    "Can only compute total water of the ocean with a moist model and with SlabOceanSST",
 )
 
 function compute_watero!(
@@ -127,7 +127,7 @@ function compute_watero!(
     cache,
     time,
     moisture_model::Union{EquilMoistModel, NonEquilMoistModel},
-    surface_model::PrognosticSurfaceTemperature,
+    surface_model::SlabOceanSST,
 )
     if isnothing(out)
         return [horizontal_integral_at_boundary(state.sfc.water)]

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -694,16 +694,16 @@ add_diagnostic_variable!(
 # Precipitation (2d)
 ###
 compute_pr!(out, state, cache, time) =
-    compute_pr!(out, state, cache, time, cache.atmos.precip_model)
-compute_pr!(_, _, _, _, precip_model::T) where {T} =
-    error_diagnostic_variable("pr", precip_model)
+    compute_pr!(out, state, cache, time, cache.atmos.microphysics_model)
+compute_pr!(_, _, _, _, microphysics_model::T) where {T} =
+    error_diagnostic_variable("pr", microphysics_model)
 
 function compute_pr!(
     out,
     state,
     cache,
     time,
-    precip_model::Union{
+    microphysics_model::Union{
         NoPrecipitation,
         Microphysics0Moment,
         Microphysics1Moment,
@@ -730,16 +730,16 @@ add_diagnostic_variable!(
 )
 
 compute_prra!(out, state, cache, time) =
-    compute_prra!(out, state, cache, time, cache.atmos.precip_model)
-compute_prra!(_, _, _, _, precip_model::T) where {T} =
-    error_diagnostic_variable("prra", precip_model)
+    compute_prra!(out, state, cache, time, cache.atmos.microphysics_model)
+compute_prra!(_, _, _, _, microphysics_model::T) where {T} =
+    error_diagnostic_variable("prra", microphysics_model)
 
 function compute_prra!(
     out,
     state,
     cache,
     time,
-    precip_model::Union{
+    microphysics_model::Union{
         NoPrecipitation,
         Microphysics0Moment,
         Microphysics1Moment,
@@ -763,16 +763,16 @@ add_diagnostic_variable!(
 )
 
 compute_prsn!(out, state, cache, time) =
-    compute_prsn!(out, state, cache, time, cache.atmos.precip_model)
-compute_prsn!(_, _, _, _, precip_model::T) where {T} =
-    error_diagnostic_variable("prsn", precip_model)
+    compute_prsn!(out, state, cache, time, cache.atmos.microphysics_model)
+compute_prsn!(_, _, _, _, microphysics_model::T) where {T} =
+    error_diagnostic_variable("prsn", microphysics_model)
 
 function compute_prsn!(
     out,
     state,
     cache,
     time,
-    precip_model::Union{
+    microphysics_model::Union{
         NoPrecipitation,
         Microphysics0Moment,
         Microphysics1Moment,
@@ -799,7 +799,7 @@ add_diagnostic_variable!(
 # Precipitation (3d)
 ###
 compute_husra!(out, state, cache, time) =
-    compute_husra!(out, state, cache, time, cache.atmos.precip_model)
+    compute_husra!(out, state, cache, time, cache.atmos.microphysics_model)
 compute_husra!(_, _, _, _, model::T) where {T} =
     error_diagnostic_variable("husra", model)
 
@@ -808,7 +808,7 @@ function compute_husra!(
     state,
     cache,
     time,
-    precip_model::Union{Microphysics1Moment, Microphysics2Moment},
+    microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
 )
     if isnothing(out)
         return state.c.ρq_rai ./ state.c.ρ
@@ -830,7 +830,7 @@ add_diagnostic_variable!(
 )
 
 compute_hussn!(out, state, cache, time) =
-    compute_hussn!(out, state, cache, time, cache.atmos.precip_model)
+    compute_hussn!(out, state, cache, time, cache.atmos.microphysics_model)
 compute_hussn!(_, _, _, _, model::T) where {T} =
     error_diagnostic_variable("hussn", model)
 
@@ -839,7 +839,7 @@ function compute_hussn!(
     state,
     cache,
     time,
-    precip_model::Union{Microphysics1Moment, Microphysics2Moment},
+    microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
 )
     if isnothing(out)
         return state.c.ρq_sno ./ state.c.ρ
@@ -861,7 +861,7 @@ add_diagnostic_variable!(
 )
 
 compute_cdnc!(out, state, cache, time) =
-    compute_cdnc!(out, state, cache, time, cache.atmos.precip_model)
+    compute_cdnc!(out, state, cache, time, cache.atmos.microphysics_model)
 compute_cdnc!(_, _, _, _, model::T) where {T} =
     error_diagnostic_variable("cdnc", model)
 
@@ -870,7 +870,7 @@ function compute_cdnc!(
     state,
     cache,
     time,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
 )
     if isnothing(out)
         return state.c.ρn_liq
@@ -892,7 +892,7 @@ add_diagnostic_variable!(
 )
 
 compute_ncra!(out, state, cache, time) =
-    compute_ncra!(out, state, cache, time, cache.atmos.precip_model)
+    compute_ncra!(out, state, cache, time, cache.atmos.microphysics_model)
 compute_ncra!(_, _, _, _, model::T) where {T} =
     error_diagnostic_variable("ncra", model)
 
@@ -901,7 +901,7 @@ function compute_ncra!(
     state,
     cache,
     time,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
 )
     if isnothing(out)
         return state.c.ρn_rai

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -223,7 +223,7 @@ function default_diagnostics(
     diagnostics = []
 
     # Add moisture and precipitation model diagnostics
-    for model in (atmos_water.moisture_model, atmos_water.precip_model)
+    for model in (atmos_water.moisture_model, atmos_water.microphysics_model)
         !isnothing(model) && append!(
             diagnostics,
             default_diagnostics(model, duration, start_date; output_writer),

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -448,7 +448,7 @@ compute_husraup!(out, state, cache, time) = compute_husraup!(
     state,
     cache,
     time,
-    cache.atmos.precip_model,
+    cache.atmos.microphysics_model,
     cache.atmos.turbconv_model,
 )
 compute_husraup!(
@@ -456,7 +456,7 @@ compute_husraup!(
     _,
     _,
     _,
-    precip_model::T1,
+    microphysics_model::T1,
     turbconv_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
     "Can only compute updraft rain water specific humidity with a 1M precip model and with EDMFX",
@@ -467,7 +467,7 @@ function compute_husraup!(
     state,
     cache,
     time,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
     if isnothing(out)
@@ -496,7 +496,7 @@ compute_hussnup!(out, state, cache, time) = compute_hussnup!(
     state,
     cache,
     time,
-    cache.atmos.precip_model,
+    cache.atmos.microphysics_model,
     cache.atmos.turbconv_model,
 )
 compute_hussnup!(
@@ -504,7 +504,7 @@ compute_hussnup!(
     _,
     _,
     _,
-    precip_model::T1,
+    microphysics_model::T1,
     turbconv_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
     "Can only compute updraft snow specific humidity with a 1M precip model and with EDMFX",
@@ -515,7 +515,7 @@ function compute_hussnup!(
     state,
     cache,
     time,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
     if isnothing(out)
@@ -1042,7 +1042,7 @@ compute_husraen!(out, state, cache, time) = compute_husraen!(
     state,
     cache,
     time,
-    cache.atmos.precip_model,
+    cache.atmos.microphysics_model,
     cache.atmos.turbconv_model,
 )
 compute_husraen!(
@@ -1050,7 +1050,7 @@ compute_husraen!(
     _,
     _,
     _,
-    precip_model::T1,
+    microphysics_model::T1,
     turbconv_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
     "Can only compute updraft rain specific humidity and with a 1M model and with EDMFX",
@@ -1061,7 +1061,7 @@ function compute_husraen!(
     state,
     cache,
     time,
-    precip_model_model::Microphysics1Moment,
+    microphysics_model_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
     thermo_params = CAP.thermodynamics_params(cache.params)
@@ -1091,7 +1091,7 @@ compute_hussnen!(out, state, cache, time) = compute_hussnen!(
     state,
     cache,
     time,
-    cache.atmos.precip_model,
+    cache.atmos.microphysics_model,
     cache.atmos.turbconv_model,
 )
 compute_hussnen!(
@@ -1099,7 +1099,7 @@ compute_hussnen!(
     _,
     _,
     _,
-    precip_model::T1,
+    microphysics_model::T1,
     turbconv_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
     "Can only compute updraft snow specific humidity and with a 1M model and with EDMFX",
@@ -1110,7 +1110,7 @@ function compute_hussnen!(
     state,
     cache,
     time,
-    precip_model_model::Microphysics1Moment,
+    microphysics_model_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
     thermo_params = CAP.thermodynamics_params(cache.params)
@@ -1256,7 +1256,7 @@ compute_edt!(out, state, cache, time) = compute_edt!(
     state,
     cache,
     time,
-    cache.atmos.vert_diff,
+    cache.atmos.vertical_diffusion,
     cache.atmos.turbconv_model,
 )
 compute_edt!(_, _, _, _, vert_diff::T1, turbconv_model::T2) where {T1, T2} =
@@ -1311,7 +1311,7 @@ compute_evu!(out, state, cache, time) = compute_evu!(
     state,
     cache,
     time,
-    cache.atmos.vert_diff,
+    cache.atmos.vertical_diffusion,
     cache.atmos.turbconv_model,
 )
 compute_evu!(_, _, _, _, vert_diff::T1, turbconv_model::T2) where {T1, T2} =

--- a/src/initial_conditions/InitialConditions.jl
+++ b/src/initial_conditions/InitialConditions.jl
@@ -8,8 +8,8 @@ import ..NoPrecipitation
 import ..Microphysics0Moment
 import ..Microphysics1Moment
 import ..Microphysics2Moment
-import ..PrescribedSurfaceTemperature
-import ..PrognosticSurfaceTemperature
+import ..PrescribedSST
+import ..SlabOceanSST
 import ..ᶜinterp
 import ..ᶠinterp
 import ..C3

--- a/src/initial_conditions/atmos_state.jl
+++ b/src/initial_conditions/atmos_state.jl
@@ -43,7 +43,7 @@ function atmos_center_variables(ls, atmos_model)
         ls,
         atmos_model.turbconv_model,
         atmos_model.moisture_model,
-        atmos_model.precip_model,
+        atmos_model.microphysics_model,
         gs_vars,
     )
     return (; gs_vars..., sgs_vars...)
@@ -64,7 +64,7 @@ grid_scale_center_variables(ls, atmos_model) = (;
     uₕ = C12(ls.velocity, ls.geometry),
     energy_variables(ls)...,
     moisture_variables(ls, atmos_model.moisture_model)...,
-    precip_variables(ls, atmos_model.precip_model)...,
+    precip_variables(ls, atmos_model.microphysics_model)...,
 )
 
 energy_variables(ls) = (;
@@ -75,8 +75,8 @@ energy_variables(ls) = (;
     )
 )
 
-atmos_surface_field(surface_space, ::PrescribedSurfaceTemperature) = (;)
-function atmos_surface_field(surface_space, ::PrognosticSurfaceTemperature)
+atmos_surface_field(surface_space, ::PrescribedSST) = (;)
+function atmos_surface_field(surface_space, ::SlabOceanSST)
     if :lat in propertynames(Fields.coordinate_field(surface_space))
         return (;
             sfc = map(
@@ -143,7 +143,7 @@ function turbconv_center_variables(
     ls,
     turbconv_model::PrognosticEDMFX,
     moisture_model,
-    precip_model,
+    microphysics_model,
     gs_vars,
 )
     n = n_mass_flux_subdomains(turbconv_model)
@@ -161,7 +161,7 @@ function turbconv_center_variables(
     ls,
     turbconv_model::PrognosticEDMFX,
     moisture_model::NonEquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     gs_vars,
 )
     # TODO - Instead of dispatching, should we unify this with the above function?

--- a/src/initial_conditions/local_state.jl
+++ b/src/initial_conditions/local_state.jl
@@ -9,7 +9,7 @@ abstract type TurbconvState{FT} end
 """
     PrecipState{FT}
 
-A collection of values that are required to initialize the `precip_model` of
+A collection of values that are required to initialize the `microphysics_model` of
 an `AtmosModel`.
 """
 abstract type PrecipState{FT} end
@@ -94,8 +94,8 @@ EDMFState(; tke, draft_area = 0, velocity = Geometry.WVector(0)) =
 """
     NoPrecipState{FT}()
 
-Indicates that no initial conditions are available for the `precip_model`. Any
-values required by the `precip_model` are set to 0.
+Indicates that no initial conditions are available for the `microphysics_model`. Any
+values required by the `microphysics_model` are set to 0.
 """
 struct NoPrecipState{FT} <: PrecipState{FT} end
 
@@ -105,7 +105,7 @@ struct NoPrecipState{FT} <: PrecipState{FT} end
     PrecipState2M(; q_rai, q_sno)
 
 
-Stores the values of `n_liq`, `n_rai`, `q_rai`, and `q_sno` for the `precip_model`.
+Stores the values of `n_liq`, `n_rai`, `q_rai`, and `q_sno` for the `microphysics_model`.
 This struct includes both mass and number densities and can be used for initializing 
 precipitation states in both one-moment and two-moment microphysics schemes. 
 In one-moment schemes, the number densities (`n_liq`, `n_rai`) are ignored.

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -25,7 +25,7 @@ function precipitation_tendency!(
     p,
     t,
     ::EquilMoistModel,
-    precip_model::Microphysics0Moment,
+    microphysics_model::Microphysics0Moment,
     turbconv_model,
 )
     (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
@@ -61,7 +61,7 @@ function precipitation_tendency!(
     p,
     t,
     ::DryModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     _,
 )
     error("Microphysics1Moment precipitation should not be used with DryModel")
@@ -72,7 +72,7 @@ function precipitation_tendency!(
     p,
     t,
     ::EquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     _,
 )
     error(
@@ -85,7 +85,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     _,
 )
     (; turbconv_model) = p.atmos
@@ -105,7 +105,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     turbconv_model::DiagnosticEDMFX,
 )
     error("Not implemented yet")
@@ -142,7 +142,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
     turbconv_model::PrognosticEDMFX,
 )
     # Source terms from EDMFX updrafts
@@ -176,7 +176,7 @@ function precipitation_tendency!(
     p,
     t,
     ::DryModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     _,
 )
     error("Microphysics2Moment precipitation should not be used with DryModel")
@@ -187,7 +187,7 @@ function precipitation_tendency!(
     p,
     t,
     ::EquilMoistModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     _,
 )
     error(
@@ -200,7 +200,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     _,
 )
     (; ᶜSqₗᵖ, ᶜSqᵢᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ) = p.precomputed
@@ -223,7 +223,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     turbconv_model::DiagnosticEDMFX,
 )
     error("Not implemented yet")
@@ -234,7 +234,7 @@ function precipitation_tendency!(
     p,
     t,
     ::NonEquilMoistModel,
-    precip_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     turbconv_model::PrognosticEDMFX,
 )
     error("Not implemented yet")

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -119,7 +119,7 @@ NVTX.@annotate function horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
                 wdivₕ(Y.c.sgsʲs.:($$j).q_tot * ᶜuʲs.:($$j)) -
                 Y.c.sgsʲs.:($$j).q_tot * wdivₕ(ᶜuʲs.:($$j))
             if p.atmos.moisture_model isa NonEquilMoistModel &&
-               p.atmos.precip_model isa Microphysics1Moment
+               p.atmos.microphysics_model isa Microphysics1Moment
                 @. Yₜ.c.sgsʲs.:($$j).q_liq -=
                     wdivₕ(Y.c.sgsʲs.:($$j).q_liq * ᶜuʲs.:($$j)) -
                     Y.c.sgsʲs.:($$j).q_liq * wdivₕ(ᶜuʲs.:($$j))
@@ -363,7 +363,7 @@ function edmfx_sgs_vertical_advection_tendency!(
         )
         @. Yₜ.c.sgsʲs.:($$j).q_tot += va
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             # TODO - add precipitation terminal velocity
             # TODO - add cloud sedimentation velocity
             # TODO - add their contributions to mean energy and mass

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -531,7 +531,7 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
     (; ᶜq_tot⁰, ᶜmse⁰, ᶠu₃⁰) = p.precomputed
 
     if p.atmos.moisture_model isa NonEquilMoistModel &&
-       p.atmos.precip_model isa Microphysics1Moment
+       p.atmos.microphysics_model isa Microphysics1Moment
         (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
     end
 
@@ -549,7 +549,7 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
             (ᶜq_tot⁰ - Y.c.sgsʲs.:($$j).q_tot)
 
         if p.atmos.moisture_model isa NonEquilMoistModel &&
-           p.atmos.precip_model isa Microphysics1Moment
+           p.atmos.microphysics_model isa Microphysics1Moment
             @. Yₜ.c.sgsʲs.:($$j).q_liq +=
                 (ᶜentrʲs.:($$j) .+ ᶜturb_entrʲs.:($$j)) *
                 (ᶜq_liq⁰ - Y.c.sgsʲs.:($$j).q_liq)

--- a/src/prognostic_equations/edmfx_precipitation.jl
+++ b/src/prognostic_equations/edmfx_precipitation.jl
@@ -3,7 +3,7 @@
 #####
 
 """
-    edmfx_precipitation_tendency!(Yₜ, Y, p, t, turbconv_model, precip_model)
+    edmfx_precipitation_tendency!(Yₜ, Y, p, t, turbconv_model, microphysics_model)
 
 Applies precipitation tendencies to the EDMFX prognostic variables.
 
@@ -22,13 +22,13 @@ Arguments:
 - `p`: The cache, containing precomputed quantities and parameters.
 - `t`: The current simulation time.
 - `turbconv_model`: The turbulence convection model (e.g., `PrognosticEDMFX`).
-- `precip_model`: The precipitation model (e.g., `Microphysics0Moment`,
+- `microphysics_model`: The precipitation model (e.g., `Microphysics0Moment`,
                   `Microphysics1Moment`).
 
 Returns: `nothing`, modifies `Yₜ` in place.
 """
 
-edmfx_precipitation_tendency!(Yₜ, Y, p, t, turbconv_model, precip_model) =
+edmfx_precipitation_tendency!(Yₜ, Y, p, t, turbconv_model, microphysics_model) =
     nothing
 
 function edmfx_precipitation_tendency!(
@@ -37,7 +37,7 @@ function edmfx_precipitation_tendency!(
     p,
     t,
     turbconv_model::PrognosticEDMFX,
-    precip_model::Microphysics0Moment,
+    microphysics_model::Microphysics0Moment,
 )
     n = n_mass_flux_subdomains(turbconv_model)
     (; ᶜSqₜᵖʲs, ᶜtsʲs) = p.precomputed
@@ -69,7 +69,7 @@ function edmfx_precipitation_tendency!(
     p,
     t,
     turbconv_model::PrognosticEDMFX,
-    precip_model::Microphysics1Moment,
+    microphysics_model::Microphysics1Moment,
 )
     n = n_mass_flux_subdomains(turbconv_model)
 

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -45,7 +45,7 @@ function edmfx_sgs_mass_flux_tendency!(
     (; ᶜρa⁰, ᶜρ⁰, ᶠu³⁰, ᶜK⁰, ᶜmse⁰, ᶜq_tot⁰) = p.precomputed
     if (
         p.atmos.moisture_model isa NonEquilMoistModel &&
-        p.atmos.precip_model isa Microphysics1Moment
+        p.atmos.microphysics_model isa Microphysics1Moment
     )
         (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
     end
@@ -117,7 +117,7 @@ function edmfx_sgs_mass_flux_tendency!(
 
         if (
             p.atmos.moisture_model isa NonEquilMoistModel &&
-            p.atmos.precip_model isa Microphysics1Moment
+            p.atmos.microphysics_model isa Microphysics1Moment
         )
             # Liquid, ice, rain and snow specific humidity fluxes
             for j in 1:n
@@ -348,7 +348,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
     (; ᶜρa⁰, ᶜu⁰, ᶜK⁰, ᶜmse⁰, ᶜq_tot⁰, ᶜtke⁰, ᶜmixing_length) = p.precomputed
     if (
         p.atmos.moisture_model isa NonEquilMoistModel &&
-        p.atmos.precip_model isa Microphysics1Moment
+        p.atmos.microphysics_model isa Microphysics1Moment
     )
         (; ᶜq_liq⁰, ᶜq_ice⁰, ᶜq_rai⁰, ᶜq_sno⁰) = p.precomputed
     end
@@ -400,7 +400,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
         end
         if (
             p.atmos.moisture_model isa NonEquilMoistModel &&
-            p.atmos.precip_model isa Microphysics1Moment
+            p.atmos.microphysics_model isa Microphysics1Moment
         )
             # Liquid, ice, rain and snow specific humidity diffusion
             α_vert_diff_tracer = CAP.α_vert_diff_tracer(params)

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -169,8 +169,9 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
             )...,
             (@name(c.uₕ), @name(c.uₕ)) =>
                 !isnothing(atmos.turbconv_model) ||
-                    !disable_momentum_vertical_diffusion(atmos.vert_diff) ?
-                similar(Y.c, TridiagonalRow) : FT(-1) * I,
+                    !disable_momentum_vertical_diffusion(
+                        atmos.vertical_diffusion,
+                    ) ? similar(Y.c, TridiagonalRow) : FT(-1) * I,
         )
     elseif atmos.moisture_model isa DryModel
         MatrixFields.unrolled_map(
@@ -555,7 +556,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
         if (
             MatrixFields.has_field(Y, @name(c.sgs⁰.ρatke)) ||
             !isnothing(p.atmos.turbconv_model) ||
-            !disable_momentum_vertical_diffusion(p.atmos.vert_diff)
+            !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
         )
             @. ᶜdiffusion_u_matrix =
                 ᶜadvdivᵥ_matrix() ⋅
@@ -650,7 +651,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
 
         if (
             !isnothing(p.atmos.turbconv_model) ||
-            !disable_momentum_vertical_diffusion(p.atmos.vert_diff)
+            !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
         )
             ∂ᶜuₕ_err_∂ᶜuₕ = matrix[@name(c.uₕ), @name(c.uₕ)]
             @. ∂ᶜuₕ_err_∂ᶜuₕ =

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -210,7 +210,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             Y,
             p,
             t,
-            p.atmos.vert_diff,
+            p.atmos.vertical_diffusion,
         )
         edmfx_sgs_diffusive_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
@@ -236,7 +236,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             Y,
             p,
             p.atmos.moisture_model,
-            p.atmos.precip_model,
+            p.atmos.microphysics_model,
         )
     end
 
@@ -246,7 +246,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
         p,
         t,
         p.atmos.turbconv_model,
-        p.atmos.precip_model,
+        p.atmos.microphysics_model,
     )
     precipitation_tendency!(
         Yₜ,
@@ -254,7 +254,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
         p,
         t,
         p.atmos.moisture_model,
-        p.atmos.precip_model,
+        p.atmos.microphysics_model,
         p.atmos.turbconv_model,
     )
 

--- a/src/prognostic_equations/surface_flux.jl
+++ b/src/prognostic_equations/surface_flux.jl
@@ -106,7 +106,7 @@ function surface_flux_tendency!(Yₜ, Y, p, t)
     FT = eltype(Y)
     (; ᶜh_tot, ᶜspecific, sfc_conditions) = p.precomputed
 
-    if !disable_momentum_vertical_diffusion(p.atmos.vert_diff)
+    if !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
         btt =
             boundary_tendency_momentum(Y.c.ρ, Y.c.uₕ, sfc_conditions.ρ_flux_uₕ)
         @. Yₜ.c.uₕ -= btt

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -13,13 +13,13 @@ Computes and applies tendencies due to vertical turbulent diffusion,
 representing mixing processes within the planetary boundary layer and free atmosphere.
 
 This function is dispatched based on the type of the vertical diffusion model
-(`vert_diff_model`), which is accessed via `p.atmos.vert_diff`.
+(`vert_diff_model`), which is accessed via `p.atmos.vertical_diffusion`.
 
 **Dispatch details:**
 
 1.  **`vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)`**:
     This is the main entry point, which internally calls the more specific method
-    using `p.atmos.vert_diff` to determine the diffusion model.
+    using `p.atmos.vertical_diffusion` to determine the diffusion model.
 
 2.  **`vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, ::Nothing)`**:
     If the `vert_diff_model` is `Nothing` (i.e., vertical diffusion is turned off
@@ -54,7 +54,7 @@ Arguments for all methods:
 - `Y`: The current state vector.
 - `p`: Cache containing parameters (e.g., `p.params` for `CAP.α_vert_diff_tracer`),
        precomputed fields (e.g., `ᶜK_u`, `ᶜK_h`, `ᶜh_tot`, `ᶜspecific` tracer values),
-       atmospheric model configurations (like `p.atmos.vert_diff`), and scratch space.
+       atmospheric model configurations (like `p.atmos.vertical_diffusion`), and scratch space.
 - `t`: Current simulation time (not directly used in diffusion calculations).
 - `vert_diff_model` (for dispatched methods): The specific vertical diffusion model instance.
 
@@ -63,7 +63,13 @@ various tracer fields such as `Yₜ.c.ρq_tot`).
 """
 
 vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t) =
-    vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, p.atmos.vert_diff)
+    vertical_diffusion_boundary_layer_tendency!(
+        Yₜ,
+        Y,
+        p,
+        t,
+        p.atmos.vertical_diffusion,
+    )
 
 vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing
 
@@ -79,7 +85,7 @@ function vertical_diffusion_boundary_layer_tendency!(
     (; ᶜu, ᶜh_tot, ᶜspecific, ᶜK_u, ᶜK_h) = p.precomputed
     ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
 
-    if !disable_momentum_vertical_diffusion(p.atmos.vert_diff)
+    if !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
         ᶠstrain_rate = p.scratch.ᶠtemp_UVWxUVW
         ᶠstrain_rate .= compute_strain_rate_face(ᶜu)
         @. Yₜ.c.uₕ -= C12(

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -125,12 +125,16 @@ end
 
 function get_surface_model(parsed_args)
     prognostic_surface_name = parsed_args["prognostic_surface"]
-    return if prognostic_surface_name in
-              ("false", false, "PrescribedSurfaceTemperature")
-        PrescribedSurfaceTemperature()
-    elseif prognostic_surface_name in
-           ("true", true, "PrognosticSurfaceTemperature")
-        PrognosticSurfaceTemperature()
+    return if prognostic_surface_name in ("false", false, "PrescribedSST")
+        PrescribedSST()
+    elseif prognostic_surface_name in ("true", true, "SlabOceanSST")
+        SlabOceanSST()
+    elseif prognostic_surface_name == "PrognosticSurfaceTemperature"
+        @warn "The `PrognosticSurfaceTemperature` option is deprecated. Use `SlabOceanSST` instead."
+        SlabOceanSST()
+    elseif prognostic_surface_name == "PrescribedSurfaceTemperature"
+        @warn "The `PrescribedSurfaceTemperature` option is deprecated. Use `PrescribedSST` instead."
+        PrescribedSST()
     else
         error("Uncaught surface model `$prognostic_surface_name`.")
     end
@@ -310,18 +314,18 @@ function get_radiation_mode(parsed_args, ::Type{FT}) where {FT}
     end
 end
 
-function get_precipitation_model(parsed_args)
-    precip_model = parsed_args["precip_model"]
-    return if precip_model == nothing || precip_model == "nothing"
+function get_microphysics_model(parsed_args)
+    microphysics_model = parsed_args["precip_model"]
+    return if isnothing(microphysics_model) || microphysics_model == "nothing"
         NoPrecipitation()
-    elseif precip_model == "0M"
+    elseif microphysics_model == "0M"
         Microphysics0Moment()
-    elseif precip_model == "1M"
+    elseif microphysics_model == "1M"
         Microphysics1Moment()
-    elseif precip_model == "2M"
+    elseif microphysics_model == "2M"
         Microphysics2Moment()
     else
-        error("Invalid precip_model $(precip_model)")
+        error("Invalid microphysics_model $(microphysics_model)")
     end
 end
 

--- a/src/solver/solve.jl
+++ b/src/solver/solve.jl
@@ -229,7 +229,7 @@ function check_conservation(sol)
     energy_atmos_change = sum(sol.u[end].c.ρe_tot) - sum(sol.u[1].c.ρe_tot)
     p = sol.prob.p
     sfc = p.atmos.surface_model
-    if sfc isa PrognosticSurfaceTemperature
+    if sfc isa SlabOceanSST
         sfc_cρh = sfc.ρ_ocean * sfc.cp_ocean * sfc.depth_ocean
         energy_total +=
             horizontal_integral_at_boundary(sol.u[1].sfc.T .* sfc_cρh)
@@ -252,7 +252,7 @@ function check_conservation(sol)
     if :ρq_tot in propertynames(sol.u[1].c)
         water_total = sum(sol.u[end].c.ρq_tot)
         water_atmos_change = sum(sol.u[end].c.ρq_tot) - sum(sol.u[1].c.ρq_tot)
-        if sfc isa PrognosticSurfaceTemperature
+        if sfc isa SlabOceanSST
             water_surface_change = horizontal_integral_at_boundary(
                 sol.u[end].sfc.water .- sol.u[1].sfc.water,
             )

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -20,7 +20,7 @@ function get_atmos(config::AtmosConfig, params)
     FT = eltype(config)
     check_case_consistency(parsed_args)
     moisture_model = get_moisture_model(parsed_args)
-    precip_model = get_precipitation_model(parsed_args)
+    microphysics_model = get_microphysics_model(parsed_args)
     cloud_model = get_cloud_model(parsed_args)
 
     implicit_noneq_cloud_formation =
@@ -82,7 +82,7 @@ function get_atmos(config::AtmosConfig, params)
         scale_blending_method = get_scale_blending_method(parsed_args),
     )
 
-    vert_diff = get_vertical_diffusion_model(
+    vertical_diffusion = get_vertical_diffusion_model(
         disable_momentum_vertical_diffusion,
         parsed_args,
         params,
@@ -92,7 +92,7 @@ function get_atmos(config::AtmosConfig, params)
     atmos = AtmosModel(;
         # AtmosWater - Moisture, Precipitation & Clouds
         moisture_model,
-        precip_model,
+        microphysics_model,
         cloud_model,
         noneq_cloud_formation_mode = implicit_noneq_cloud_formation ?
                                      Implicit() : Explicit(),
@@ -141,7 +141,7 @@ function get_atmos(config::AtmosConfig, params)
         surface_albedo = get_surface_albedo_model(parsed_args, params, FT),
 
         # Top-level options (not grouped)
-        vert_diff,
+        vertical_diffusion,
         numerics = get_numerics(parsed_args, FT),
         disable_surface_flux_tendency = parsed_args["disable_surface_flux_tendency"],
     )

--- a/src/surface_conditions/SurfaceConditions.jl
+++ b/src/surface_conditions/SurfaceConditions.jl
@@ -7,8 +7,8 @@ import ..ZonallyAsymmetricSST
 import ..ZonallySymmetricSST
 import ..RCEMIPIISST
 import ..ExternalTVColumnSST
-import ..PrognosticSurfaceTemperature
-import ..PrescribedSurfaceTemperature
+import ..SlabOceanSST
+import ..PrescribedSST
 import ..gcm_driven_timeseries
 
 import ..CT1, ..CT2, ..C12, ..CT12, ..C3

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -33,7 +33,7 @@ function update_surface_conditions!(Y, p, t)
             t,
         )
         sfc_temp_var = Fields.field_values(p.external_forcing.surface_inputs.ts)
-    elseif p.atmos.surface_model isa PrognosticSurfaceTemperature
+    elseif p.atmos.surface_model isa SlabOceanSST
         sfc_temp_var = Fields.field_values(Y.sfc.T)
     else
         sfc_temp_var = nothing

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -32,12 +32,12 @@ import Test: @test
     ᶜYₜ = zero(Y)
 
     # Set all model choices
-    (; turbconv_model, moisture_model, precip_model) = p.atmos
+    (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, precip_model)
-    CA.set_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    CA.set_precipitation_surface_fluxes!(Y, p, precip_model)
+    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
+    CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
         :ᶜS_ρq_tot,
         :ᶜS_ρe_tot,
@@ -62,7 +62,7 @@ import Test: @test
         p,
         FT(0),
         moisture_model,
-        precip_model,
+        microphysics_model,
         turbconv_model,
     )
     @test ᶜYₜ.c.ρ == ᶜYₜ.c.ρq_tot
@@ -74,7 +74,7 @@ import Test: @test
         Y,
         p,
         moisture_model,
-        precip_model,
+        microphysics_model,
     ) isa Nothing
 end
 
@@ -97,12 +97,12 @@ end
     ᶜYₜ = zero(Y)
 
     # Set all model choices
-    (; turbconv_model, moisture_model, precip_model) = p.atmos
+    (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, precip_model)
-    CA.set_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    CA.set_precipitation_surface_fluxes!(Y, p, precip_model)
+    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
+    CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
         :ᶜSqₗᵖ,
         :ᶜSqᵢᵖ,
@@ -131,7 +131,7 @@ end
         p,
         FT(0),
         moisture_model,
-        precip_model,
+        microphysics_model,
         turbconv_model,
     )
 
@@ -153,7 +153,7 @@ end
     @assert iszero(ᶜYₜ.c.ρ)
 
     # test nonequilibrium cloud condensate
-    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, precip_model)
+    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, microphysics_model)
     @assert !any(isnan, ᶜYₜ.c.ρq_liq)
     @assert !any(isnan, ᶜYₜ.c.ρq_ice)
 
@@ -188,12 +188,12 @@ end
     ᶜYₜ = zero(Y)
 
     # Set all model choices
-    (; turbconv_model, moisture_model, precip_model) = p.atmos
+    (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, precip_model)
-    CA.set_precipitation_cache!(Y, p, precip_model, turbconv_model)
-    CA.set_precipitation_surface_fluxes!(Y, p, precip_model)
+    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
+    CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
         :ᶜSqₗᵖ,
         :ᶜSqᵢᵖ,
@@ -223,7 +223,7 @@ end
         p,
         FT(0),
         moisture_model,
-        precip_model,
+        microphysics_model,
         turbconv_model,
     )
 
@@ -249,7 +249,7 @@ end
     @assert iszero(ᶜYₜ.c.ρ)
 
     # test nonequilibrium cloud condensate
-    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, precip_model)
+    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, microphysics_model)
     @assert !any(isnan, ᶜYₜ.c.ρq_liq)
     @assert !any(isnan, ᶜYₜ.c.ρq_ice)
     @assert !any(isnan, ᶜYₜ.c.ρn_liq)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Finish renaming variables after #3875. This is a breaking PR due to name changes within AtmosModel.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Rename:
- AtmosModel.vert_diff -> vertical_diffusion
- AtmosModel.water.precip_model -> microphysics_model
- PrognosticSurfaceTemperature -> SlabOceanSST
- PrescribedSurfaceTemperature -> PrescribedSST

Note that all parsed args are still supported but `"prognostic_surface" = "prognostic/prescribedsurfacetemperature" is deprecated.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
