### PR TITLE
Adds ability to run ERA5 simulations with temperature change

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -271,6 +271,9 @@ site_latitude:
 site_longitude:
   help: "Site longitude for single column model. Used for externally driven time varying forcing model to generate the forcing file. Artifact support is currently for eastern Pacific region in July 2007 only. [`-149.0` (default)]"
   value: -149.0
+era5_diurnal_warming:
+  help: Applies a warming scenario by adding a constant temperature offset (in Kelvin). Supported only by the `ReanalysisMonthlyAveragedDiurnal` forcing model. This affects the target surface temperature for the entire simulation, the initial atmospheric temperature profile, and the relaxation temperature profile above `gcmdriven_relaxation_minimum_height`. Specific humidity is increased to hold relative humidity constant in the initial and relaxation profiles.
+  value: ~
 subsidence:
   help: "Subsidence [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `DYCOMS`, `ISDAC`]"
   value: ~

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -466,6 +466,10 @@ function get_external_forcing_model(parsed_args, ::Type{FT}) where {FT}
         @assert parsed_args["config"] == "column" "ReanalysisTimeVarying and ReanalysisMonthlyAveragedDiurnal are only supported in column mode."
         @assert all(reanalysis_required_fields .== "ReanalysisTimeVarying") "All of external_forcing, surface_setup, surface_temperature and initial_condition must be set to ReanalysisTimeVarying."
     end
+    if !isnothing(parsed_args["era5_diurnal_warming"])
+        @assert external_forcing == "ReanalysisMonthlyAveragedDiurnal" "era5_diurnal_warming is only supported for ReanalysisMonthlyAveragedDiurnal."
+        @assert parsed_args["era5_diurnal_warming"] isa Number "era5_diurnal_warming is expected to be a number, but was supplied as a $(typeof(parsed_args["era5_diurnal_warming"]))"
+    end
     return if isnothing(external_forcing)
         nothing
     elseif external_forcing == "GCM"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
In order to understand feedbacks on turbulence and convection closures under global warming we want to be able to run perturbation experiments. This PR introduces one setup that uses the ERA5 monthly diurnal setup and allows the user to increase the temperature (air and surface) by a specified amount with , e.g.,`era5_diurnal_warming: 4` for +4K experiments, in the config file. The specific humidity profile is adjusted by keeping the relative humidity constant. While this setup does not change large-scale dynamics, it does allow us to focus on feedbacks in just the boundary layer. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
I have not added a buildkite configuration as an integration test because the base model is already tested. Instead I rely on unit tests to check that the forcing file created has the desired behavior (increased temperature and specific humidity). 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
