### PR TITLE
remove get_wstar function

### DIFF
--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -45,13 +45,6 @@ include(joinpath("cache", "cloud_fraction.jl"))
 include(joinpath("cache", "surface_albedo.jl"))
 
 include(joinpath("initial_conditions", "InitialConditions.jl"))
-include(
-    joinpath(
-        "parameterized_tendencies",
-        "turbulence_convection",
-        "tc_functions.jl",
-    ),
-)
 include(joinpath("surface_conditions", "SurfaceConditions.jl"))
 include(joinpath("utils", "discrete_hydrostatic_balance.jl"))
 

--- a/src/parameterized_tendencies/turbulence_convection/tc_functions.jl
+++ b/src/parameterized_tendencies/turbulence_convection/tc_functions.jl
@@ -1,6 +1,0 @@
-# convective velocity scale
-function get_wstar(bflux::FT) where {FT}
-    # average depth of the mixed layer (prescribed for now)
-    zi = FT(1000)
-    return cbrt(max(bflux * zi, 0))
-end

--- a/src/surface_conditions/SurfaceConditions.jl
+++ b/src/surface_conditions/SurfaceConditions.jl
@@ -13,7 +13,6 @@ import ..gcm_driven_timeseries
 
 import ..CT1, ..CT2, ..C12, ..CT12, ..C3
 import ..unit_basis_vector_data, ..projected_vector_data
-import ..get_wstar
 
 import ClimaCore: DataLayouts, Geometry, Fields
 import ClimaCore.Geometry: ⊗

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -309,10 +309,11 @@ function surface_state_to_conditions(
                     ts,
                     SF.PointValueScheme(),
                 )
-                gustiness = get_wstar(buoyancy_flux)
                 # TODO: We are assuming that the average mixed layer depth is
                 # always 1000 meters. This needs to be adjusted for deep
                 # convective cases like TRMM.
+                zi = FT(1000)
+                gustiness = cbrt(max(buoyancy_flux * zi, 0))
             else
                 gustiness = surf_state.gustiness
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
`get_wstar` is only used once in the code for a few edmf single column cases. This PR removes it and calculates w_star in surface_conditions.jl directly.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
