### PR TITLE
Sa/fix negative clw

### DIFF
--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -79,50 +79,10 @@ function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:none})
     ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
     return @. lazy(-(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠu³ * ᶠinterp(ᶜχ))))
 end
-function vertical_transport_precip_massflux(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:none})
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(
-        -(ᶜprecip_massflux_divᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠu³ * ᶠinterp(ᶜχ))),
-    )
-end
-function vertical_transport_sedimentation(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:none})
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(
-        -(ᶜprecipdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠu³ * ᶠinterp(ᶜχ))),
-    )
-end
 function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:first_order})
     ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
     ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
     return @. lazy(-(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠupwind1(ᶠu³, ᶜχ))))
-end
-function vertical_transport_precip_massflux(
-    ᶜρ,
-    ᶠu³,
-    ᶜχ,
-    dt,
-    ::Val{:first_order},
-)
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(
-        -(ᶜprecip_massflux_divᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠupwind1(ᶠu³, ᶜχ))),
-    )
-end
-function vertical_transport_sedimentation(
-    ᶜρ,
-    ᶠu³,
-    ᶜχ,
-    dt,
-    ::Val{:first_order},
-)
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(
-        -(ᶜprecipdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠupwind1(ᶠu³, ᶜχ))),
-    )
 end
 @static if pkgversion(ClimaCore) ≥ v"0.14.22"
     function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:vanleer_limiter})
@@ -167,6 +127,17 @@ function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:zalesak})
                 )
             ),
         )),
+    )
+end
+function vertical_transport_sedimentation(
+    ᶜρ,
+    ᶜw,
+    ᶜχ,
+    ᶠJ,
+)
+    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
+    return @. lazy(
+        -(ᶜprecipdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(-(ᶜw)) * ᶜχ))),
     )
 end
 

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -31,11 +31,6 @@ const ᶜadvdivᵥ = Operators.DivergenceF2C(
     top = Operators.SetValue(CT3(0)),
 )
 
-const ᶜprecip_massflux_divᵥ = Operators.DivergenceF2C(
-    bottom = Operators.SetDivergence(0),
-    top = Operators.SetValue(CT3(0)),
-)
-
 # Subsidence has extrapolated tendency at the top, and has no flux at the bottom.
 # TODO: This is not accurate and causes some issues at the domain top.
 const ᶜsubdivᵥ = Operators.DivergenceF2C(

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -23,7 +23,8 @@ value = 0.1
 value = 0
 
 [detr_inv_tau]
-value = 0
+value = 0.0001
+# Set equal to entr_inv_tau to prevent spurious growth of ar at high altitudes (seen in single-column RICO)
 
 [detr_coeff]
 value = 0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Resolve negative cloud mass by:
- unwinding sgs mass flux for tracers
- using flux form updraft velocity advection of tracers
- setting minimum detr equal to minimum entr
- ensuring updraft sedimentation is done consistently with the gs sedimentation

With these fixes, we almost don't get any negative tracers. An exception is the cell at the bottom boundary where applying the BC that updates updraft area fraction violates tracer mass conservation.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
