### PR TITLE
Try using an alternative reconstruction of kinetic energy

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -313,10 +313,10 @@ end
 
 # This is used to set the grid-scale velocity quantities ᶜu, ᶠu³, ᶜK based on
 # ᶠu₃, and it is also used to set the SGS quantities based on ᶠu₃⁰ and ᶠu₃ʲ.
-function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠu₃, ᶜuₕ, ᶠuₕ³)
+function set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, ᶠu₃, ᶜρ, ᶜuₕ, ᶠuₕ³)
     @. ᶜu = C123(ᶜuₕ) + ᶜinterp(C123(ᶠu₃))
     @. ᶠu³ = ᶠuₕ³ + CT3(ᶠu₃)
-    ᶜK .= compute_kinetic(ᶜuₕ, ᶠu₃)
+    ᶜK .= compute_kinetic(ᶜρ, ᶜuₕ, ᶠu₃)
     return nothing
 end
 
@@ -447,9 +447,9 @@ NVTX.@annotate function set_implicit_precomputed_quantities_part1!(Y, p, t)
     set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
     set_velocity_at_top!(Y, turbconv_model)
 
-    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.u₃, Y.c.uₕ, ᶠuₕ³)
+    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y.f.u₃, Y.c.ρ, Y.c.uₕ, ᶠuₕ³)
     ᶜJ = Fields.local_geometry_field(Y.c).J
-    @. ᶠu = CT123(ᶠwinterp(Y.c.ρ * ᶜJ, CT12(ᶜu))) + CT123(ᶠu³)
+    @. ᶠu = CT123(ᶠinterp(CT12(ᶜu))) + CT123(ᶠu³)
     if n > 0
         # TODO: In the following increments to ᶜK, we actually need to add
         # quantities of the form ᶜρaχ⁰ / ᶜρ⁰ and ᶜρaχʲ / ᶜρʲ to ᶜK, rather than

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -28,7 +28,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     ᶜtke⁰ = @. lazy(specific_tke(Y.c.ρ, Y.c.sgs⁰.ρatke, ᶜρa⁰, turbconv_model))
 
     set_sgs_ᶠu₃!(u₃⁰, ᶠu₃⁰, Y, turbconv_model)
-    set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.uₕ, ᶠuₕ³)
+    set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.ρ, Y.c.uₕ, ᶠuₕ³)
     # @. ᶜK⁰ += ᶜtke⁰
     ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
 
@@ -95,7 +95,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
             ᶜq_snoʲ = Y.c.sgsʲs.:($j).q_sno
         end
 
-        set_velocity_quantities!(ᶜuʲ, ᶠu³ʲ, ᶜKʲ, ᶠu₃ʲ, Y.c.uₕ, ᶠuₕ³)
+        set_velocity_quantities!(ᶜuʲ, ᶠu³ʲ, ᶜKʲ, ᶠu₃ʲ, Y.c.ρ, Y.c.uₕ, ᶠuₕ³)
         @. ᶠKᵥʲ = (adjoint(CT3(ᶠu₃ʲ)) * ᶠu₃ʲ) / 2
         if p.atmos.moisture_model isa NonEquilMoistModel && (
             p.atmos.microphysics_model isa Microphysics1Moment ||

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -484,7 +484,7 @@ function _overwrite_initial_conditions_from_file!(
     Y.c.uₕ .= C12.(Geometry.UVVector.(vel))
     Y.f.u₃ .= ᶠinterp.(C3.(Geometry.WVector.(vel)))
     e_kin = similar(ᶜT)
-    e_kin .= compute_kinetic(Y.c.uₕ, Y.f.u₃)
+    e_kin .= compute_kinetic(Y.c.ρ, Y.c.uₕ, Y.f.u₃)
     e_pot = Fields.coordinate_field(Y.c).z .* thermo_params.grav
     Y.c.ρe_tot .= TD.total_energy.(thermo_params, ᶜts, e_kin, e_pot) .* Y.c.ρ
     if hasproperty(Y.c, :ρq_tot)

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -288,7 +288,10 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
                 ᶠω¹²ʲs.:($$j) × ᶠinterp(CT12(ᶜuʲs.:($$j))) +
-                ᶠgradᵥ(ᶜKʲs.:($$j) - ᶜinterp(ᶠKᵥʲs.:($$j)))
+                ᶠgradᵥ(
+                    ᶜKʲs.:($$j) -
+                    ᶜinterp(ᶠinterp(Y.c.ρ * ᶜJ) * ᶠKᵥʲs.:($$j)) / (Y.c.ρ * ᶜJ),
+                )
         end
     else
         # deep atmosphere
@@ -299,7 +302,10 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
                 (ᶠf¹² + ᶠω¹²ʲs.:($$j)) × ᶠinterp(CT12(ᶜuʲs.:($$j))) +
-                ᶠgradᵥ(ᶜKʲs.:($$j) - ᶜinterp(ᶠKᵥʲs.:($$j)))
+                ᶠgradᵥ(
+                    ᶜKʲs.:($$j) -
+                    ᶜinterp(ᶠinterp(Y.c.ρ * ᶜJ) * ᶠKᵥʲs.:($$j)) / (Y.c.ρ * ᶜJ),
+                )
         end
     end
 

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -413,7 +413,8 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
         @. ∂ᶜK_∂ᶜuₕ = DiagonalMatrixRow(adjoint(CTh(ᶜuₕ)))
     end
     @. ∂ᶜK_∂ᶠu₃ =
-        ᶜinterp_matrix() ⋅ DiagonalMatrixRow(adjoint(CT3(ᶠu₃))) +
+        (DiagonalMatrixRow(1 / (ᶜρ * ᶜJ)) ⋅ ᶜinterp_matrix()) ⋅
+        DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) * adjoint(CT3(ᶠu₃))) +
         DiagonalMatrixRow(adjoint(CT3(ᶜuₕ))) ⋅ ᶜinterp_matrix()
 
     @. ᶠp_grad_matrix = DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix()

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -48,7 +48,7 @@ end
     CT123 = Geometry.Contravariant123Vector
     # Exercise function
     κ = zeros(cent_space)
-    κ .= CA.compute_kinetic(uₕ, uᵥ)
+    κ .= CA.compute_kinetic(1, uₕ, uᵥ)
     ᶜκ_exact = @. 1 // 2 *
                   cos(z)^2 *
                   ((sin(x)^2) * (cos(y)^2) + (cos(x)^2) * (sin(y)^2))


### PR DESCRIPTION
This PR implements an alternative to the reconstruction in #4015, replacing the kinetic energy `(gʰʰuₕ⋅uₕ)ᶜ + 2(gᵛʰuₕ)ᶜ⋅⟨(uᵥ)ᶠ⟩ + ⟨(gᵛᵛuᵥ⋅uᵥ)ᶠ⟩` with `(gʰʰuₕ⋅uₕ)ᶜ + 2(gᵛʰuₕ)ᶜ⋅⟨(uᵥ)ᶠ⟩ + ⌈(gᵛᵛuᵥ⋅uᵥ)ᶠ⌋`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
