### PR TITLE
Disable Aqua persistent tasks test

### DIFF
--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -24,7 +24,8 @@ using Aqua
 end
 
 @testset "Aqua tests (all)" begin
-    Aqua.test_all(ClimaAtmos)
+    Aqua.test_all(ClimaAtmos; persistent_tasks = false)
+    # TODO: Set persistent_tasks = true when RecursiveArrayTools releases fix to circular deps
 end
 
 nothing


### PR DESCRIPTION
v3.37 of RecursiveArrayTools causes a circular
dependency with julia 1.10. This temporarily
disables the aqua test that errors because of this.

See the [issue](https://github.com/SciML/RecursiveArrayTools.jl/issues/477) in RecursiveArrayTools.



<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
