### PR TITLE
Bugfix: microphysics sources when running with edmf

### DIFF
--- a/src/parameterized_tendencies/microphysics/cloud_condensate.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_condensate.jl
@@ -2,7 +2,7 @@
 ##### DryModel, EquilMoistModel
 #####
 
-cloud_condensate_tendency!(Yₜ, Y, p, _, _) = nothing
+cloud_condensate_tendency!(Yₜ, Y, p, _, _, _) = nothing
 
 #####
 ##### NonEquilMoistModel
@@ -14,6 +14,7 @@ function cloud_condensate_tendency!(
     p,
     ::NonEquilMoistModel,
     ::Union{NoPrecipitation, Microphysics0Moment},
+    _,
 )
     error(
         "NonEquilMoistModel can only be run with Microphysics1Moment or Microphysics2Moment precipitation",
@@ -26,6 +27,7 @@ function cloud_condensate_tendency!(
     p,
     ::NonEquilMoistModel,
     ::Microphysics1Moment,
+    _,
 )
     (; ᶜts) = p.precomputed
     (; params, dt) = p
@@ -69,6 +71,7 @@ function cloud_condensate_tendency!(
     p,
     ::NonEquilMoistModel,
     ::Microphysics2Moment,
+    _,
 )
     (; ᶜts) = p.precomputed
     (; params, dt) = p
@@ -169,4 +172,39 @@ function cloud_condensate_tendency!(
         dt,
     )
     @. Yₜ.c.ρn_liq += Y.c.ρ * Snₗ
+end
+
+#####
+##### PrognosticEDMF and DiagnosticEDMF
+#####
+
+function cloud_condensate_tendency!(
+    Yₜ,
+    Y,
+    p,
+    ::NonEquilMoistModel,
+    ::Union{NoPrecipitation, Microphysics0Moment},
+    ::Union{PrognosticEDMFX, DiagnosticEDMFX},
+)
+    nothing
+end
+function cloud_condensate_tendency!(
+    Yₜ,
+    Y,
+    p,
+    ::NonEquilMoistModel,
+    ::Microphysics1Moment,
+    ::Union{PrognosticEDMFX, DiagnosticEDMFX},
+)
+    nothing
+end
+function cloud_condensate_tendency!(
+    Yₜ,
+    Y,
+    p,
+    ::NonEquilMoistModel,
+    ::Microphysics2Moment,
+    ::Union{PrognosticEDMFX, DiagnosticEDMFX},
+)
+    nothing
 end

--- a/src/prognostic_equations/edmfx_precipitation.jl
+++ b/src/prognostic_equations/edmfx_precipitation.jl
@@ -78,17 +78,10 @@ function edmfx_precipitation_tendency!(
     # TODO what about the mass end energy outflow via bottom boundary?
 
     for j in 1:n
-        @. Yₜ.c.sgsʲs.:($$j).q_liq +=
-            ᶜSqₗᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_liq)
-
-        @. Yₜ.c.sgsʲs.:($$j).q_ice +=
-            ᶜSqᵢᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_ice)
-
-        @. Yₜ.c.sgsʲs.:($$j).q_rai +=
-            ᶜSqᵣᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_rai)
-
-        @. Yₜ.c.sgsʲs.:($$j).q_sno +=
-            ᶜSqₛᵖʲs.:($$j) * (1 - Y.c.sgsʲs.:($$j).q_sno)
+        @. Yₜ.c.sgsʲs.:($$j).q_liq += ᶜSqₗᵖʲs.:($$j)
+        @. Yₜ.c.sgsʲs.:($$j).q_ice += ᶜSqᵢᵖʲs.:($$j)
+        @. Yₜ.c.sgsʲs.:($$j).q_rai += ᶜSqᵣᵖʲs.:($$j)
+        @. Yₜ.c.sgsʲs.:($$j).q_sno += ᶜSqₛᵖʲs.:($$j)
     end
     return nothing
 end

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -17,6 +17,7 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
             p,
             p.atmos.moisture_model,
             p.atmos.microphysics_model,
+            p.atmos.turbconv_model,
         )
     end
 

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -241,6 +241,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             p,
             p.atmos.moisture_model,
             p.atmos.microphysics_model,
+            p.atmos.turbconv_model,
         )
     end
 

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -75,6 +75,7 @@ import Test: @test
         p,
         moisture_model,
         microphysics_model,
+        turbconv_model,
     ) isa Nothing
 end
 
@@ -153,7 +154,14 @@ end
     @assert iszero(ᶜYₜ.c.ρ)
 
     # test nonequilibrium cloud condensate
-    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, microphysics_model)
+    CA.cloud_condensate_tendency!(
+        ᶜYₜ,
+        Y,
+        p,
+        moisture_model,
+        microphysics_model,
+        turbconv_model,
+    )
     @assert !any(isnan, ᶜYₜ.c.ρq_liq)
     @assert !any(isnan, ᶜYₜ.c.ρq_ice)
 
@@ -250,7 +258,14 @@ end
     @assert iszero(ᶜYₜ.c.ρ)
 
     # test nonequilibrium cloud condensate
-    CA.cloud_condensate_tendency!(ᶜYₜ, Y, p, moisture_model, microphysics_model)
+    CA.cloud_condensate_tendency!(
+        ᶜYₜ,
+        Y,
+        p,
+        moisture_model,
+        microphysics_model,
+        turbconv_model,
+    )
     @assert !any(isnan, ᶜYₜ.c.ρq_liq)
     @assert !any(isnan, ᶜYₜ.c.ρq_ice)
     @assert !any(isnan, ᶜYₜ.c.ρn_liq)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- When running with edmf cloud condensate tendencies should not be called.
- Sources in edmf subdomains are updated according to updating working fluid assumptions.



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
