### PR TITLE
Add Rainwater Path Diagnostic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ ClimaAtmos.jl Release Notes
 
 main
 -------
+### Add RWP diagnostic
+PR [#3936](https://github.com/CliMA/ClimaAtmos.jl/pull/3936) adds implementation for rainwater path diagnostic.
+
 PR [#3917](https://github.com/CliMA/ClimaAtmos.jl/pull/3917) adds common numercis configs for different resolutions. 
 These configurations are intended to serve as the default settings. Please modify them only if you are certain of the implications.
 

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -31,7 +31,7 @@ dt_save_state_to_disk: 10mins
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr, lwp, rwp]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup]
     period: 10mins

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -1522,12 +1522,12 @@ function compute_rwp!(
     if isnothing(out)
         out = zeros(axes(Fields.level(state.f, half)))
         rw = cache.scratch.ᶜtemp_scalar
-        @. rw = state.c.ρ * cache.precomputed.cloud_diagnostics_tuple.q_rai
+        @. rw = state.c.ρq_rai
         Operators.column_integral_definite!(out, rw)
         return out
     else
         rw = cache.scratch.ᶜtemp_scalar
-        @. rw = state.c.ρ * cache.precomputed.cloud_diagnostics_tuple.q_rai
+        @. rw = state.c.ρq_rai
         Operators.column_integral_definite!(out, rw)
     end
 end

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -252,7 +252,7 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics = ["husra", "hussn"] # add diagnostic for lwp here
+    precip_diagnostics = ["husra", "hussn", "lwp", "rwp"]
 
     average_func = frequency_averages(duration)
 
@@ -265,7 +265,7 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics = ["husra", "hussn", "cdnc", "ncra"]
+    precip_diagnostics = ["husra", "hussn", "cdnc", "ncra", "lwp", "rwp", "reffclw"]
 
     average_func = frequency_averages(duration)
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -252,7 +252,7 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics = ["husra", "hussn", "lwp", "rwp"]
+    precip_diagnostics = ["husra", "hussn"]
 
     average_func = frequency_averages(duration)
 
@@ -265,7 +265,8 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics = ["husra", "hussn", "cdnc", "ncra", "lwp", "rwp", "reffclw"]
+    precip_diagnostics =
+        ["husra", "hussn", "cdnc", "ncra"]
 
     average_func = frequency_averages(duration)
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -252,7 +252,7 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics = ["husra", "hussn"]
+    precip_diagnostics = ["husra", "hussn"] # add diagnostic for lwp here
 
     average_func = frequency_averages(duration)
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -265,8 +265,7 @@ function default_diagnostics(
     start_date;
     output_writer,
 )
-    precip_diagnostics =
-        ["husra", "hussn", "cdnc", "ncra"]
+    precip_diagnostics = ["husra", "hussn", "cdnc", "ncra"]
 
     average_func = frequency_averages(duration)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Implementing rainwater path as a diagnostic variable.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- Is there a way to add precomputed q_rai? can do state.c.ρ * cache.precomputed.cloud_diagnostics_tuple.q_rai to speed up.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Implemented RWP in core_diagnostics.jl.
- Add as a default diagnostic for 1M and 2M microphysics (along with LWP, and effective radius for 2M).
- Add as a diagnostic for "config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml".

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
