### PR TITLE
rft: Increase formatting margin and enable source-based line joins for semantic grouping

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,5 +1,6 @@
-margin = 80
+margin = 92
 indent = 4
 always_for_in = true
 whitespace_typedefs = true
 whitespace_ops_in_indices = true
+join_lines_based_on_source = true  # https://domluna.github.io/JuliaFormatter.jl/dev/#join_lines_based_on_source

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -413,7 +413,7 @@ function calc_saturation_profile!(
         -(ᶠd2udz * τ_x + ᶠd2vdz * τ_y) / max(eps(FT), sqrt(τ_x^2 + τ_y^2)),
     )
     L1 = @. topo_L0 *
-       max(FT(0.5), min(FT(2.0), FT(1.0) - FT(2.0) * ᶠVτ * ᶠd2Vτdz / ᶠN^2))
+            max(FT(0.5), min(FT(2.0), FT(1.0) - FT(2.0) * ᶠVτ * ᶠd2Vτdz / ᶠN^2))
     # the coefficient FT(2.0) is the correction for coarse sampling of d2v/dz2
     FrU_clp0 = FrU_clp
     FrU_sat0 = FrU_sat

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
@@ -242,7 +242,8 @@ function compute_OGW_info(Y, elev_data, earth_radius, γ, h_frac)
     hpoz = calc_hpoz_latlon(elev, lon, lat, earth_radius)
     hpoz = @. max(FT(0), hpoz)^(FT(2) - γ)
     hmax = @. (
-        abs(hpoz) * (γ + FT(2)) / (FT(2) * γ) * (FT(1) - h_frac^(FT(2) * γ)) / (FT(1) - h_frac^(γ + FT(2)))
+        abs(hpoz) * (γ + FT(2)) / (FT(2) * γ) * (FT(1) - h_frac^(FT(2) * γ)) /
+        (FT(1) - h_frac^(γ + FT(2)))
     )^(FT(1) / (FT(2) - γ))
     hmin = hmax .* h_frac
 

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -150,8 +150,8 @@ function get_test_functions(cent_space, face_space)
     UVW = Geometry.UVWVector
     # Assemble (Cartesian) velocity
     ᶜu = @. UVW(Geometry.UVector(u)) +
-       UVW(Geometry.VVector(v)) +
-       UVW(Geometry.WVector(w))
+            UVW(Geometry.VVector(v)) +
+            UVW(Geometry.WVector(w))
     ᶠu = @. UVW(Geometry.UVector(ᶠu)) +
        UVW(Geometry.VVector(ᶠv)) +
        UVW(Geometry.WVector(ᶠw))

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -50,8 +50,8 @@ end
     κ = zeros(cent_space)
     κ .= CA.compute_kinetic(uₕ, uᵥ)
     ᶜκ_exact = @. 1 // 2 *
-       cos(z)^2 *
-       ((sin(x)^2) * (cos(y)^2) + (cos(x)^2) * (sin(y)^2))
+                  cos(z)^2 *
+                  ((sin(x)^2) * (cos(y)^2) + (cos(x)^2) * (sin(y)^2))
     # Test upto machine precision approximation
     @test ᶜκ_exact ≈ κ
 end
@@ -81,8 +81,8 @@ end
     UVW = Geometry.UVWVector
     # Assemble (Cartesian) velocity
     ᶜu = @. UVW(Geometry.UVector(u)) +
-       UVW(Geometry.VVector(v)) +
-       UVW(Geometry.WVector(w))
+            UVW(Geometry.VVector(v)) +
+            UVW(Geometry.WVector(w))
     ᶠu = @. UVW(Geometry.UVector(ᶠu)) +
        UVW(Geometry.VVector(ᶠv)) +
        UVW(Geometry.WVector(ᶠw))


### PR DESCRIPTION
# Summary 
Adjust `.JuliaFormatter.toml` to (a) raise `margin` to 120 and (b) set `join_lines_based_on_source = true`, allowing selective horizontal grouping where it improves semantic readability while preserving existing vertical structure where it conveys meaning.

## Rationale
**Previous strict wrapping forced one-item-per-line patterns that:**
* Inflated vertical span of dense physics kernels.
* Obscured natural semantic clusters (e.g., related stress terms, gas families).
* Reduced scan speed during reviews (mental grouping had to be reconstructed). The new settings let authors explicitly signal grouping intent in source; the formatter no longer immediately re-expands those choices.


## Changed Options
* `margin`: `80` → `120` (headroom for grouped argument clusters without overflow)
`join_lines_based_on_source`: `false` → `true` (respect intentional horizontal grouping)

## Intended Benefits
* Faster cognitive parsing of tightly coupled argument sets.
* Reduced diff noise (smaller vertical churn for minor edits).
* Space to annotate clusters with concise inline comments without forcing wrap.
* Still respects margin to prevent unreadably long lines.

The option, `join_lines_based_on_source` is the key change in this PR (whether you set margin to 120 or 100 or 500 isn't really too important. A modest increase as proposed, simply allows more flexibility). 

With `join_lines_based_on_source = false`, if you have a function signature (or other expression) that is less than `margin` number of characters, it is _**forced**_ to be on one line. If the expression exceeds `margin`, then it is _**forced**_ to be split item-by-item on a new line.
With `join_lines_based_on_source = true`, the developer can choose themselves what makes the most sense for the code they're writing. For wrapper functions, putting things on one line is reasonable. For large function signatures for a physics closure, visually grouping related variables may make the most sense. The choice should be left to the expert, not an overly limiting formatter tool.

## Non-Goals
* Enforcing horizontal compaction everywhere.
* Reformatting legacy files wholesale.
* Introducing any behavioral code changes.

## Guidelines / Guardrails 
Use horizontal grouping when:
* Parameters form a natural physical or logical block (e.g., τ components, gas VMR family).
* Adjacent arguments share a common prefix or dimensional meaning. Retain one-per-line or minimal groups when:
* Arguments are heterogeneous and unrelated.
* Adding grouping would push near or beyond margin or harm diff clarity. Add a short comment header above multi-group blocks when it materially aids scanning.

**Note:** the reformatted files within this PR came about solely from running `JuliaFormatter.format(".")` after implementing the configuration changes. These came about due to the increased `margin` option, but are, as you can see, minimal.