### PR TITLE
DiagnosticEDMF + NonEquil + 1M

### DIFF
--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -13,9 +13,9 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-moist: equil
+moist: nonequil
 cloud_model: "quadrature_sgs"
-precip_model: "0M"
+precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8
@@ -28,10 +28,14 @@ z_stretch: false
 dt: 100secs
 t_end: 6hours
 dt_save_state_to_disk: 10mins
-toml: [toml/diagnostic_edmfx_0M.toml]
+toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
     period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
     period: 10mins

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -12,9 +12,9 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-moist: equil
+moist: nonequil
 cloud_model: "quadrature_sgs"
-precip_model: "0M"
+precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8
@@ -27,10 +27,14 @@ z_stretch: false
 dt: 100secs
 t_end: 8hours
 dt_save_state_to_disk: 10mins
-toml: [toml/diagnostic_edmfx_0M.toml]
+toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 100]
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
     period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
     period: 10mins

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -11,11 +11,11 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-moist: equil
+moist: nonequil
 cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 apply_limiter: false
-precip_model: "0M"
+precip_model: "1M"
 config: box
 x_max: 1e8
 y_max: 1e8
@@ -24,14 +24,18 @@ y_elem: 2
 z_elem: 82
 z_max: 16400
 z_stretch: false
-dt: 200secs
+dt: 100secs
 t_end: 6hours
 dt_save_state_to_disk: 10mins
 FLOAT_TYPE: "Float64"
-toml: [toml/diagnostic_edmfx_0M.toml]
+toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 82]
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
     period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
     period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1391,15 +1391,18 @@ EDMFBoxPlots = Union{
     Val{:prognostic_edmfx_bomex_box},
     Val{:rcemipii_box_diagnostic_edmfx},
     Val{:prognostic_edmfx_soares_column},
-    Val{:diagnostic_edmfx_dycoms_rf02_box},
-    Val{:diagnostic_edmfx_rico_box},
-    Val{:diagnostic_edmfx_trmm_box},
     Val{:diagnostic_edmfx_trmm_stretched_box},
 }
 
 EDMFBoxPlotsWithPrecip = Union{
     Val{:prognostic_edmfx_rico_column},
     Val{:prognostic_edmfx_trmm_column},
+}
+
+DiagEDMFBoxPlotsWithPrecip = Union{
+    Val{:diagnostic_edmfx_dycoms_rf02_box},
+    Val{:diagnostic_edmfx_rico_box},
+    Val{:diagnostic_edmfx_trmm_box},
 }
 """
     plot_edmf_vert_profile!(grid_loc, var_group)
@@ -1476,14 +1479,23 @@ function pair_edmf_names(short_names)
 end
 
 function make_plots(
-    sim_type::Union{EDMFBoxPlots, EDMFBoxPlotsWithPrecip},
+    sim_type::Union{
+        EDMFBoxPlots,
+        EDMFBoxPlotsWithPrecip,
+        DiagEDMFBoxPlotsWithPrecip,
+    },
     output_paths::Vector{<:AbstractString},
 )
     simdirs = SimDir.(output_paths)
 
-    precip_names =
-        sim_type isa EDMFBoxPlotsWithPrecip ?
-        ("husra", "hussn", "husraup", "hussnup", "husraen", "hussnen") : ()
+    if sim_type isa EDMFBoxPlotsWithPrecip
+        precip_names =
+            ("husra", "hussn", "husraup", "hussnup", "husraen", "hussnen")
+    elseif sim_type isa DiagEDMFBoxPlotsWithPrecip
+        precip_names = ("husra", "hussn", "husraup", "hussnup")
+    else
+        precip_names = ()
+    end
 
     short_names = [
         "wa",

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -343,7 +343,8 @@ function set_precipitation_cache!(
     ::Microphysics1Moment,
     ::DiagnosticEDMFX,
 )
-    error("Not implemented yet")
+    # Nothing needs to be done on the grid mean. The Sources are computed
+    # in edmf sub-domains.
     return nothing
 end
 function set_precipitation_cache!(

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -170,6 +170,15 @@ function precomputed_quantities(Y, atmos)
         ᶜgradᵥ_θ_liq_ice = Fields.Field(C3{FT}, cspace),
     )
 
+    diagnostic_precipitation_sgs_quantities =
+        atmos.microphysics_model isa Microphysics1Moment ?
+        (;
+            ᶜq_liqʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_iceʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_raiʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_snoʲs = similar(Y.c, NTuple{n, FT}),
+        ) : (;)
+
     diagnostic_sgs_quantities =
         atmos.turbconv_model isa DiagnosticEDMFX ?
         (;
@@ -191,6 +200,7 @@ function precomputed_quantities(Y, atmos)
             ᶜK⁰ = similar(Y.c, FT),
             ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
             precipitation_sgs_quantities...,
+            diagnostic_precipitation_sgs_quantities...,
         ) : (;)
     smagorinsky_lilly_quantities =
         if atmos.smagorinsky_lilly isa SmagorinskyLilly

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -361,6 +361,20 @@ function compute_clwup!(
         out .= (state.c.sgsʲs.:1).q_liq
     end
 end
+function compute_clwup!(
+    out,
+    state,
+    cache,
+    time,
+    moisture_model::NonEquilMoistModel,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜq_liqʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜq_liqʲs.:1)
+    end
+end
 
 add_diagnostic_variable!(
     short_name = "clwup",
@@ -428,6 +442,20 @@ function compute_cliup!(
         out .= (state.c.sgsʲs.:1).q_ice
     end
 end
+function compute_cliup!(
+    out,
+    state,
+    cache,
+    time,
+    moisture_model::NonEquilMoistModel,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜq_iceʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜq_iceʲs.:1)
+    end
+end
 
 add_diagnostic_variable!(
     short_name = "cliup",
@@ -476,6 +504,20 @@ function compute_husraup!(
         out .= (state.c.sgsʲs.:1).q_rai
     end
 end
+function compute_husraup!(
+    out,
+    state,
+    cache,
+    time,
+    moisture_model::Microphysics1Moment,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜq_raiʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜq_raiʲs.:1)
+    end
+end
 
 add_diagnostic_variable!(
     short_name = "husraup",
@@ -522,6 +564,20 @@ function compute_hussnup!(
         return (state.c.sgsʲs.:1).q_sno
     else
         out .= (state.c.sgsʲs.:1).q_sno
+    end
+end
+function compute_hussnup!(
+    out,
+    state,
+    cache,
+    time,
+    moisture_model::Microphysics1Moment,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜq_snoʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜq_snoʲs.:1)
     end
 end
 
@@ -651,12 +707,14 @@ end
 function compute_aren!(out, state, cache, time, turbconv_model::DiagnosticEDMFX)
     thermo_params = CAP.thermodynamics_params(cache.params)
     if isnothing(out)
-        return draft_area.(
+        return 1 .-
+               draft_area.(
             cache.precomputed.ᶜρaʲs.:1,
             TD.air_density.(thermo_params, cache.precomputed.ᶜtsʲs.:1),
         )
     else
         out .=
+            1.0 -
             draft_area.(
                 cache.precomputed.ᶜρaʲs.:1,
                 TD.air_density.(thermo_params, cache.precomputed.ᶜtsʲs.:1),
@@ -684,7 +742,7 @@ function compute_rhoaen!(
     state,
     cache,
     time,
-    turbconv_model::Union{PrognosticEDMFX, DiagnosticEDMFX},
+    turbconv_model::PrognosticEDMFX,
 )
     thermo_params = CAP.thermodynamics_params(cache.params)
     if isnothing(out)

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -108,33 +108,27 @@ function precipitation_tendency!(
     microphysics_model::Microphysics1Moment,
     turbconv_model::DiagnosticEDMFX,
 )
-    error("Not implemented yet")
-    ## Source terms from EDMFX environment
-    #(; ᶜSeₜᵖ⁰, ᶜSqₜᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰) = p.precomputed
-    ## Source terms from EDMFX updrafts
-    #(; ᶜSeₜᵖʲs, ᶜSqₜᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
-    ## Grid mean precipitation sinks
-    #(; ᶜSqₜᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ, ᶜSeₜᵖ) = p.precipitation
+    # Source terms from EDMFX environment
+    (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰) = p.precomputed
+    # Source terms from EDMFX updrafts
+    (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
 
-    #(; ᶜρaʲs) = p.precomputed
+    (; ᶜρaʲs) = p.precomputed
 
-    ## Update from environment precipitation sources
-    ## and the grid mean precipitation sinks
-    #@. Yₜ.c.ρ += Y.c.ρ * (ᶜSqₜᵖ⁰ + ᶜSqₜᵖ)
-    #@. Yₜ.c.ρq_tot += Y.c.ρ * (ᶜSqₜᵖ⁰ + ᶜSqₜᵖ)
-    #@. Yₜ.c.ρe_tot += Y.c.ρ * (ᶜSeₜᵖ⁰ + ᶜSeₜᵖ)
-    #@. Yₜ.c.ρq_rai += Y.c.ρ * (ᶜSqᵣᵖ⁰ + ᶜSqᵣᵖ)
-    #@. Yₜ.c.ρq_sno += Y.c.ρ * (ᶜSqₛᵖ⁰ + ᶜSqₛᵖ)
+    # Update from environment precipitation sources
+    @. Yₜ.c.ρq_liq += Y.c.ρ * ᶜSqₗᵖ⁰
+    @. Yₜ.c.ρq_ice += Y.c.ρ * ᶜSqᵢᵖ⁰
+    @. Yₜ.c.ρq_rai += Y.c.ρ * ᶜSqᵣᵖ⁰
+    @. Yₜ.c.ρq_sno += Y.c.ρ * ᶜSqₛᵖ⁰
 
-    ## Update from the updraft precipitation sources
-    #n = n_mass_flux_subdomains(p.atmos.turbconv_model)
-    #for j in 1:n
-    #    @. Yₜ.c.ρ += ᶜρaʲs.:($$j) * ᶜSqₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_tot += ᶜρaʲs.:($$j) * ᶜSqₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρe_tot += ᶜρaʲs.:($$j) * ᶜSeₜᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_rai += ᶜρaʲs.:($$j) * ᶜSqᵣᵖʲs.:($$j)
-    #    @. Yₜ.c.ρq_sno += ᶜρaʲs.:($$j) * ᶜSqₛᵖʲs.:($$j)
-    #end
+    # Update from the updraft precipitation sources
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    for j in 1:n
+        @. Yₜ.c.ρq_liq += ᶜρaʲs.:($$j) * ᶜSqₗᵖʲs.:($$j)
+        @. Yₜ.c.ρq_ice += ᶜρaʲs.:($$j) * ᶜSqᵢᵖʲs.:($$j)
+        @. Yₜ.c.ρq_rai += ᶜρaʲs.:($$j) * ᶜSqᵣᵖʲs.:($$j)
+        @. Yₜ.c.ρq_sno += ᶜρaʲs.:($$j) * ᶜSqₛᵖʲs.:($$j)
+    end
 end
 function precipitation_tendency!(
     Yₜ,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -23,6 +23,23 @@ function get_atmos(config::AtmosConfig, params)
     microphysics_model = get_microphysics_model(parsed_args)
     cloud_model = get_cloud_model(parsed_args)
 
+    if moisture_model isa DryModel
+        @warn "Running simulations without any moisture present."
+        @assert microphysics_model isa NoPrecipitation
+    end
+    if moisture_model isa EquilMoistModel
+        @warn "Running simulations with equilibrium thermodynamics assumptions."
+        @assert microphysics_model isa
+                Union{NoPrecipitation, Microphysics0Moment}
+    end
+    if moisture_model isa NonEquilMoistModel
+        @assert microphysics_model isa
+                Union{NoPrecipitation, Microphysics1Moment, Microphysics2Moment}
+    end
+    if microphysics_model isa NoPrecipitation
+        @warn "Running simulations without any precipitation formation."
+    end
+
     implicit_noneq_cloud_formation =
         parsed_args["implicit_noneq_cloud_formation"]
     @assert implicit_noneq_cloud_formation in (true, false)

--- a/toml/diagnostic_edmfx_1M.toml
+++ b/toml/diagnostic_edmfx_1M.toml
@@ -1,0 +1,26 @@
+[condensation_evaporation_timescale]
+value = 100
+
+[sublimation_deposition_timescale]
+value = 100
+
+[entr_inv_tau]
+value = 0.002
+
+[entr_coeff]
+value = 0
+
+[detr_inv_tau]
+value = 0
+
+[detr_vertdiv_coeff]
+value = 0.6
+
+[detr_buoy_coeff]
+value = 0.12
+
+[min_area_limiter_scale]
+value = 0
+
+[max_area_limiter_scale]
+value = 0


### PR DESCRIPTION
This PR adds the `NonEquilibrium` moisture and `1Moment` microphysics to `DiagnosticEDMF`. The cloud and precipitation source terms are computed in the updraft and environment subdomains. Precipitation advection is only done for the grid mean values of cloud condensate and precipitation. We decided that, without the previous time-step memory, it doesn't make sense to compute advective tendencies in the  diagnostic edmf updraft subdomain.

I switched the defaults, so that now DyCOMS RF02, RICO and TRMM are running with NonEquil +1Moment for diagnostic EDMF in the CI. I think that many issues could be improved by calibrating some of the free parameters. For example, I can get deeper convection and snow/ice in TRMM by reducing the cloud relevant relaxation timescales. But that also leads to reducing the model time step. I'll do more testing and change those once I start testing in AMIP. I just want to move away from only testing in the single column. 

I will wait for this PR https://github.com/CliMA/ClimaAtmos.jl/pull/3913 to go in, to make sure I'm looking at fresh mse tables changes. 