### PR TITLE
Reducing the noise in ice and snow for warm cases

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-251
+252
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+252
+- Limit the noise in ice and snow 1M microphysics scheme in cloud formation and
+  limiter formulation.
+
 251
 - Remove ᶜtke⁰, ᶜh_tot, ᶜmse⁰, ᶜρ⁰, and specific quantities from precomputed quantities cache.
   Introduce helper functions to compute sums over draft, environmental volumetric variables,
@@ -27,7 +31,7 @@
 
 250
 - Add ARG aerosol activation for 2M microphysics; increase the allocation limit for `flame_callbacks`
-  from 391864 to 391942 to account for additional allocations when constructing `ClimaAtmosParameters` 
+  from 391864 to 391942 to account for additional allocations when constructing `ClimaAtmosParameters`
   with the new aerosol parameters in `microphysics_2m_parameters`.
 
 249

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -127,6 +127,12 @@ function cloud_sources(
         S = FT(0)
     end
 
+    # Additional condition to avoid creating ice in conditions above freezing
+    # Representing the lack of INPs in warm temperatures
+    if T > thp.T_freeze && S > FT(0)
+        S = FT(0)
+    end
+
     return ifelse(
         S > FT(0),
         triangle_inequality_limiter(S, limit(qᵥ - qₛᵢ, dt, 2)),
@@ -383,7 +389,7 @@ Computes the source term for cloud droplet number concentration per mass due to 
 based on the Abdul-Razzak and Ghan (2000) parameterization.
 
 This function estimates the number of aerosols activated into cloud droplets per mass of air per second
-from a bi-modal aerosol distribution (sea salt and sulfate), given local supersaturation and vertical 
+from a bi-modal aerosol distribution (sea salt and sulfate), given local supersaturation and vertical
 velocity. The result is returned as a tendency (per second) of liquid droplet number concentration.
 
 # Arguments

--- a/src/prognostic_equations/limited_tendencies.jl
+++ b/src/prognostic_equations/limited_tendencies.jl
@@ -54,11 +54,12 @@ Returns:
 - The limited force value.
 
 Reference:
-- Horn, M. (2012). "ASAMgpu V1.0 – a moist fully compressible atmospheric model using 
+- Horn, M. (2012). "ASAMgpu V1.0 – a moist fully compressible atmospheric model using
     graphics processing units (GPUs)". Geoscientific Model Development,
     5, 345–353. https://doi.org/10.5194/gmd-5-345-2012
 """
 
 function triangle_inequality_limiter(force, limit)
-    return force + limit - sqrt(force^2 + limit^2)
+    FT = eltype(force)
+    return force == FT(0) ? force : force + limit - sqrt(force^2 + limit^2)
 end


### PR DESCRIPTION
While working with EDMF in single column dycoms, I noticed we were getting small values of ice and snow. This is unphysical, because we never reach cold temperatures in that single column simulation.

I tracked it back to two issues:
- For force == 0 limiters were sometimes giving us small tendency from roundoff errors of lim - sqrt(lim^2) not being exactly zero.
- We were still making ice for temperatures greater than freezing. Limiters don't make that go away. So I added an explicit statement that no ice is being formed when it's warm. You can think of it as lack of ice nucleating particles.