### PR TITLE
Improve CAM_SE hyperdiff Robustness

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -29,10 +29,10 @@ z_max:
   value: 30000.0
 vorticity_hyperdiffusion_coefficient:
   help: "Hyperdiffusion coefficient for vorticity (m s-1)"
-  value: 1.5
+  value: 0.1857
 scalar_hyperdiffusion_coefficient:
   help: "Hyperdiffusion coefficient for scalar (m s-1)"
-  value: 1.5
+  value: 0.929738
 # Topography
 topography:
   help: "Define the surface elevation profile [`NoWarp` (default), `Earth`, `DCMIP200`, `Hughes2023`, `Agnesi`, `Schar`, `Cosine2D`, `Cosine3D`]"
@@ -152,7 +152,7 @@ vert_diff:
   help: "Vertical diffusion [`false` (default), `VerticalDiffusion`, `true` (defaults to `VerticalDiffusion`), `DecayWithHeightDiffusion`]"
   value: false
 hyperdiff:
-  help: "Hyperdiffusion [`ClimaHyperdiffusion` (or `true`), `CAM_SE` (default), `none` (or `false`)]"
+  help: "Hyperdiffusion. Use `CAM_SE` for sensible default values and ClimaHyperdiffusion for user control. [`CAM_SE` (default), `ClimaHyperdiffusion` (or `true`), `none` (or `false`)]"
   value: "CAM_SE"
 smagorinsky_lilly:
   help: "Smagorinsky-Lilly diffusive closure [`false` (default), `true`]"
@@ -177,7 +177,7 @@ moist:
   value: "dry"
 divergence_damping_factor:
   help: "Divergence damping factor"
-  value: 1.0
+  value: 5.0
 rayleigh_sponge:
   help: "Rayleigh sponge [`true`, `false` (default)]"
   value: false

--- a/config/model_configs/baroclinic_wave_topography_dcmip_rs.yml
+++ b/config/model_configs/baroclinic_wave_topography_dcmip_rs.yml
@@ -6,6 +6,9 @@ initial_condition: "DryBaroclinicWave"
 t_end: "6days"
 dt: "200secs"
 hyperdiff: "ClimaHyperdiffusion"
+vorticity_hyperdiffusion_coefficient: 1.5
+scalar_hyperdiffusion_coefficient: 1.5
+divergence_damping_factor: 1.0
 disable_surface_flux_tendency: true
 netcdf_output_at_levels: false
 diagnostics:

--- a/test/solver/model_getters.jl
+++ b/test/solver/model_getters.jl
@@ -4,22 +4,24 @@ import ClimaAtmos as CA
 
 @testset "Hyperdiffusion config" begin
     @info "CAM_SE (Special case of ClimaHyperdiffusion)"
+
+    # Test that CAM_SE uses the correct hardcoded coefficients
+    # These match the values from https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2017MS001257
     config = CA.AtmosConfig(
         Dict(
             "hyperdiff" => "CAM_SE",
-            "vorticity_hyperdiffusion_coefficient" => 0.2,
-            "scalar_hyperdiffusion_coefficient" => 99.0,
-            "divergence_damping_factor" => 99.0,
+            "vorticity_hyperdiffusion_coefficient" => 0.1857,
+            "scalar_hyperdiffusion_coefficient" => 0.929738,
+            "divergence_damping_factor" => 5.0,
         ),
-        job_id = "model3",
+        job_id = "test_hyperdiff_cam_se_args",
     )
+
     parsed_args = config.parsed_args
     FT = eltype(config)
     hyperdiff_model = CA.get_hyperdiffusion_model(parsed_args, FT)
-    # Coefficients are currently hardcoded in the CAM_SE type!!!
-    # Regardless of user specified coeffs above, the CAM_SE selection
-    # should override these coefficients to match values in
-    # https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2017MS001257
+
+    # Test that CAM_SE returns the correct coefficient values
     cam_se_ν₄_vort = FT(0.150 * 1.238)
     cam_se_ν₄_scalar = FT(0.751 * 1.238)
     cam_se_ν₄_dd = FT(5)
@@ -28,12 +30,28 @@ import ClimaAtmos as CA
     @test hyperdiff_model.ν₄_scalar_coeff == cam_se_ν₄_scalar
     @test hyperdiff_model.divergence_damping_factor == cam_se_ν₄_dd
 
-    @info "Test unrecognized Hyperdiffusion scheme"
-    config = CA.AtmosConfig(
-        Dict("hyperdiff" => "UnknownHyperdiffusion"),
-        job_id = "model4",
+    @info "Test CAM_SE coefficient validation"
+    # Test that CAM_SE throws an error when user tries to set different coefficients
+    config_wrong = CA.AtmosConfig(
+        Dict(
+            "hyperdiff" => "CAM_SE",
+            "vorticity_hyperdiffusion_coefficient" => 0.18571, # deliberately wrong value
+            "scalar_hyperdiffusion_coefficient" => 0.929738,
+            "divergence_damping_factor" => 5.0,
+        ),
+        job_id = "test_hyperdiff_cam_se_wrong_args",
     )
-    parsed_args = config.parsed_args
-    FT = eltype(config)
-    @test_throws ErrorException CA.get_hyperdiffusion_model(parsed_args, FT)
+    @test_throws AssertionError CA.AtmosSimulation(config_wrong)
+
+    @info "Test unrecognized Hyperdiffusion scheme"
+    config_unknown = CA.AtmosConfig(
+        Dict("hyperdiff" => "UnknownHyperdiffusion"),
+        job_id = "test_unknown_hyperdiff",
+    )
+    parsed_args_unknown = config_unknown.parsed_args
+    FT = eltype(config_unknown)
+    @test_throws ErrorException CA.get_hyperdiffusion_model(
+        parsed_args_unknown,
+        FT,
+    )
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Improve the robustness of error handling for the CAM_SE hyperdiffusion setup and fixes a bug where the yaml does not accurately reflect the hyperdiffusion coefficients used to run the simulation. As we have access to limited values in the function, to do this we need to change the values in default config to the CAM_SE values as suggested by @akshaysridhar . 


Closes #3888 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->

- [ ] Does the atol seem appropriate?
- [ ] Should we test more variants in the test or are these two sufficient?
- [ ] Could we be more succinct with the checks in model_getters? I was trying to write most clearly


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
