### PR TITLE
Fix blank mse_summary

### DIFF
--- a/reproducibility_tests/reproducibility_utils.jl
+++ b/reproducibility_tests/reproducibility_utils.jl
@@ -722,7 +722,7 @@ where `is_mse_file` is `true`.
 """
 function get_computed_mses(;
     job_ids::Vector{String},
-    subfolder::String = "output_active",
+    subfolder::String = joinpath("output_active", "reproducibility_bundle"),
     is_mse_file::Function = default_is_mse_file,
     expected_filename_prefix = "computed_mse",
 )
@@ -733,14 +733,14 @@ function get_computed_mses(;
     isempty(job_ids) && return computed_mses
 
     for job_id in job_ids
-        all_files = readdir(joinpath(job_id, subfolder); join = true)
-        for file in all_files
-            computed_mses[job_id] =
-                if is_mse_file(file, expected_filename_prefix)
-                    parse_file(file)
-                else
-                    false
-                end
+        all_files = filter(
+            file -> is_mse_file(file, expected_filename_prefix),
+            readdir(joinpath(job_id, subfolder); join = true),
+        )
+        computed_mses[job_id] = false
+        for file in all_files # this just parses and returns the last file sorted by name
+            computed_mses[job_id] = parse_file(file)
+            # TODO:Some sort of combined MSE for all comparisons, or just return latest commit
         end
     end
     return computed_mses

--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -608,6 +608,7 @@ end
         d1 = make_mse(mses1, dir, "d1")
         d2 = make_mse(mses2, dir, "d2")
         d3 = make_mse(mses3, dir, "d3")
+        d3 = make_mse(mses3, dir, "d3")
 
         job_ids = ["d1", "d2", "d3"]
         computed_mses = get_computed_mses(;
@@ -641,6 +642,7 @@ end
         d1 = make_mse(mses1, dir, "d1")
         d2 = make_mse(mses2, dir, "d2"; mse_file = "comuted_mse.dat") # intentional typo
         d3 = make_mse(mses3, dir, "d3")
+        Base.touch(joinpath(d3, "prog_state.hdf5")) # not an mse file
 
         job_ids = ["d1", "d2", "d3"]
         computed_mses = get_computed_mses(;


### PR DESCRIPTION
The mse_summary.jl script always prints no summaries or error. This is because the reproducibility files are now placed in a separate subfolder, which also contains a prog_state file. This commit updates the `get_computed_mses` default value for `subfolder` to reflect this, and ignores the prog_state file when searching for the most current comparison.


closes #3892


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
