### PR TITLE
make sedimentation and advection implicit in prognostic edmf with 1m

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -853,6 +853,15 @@ steps:
         artifact_paths: "prognostic_edmfx_rico_column/output_active/*"
         agents:
           slurm_mem: 20GB
+      
+      - label: ":umbrella: Prognostic EDMFX Rico in a column (implicit)"
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_rico_implicit_column.yml
+          --job_id prognostic_edmfx_rico_implicit_column
+        artifact_paths: "prognostic_edmfx_rico_implicit_column/output_active/*"
+        agents:
+          slurm_mem: 20GB
 
       - label: ":umbrella: Prognostic EDMFX Rico with 2-moment in a column"
         command: >

--- a/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
@@ -1,0 +1,42 @@
+initial_condition: "Rico"
+subsidence: "Rico"
+ls_adv: "Rico"
+surface_setup: "Rico"
+turbconv: "prognostic_edmfx"
+implicit_diffusion: true
+implicit_sgs_advection: true
+approximate_linear_solve_iters: 2
+max_newton_iters_ode: 3
+edmfx_upwinding: first_order
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+edmfx_filter: true
+prognostic_tke: true
+moist: "nonequil"
+cloud_model: "quadrature_sgs"
+call_cloud_diagnostics_per_stage: true
+precip_model: "1M"
+config: "column"
+z_max: 4e3
+x_elem: 2
+y_elem: 2
+z_elem: 100
+z_stretch: false
+perturb_initstate: false
+dt: "60secs"
+t_end: "6hours"
+dt_save_state_to_disk: "60mins"
+toml: [toml/prognostic_edmfx_1M.toml]
+netcdf_interpolation_num_points: [8, 8, 100]
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
+    period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1398,6 +1398,7 @@ EDMFBoxPlots = Union{
 
 EDMFBoxPlotsWithPrecip = Union{
     Val{:prognostic_edmfx_rico_column},
+    Val{:prognostic_edmfx_rico_implicit_column},
     Val{:prognostic_edmfx_rico_column_2M},
     Val{:prognostic_edmfx_trmm_column},
     Val{:prognostic_edmfx_trmm_column_sparse_autodiff},


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Part of https://github.com/CliMA/ClimaAtmos.jl/issues/3998: ∂ᶜqʲ_err_∂ᶜqʲ in sedimenation and updraft advection

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
