### PR TITLE
feat: add P3 ice microphysics model

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -113,7 +113,8 @@ function precomputed_quantities(Y, atmos)
             ᶜSqᵣᵖ = similar(Y.c, FT),
             ᶜSqₛᵖ = similar(Y.c, FT),
         )
-    elseif atmos.microphysics_model isa Microphysics2Moment
+    elseif atmos.microphysics_model isa Union{Microphysics2Moment, Microphysics2MomentP3}
+        # 2-moment microphysics
         precipitation_quantities = (;
             ᶜwᵣ = similar(Y.c, FT),
             ᶜwₛ = similar(Y.c, FT),
@@ -126,6 +127,23 @@ function precomputed_quantities(Y, atmos)
             ᶜSnₗᵖ = similar(Y.c, FT),
             ᶜSnᵣᵖ = similar(Y.c, FT),
         )
+        # Add additional quantities for 2M + P3
+        if atmos.microphysics_model isa Microphysics2MomentP3
+            precipitation_quantities = (;
+                # liquid quantities (2M warm rain)
+                precipitation_quantities...,
+                # ice quantities (P3)
+                ᶜwᵢ = similar(Y.c, FT),
+                ᶜwnᵢ = similar(Y.c, FT),
+                ᶜlogλ = similar(Y.c, FT),
+                ᶜScoll = similar(Y.c,
+                    @NamedTuple{
+                        ∂ₜq_c::FT, ∂ₜq_r::FT, ∂ₜN_c::FT, ∂ₜN_r::FT,
+                        ∂ₜL_rim::FT, ∂ₜL_ice::FT, ∂ₜB_rim::FT,
+                    }
+                ),
+            )
+        end
     else
         precipitation_quantities = (;)
     end

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -35,6 +35,7 @@ import ..NoPrecipitation
 import ..Microphysics0Moment
 import ..Microphysics1Moment
 import ..Microphysics2Moment
+import ..Microphysics2MomentP3
 
 # radiation
 import ClimaAtmos.RRTMGPInterface as RRTMGPI

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -738,6 +738,7 @@ function compute_pr!(
         Microphysics0Moment,
         Microphysics1Moment,
         Microphysics2Moment,
+        Microphysics2MomentP3,
     },
 )
     if isnothing(out)
@@ -774,6 +775,7 @@ function compute_prra!(
         Microphysics0Moment,
         Microphysics1Moment,
         Microphysics2Moment,
+        Microphysics2MomentP3,
     },
 )
     if isnothing(out)
@@ -807,6 +809,7 @@ function compute_prsn!(
         Microphysics0Moment,
         Microphysics1Moment,
         Microphysics2Moment,
+        Microphysics2MomentP3,
     },
 )
     if isnothing(out)
@@ -838,7 +841,9 @@ function compute_husra!(
     state,
     cache,
     time,
-    microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
+    microphysics_model::Union{
+        Microphysics1Moment, Microphysics2Moment, Microphysics2MomentP3,
+    },
 )
     if isnothing(out)
         return state.c.ρq_rai ./ state.c.ρ
@@ -869,7 +874,9 @@ function compute_hussn!(
     state,
     cache,
     time,
-    microphysics_model::Union{Microphysics1Moment, Microphysics2Moment},
+    microphysics_model::Union{
+        Microphysics1Moment, Microphysics2Moment, Microphysics2MomentP3,
+    },
 )
     if isnothing(out)
         return state.c.ρq_sno ./ state.c.ρ
@@ -900,7 +907,7 @@ function compute_cdnc!(
     state,
     cache,
     time,
-    microphysics_model::Microphysics2Moment,
+    microphysics_model::Union{Microphysics2Moment, Microphysics2MomentP3},
 )
     if isnothing(out)
         return state.c.ρn_liq
@@ -931,7 +938,7 @@ function compute_ncra!(
     state,
     cache,
     time,
-    microphysics_model::Microphysics2Moment,
+    microphysics_model::Union{Microphysics2Moment, Microphysics2MomentP3},
 )
     if isnothing(out)
         return state.c.ρn_rai
@@ -1554,7 +1561,7 @@ function compute_rwp!(
     cache,
     time,
     moisture_model::T,
-) where {T <: Union{Microphysics1Moment, Microphysics2Moment}}
+) where {T <: Union{Microphysics1Moment, Microphysics2Moment, Microphysics2MomentP3}}
     if isnothing(out)
         out = zeros(axes(Fields.level(state.f, half)))
         rw = cache.scratch.ᶜtemp_scalar

--- a/src/initial_conditions/InitialConditions.jl
+++ b/src/initial_conditions/InitialConditions.jl
@@ -8,6 +8,7 @@ import ..NoPrecipitation
 import ..Microphysics0Moment
 import ..Microphysics1Moment
 import ..Microphysics2Moment
+import ..Microphysics2MomentP3
 import ..PrescribedSST
 import ..SlabOceanSST
 import ..ᶜinterp

--- a/src/initial_conditions/atmos_state.jl
+++ b/src/initial_conditions/atmos_state.jl
@@ -134,6 +134,21 @@ precip_variables(ls, ::Microphysics2Moment) = (;
     ρq_sno = ls.ρ * ls.precip_state.q_sno,
 )
 
+function precip_variables(ls, ::Microphysics2MomentP3)
+    (; ρ) = ls
+    (; n_liq, n_rai, q_rai) = ls.precip_state.warm
+    (; n_ice, q_ice, q_rim, b_rim) = ls.precip_state.cold
+    # warm state
+    ls_warm = (; ρ, precip_state = ls.precip_state.warm)
+    warm_state = precip_variables(ls_warm, Microphysics2Moment())
+    # cold state
+    cold_state = (;
+        ρq_ice = ρ * q_ice, ρn_ice = ρ * n_ice,
+        ρq_rim = ρ * q_rim, ρb_rim = ρ * b_rim,
+    )
+    return (; warm_state..., cold_state...)
+end
+
 # We can use paper-based cases for LES type configurations (no TKE)
 # or SGS type configurations (initial TKE needed), so we do not need to assert
 # that there is no TKE when there is no turbconv_model.

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -69,6 +69,7 @@ Base.@kwdef struct ClimaAtmosParameters{
     MP0M,
     MP1M,
     MP2M,
+    MP2MP3,
     SFP,
     TCP,
     STP,
@@ -82,6 +83,7 @@ Base.@kwdef struct ClimaAtmosParameters{
     microphysics_0m_params::MP0M
     microphysics_1m_params::MP1M
     microphysics_2m_params::MP2M
+    microphysics_2mp3_params::MP2MP3
     surface_fluxes_params::SFP
     turbconv_params::TCP
     surface_temp_params::STP

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -54,6 +54,7 @@ function ClimaAtmosParameters(
     microphysics_0m_params = CM.Parameters.Parameters0M(toml_dict)
     microphysics_1m_params = microphys_1m_parameters(toml_dict)
     microphysics_2m_params = microphys_2m_parameters(toml_dict)
+    microphysics_2mp3_params = get_microphysics_2m_p3_parameters(toml_dict)
 
     # If parsed_args is provided, we can save parameter space by only loading parameters
     # needed for the microphysics model that is actually used.
@@ -62,11 +63,14 @@ function ClimaAtmosParameters(
         cm_model isa Microphysics0Moment || (microphysics_0m_params = nothing)
         cm_model isa Union{Microphysics1Moment, Microphysics2Moment} ||
             (microphysics_1m_params = nothing)
-        cm_model isa Microphysics2Moment || (microphysics_2m_params = nothing)
+        cm_model isa Union{Microphysics2Moment, Microphysics2MomentP3} ||
+            (microphysics_2m_params = nothing)
+        cm_model isa Microphysics2MomentP3 || (microphysics_2mp3_params = nothing)
     end
     MP0M = typeof(microphysics_0m_params)
     MP1M = typeof(microphysics_1m_params)
     MP2M = typeof(microphysics_2m_params)
+    MP2MP3 = typeof(microphysics_2mp3_params)
 
     vert_diff_params = vert_diff_parameters(toml_dict)
     VDP = typeof(vert_diff_params)
@@ -85,6 +89,7 @@ function ClimaAtmosParameters(
         MP0M,
         MP1M,
         MP2M,
+        MP2MP3,
         SFP,
         TCP,
         STP,
@@ -99,6 +104,7 @@ function ClimaAtmosParameters(
         microphysics_0m_params,
         microphysics_1m_params,
         microphysics_2m_params,
+        microphysics_2mp3_params,
         surface_fluxes_params,
         turbconv_params,
         surface_temp_params,
@@ -183,6 +189,29 @@ microphys_2m_parameters(toml_dict::CP.ParamDict) = (;
     arg = CM.Parameters.AerosolActivationParameters(toml_dict),
     aerosol = prescribed_aerosol_parameters(toml_dict),
 )
+
+get_microphysics_2m_p3_parameters(::Type{FT}) where {FT <: AbstractFloat} =
+    get_microphysics_2m_p3_parameters(CP.create_toml_dict(FT))
+
+"""
+    get_microphysics_2m_p3_parameters(FT)
+    get_microphysics_2m_p3_parameters(toml_dict)
+
+Get the parameters for the 2-moment warm rain + P3 ice microphysics scheme.
+
+# Arguments
+ - `FT`: The floating point type to use for the parameters, `Float32` or `Float64`.
+ - `toml_dict`: A TOML dictionary containing the parameters, see [`CP.create_toml_dict()`](@ref).
+"""
+function get_microphysics_2m_p3_parameters(toml_dict::CP.ParamDict)
+    return (;
+        warm = microphys_2m_parameters(toml_dict),
+        cold = (;
+            params = CM.Parameters.ParametersP3(toml_dict; slope_law = :constant),
+            velocity_params = CM.Parameters.Chen2022VelType(toml_dict),
+        ),
+    )
+end
 
 function vert_diff_parameters(toml_dict)
     name_map = (; :C_E => :C_E, :H_diffusion => :H, :D_0_diffusion => :D₀)

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -230,6 +230,17 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
             ),
         )
     end
+    if microphysics_model isa Microphysics2MomentP3
+        (; ρ, ρn_ice, ρq_rim, ρb_rim) = Y.c
+        ᶜwnᵢ = @. lazy(Geometry.WVector(p.precomputed.ᶜwnᵢ))
+        ᶜwᵢ = @. lazy(Geometry.WVector(p.precomputed.ᶜwᵢ))
+        ᶠρ = @. lazy(ᶠinterp(ρ * ᶜJ) / ᶠJ)
+
+        # Note: `ρq_ice` is handled above, in `moisture_model isa NonEquilMoistModel`
+        @. Yₜ.c.ρn_ice -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwnᵢ * specific(ρn_ice, ρ)))
+        @. Yₜ.c.ρq_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρq_rim, ρ)))
+        @. Yₜ.c.ρb_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρb_rim, ρ)))
+    end
 
     # TODO - decide if this needs to be explicit or implicit
     #vertical_advection_of_water_tendency!(Yₜ, Y, p, t)

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -98,7 +98,9 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
         @name(c.ρq_rai),
         @name(c.ρq_sno),
         @name(c.ρn_liq),
-        @name(c.ρn_rai)
+        @name(c.ρn_rai),
+        # P3 frozen
+        @name(c.ρn_ice), @name(c.ρq_rim), @name(c.ρb_rim),
     )
     available_condensate_names =
         MatrixFields.unrolled_filter(is_in_Y, condensate_names)
@@ -505,6 +507,9 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
         (@name(c.ρq_sno), @name(ᶜwₛ)),
         (@name(c.ρn_liq), @name(ᶜwₙₗ)),
         (@name(c.ρn_rai), @name(ᶜwₙᵣ)),
+        (@name(c.ρn_ice), @name(ᶜwnᵢ)),
+        (@name(c.ρq_rim), @name(ᶜwᵢ)),
+        (@name(c.ρb_rim), @name(ᶜwᵢ)),
     )
     if !(p.atmos.moisture_model isa DryModel) || use_derivative(diffusion_flag)
         ∂ᶜρe_tot_err_∂ᶜρe_tot = matrix[@name(c.ρe_tot), @name(c.ρe_tot)]

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -325,6 +325,8 @@ function get_microphysics_model(parsed_args)
         Microphysics1Moment()
     elseif microphysics_model == "2M"
         Microphysics2Moment()
+    elseif microphysics_model == "2MP3"
+        Microphysics2MomentP3()
     else
         error("Invalid microphysics_model $(microphysics_model)")
     end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -33,8 +33,10 @@ function get_atmos(config::AtmosConfig, params)
                 Union{NoPrecipitation, Microphysics0Moment}
     end
     if moisture_model isa NonEquilMoistModel
-        @assert microphysics_model isa
-                Union{NoPrecipitation, Microphysics1Moment, Microphysics2Moment}
+        @assert microphysics_model isa Union{
+            NoPrecipitation, Microphysics1Moment,
+            Microphysics2Moment, Microphysics2MomentP3,
+        }
     end
     if microphysics_model isa NoPrecipitation
         @warn "Running simulations without any precipitation formation."

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -19,6 +19,13 @@ struct Microphysics1Moment <: AbstractPrecipitationModel end
 struct Microphysics2Moment <: AbstractPrecipitationModel end
 
 """
+    Microphysics2MomentP3 <: AbstractPrecipitationModel
+
+Struct used for dispatch to the 2-moment warm rain + P3 ice microphysics parameterizations
+"""
+struct Microphysics2MomentP3 <: AbstractPrecipitationModel end
+
+"""
 
     AbstractSGSamplingType
 


### PR DESCRIPTION
This pull request adds support for the 2-moment microphysics scheme with P3 ice microphysics ("2MP3") to the codebase, including a new test configuration, initial condition, diagnostics, and all required model infrastructure. The changes ensure that the new scheme is handled correctly throughout the precipitation, cache, initial condition, and diagnostic modules, and integrates it into CI and post-processing.

**Support for 2MP3 microphysics scheme:**

* Added the `Microphysics2MomentP3` model throughout the codebase, including imports, cache allocation, precipitation tendencies, and diagnostics, enabling full support for the new scheme. [[1]](diffhunk://#diff-6ca9085fa8b57bc6250457214e83fae1feae11991d710726d9fa0a9ebfb65efbR8) [[2]](diffhunk://#diff-803c87116ce03f68c5228f901e3e4ca9b47860e1902febd0ba2ed2d00d49a0d0R37) [[3]](diffhunk://#diff-d65467c8c173fed5e8d0cadd4a43471684441e4f462c04a5cb24ddcc20cc4563R11) [[4]](diffhunk://#diff-471fb2001bc0d6f84924896fd8c99bd3d4edcc84bd5d79da9e9f35afef17f9cdL116-R118) [[5]](diffhunk://#diff-471fb2001bc0d6f84924896fd8c99bd3d4edcc84bd5d79da9e9f35afef17f9cdR131-R153) [[6]](diffhunk://#diff-6ca9085fa8b57bc6250457214e83fae1feae11991d710726d9fa0a9ebfb65efbR191-R265) [[7]](diffhunk://#diff-6ca9085fa8b57bc6250457214e83fae1feae11991d710726d9fa0a9ebfb65efbR504-R545) [[8]](diffhunk://#diff-6ca9085fa8b57bc6250457214e83fae1feae11991d710726d9fa0a9ebfb65efbR635-R639) [[9]](diffhunk://#diff-d0a794bb7170232a067c333961596286b59d804fa1456eb19a08ca6ee56c4b93R754-R792) [[10]](diffhunk://#diff-57c063b5bee29a371edd7a85f7fe4006a1c9d7aa08965a2327c7e043a9b5ad5eR262-R297) [[11]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R741) [[12]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R778) [[13]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R812) [[14]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L841-R848) [[15]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L872-R883) [[16]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L903-R914) [[17]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L934-R945) [[18]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L1557-R1570)

**New test configuration and initial condition:**

* Added a new single-column test configuration file for the 2MP3 scheme (`single_column_precipitation_2MP3_test.yml`), and created the corresponding initial condition `ColdPrecipitatingColumn` and state types (`PrecipState2MP3`). [[1]](diffhunk://#diff-5e50b12fc8ed006800a2dc6b050e5675889d153b30666b4244069c22e925d4f9R1-R22) [[2]](diffhunk://#diff-129521b7d73944a04f165ea2d06b601eca86f361553d5203f6df5d457b01ca4fR1317-R1368) [[3]](diffhunk://#diff-db3c8ac786cf9b4b142bc6330101c2cdf0ecc5b2d921d9bd481a4c4f0ca955d0R122-R126) [[4]](diffhunk://#diff-00a778ba054a93aba25a13e24d9a88ef8bc801cb578e34c07749b635783b2ef4R137-R153)

**Continuous integration and post-processing updates:**

* Integrated the new test into the CI pipeline and post-processing plotting routines, ensuring automated testing and visualization for the 2MP3 scheme. (.buildkite/pipeline.yml, [post_processing/ci_plots.jlR627](diffhunk://#diff-e4cba714c103063a9c604a1ab7a5e42151936b5ba5dce44fc5df390d42ee00e6R627))

**Parameter infrastructure updates:**

* Extended the parameters struct to include `microphysics_2mp3_params` for the new scheme. [[1]](diffhunk://#diff-befd0462e59148ffd45bcc4e5a154c3ba2acc53c9f8accab9d3b0a66835db6f0R72) [[2]](diffhunk://#diff-befd0462e59148ffd45bcc4e5a154c3ba2acc53c9f8accab9d3b0a66835db6f0R86)

**Diagnostics and output compatibility:**

* Updated diagnostics functions to correctly handle the new scheme, ensuring all relevant output variables are available for 2MP3 runs. [[1]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R741) [[2]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R778) [[3]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83R812) [[4]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L841-R848) [[5]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L872-R883) [[6]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L903-R914) [[7]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L934-R945) [[8]](diffhunk://#diff-e8c07a94c97c4fc3823154d810842bbf05dfd6af22ca6d322da76a9f590d7a83L1557-R1570)