### PR TITLE
separate sedimentation of qt and mse in prognostic edmf

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -422,16 +422,6 @@ function edmfx_sgs_vertical_advection_tendency!(
 
             # Sedimentation
             # TODO - lazify ᶜwₗʲs computation. No need to cache it.
-            (; ᶜwₕʲs, ᶜwₜʲs) = p.precomputed
-            ᶠwₕʲ = (@. lazy(CT3(ᶠinterp(Geometry.WVector(-1 * ᶜwₕʲs.:(1))))))
-            ᶠwₜʲ = (@. lazy(CT3(ᶠinterp(Geometry.WVector(-1 * ᶜwₜʲs.:(1))))))
-            # Advective form advection of mse with sedimentation velocities
-            va = vertical_advection(ᶠwₕʲ, Y.c.sgsʲs.:(1).mse, edmfx_upwinding)
-            @. Yₜ.c.sgsʲs.:(1).mse += va
-            # Advective form advection of q_tot with sedimentation velocities
-            va = vertical_advection(ᶠwₜʲ, Y.c.sgsʲs.:(1).q_tot, edmfx_upwinding)
-            @. Yₜ.c.sgsʲs.:(1).q_tot += va
-
             sgs_microphysics_tracers = (
                 (@name(c.sgsʲs.:(1).q_liq), @name(q_liq), @name(ᶜwₗʲs.:(1))),
                 (@name(c.sgsʲs.:(1).q_ice), @name(q_ice), @name(ᶜwᵢʲs.:(1))),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
In preparation for making sedimentation of microphysics tracers implicit.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
