### PR TITLE
Modify advection to discretely conserve vorticity

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-264
+265
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+265
+- Modify advection to discretely conserve vorticity
+
 264
 - Allow entrainment and detrainment when updraft area fraction is negligible
 

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -199,7 +199,7 @@ add_diagnostic_variable!(
     units = "s^-1",
     comments = "Vertical component of relative vorticity",
     compute! = (out, state, cache, time) -> begin
-        vort = @. w_component.(Geometry.WVector(curlₕ(cache.precomputed.ᶜu)))
+        vort = @. w_component.(Geometry.WVector(wcurlₕ(cache.precomputed.ᶜu)))
         # We need to ensure smoothness, so we call DSS
         Spaces.weighted_dss!(vort)
         if isnothing(out)

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -232,7 +232,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     ᶠω¹²ʲs = p.scratch.ᶠtemp_CT12ʲs
 
     if point_type <: Geometry.Abstract3DPoint
-        @. ᶜω³ = curlₕ(Y.c.uₕ)
+        @. ᶜω³ = wcurlₕ(Y.c.uₕ)
     elseif point_type <: Geometry.Abstract2DPoint
         @. ᶜω³ = zero(ᶜω³)
     end
@@ -241,9 +241,9 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     for j in 1:n
         @. ᶠω¹²ʲs.:($$j) = ᶠω¹²
     end
-    @. ᶠω¹² += CT12(curlₕ(Y.f.u₃))
+    @. ᶠω¹² += CT12(wcurlₕ(Y.f.u₃))
     for j in 1:n
-        @. ᶠω¹²ʲs.:($$j) += CT12(curlₕ(Y.f.sgsʲs.:($$j).u₃))
+        @. ᶠω¹²ʲs.:($$j) += CT12(wcurlₕ(Y.f.sgsʲs.:($$j).u₃))
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR replaces the strong curl operators in our advection tendency with weak curl operators, ensuring that we have discrete conservation of vorticity.

This supersedes #4015, which would give us discrete horizontal dot product identity instead of vorticity conservation. It also supersedes #3552, which is essentially a combination of this PR and #4015.

The reconstruction of the advection tendency in #4015 is equivalent to Oswald's, which is itself a non-orthogonal generalization of the reconstruction used by Taylor et al. in "An Energy Consistent Discretization of the Nonhydrostatic Equations in Primitive Variables". Despite its use in other models, that reconstruction introduces spurious vertical waves in our spherical configurations and makes most of the longruns unstable. There are probably some interesting rules governing which reconstruction works better for a particular combination of tendencies and timestepping scheme, which may be worth exploring in the future if we want to have Rosenbrock timesteppers. For now, we will just use the reconstruction that's best for our typical configurations.

After this is merged in, I will also remove the changes introduced in #4015 from the dycore paper. This will finally make the reconstruction described in the paper match the one we're actually using.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
