### PR TITLE
Add 2M microphysics to diagnostic EDMF dycoms RF02

### DIFF
--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_2M_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_2M_box.yml
@@ -1,0 +1,41 @@
+initial_condition: DYCOMS_RF02
+subsidence: DYCOMS
+scm_coriolis: DYCOMS_RF02
+rad: DYCOMS
+surface_setup: DYCOMS_RF02
+turbconv: diagnostic_edmfx
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
+prognostic_tke: true
+edmfx_upwinding: first_order
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_nh_pressure: true
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+moist: nonequil
+cloud_model: "quadrature_sgs"
+precip_model: "2M"
+call_cloud_diagnostics_per_stage: true
+config: box
+x_max: 1e8
+y_max: 1e8
+x_elem: 2
+y_elem: 2
+z_elem: 30
+z_max: 1500
+z_stretch: false
+dt: 10secs
+t_end: 6hours
+dt_save_state_to_disk: 10mins
+toml: [toml/diagnostic_edmfx_2M.toml]
+netcdf_interpolation_num_points: [8, 8, 30]
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr, cdnc, ncra]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke, ncraup, cdncup]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
+    period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1403,6 +1403,7 @@ EDMFBoxPlotsWithPrecip = Union{
 
 DiagEDMFBoxPlotsWithPrecip = Union{
     Val{:diagnostic_edmfx_dycoms_rf02_box},
+    Val{:diagnostic_edmfx_dycoms_rf02_2M_box},
     Val{:diagnostic_edmfx_rico_box},
     Val{:diagnostic_edmfx_trmm_box},
 }
@@ -1511,7 +1512,20 @@ function make_plots(
                 ("husra", "hussn", "husraup", "hussnup", "husraen", "hussnen")
         end
     elseif sim_type isa DiagEDMFBoxPlotsWithPrecip
-        precip_names = ("husra", "hussn", "husraup", "hussnup")
+        if sim_type isa Val{:diagnostic_edmfx_dycoms_rf02_2M_box}
+            precip_names = (
+                "husra",
+                "hussn",
+                "husraup",
+                "hussnup",
+                "cdnc",
+                "ncra",
+                "cdncup",
+                "ncraup",
+            )
+        else
+            precip_names = ("husra", "hussn", "husraup", "hussnup")
+        end
     else
         precip_names = ()
     end

--- a/src/cache/precipitation_precomputed_quantities.jl
+++ b/src/cache/precipitation_precomputed_quantities.jl
@@ -411,7 +411,8 @@ function set_precipitation_cache!(
     ::Microphysics2Moment,
     ::DiagnosticEDMFX,
 )
-    error("Not implemented yet")
+    # Nothing needs to be done on the grid mean. The Sources are computed
+    # in edmf sub-domains.
     return nothing
 end
 function set_precipitation_cache!(

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -138,12 +138,12 @@ function precomputed_quantities(Y, atmos)
             ᶜSqᵢᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSqᵣᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSqₛᵖʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwₗʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwᵢʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwᵣʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwₛʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwₜʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwₕʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜwₗʲs = similar(Y.c, NTuple{n, FT}), # TODO I don't think I need those
+            ᶜwᵢʲs = similar(Y.c, NTuple{n, FT}), #
+            ᶜwᵣʲs = similar(Y.c, NTuple{n, FT}), #
+            ᶜwₛʲs = similar(Y.c, NTuple{n, FT}), #
+            ᶜwₜʲs = similar(Y.c, NTuple{n, FT}), #
+            ᶜwₕʲs = similar(Y.c, NTuple{n, FT}), #
             ᶜSqₗᵖ⁰ = similar(Y.c, FT),
             ᶜSqᵢᵖ⁰ = similar(Y.c, FT),
             ᶜSqᵣᵖ⁰ = similar(Y.c, FT),
@@ -157,8 +157,8 @@ function precomputed_quantities(Y, atmos)
             ᶜSqₛᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSnₗᵖʲs = similar(Y.c, NTuple{n, FT}),
             ᶜSnᵣᵖʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwₗʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜwᵢʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜwₗʲs = similar(Y.c, NTuple{n, FT}),   # TODO - I don't think I need those
+            ᶜwᵢʲs = similar(Y.c, NTuple{n, FT}),   # for diagnostci EDMF
             ᶜwᵣʲs = similar(Y.c, NTuple{n, FT}),
             ᶜwₛʲs = similar(Y.c, NTuple{n, FT}),
             ᶜwₜʲs = similar(Y.c, NTuple{n, FT}),
@@ -206,8 +206,16 @@ function precomputed_quantities(Y, atmos)
             ᶜq_iceʲs = similar(Y.c, NTuple{n, FT}),
             ᶜq_raiʲs = similar(Y.c, NTuple{n, FT}),
             ᶜq_snoʲs = similar(Y.c, NTuple{n, FT}),
+        ) :
+        atmos.microphysics_model isa Microphysics2Moment ?
+        (;
+            ᶜq_liqʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_iceʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_raiʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜq_snoʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜn_liqʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜn_raiʲs = similar(Y.c, NTuple{n, FT}),
         ) : (;)
-
     diagnostic_sgs_quantities =
         atmos.turbconv_model isa DiagnosticEDMFX ?
         (;

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -915,7 +915,7 @@ add_diagnostic_variable!(
     standard_name = "number_concentration_of_cloud_liquid_water_particles_in_air",
     units = "m^-3",
     comments = """
-    This is calculated as the number of cloud liquid water droplets in the grid 
+    This is calculated as the number of cloud liquid water droplets in the grid
     cell divided by the cell volume.
     """,
     compute! = compute_cdnc!,
@@ -1479,7 +1479,7 @@ function compute_cape!(out, state, cache, time)
     ᶜbuoyancy = cache.scratch.ᶜtemp_scalar
     ᶜbuoyancy .= g .* (parcel_Tv .- env_Tv) ./ env_Tv
 
-    # restrict to tropospheric buoyancy (generously below 20km) TODO: integrate from LFC to LNB 
+    # restrict to tropospheric buoyancy (generously below 20km) TODO: integrate from LFC to LNB
     FT = Spaces.undertype(axes(ᶜbuoyancy))
     ᶜbuoyancy .=
         ᶜbuoyancy .*
@@ -1553,7 +1553,7 @@ function compute_rwp!(
     state,
     cache,
     time,
-    moisture_model::T,
+    microphysics_model::T,
 ) where {T <: Union{Microphysics1Moment, Microphysics2Moment}}
     if isnothing(out)
         out = zeros(axes(Fields.level(state.f, half)))

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -411,13 +411,27 @@ function compute_cdncup!(
     state,
     cache,
     time,
-    microphysics_model_model::Microphysics2Moment,
+    microphysics_model::Microphysics2Moment,
     turbconv_model::PrognosticEDMFX,
 )
     if isnothing(out)
         return (state.c.sgsʲs.:1).n_liq
     else
         out .= (state.c.sgsʲs.:1).n_liq
+    end
+end
+function compute_cdncup!(
+    out,
+    state,
+    cache,
+    time,
+    microphysics_model::Microphysics2Moment,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜn_liqʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜn_liqʲs.:1)
     end
 end
 
@@ -554,7 +568,7 @@ function compute_husraup!(
     state,
     cache,
     time,
-    moisture_model::Microphysics1Moment,
+    moisture_model::Union{Microphysics1Moment, Microphysics2Moment},
     turbconv_model::DiagnosticEDMFX,
 )
     if isnothing(out)
@@ -606,6 +620,20 @@ function compute_ncraup!(
         return (state.c.sgsʲs.:1).n_rai
     else
         out .= (state.c.sgsʲs.:1).n_rai
+    end
+end
+function compute_ncraup!(
+    out,
+    state,
+    cache,
+    time,
+    moisture_model::Microphysics2Moment,
+    turbconv_model::DiagnosticEDMFX,
+)
+    if isnothing(out)
+        return (cache.precomputed.ᶜn_raiʲs.:1)
+    else
+        out .= (cache.precomputed.ᶜn_raiʲs.:1)
     end
 end
 
@@ -661,7 +689,7 @@ function compute_hussnup!(
     state,
     cache,
     time,
-    moisture_model::Microphysics1Moment,
+    moisture_model::Union{Microphysics1Moment, Microphysics2Moment},
     turbconv_model::DiagnosticEDMFX,
 )
     if isnothing(out)

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -222,7 +222,30 @@ function precipitation_tendency!(
     microphysics_model::Microphysics2Moment,
     turbconv_model::DiagnosticEDMFX,
 )
-    error("Not implemented yet")
+    # Source terms from EDMFX environment
+    (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰, ᶜSnₗᵖ⁰, ᶜSnᵣᵖ⁰) = p.precomputed
+    # Source terms from EDMFX updrafts
+    (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs, ᶜSnₗᵖʲs, ᶜSnᵣᵖʲs) = p.precomputed
+    (; ᶜρaʲs) = p.precomputed
+
+    # Update from environment precipitation sources
+    @. Yₜ.c.ρq_liq += Y.c.ρ * ᶜSqₗᵖ⁰
+    @. Yₜ.c.ρq_ice += Y.c.ρ * ᶜSqᵢᵖ⁰
+    @. Yₜ.c.ρq_rai += Y.c.ρ * ᶜSqᵣᵖ⁰
+    @. Yₜ.c.ρq_sno += Y.c.ρ * ᶜSqₛᵖ⁰
+    @. Yₜ.c.ρn_liq += Y.c.ρ * ᶜSnₗᵖ⁰
+    @. Yₜ.c.ρn_rai += Y.c.ρ * ᶜSnᵣᵖ⁰
+
+    # Update from the updraft precipitation sources
+    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
+    for j in 1:n
+        @. Yₜ.c.ρq_liq += ᶜρaʲs.:($$j) * ᶜSqₗᵖʲs.:($$j)
+        @. Yₜ.c.ρq_ice += ᶜρaʲs.:($$j) * ᶜSqᵢᵖʲs.:($$j)
+        @. Yₜ.c.ρq_rai += ᶜρaʲs.:($$j) * ᶜSqᵣᵖʲs.:($$j)
+        @. Yₜ.c.ρq_sno += ᶜρaʲs.:($$j) * ᶜSqₛᵖʲs.:($$j)
+        @. Yₜ.c.ρn_liq += ᶜρaʲs.:($$j) * ᶜSnₗᵖʲs.:($$j)
+        @. Yₜ.c.ρn_rai += ᶜρaʲs.:($$j) * ᶜSnᵣᵖʲs.:($$j)
+    end
 end
 function precipitation_tendency!(
     Yₜ,

--- a/toml/diagnostic_edmfx_2M.toml
+++ b/toml/diagnostic_edmfx_2M.toml
@@ -1,0 +1,32 @@
+[condensation_evaporation_timescale]
+value = 100
+
+[sublimation_deposition_timescale]
+value = 100
+
+[entr_inv_tau]
+value = 0.002
+
+[entr_coeff]
+value = 0
+
+[detr_inv_tau]
+value = 0
+
+[detr_vertdiv_coeff]
+value = 0.6
+
+[detr_buoy_coeff]
+value = 0.12
+
+[min_area_limiter_scale]
+value = 0
+
+[max_area_limiter_scale]
+value = 0
+
+[seasalt_calibration_coefficient]
+value = 1e-8
+
+[reference_seasalt_aerosol_mass_concentration]
+value = 1e10


### PR DESCRIPTION
Hi Folks! This PR adds 2-moment microphysics to diagnostic EDMF.

@sajjadazimi - could I ask you to take a look? I wasn't sure about two things:
1. What velocity I should be using in the aerosol activation. 
2. How to interact with global aerosol data. 

For the second point I temporarily hijacked two parameters: `seasalt_calibration_coefficient`, `reference_seasalt_aerosol_mass_concentration` to allow the users to prescribe the assumed mode size and concentration for seasalt aerosol. Once we make the breaking release of CliMA Params I will add proper parameters for it. 

We do get some clouds and drizzle and the results differ for high and low concentrations. But in the couple of configurations I tried we have been raining out a lot of the water very early on. 




