### PR TITLE
Redefine sedimentation velocity in Prognostic EDMF (1M/2M)

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-256
+257
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+257
+- Redefine sedimentation velocity for Prognostic EDMF with 1-moment or 2-moment microphysics
+  on the grid scale; fix a bug in EDMFx SGS mass flux.
+
 256
 - Fix a bug in EDMF diffusive flux
 

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -121,8 +121,8 @@ function precomputed_quantities(Y, atmos)
             ᶜSqᵢᵖ = similar(Y.c, FT),
             ᶜSqᵣᵖ = similar(Y.c, FT),
             ᶜSqₛᵖ = similar(Y.c, FT),
-            ᶜwnₗ = similar(Y.c, FT),
-            ᶜwnᵣ = similar(Y.c, FT),
+            ᶜwₙₗ = similar(Y.c, FT),
+            ᶜwₙᵣ = similar(Y.c, FT),
             ᶜSnₗᵖ = similar(Y.c, FT),
             ᶜSnᵣᵖ = similar(Y.c, FT),
         )
@@ -531,6 +531,7 @@ NVTX.@annotate function set_explicit_precomputed_quantities!(Y, p, t)
         p,
         p.atmos.moisture_model,
         p.atmos.microphysics_model,
+        p.atmos.turbconv_model,
     )
     # Needs to be done after edmf precipitation is computed in sub-domains
     set_precipitation_cache!(

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -30,7 +30,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     set_sgs_ᶠu₃!(u₃⁰, ᶠu₃⁰, Y, turbconv_model)
     set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.uₕ, ᶠuₕ³)
     # @. ᶜK⁰ += ᶜtke⁰
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
 
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)
 
@@ -38,10 +38,10 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
         p.atmos.microphysics_model isa Microphysics1Moment ||
         p.atmos.microphysics_model isa Microphysics2Moment
     )
-        ᶜq_liq⁰ = ᶜspecific_env_value(Val(:q_liq), Y, p)
-        ᶜq_ice⁰ = ᶜspecific_env_value(Val(:q_ice), Y, p)
-        ᶜq_rai⁰ = ᶜspecific_env_value(Val(:q_rai), Y, p)
-        ᶜq_sno⁰ = ᶜspecific_env_value(Val(:q_sno), Y, p)
+        ᶜq_liq⁰ = ᶜspecific_env_value(@name(q_liq), Y, p)
+        ᶜq_ice⁰ = ᶜspecific_env_value(@name(q_ice), Y, p)
+        ᶜq_rai⁰ = ᶜspecific_env_value(@name(q_rai), Y, p)
+        ᶜq_sno⁰ = ᶜspecific_env_value(@name(q_sno), Y, p)
         @. ᶜts⁰ = TD.PhaseNonEquil_phq(
             thermo_params,
             ᶜp,
@@ -470,7 +470,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     (; ᶜgradᵥ_θ_virt⁰, ᶜgradᵥ_q_tot⁰, ᶜgradᵥ_θ_liq_ice⁰) = p.precomputed
     # First order approximation: Use environmental mean fields.
     @. ᶜgradᵥ_θ_virt⁰ = ᶜgradᵥ(ᶠinterp(TD.virtual_pottemp(thermo_params, ᶜts⁰)))       # ∂θv∂z_unsat
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
     @. ᶜgradᵥ_q_tot⁰ = ᶜgradᵥ(ᶠinterp(ᶜq_tot⁰))                                        # ∂qt∂z_sat
     @. ᶜgradᵥ_θ_liq_ice⁰ =
         ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts⁰)))                    # ∂θl∂z_sat
@@ -546,7 +546,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
         )
     end
     # sources from the environment
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
     @. ᶜSqₜᵖ⁰ = q_tot_0M_precipitation_sources(thp, cmp, dt, ᶜq_tot⁰, ᶜts⁰)
     return nothing
 end
@@ -630,7 +630,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
                 ᶜwₛʲs.:($$j) *
                 Y.c.sgsʲs.:($$j).q_sno *
                 (Iᵢ(thp, ᶜtsʲs.:($$j)) + ᶜΦ)
-            ) / abs(Y.c.sgsʲs.:($$j).mse),
+            ) / (Y.c.sgsʲs.:($$j).mse),
             FT(0),
         )
 
@@ -696,11 +696,11 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     end
 
     # Precipitation sources and sinks from the environment
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
-    ᶜq_liq⁰ = ᶜspecific_env_value(Val(:q_liq), Y, p)
-    ᶜq_ice⁰ = ᶜspecific_env_value(Val(:q_ice), Y, p)
-    ᶜq_rai⁰ = ᶜspecific_env_value(Val(:q_rai), Y, p)
-    ᶜq_sno⁰ = ᶜspecific_env_value(Val(:q_sno), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
+    ᶜq_liq⁰ = ᶜspecific_env_value(@name(q_liq), Y, p)
+    ᶜq_ice⁰ = ᶜspecific_env_value(@name(q_ice), Y, p)
+    ᶜq_rai⁰ = ᶜspecific_env_value(@name(q_rai), Y, p)
+    ᶜq_sno⁰ = ᶜspecific_env_value(@name(q_sno), Y, p)
     ᶜρ⁰ = @. lazy(TD.air_density(thp, ᶜts⁰))
     compute_precipitation_sources!(
         ᶜSᵖ,
@@ -788,7 +788,8 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     ) = p.precomputed
     (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜSnₗᵖ⁰, ᶜSnᵣᵖ⁰, ᶜts⁰, ᶜu⁰) =
         p.precomputed
-    (; ᶜwₗʲs, ᶜwᵢʲs, ᶜwᵣʲs, ᶜwₛʲs, ᶜwₙₗʲs, ᶜwₙᵣʲs, ᶜwₜʲs, ᶜwₕʲs) = p.precomputed
+    (; ᶜwₗʲs, ᶜwᵢʲs, ᶜwᵣʲs, ᶜwₛʲs, ᶜwₙₗʲs, ᶜwₙᵣʲs, ᶜwₜʲs, ᶜwₕʲs, ᶜuʲs) =
+        p.precomputed
 
     ᶜSᵖ = p.scratch.ᶜtemp_scalar
     ᶜS₂ᵖ = p.scratch.ᶜtemp_scalar_2
@@ -825,7 +826,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
                 cm2p.rtv,
                 max(zero(Y.c.ρ), Y.c.sgsʲs.:($$j).q_rai),
                 ᶜρʲs.:($$j),
-                max(zero(Y.c.ρ), Y.c.sgsʲs.:($$j).n_rai),
+                max(zero(Y.c.ρ), ᶜρʲs.:($$j) * Y.c.sgsʲs.:($$j).n_rai),
             ),
             1,
         )
@@ -835,7 +836,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
                 cm2p.rtv,
                 max(zero(Y.c.ρ), Y.c.sgsʲs.:($$j).q_rai),
                 ᶜρʲs.:($$j),
-                max(zero(Y.c.ρ), Y.c.sgsʲs.:($$j).n_rai),
+                max(zero(Y.c.ρ), ᶜρʲs.:($$j) * Y.c.sgsʲs.:($$j).n_rai),
             ),
             2,
         )
@@ -899,7 +900,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
                 ᶜwₛʲs.:($$j) *
                 Y.c.sgsʲs.:($$j).q_sno *
                 (Iᵢ(thp, ᶜtsʲs.:($$j)) + ᶜΦ)
-            ) / abs(Y.c.sgsʲs.:($$j).mse),
+            ) / (Y.c.sgsʲs.:($$j).mse),
             FT(0),
         )
 
@@ -969,13 +970,13 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_precipitation
     end
 
     # Precipitation sources and sinks from the environment
-    ᶜn_liq⁰ = ᶜspecific_env_value(Val(:n_liq), Y, p)
-    ᶜn_rai⁰ = ᶜspecific_env_value(Val(:n_rai), Y, p)
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
-    ᶜq_liq⁰ = ᶜspecific_env_value(Val(:q_liq), Y, p)
-    ᶜq_ice⁰ = ᶜspecific_env_value(Val(:q_ice), Y, p)
-    ᶜq_rai⁰ = ᶜspecific_env_value(Val(:q_rai), Y, p)
-    ᶜq_sno⁰ = ᶜspecific_env_value(Val(:q_sno), Y, p)
+    ᶜn_liq⁰ = ᶜspecific_env_value(@name(n_liq), Y, p)
+    ᶜn_rai⁰ = ᶜspecific_env_value(@name(n_rai), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
+    ᶜq_liq⁰ = ᶜspecific_env_value(@name(q_liq), Y, p)
+    ᶜq_ice⁰ = ᶜspecific_env_value(@name(q_ice), Y, p)
+    ᶜq_rai⁰ = ᶜspecific_env_value(@name(q_rai), Y, p)
+    ᶜq_sno⁰ = ᶜspecific_env_value(@name(q_sno), Y, p)
     ᶜρ⁰ = @. lazy(TD.air_density(thp, ᶜts⁰))
     compute_warm_precipitation_sources_2M!(
         ᶜSᵖ,

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -8,6 +8,7 @@ import ClimaComms
 import ClimaCore:
     Fields, Geometry, InputOutput, Meshes, Spaces, Operators, Domains, Grids
 import ClimaCore.Utilities: half
+import ClimaCore.MatrixFields: @name
 import Thermodynamics as TD
 
 # compute lazily to reduce allocations

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -1101,7 +1101,7 @@ function compute_clwen!(
     moisture_model::NonEquilMoistModel,
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜq_liq⁰ = ᶜspecific_env_value(Val(:q_liq), state, cache)
+    ᶜq_liq⁰ = ᶜspecific_env_value(@name(q_liq), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜq_liq⁰)
     else
@@ -1147,7 +1147,7 @@ function compute_cdncen!(
     microphysics_model_model::Microphysics2Moment,
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜn_liq⁰ = ᶜspecific_env_value(Val(:n_liq), state, cache)
+    ᶜn_liq⁰ = ᶜspecific_env_value(@name(n_liq), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜn_liq⁰)
     else
@@ -1212,7 +1212,7 @@ function compute_clien!(
     moisture_model::NonEquilMoistModel,
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜq_ice⁰ = ᶜspecific_env_value(Val(:q_ice), state, cache)
+    ᶜq_ice⁰ = ᶜspecific_env_value(@name(q_ice), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜq_ice⁰)
     else
@@ -1261,7 +1261,7 @@ function compute_husraen!(
     microphysics_model_model::Union{Microphysics1Moment, Microphysics2Moment},
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜq_rai⁰ = ᶜspecific_env_value(Val(:q_rai), state, cache)
+    ᶜq_rai⁰ = ᶜspecific_env_value(@name(q_rai), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜq_rai⁰)
     else
@@ -1307,7 +1307,7 @@ function compute_ncraen!(
     microphysics_model_model::Microphysics2Moment,
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜn_rai⁰ = ᶜspecific_env_value(Val(:n_rai), state, cache)
+    ᶜn_rai⁰ = ᶜspecific_env_value(@name(n_rai), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜn_rai⁰)
     else
@@ -1356,7 +1356,7 @@ function compute_hussnen!(
     microphysics_model_model::Union{Microphysics1Moment, Microphysics2Moment},
     turbconv_model::PrognosticEDMFX,
 )
-    ᶜq_sno⁰ = ᶜspecific_env_value(Val(:q_sno), state, cache)
+    ᶜq_sno⁰ = ᶜspecific_env_value(@name(q_sno), state, cache)
     if isnothing(out)
         return Base.materialize(ᶜq_sno⁰)
     else

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -531,15 +531,15 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
     (; ᶠu₃⁰) = p.precomputed
 
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)
-    ᶜq_tot⁰ = ᶜspecific_env_value(Val(:q_tot), Y, p)
+    ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
 
     microphysics_tracers = (
-        (@name(c.sgsʲs.:(1).q_liq), :q_liq),
-        (@name(c.sgsʲs.:(1).q_ice), :q_ice),
-        (@name(c.sgsʲs.:(1).q_rai), :q_rai),
-        (@name(c.sgsʲs.:(1).q_sno), :q_sno),
-        (@name(c.sgsʲs.:(1).n_liq), :n_liq),
-        (@name(c.sgsʲs.:(1).n_rai), :n_rai),
+        (@name(c.sgsʲs.:(1).q_liq), @name(q_liq)),
+        (@name(c.sgsʲs.:(1).q_ice), @name(q_ice)),
+        (@name(c.sgsʲs.:(1).q_rai), @name(q_rai)),
+        (@name(c.sgsʲs.:(1).q_sno), @name(q_sno)),
+        (@name(c.sgsʲs.:(1).n_liq), @name(n_liq)),
+        (@name(c.sgsʲs.:(1).n_rai), @name(n_rai)),
     )
 
     for j in 1:n
@@ -558,7 +558,7 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
 
         MatrixFields.unrolled_foreach(microphysics_tracers) do (χʲ_name, χ_name)
             MatrixFields.has_field(Y, χʲ_name) || return
-            ᶜχ⁰ = ᶜspecific_env_value(Val(χ_name), Y, p)
+            ᶜχ⁰ = ᶜspecific_env_value(χ_name, Y, p)
             ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
             ᶜχʲₜ = MatrixFields.get_field(Yₜ, χʲ_name)
             @. ᶜχʲₜ += (ᶜentrʲ .+ ᶜturb_entrʲ) * (ᶜχ⁰ - ᶜχʲ)

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -193,15 +193,15 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         )
     end
     if microphysics_model isa Microphysics2Moment
-        (; ᶜwnₗ, ᶜwnᵣ, ᶜwᵣ, ᶜwₛ) = p.precomputed
+        (; ᶜwₙₗ, ᶜwₙᵣ, ᶜwᵣ, ᶜwₛ) = p.precomputed
         @. Yₜ.c.ρn_liq -= ᶜprecipdivᵥ(
             ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwnₗ)) * specific(Y.c.ρn_liq, Y.c.ρ),
+                Geometry.WVector(-(ᶜwₙₗ)) * specific(Y.c.ρn_liq, Y.c.ρ),
             ),
         )
         @. Yₜ.c.ρn_rai -= ᶜprecipdivᵥ(
             ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwnᵣ)) * specific(Y.c.ρn_rai, Y.c.ρ),
+                Geometry.WVector(-(ᶜwₙᵣ)) * specific(Y.c.ρn_rai, Y.c.ρ),
             ),
         )
         @. Yₜ.c.ρq_rai -= ᶜprecipdivᵥ(

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -498,8 +498,8 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
         (@name(c.ρq_ice), @name(ᶜwᵢ)),
         (@name(c.ρq_rai), @name(ᶜwᵣ)),
         (@name(c.ρq_sno), @name(ᶜwₛ)),
-        (@name(c.ρn_liq), @name(ᶜwnₗ)),
-        (@name(c.ρn_rai), @name(ᶜwnᵣ)),
+        (@name(c.ρn_liq), @name(ᶜwₙₗ)),
+        (@name(c.ρn_rai), @name(ᶜwₙᵣ)),
     )
     if !(p.atmos.moisture_model isa DryModel) || use_derivative(diffusion_flag)
         ∂ᶜρe_tot_err_∂ᶜρe_tot = matrix[@name(c.ρe_tot), @name(c.ρe_tot)]

--- a/src/utils/variable_manipulations.jl
+++ b/src/utils/variable_manipulations.jl
@@ -275,7 +275,7 @@ end
 
 
 """
-    ᶜspecific_env_value(::Val{χ_name}, Y, p)
+    ᶜspecific_env_value(χ_name, Y, p)
 
 Calculates the specific value of a quantity `χ` in the environment (`χ⁰`).
 
@@ -286,20 +286,20 @@ regularized `specific` function, which provides a stable result even when the
 environment area fraction is very small.
 
 Arguments:
-- `::Val{χ_name}`: A `Val` type containing the symbol for the specific quantity `χ` (e.g., `Val(:h_tot)`, `Val(:q_tot)`).
+- `χ_name`: A `MatrixFields.FieldName`, containing name for the specific quantity `χ` (e.g., `@name(h_tot)`, `@name(q_tot)`).
 - `Y`: The state, containing grid-mean and draft subdomain states.
 - `p`: The cache, containing precomputed quantities and turbconv_model.
 
 Returns:
 - The specific value of the quantity `χ` in the environment.
 """
-function ᶜspecific_env_value(::Val{χ_name}, Y, p) where {χ_name}
+function ᶜspecific_env_value(χ_name, Y, p)
     turbconv_model = p.atmos.turbconv_model
 
-    # Grid-scale density-weighted variable name, e.g., :ρq_tot
-    ρχ_name = Symbol(:ρ, χ_name)
+    # Grid-scale density-weighted variable name, e.g., ρq_tot
+    ρχ_name = get_ρχ_name(χ_name)
 
-    ᶜρχ = getproperty(Y.c, ρχ_name)
+    ᶜρχ = MatrixFields.get_field(Y.c, ρχ_name)
 
     # environment density-area-weighted mse (`ρa⁰χ⁰`).
     # Numerator: ρa⁰χ⁰ = ρχ - (Σ ρaʲ * χʲ)
@@ -308,7 +308,9 @@ function ᶜspecific_env_value(::Val{χ_name}, Y, p) where {χ_name}
 
         ᶜρaχ⁰ = ᶜenv_value(
             ᶜρχ,
-            sgsʲ -> getfield(sgsʲ, :ρa) * sgsʲ.:($χ_name),
+            sgsʲ ->
+                MatrixFields.get_field(sgsʲ, @name(ρa)) *
+                MatrixFields.get_field(sgsʲ, χ_name),
             Y.c.sgsʲs,
         )
         # Denominator: ρa⁰ = ρ - Σ ρaʲ
@@ -325,6 +327,30 @@ function ᶜspecific_env_value(::Val{χ_name}, Y, p) where {χ_name}
         Y.c.ρ,                      # Fallback ρ is the grid-mean value
         turbconv_model,
     ))
+end
+
+"""
+    get_ρχ_name(χ_name::FieldName)
+
+Construct the `FieldName` corresponding to the product ρ·χ.
+
+Given a tracer name `χ_name`, this function returns the new name that
+represents the corresponding density-weighted quantity (ρ times χ). 
+
+The function works recursively on hierarchical field names: If `χ_name` 
+is a base name (no children), it returns a new name prefixed with `ρ`.
+If `χ_name` has internal structure (e.g. a composite name), the function
+recurses into the child names and prepends `ρ` at the lowest level.
+"""
+function get_ρχ_name(χ_name)
+    parent_name = MatrixFields.extract_first(χ_name)
+    child_name = MatrixFields.drop_first(χ_name)
+    ρχ_name =
+        (child_name == MatrixFields.@name()) ?
+        MatrixFields.FieldName(Symbol(:ρ, MatrixFields.extract_first(χ_name))) :
+        MatrixFields.append_internal_name(parent_name, get_ρχ_name(child_name))
+
+    return ρχ_name
 end
 
 """

--- a/test/parameterized_tendencies/microphysics/precipitation.jl
+++ b/test/parameterized_tendencies/microphysics/precipitation.jl
@@ -35,7 +35,13 @@ import Test: @test
     (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_velocities!(
+        Y,
+        p,
+        moisture_model,
+        microphysics_model,
+        turbconv_model,
+    )
     CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
     CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
@@ -101,7 +107,13 @@ end
     (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_velocities!(
+        Y,
+        p,
+        moisture_model,
+        microphysics_model,
+        turbconv_model,
+    )
     CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
     CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
@@ -200,7 +212,13 @@ end
     (; turbconv_model, moisture_model, microphysics_model) = p.atmos
 
     # Test cache to verify expected variables exist in tendency function
-    CA.set_precipitation_velocities!(Y, p, moisture_model, microphysics_model)
+    CA.set_precipitation_velocities!(
+        Y,
+        p,
+        moisture_model,
+        microphysics_model,
+        turbconv_model,
+    )
     CA.set_precipitation_cache!(Y, p, microphysics_model, turbconv_model)
     CA.set_precipitation_surface_fluxes!(Y, p, microphysics_model)
     test_varnames = (
@@ -216,8 +234,8 @@ end
         :ᶜwᵢ,
         :ᶜwᵣ,
         :ᶜwₛ,
-        :ᶜwnₗ,
-        :ᶜwnᵣ,
+        :ᶜwₙₗ,
+        :ᶜwₙᵣ,
         :ᶜwₜqₜ,
         :ᶜwₕhₜ,
     )
@@ -250,8 +268,8 @@ end
     @assert !any(isnan, p.precomputed.ᶜwᵢ)
     @assert !any(isnan, p.precomputed.ᶜwᵣ)
     @assert !any(isnan, p.precomputed.ᶜwₛ)
-    @assert !any(isnan, p.precomputed.ᶜwnₗ)
-    @assert !any(isnan, p.precomputed.ᶜwnᵣ)
+    @assert !any(isnan, p.precomputed.ᶜwₙₗ)
+    @assert !any(isnan, p.precomputed.ᶜwₙᵣ)
 
     # test water budget
     @test ᶜYₜ.c.ρ == ᶜYₜ.c.ρq_tot
@@ -275,8 +293,8 @@ end
     @test minimum(p.precomputed.ᶜwᵢ) >= FT(0)
     @test minimum(p.precomputed.ᶜwᵣ) >= FT(0)
     @test minimum(p.precomputed.ᶜwₛ) >= FT(0)
-    @test minimum(p.precomputed.ᶜwnₗ) >= FT(0)
-    @test minimum(p.precomputed.ᶜwnᵣ) >= FT(0)
+    @test minimum(p.precomputed.ᶜwₙₗ) >= FT(0)
+    @test minimum(p.precomputed.ᶜwₙᵣ) >= FT(0)
 
     # test if cloud fraction diagnostics make sense
     @assert !any(isnan, p.precomputed.cloud_diagnostics_tuple.cf)


### PR DESCRIPTION
This PR fixes the computation of terminal velocities. They are now calculated consistently from the subdomain terminal velocities for both 1-moment and 2-moment microphysics.  

It also fixes a bug: after applying boundary conditions for the area fraction, the constraint  

$$
\langle \hat{\rho} u^j \rangle = \rho u
$$  

was not satisfied at the boundary. This introduced errors in the SGS mass flux computations. I now recompute $u^{3,0}$ so that the constraint holds.  

By the new definition of sedimentation velocities, the sum of fluxes of any tracer or energy over subdomains equals the flux at grid scale. As a result, there is no need to add sedimentation effects into the computation of SGS mass fluxes. The general form of the EDMF tracer flux is  

$$
F_\chi = \langle \hat{\rho} \\, a \\, w^j \chi^j \rangle - \rho w \chi ,
$$

where  
- $w = w_\text{air} + w_\chi$ is the vertical velocity, including both air motion and the sedimentation velocity of tracer $\chi$,  
- $\langle \cdot \rangle$ denotes the sum over subdomains, and  
- the second term is the resolved grid-scale flux.  

---

### Cancellation for tracers  

If we define the terminal velocities such that  

$$
\langle \hat{\rho} \\, a \\, w_\chi^j \chi^j \rangle = \rho w_\chi \chi ,
$$

then sedimentation contributions cancel in the SGS flux:  

$$
\begin{aligned}
F_\chi &= \langle \hat{\rho} \\, a \\, (w_\text{air}^j + w_\chi^j)\chi^j \rangle 
         - \rho (w_\text{air} + w_\chi)\chi \\
       &= \langle \hat{\rho} \\, a \\, w_\text{air}^j \chi^j \rangle - \rho w_\text{air} \chi .
\end{aligned}
$$

This cancellation holds for all tracers ($q_\text{liq}, q_\text{ice}, q_\text{rai}, q_\text{sno}$), their sum (total water sedimentation), and also for energy.  

---

### Energy case  

For total energy, the flux is  

$$
F_h = \Big\langle \hat{\rho} \big( w_\text{air}^j h_\text{tot}^j + 
 \sum_p w_p^j q_p^j h_p^j \big)\Big\rangle - \rho \Big( w_\text{air} h_\text{tot} + \sum_p w_p q_p h_p \Big) ,
$$

where $p$ runs over the precipitating species (liq, ice, rain, snow).  

We define the sedimentation velocity of energy as  

$$
w^j_h = \frac{\sum_p w^j_p q^j_p h^j_p}{h^j_\text{tot}} .
$$

The grid-scale sedimentation velocity of energy is defined analogously to tracers, such that the sum of subdomain energy fluxes equals the grid-scale energy flux. Therefore, as with tracers, energy sedimentation does not contribute to SGS fluxes.

