### PR TITLE
fix conservation check for 1M

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -312,6 +312,14 @@ steps:
         artifact_paths: "baroclinic_wave_equil_conservation_source/output_active/*"
         agents:
           slurm_mem: 16GB
+      
+      - label: ":computer: baroclinic wave nonequil moist check conservation with sources"
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl --config_file $CONFIG_PATH/baroclinic_wave_nonequil_conservation_source.yml
+          --job_id baroclinic_wave_nonequil_conservation_source
+        artifact_paths: "baroclinic_wave_nonequil_conservation_source/output_active/*"
+        agents:
+          slurm_mem: 16GB
 
   - group: "Sphere Examples (Dycore)"
     steps:

--- a/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
@@ -1,0 +1,15 @@
+FLOAT_TYPE: "Float32"
+initial_condition: "MoistBaroclinicWave"
+t_end: "5days"
+moist: "nonequil"
+surface_setup: DefaultMoninObukhov
+prognostic_surface: "SlabOceanSST"
+rad: "clearsky"
+precip_model: "1M"
+vert_diff: true
+dt_save_state_to_disk: "5days"
+check_conservation: true
+diagnostics:
+  - short_name: [massa, energya, watera, energyo, watero]
+    period: 1days
+    writer: dict

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -458,8 +458,8 @@ function set_precipitation_surface_fluxes!(
     microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
 )
     (; surface_rain_flux, surface_snow_flux) = p.precomputed
-    (; col_integrated_precip_energy_tendency,) = p.conservation_check
-    (; ᶜwᵣ, ᶜwₛ, ᶜwₗ, ᶜwᵢ) = p.precomputed
+    (; col_integrated_precip_energy_tendency) = p.conservation_check
+    (; ᶜwᵣ, ᶜwₛ, ᶜwₗ, ᶜwᵢ, ᶜwₕhₜ) = p.precomputed
     ᶜJ = Fields.local_geometry_field(Y.c).J
     ᶠJ = Fields.local_geometry_field(Y.f).J
     sfc_J = Fields.level(ᶠJ, Fields.half)
@@ -495,8 +495,14 @@ function set_precipitation_surface_fluxes!(
     sfc_wₛ = Fields.Field(Fields.field_values(Fields.level(ᶜwₛ, 1)), sfc_space)
     sfc_wₗ = Fields.Field(Fields.field_values(Fields.level(ᶜwₗ, 1)), sfc_space)
     sfc_wᵢ = Fields.Field(Fields.field_values(Fields.level(ᶜwᵢ, 1)), sfc_space)
+    sfc_wₕhₜ = Fields.Field(
+        Fields.field_values(Fields.level(ᶜwₕhₜ.components.data.:1, 1)),
+        sfc_space,
+    )
 
     @. surface_rain_flux = sfc_ρ * (sfc_qᵣ * (-sfc_wᵣ) + sfc_qₗ * (-sfc_wₗ))
     @. surface_snow_flux = sfc_ρ * (sfc_qₛ * (-sfc_wₛ) + sfc_qᵢ * (-sfc_wᵢ))
+    @. col_integrated_precip_energy_tendency = sfc_ρ * (-sfc_wₕhₜ)
+
     return nothing
 end

--- a/src/prognostic_equations/surface_temp.jl
+++ b/src/prognostic_equations/surface_temp.jl
@@ -78,8 +78,7 @@ function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanSST)
     end
 
     # 2. Turbulent surface energy fluxes (sensible + latent heat) from surface to atmosphere
-    if !isnothing(p.atmos.vertical_diffusion) ||
-       !isnothing(p.atmos.turbconv_model)
+    if !(p.atmos.disable_surface_flux_tendency)
         turb_e_flux_sfc_to_atm =
             Geometry.WVector.(
                 p.precomputed.sfc_conditions.ρ_flux_h_tot
@@ -119,8 +118,7 @@ function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanSST)
     # --- WATER BALANCE (if moisture is active) ---
     if !(p.atmos.moisture_model isa DryModel)
         # 1. Turbulent surface water fluxes (evaporation/condensation)
-        if !isnothing(p.atmos.vertical_diffusion) ||
-           !isnothing(p.atmos.turbconv_model)
+        if !(p.atmos.disable_surface_flux_tendency)
             sfc_turb_w_flux =
                 Geometry.WVector.(
                     p.precomputed.sfc_conditions.ρ_flux_q_tot


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds accumulation of energy source and sink due to precipitation for 1M microphysics. Also, previously we separated surface flux tendency from vertical diffusion, but didn't change the condition in slab ocean tendency. This PR fixes it.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
