### PR TITLE
Illustrative grouping examples using updated formatter flexibility

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,5 +1,6 @@
-margin = 80
+margin = 120
 indent = 4
 always_for_in = true
 whitespace_typedefs = true
 whitespace_ops_in_indices = true
+join_lines_based_on_source = true  # https://domluna.github.io/JuliaFormatter.jl/dev/#join_lines_based_on_source

--- a/src/diagnostics/conservation_diagnostics.jl
+++ b/src/diagnostics/conservation_diagnostics.jl
@@ -40,17 +40,11 @@ add_diagnostic_variable!(
 ###
 # Total water of the air (scalar)
 ###
-compute_watera!(out, state, cache, time) =
-    compute_watera!(out, state, cache, time, cache.atmos.moisture_model)
-compute_watera!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("watera", model)
+compute_watera!(out, state, cache, time) = compute_watera!(out, state, cache, time, cache.atmos.moisture_model)
+compute_watera!(_, _, _, _, model::T) where {T} = error_diagnostic_variable("watera", model)
 
 function compute_watera!(
-    out,
-    state,
-    cache,
-    time,
-    moisture_model::T,
+    out, state, cache, time, moisture_model::T,
 ) where {T <: Union{EquilMoistModel, NonEquilMoistModel}}
     if isnothing(out)
         return [sum(state.c.ρq_tot)]
@@ -69,10 +63,8 @@ add_diagnostic_variable!(
 ###
 # Total energy of the slab ocean (scalar)
 ###
-compute_energyo!(out, state, cache, time) =
-    compute_energyo!(out, state, cache, time, cache.atmos.surface_model)
-compute_energyo!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("energyo", model)
+compute_energyo!(out, state, cache, time) = compute_energyo!(out, state, cache, time, cache.atmos.surface_model)
+compute_energyo!(_, _, _, _, model::T) where {T} = error_diagnostic_variable("energyo", model)
 
 function compute_energyo!(
     out,
@@ -81,10 +73,7 @@ function compute_energyo!(
     time,
     surface_model::T,
 ) where {T <: SlabOceanSST}
-    sfc_cρh =
-        surface_model.ρ_ocean *
-        surface_model.cp_ocean *
-        surface_model.depth_ocean
+    sfc_cρh = surface_model.ρ_ocean * surface_model.cp_ocean * surface_model.depth_ocean
     if isnothing(out)
         return [horizontal_integral_at_boundary(state.sfc.T .* sfc_cρh)]
     else
@@ -103,31 +92,19 @@ add_diagnostic_variable!(
 # Total water of the slab ocean (scalar)
 ###
 compute_watero!(out, state, cache, time) = compute_watero!(
-    out,
-    state,
-    cache,
-    time,
-    cache.atmos.moisture_model,
-    cache.atmos.surface_model,
+    out, state, cache, time,
+    cache.atmos.moisture_model, cache.atmos.surface_model,
 )
 compute_watero!(
-    _,
-    _,
-    _,
-    _,
-    moisture_model::T1,
-    surface_model::T2,
+    _, _, _, _,
+    moisture_model::T1, surface_model::T2,
 ) where {T1, T2} = error_diagnostic_variable(
     "Can only compute total water of the ocean with a moist model and with SlabOceanSST",
 )
 
 function compute_watero!(
-    out,
-    state,
-    cache,
-    time,
-    moisture_model::Union{EquilMoistModel, NonEquilMoistModel},
-    surface_model::SlabOceanSST,
+    out, state, cache, time,
+    moisture_model::Union{EquilMoistModel, NonEquilMoistModel}, surface_model::SlabOceanSST,
 )
     if isnothing(out)
         return [horizontal_integral_at_boundary(state.sfc.water)]
@@ -137,8 +114,6 @@ function compute_watero!(
 end
 
 add_diagnostic_variable!(
-    short_name = "watero",
-    long_name = "Total Water of the Ocean",
-    units = "kg",
-    compute! = compute_watero!,
+    short_name = "watero", long_name = "Total Water of the Ocean",
+    units = "kg", compute! = compute_watero!,
 )

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -450,7 +450,7 @@ function _overwrite_initial_conditions_from_file!(
     # p is then updated with the integral result, given p_sfc,
     # following which the thermodynamic state is constructed.
     ᶜ∂lnp∂z = @. -thermo_params.grav /
-       (TD.gas_constant_air(thermo_params, TD.PhasePartition(ᶜq_tot)) * ᶜT)
+                 (TD.gas_constant_air(thermo_params, TD.PhasePartition(ᶜq_tot)) * ᶜT)
     ᶠlnp_over_psfc = zeros(face_space)
     Operators.column_integral_indefinite!(ᶠlnp_over_psfc, ᶜ∂lnp∂z)
     ᶠp = p_sfc .* exp.(ᶠlnp_over_psfc)

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -413,7 +413,7 @@ function calc_saturation_profile!(
         -(ᶠd2udz * τ_x + ᶠd2vdz * τ_y) / max(eps(FT), sqrt(τ_x^2 + τ_y^2)),
     )
     L1 = @. topo_L0 *
-       max(FT(0.5), min(FT(2.0), FT(1.0) - FT(2.0) * ᶠVτ * ᶠd2Vτdz / ᶠN^2))
+            max(FT(0.5), min(FT(2.0), FT(1.0) - FT(2.0) * ᶠVτ * ᶠd2Vτdz / ᶠN^2))
     # the coefficient FT(2.0) is the correction for coarse sampling of d2v/dz2
     FrU_clp0 = FrU_clp
     FrU_sat0 = FrU_sat

--- a/src/parameterized_tendencies/microphysics/precipitation.jl
+++ b/src/parameterized_tendencies/microphysics/precipitation.jl
@@ -9,24 +9,14 @@ precipitation_tendency!(Yₜ, Y, p, t, _, ::NoPrecipitation, _) = nothing
 #####
 
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::DryModel,
-    ::Microphysics0Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::DryModel, ::Microphysics0Moment, _,
 )
     error("Microphysics0Moment precipitation should not be run with DryModel.")
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::EquilMoistModel,
-    microphysics_model::Microphysics0Moment,
-    turbconv_model,
+    Yₜ, Y, p, t,
+    ::EquilMoistModel, microphysics_model::Microphysics0Moment, turbconv_model,
 )
     (; ᶜS_ρq_tot, ᶜS_ρe_tot) = p.precomputed
 
@@ -38,13 +28,8 @@ function precipitation_tendency!(
     return nothing
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    ::Microphysics0Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, ::Microphysics0Moment, _,
 )
     error(
         "Microphysics0Moment precipitation and NonEquilibriumMost model precipitation_tendency has not been implemented.",
@@ -56,37 +41,22 @@ end
 #####
 
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::DryModel,
-    microphysics_model::Microphysics1Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::DryModel, microphysics_model::Microphysics1Moment, _,
 )
     error("Microphysics1Moment precipitation should not be used with DryModel")
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::EquilMoistModel,
-    microphysics_model::Microphysics1Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::EquilMoistModel, microphysics_model::Microphysics1Moment, _,
 )
     error(
         "Microphysics1Moment precipitation and EquilMoistModel precipitation_tendency is not implemented",
     )
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics1Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics1Moment, _,
 )
     (; turbconv_model) = p.atmos
     (; ᶜSqₗᵖ, ᶜSqᵢᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ) = p.precomputed
@@ -100,13 +70,8 @@ function precipitation_tendency!(
     return nothing
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics1Moment,
-    turbconv_model::DiagnosticEDMFX,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics1Moment, turbconv_model::DiagnosticEDMFX,
 )
     # Source terms from EDMFX environment
     (; ᶜSqₗᵖ⁰, ᶜSqᵢᵖ⁰, ᶜSqᵣᵖ⁰, ᶜSqₛᵖ⁰) = p.precomputed
@@ -131,13 +96,8 @@ function precipitation_tendency!(
     end
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics1Moment,
-    turbconv_model::PrognosticEDMFX,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics1Moment, turbconv_model::PrognosticEDMFX,
 )
     # Source terms from EDMFX updrafts
     (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs) = p.precomputed
@@ -167,37 +127,22 @@ end
 #####
 
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::DryModel,
-    microphysics_model::Microphysics2Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::DryModel, microphysics_model::Microphysics2Moment, _,
 )
     error("Microphysics2Moment precipitation should not be used with DryModel")
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::EquilMoistModel,
-    microphysics_model::Microphysics2Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::EquilMoistModel, microphysics_model::Microphysics2Moment, _,
 )
     error(
         "Microphysics2Moment precipitation and EquilMoistModel precipitation_tendency is not implemented",
     )
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics2Moment,
-    _,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics2Moment, _,
 )
     (; ᶜSqₗᵖ, ᶜSqᵢᵖ, ᶜSqᵣᵖ, ᶜSqₛᵖ) = p.precomputed
     (; ᶜSnₗᵖ, ᶜSnᵣᵖ) = p.precomputed
@@ -214,24 +159,14 @@ function precipitation_tendency!(
     return nothing
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics2Moment,
-    turbconv_model::DiagnosticEDMFX,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics2Moment, turbconv_model::DiagnosticEDMFX,
 )
     error("Not implemented yet")
 end
 function precipitation_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    microphysics_model::Microphysics2Moment,
-    turbconv_model::PrognosticEDMFX,
+    Yₜ, Y, p, t,
+    ::NonEquilMoistModel, microphysics_model::Microphysics2Moment, turbconv_model::PrognosticEDMFX,
 )
     # Source terms from EDMFX updrafts
     (; ᶜSqₗᵖʲs, ᶜSqᵢᵖʲs, ᶜSqᵣᵖʲs, ᶜSqₛᵖʲs, ᶜSnₗᵖʲs, ᶜSnᵣᵖʲs) = p.precomputed

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -315,21 +315,9 @@ function radiation_model_cache(
         if aerosol_radiation && !(any(
             x -> x in aerosol_names,
             [
-                "DST01",
-                "DST02",
-                "DST03",
-                "DST04",
-                "DST05",
-                "SSLT01",
-                "SSLT02",
-                "SSLT03",
-                "SSLT04",
-                "SSLT05",
-                "SO4",
-                "CB1",
-                "CB2",
-                "OC1",
-                "OC2",
+                "DST01", "DST02", "DST03", "DST04", "DST05",
+                "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05",
+                "SO4", "CB1", "CB2", "OC1", "OC2",
             ],
         ))
             error(
@@ -505,11 +493,7 @@ function radiation_tendency!(Yₜ, Y, p, t, radiation_mode::RadiationDYCOMS)
         radiation_mode.F1 * exp(-(ᶠ∫_0_z_κρq)) +
         ifelse(
             ᶠz > zi,
-            ρi *
-            cp_d *
-            radiation_mode.divergence *
-            radiation_mode.alpha_z *
-            (cbrt(ᶠz - zi)^4 / 4 + zi * cbrt(ᶠz - zi)),
+            ρi * cp_d * radiation_mode.divergence * radiation_mode.alpha_z * (cbrt(ᶠz - zi)^4 / 4 + zi * cbrt(ᶠz - zi)),
             FT(0),
         ),
     )

--- a/src/surface_conditions/surface_state.jl
+++ b/src/surface_conditions/surface_state.jl
@@ -12,15 +12,9 @@ abstract type SurfaceParameterization{FT} end
 A container for state variables at the ground level, for use with SurfaceFluxes.
 """
 struct SurfaceState{
-    FT,
-    SFP <: SurfaceParameterization{FT},
-    FTN1 <: Union{FT, Nothing},
-    FTN2 <: Union{FT, Nothing},
-    FTN3 <: Union{FT, Nothing},
-    FTN4 <: Union{FT, Nothing},
-    FTN5 <: Union{FT, Nothing},
-    FTN6 <: Union{FT, Nothing},
-    FTN7 <: Union{FT, Nothing},
+    FT, SFP <: SurfaceParameterization{FT},
+    FTN1 <: Union{FT, Nothing}, FTN2 <: Union{FT, Nothing}, FTN3 <: Union{FT, Nothing}, FTN4 <: Union{FT, Nothing},
+    FTN5 <: Union{FT, Nothing}, FTN6 <: Union{FT, Nothing}, FTN7 <: Union{FT, Nothing},
 }
     parameterization::SFP
     T::FTN1
@@ -36,32 +30,12 @@ float_type(::Type{<:SurfaceParameterization{FT}}) where {FT} = FT
 
 SurfaceState(;
     parameterization::SFP,
-    T::FTN1 = nothing,
-    p::FTN2 = nothing,
-    q_vap::FTN3 = nothing,
-    u::FTN4 = nothing,
-    v::FTN5 = nothing,
-    gustiness::FTN6 = nothing,
-    beta::FTN7 = nothing,
-) where {
-    SFP <: SurfaceParameterization,
-    FTN1,
-    FTN2,
-    FTN3,
-    FTN4,
-    FTN5,
-    FTN6,
-    FTN7,
-} =
+    T::FTN1 = nothing, p::FTN2 = nothing, q_vap::FTN3 = nothing,
+    u::FTN4 = nothing, v::FTN5 = nothing,
+    gustiness::FTN6 = nothing, beta::FTN7 = nothing,
+) where {SFP <: SurfaceParameterization, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7} =
     SurfaceState{float_type(SFP), SFP, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7}(
-        parameterization,
-        T,
-        p,
-        q_vap,
-        u,
-        v,
-        gustiness,
-        beta,
+        parameterization, T, p, q_vap, u, v, gustiness, beta,
     )
 
 """
@@ -71,8 +45,7 @@ Container for heat fluxes
  - shf: Sensible heat flux
  - lhf: Latent heat flux
 """
-Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <:
-                   PrescribedFluxes{FT}
+Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     shf::FT
     lhf::FTN = nothing
 end
@@ -82,8 +55,7 @@ end
 
 Container for quantities used to calculate sensible and latent heat fluxes.
 """
-Base.@kwdef struct θAndQFluxes{FT, FTN <: Union{FT, Nothing}} <:
-                   PrescribedFluxes{FT}
+Base.@kwdef struct θAndQFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     θ_flux::FT
     q_flux::FTN = nothing
 end
@@ -122,9 +94,7 @@ Valid combinations:
 Roughnesses can be specified by either z0 or both z0m and z0b.
 """
 struct MoninObukhov{
-    FT,
-    PFN <: Union{PrescribedFluxes{FT}, Nothing},
-    FTN <: Union{FT, Nothing},
+    FT, PFN <: Union{PrescribedFluxes{FT}, Nothing}, FTN <: Union{FT, Nothing},
 } <: SurfaceParameterization{FT}
     z0m::FT
     z0b::FT
@@ -132,13 +102,7 @@ struct MoninObukhov{
     ustar::FTN
 end
 
-function MoninObukhov(;
-    z0 = nothing,
-    z0m = nothing,
-    z0b = nothing,
-    fluxes = nothing,
-    ustar = nothing,
-)
+function MoninObukhov(; z0 = nothing, z0m = nothing, z0b = nothing, fluxes = nothing, ustar = nothing)
     if !isnothing(z0)
         if isnothing(z0m) && isnothing(z0b)
             z0m = z0b = z0
@@ -146,11 +110,8 @@ function MoninObukhov(;
             error("Cannot specify z0 and z0m/z0b")
         end
     end
-    m_o(z0m::Number, z0b::Number, fluxes, ::Nothing) =
-        MoninObukhov(z0m, z0b, fluxes, nothing)
-    m_o(z0m::Number, z0b::Number, ::Nothing, ustar::Number) =
-        MoninObukhov(z0m, z0b, nothing, ustar)
-    m_o(z0m::Number, z0b::Number, fluxes::PrescribedFluxes, ustar::Number) =
-        MoninObukhov(z0m, z0b, fluxes, ustar)
+    m_o(z0m::Number, z0b::Number, fluxes, ::Nothing) = MoninObukhov(z0m, z0b, fluxes, nothing)
+    m_o(z0m::Number, z0b::Number, ::Nothing, ustar::Number) = MoninObukhov(z0m, z0b, nothing, ustar)
+    m_o(z0m::Number, z0b::Number, fluxes::PrescribedFluxes, ustar::Number) = MoninObukhov(z0m, z0b, fluxes, ustar)
     return m_o(z0m, z0b, fluxes, ustar)
 end

--- a/src/topography/steady_state_solutions.jl
+++ b/src/topography/steady_state_solutions.jl
@@ -125,10 +125,7 @@ function ∂FΔU_∂Fh_approximation(params, η, k_x, k_y, z_top)
         g / u * (
             im * k_h² / k_x * μ_sfc * ∂FΔη_z_∂Fh +
             ((1 - m_sfc) * ∂FΔη_xh_∂Fh + r * ∂FΔη_yh_∂Fh) * ∂FΔη_z_∂Fh +
-            β *
-            r *
-            (-r * ∂FΔη_x_sfc_∂Fh + ∂FΔη_y_sfc_∂Fh) *
-            (1 + ν_sfc * (1 - a))
+            β * r * (-r * ∂FΔη_x_sfc_∂Fh + ∂FΔη_y_sfc_∂Fh) * (1 + ν_sfc * (1 - a))
         )
 
     k_η² =
@@ -149,8 +146,7 @@ function ∂FΔU_∂Fh_approximation(params, η, k_x, k_y, z_top)
         ∂Δf_∂Fh / k_η² +
         (sqrt(d_sfc / d) * (im * k_x * u - ∂Δf_sfc_∂Fh / k_η_sfc²)) *
         exp(plus_or_minus * im * sqrt(Complex(k_η²)) * η)
-    ∂²FΔw_∂Fh∂η =
-        plus_or_minus * im * sqrt(Complex(k_η²)) * (∂FΔw_∂Fh - ∂Δf_∂Fh / k_η²)
+    ∂²FΔw_∂Fh∂η = plus_or_minus * im * sqrt(Complex(k_η²)) * (∂FΔw_∂Fh - ∂Δf_∂Fh / k_η²)
 
     ∂FΔp_∂Fh =
         -(im * k_x / k_h² * g * d) * (
@@ -260,13 +256,9 @@ function steady_state_velocity_agnesi(params, coord, z_top)
     n_efolding_intervals = -log(eps(FT))
     k_x_max = n_efolding_intervals / a
     return steady_state_velocity_mountain_2d(
-        topography_agnesi,
-        topography_agnesi_Fh,
+        topography_agnesi, topography_agnesi_Fh,
         params,
-        coord,
-        z_top,
-        x_center,
-        k_x_max,
+        coord, z_top, x_center, k_x_max,
     )
 end
 
@@ -284,12 +276,8 @@ function steady_state_velocity_schar(params, coord, z_top)
     n_efolding_intervals = -log(eps(FT))
     k_x_max = k_peak + 2 * sqrt(n_efolding_intervals) / a
     return steady_state_velocity_mountain_2d(
-        topography_schar,
-        topography_schar_Fh,
+        topography_schar, topography_schar_Fh,
         params,
-        coord,
-        z_top,
-        x_center,
-        k_x_max,
+        coord, z_top, x_center, k_x_max,
     )
 end

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -150,11 +150,11 @@ function get_test_functions(cent_space, face_space)
     UVW = Geometry.UVWVector
     # Assemble (Cartesian) velocity
     ᶜu = @. UVW(Geometry.UVector(u)) +
-       UVW(Geometry.VVector(v)) +
-       UVW(Geometry.WVector(w))
+            UVW(Geometry.VVector(v)) +
+            UVW(Geometry.WVector(w))
     ᶠu = @. UVW(Geometry.UVector(ᶠu)) +
-       UVW(Geometry.VVector(ᶠv)) +
-       UVW(Geometry.WVector(ᶠw))
+            UVW(Geometry.VVector(ᶠv)) +
+            UVW(Geometry.WVector(ᶠw))
     # Get covariant components
     uₕ = @. Geometry.Covariant12Vector(ᶜu)
     uᵥ = @. Geometry.Covariant3Vector(ᶠu)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -50,8 +50,8 @@ end
     κ = zeros(cent_space)
     κ .= CA.compute_kinetic(uₕ, uᵥ)
     ᶜκ_exact = @. 1 // 2 *
-       cos(z)^2 *
-       ((sin(x)^2) * (cos(y)^2) + (cos(x)^2) * (sin(y)^2))
+                  cos(z)^2 *
+                  ((sin(x)^2) * (cos(y)^2) + (cos(x)^2) * (sin(y)^2))
     # Test upto machine precision approximation
     @test ᶜκ_exact ≈ κ
 end
@@ -81,11 +81,11 @@ end
     UVW = Geometry.UVWVector
     # Assemble (Cartesian) velocity
     ᶜu = @. UVW(Geometry.UVector(u)) +
-       UVW(Geometry.VVector(v)) +
-       UVW(Geometry.WVector(w))
+            UVW(Geometry.VVector(v)) +
+            UVW(Geometry.WVector(w))
     ᶠu = @. UVW(Geometry.UVector(ᶠu)) +
-       UVW(Geometry.VVector(ᶠv)) +
-       UVW(Geometry.WVector(ᶠw))
+            UVW(Geometry.VVector(ᶠv)) +
+            UVW(Geometry.WVector(ᶠw))
     ᶜϵ .= CA.compute_strain_rate_center(Geometry.Covariant123Vector.(ᶠu))
     ᶠϵ .= CA.compute_strain_rate_face(Geometry.Covariant123Vector.(ᶜu))
 


### PR DESCRIPTION
**Important** This PR is illustrative. It need not be merged. Its purpose is to demonstrate how the new formatter settings (margin 120 + source-preserving joins) can surface domain semantics.

## Overview of example sites
1. `src/diagnostics/conservation_diagnostics.jl`
    * reduced vertical bloat of wrapper functions, making it easier to scan the file
2. `src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl`
    * arguments regrouped into labeled semantic clusters with comments
3.  `src/parameterized_tendencies/microphysics/microphysics_wrappers.jl`
    * reduced vertical bloat of repeated functions for dispatch.
    * Allows easier scanning: getting to the "physics" within the code, instead of scrolling past lines and lines of function arguments
4. `src/parameterized_tendencies/microphysics/precipitation.jl`
    * same as above, including semantic grouping: `Yₜ, Y, p, t,` on one line, dispatched arguments on the next (model choices)
5. `src/parameterized_tendencies/radiation/RRTMGPInterface.jl`
    * reduced vertical bloat of wrapper functions
    * semantic grouping within some functions and lists
6. `src/parameterized_tendencies/radiation/radiation.jl`, `src/solver/model_getters.jl`, `src/surface_conditions/surface_state.jl`, `src/topography/steady_state_solutions.jl`
    * additional examples of the above points