### PR TITLE
Reorder `make_plots` for `EDMFSpherePlots` and make comparison plot column widths equal

### DIFF
--- a/.buildkite/ci_driver.jl
+++ b/.buildkite/ci_driver.jl
@@ -5,8 +5,8 @@
 # (See also Base.type_limited_string_from_context())
 redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
 # PrecompileCI is a local package that forces commonly used methods to be precompiled,
-# allowing them to be reused between Julia sessions. 
-# To load in the precompiled methods, run `using PrecompileCI` before loading ClimaAtmos. 
+# allowing them to be reused between Julia sessions.
+# To load in the precompiled methods, run `using PrecompileCI` before loading ClimaAtmos.
 # To see what methods are precompiled, open julia: `julia --project=.buildkite/PrecompileCI`
 # and run `using PrecompileTools; PrecompileTools.verbose[] = true; include(".buildkite/PrecompileCI/src/PrecompileCI.jl")`
 using PrecompileCI

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -249,7 +249,15 @@ function make_plots_generic(
     grid_pos = 1
 
     for var in vars
+        # Print info about variable we're plotting and where
+        if isa(var, Tuple)
+            var_name = parse_var_attributes(var[1])
+        else
+            var_name = parse_var_attributes(var)
+        end
+        println("Plotting variable: $(var_name) in grid position: $(grid_pos)")
         if grid_pos > MAX_PLOTS_PER_PAGE
+            println("Starting new page")
             fig = makefig()
             grid = gridlayout()
             grid_pos = 1

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -255,13 +255,14 @@ function make_plots_generic(
         else
             var_name = parse_var_attributes(var)
         end
-        println("Plotting variable: $(var_name) in grid position: $(grid_pos)")
         if grid_pos > MAX_PLOTS_PER_PAGE
             println("Starting new page")
             fig = makefig()
             grid = gridlayout()
             grid_pos = 1
         end
+
+        println("Plotting variable: $(var_name) in grid position: $(grid_pos)")
 
         plot_fn(grid[grid_pos], var, args...; kwargs...)
         grid_pos += 1

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -231,7 +231,7 @@ function make_plots_generic(
                 normalized_path =
                     lpad(path, LABEL_LENGTH + 1, " ")[(end - LABEL_LENGTH):end]
 
-                CairoMakie.Label(fig[0, col], path)
+                CairoMakie.Label(fig[0, col], normalized_path)
             end
         end
         return fig

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1597,25 +1597,20 @@ function make_plots(::EDMFSpherePlots, output_paths::Vector{<:AbstractString})
 
     short_name_tuples = pair_edmf_names(short_names)
 
-    # The hierarchy is:
-    # - A vector looping over variables
-    #     - Containing, a vector looping over latitudes
-    #     - Containing, tuples with one or two variables
-    #   - Repeated for each simdir
-    # All of this is flattened out to be a vector of tuples (with the two gridmean/updraft
-    # variables)
+    # Create a flat sequence of variable groups iterating over variable,
+    # latitude, and simulation directory
     var_groups_zt = vcat(
-        map_comparison(simdirs, short_name_tuples) do simdir, name_tuple
-            return [
-                (
+        [
+            map_comparison(simdirs, latitudes) do simdir, lat
+                return (
                     slice(
                         get(simdir; short_name, reduction, period),
                         lon = 0.0,
                         lat = lat,
                     ) for short_name in name_tuple
-                ) for lat in latitudes
-            ]
-        end...,
+                )
+            end for name_tuple in short_name_tuples
+        ]...,
     )
 
     var_groups_z = [


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

Resolves #3915 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->

- [ ] Maybe don't use a comprehension to create `var_groups_zt`, because it's confusing?

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

`summary_comparison.pdf` files will now look like:

<img width="680" height="847" alt="image" src="https://github.com/user-attachments/assets/38023782-6249-4ee5-b2ca-4806d72525f3" />

I also added some print statements to log what happens in plotting. Let me know if that is not desired, or if I should use the logging macros or something. I see no other logging happening in `ci_plots.jl`, so I'm assuming it's a convention to keep things quiet.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
