### PR TITLE
Fix energy conservation with sparse autodiff

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -286,6 +286,12 @@ steps:
           --job_id baroclinic_wave_conservation
         artifact_paths: "baroclinic_wave_conservation/output_active/*"
 
+      - label: ":computer: baroclinic wave check conservation float64 sparse autodiff"
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl --config_file $CONFIG_PATH/baroclinic_wave_conservation_ft64_sparse_autodiff.yml
+          --job_id baroclinic_wave_conservation_ft64_sparse_autodiff
+        artifact_paths: "baroclinic_wave_conservation_ft64_sparse_autodiff/output_active/*"
+
       - label: ":computer: baroclinic wave moist check conservation"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl --config_file $CONFIG_PATH/baroclinic_wave_equil_conservation.yml
@@ -303,7 +309,6 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl --config_file $CONFIG_PATH/baroclinic_wave_equil_conservation_ft64_sparse_autodiff.yml
           --job_id baroclinic_wave_equil_conservation_ft64_sparse_autodiff
         artifact_paths: "baroclinic_wave_equil_conservation_ft64_sparse_autodiff/output_active/*"
-        soft_fail: true
 
       - label: ":computer: baroclinic wave moist check conservation with sources"
         command: >

--- a/config/model_configs/baroclinic_wave_conservation_ft64_sparse_autodiff.yml
+++ b/config/model_configs/baroclinic_wave_conservation_ft64_sparse_autodiff.yml
@@ -1,0 +1,14 @@
+FLOAT_TYPE: "Float64"
+initial_condition: "DryBaroclinicWave"
+t_end: "5days"
+dt_save_state_to_disk: "5days"
+disable_surface_flux_tendency: true
+use_auto_jacobian: true
+update_jacobian_every: dt
+debug_jacobian: true
+check_conservation: true
+diagnostics:
+  - short_name: [massa, energya]
+    period: 1days
+    writer: dict
+use_itime: true

--- a/src/prognostic_equations/implicit/auto_dense_jacobian.jl
+++ b/src/prognostic_equations/implicit/auto_dense_jacobian.jl
@@ -48,7 +48,7 @@ AutoDenseJacobian(max_simultaneous_derivatives = 32) =
 # The number of derivatives computed simultaneously by AutoDenseJacobian.
 max_simultaneous_derivatives(::AutoDenseJacobian{S}) where {S} = S
 
-function jacobian_cache(alg::AutoDenseJacobian, Y, atmos)
+function jacobian_cache(alg::AutoDenseJacobian, Y, atmos; kwargs...)
     FT = eltype(Y)
     DA = ClimaComms.array_type(Y)
 


### PR DESCRIPTION
This PR fixes energy conservation when using `AutoSparseJacobian` by adding padding bands to most of the `∂ᶜρe_totₜ/∂ᶜχ` blocks, and also by explicitly handling the quaddiagonal bands of the `∂ᶜρe_totₜ/∂ᶠu₃` block.

Based on the baroclinic wave conservation tests (dry and moist), even errors as small as one part in a trillion in the `∂ᶜρe_totₜ/∂ᶠu₃` block seem to affect energy conservation when using Float64 precision. These changes eliminate all such errors, so that the energy conservation is even better than with `ManualSparseJacobian`.

This PR also adds a Float64 baroclinic wave conservation test with sparse autodiff, and it clarifies the bandwidth tables printed when debugging the Jacobian.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
