### PR TITLE
Fix updraft values for vanishing ar

### DIFF
--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -27,7 +27,7 @@ z_elem: 100
 z_stretch: false
 perturb_initstate: false
 dt: "5secs"
-t_end: "12hours"
+t_end: "24hours"
 dt_save_state_to_disk: "60mins"
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 100]

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-263
+264
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+264
+- Allow entrainment and detrainment when updraft area fraction is negligible
+
 263
 - Make vertical diffusion of updrafts implicit
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Return constant entr and detr values instead of zero for vanishing `ar` conditions:
This allows updraft variables follow GS variables where `ar` is negligible. For small `ar` entrainment coefficient will not be zero that results in a tendency that brings updraft tracer and energy values close to the grid mean values. This is important to prevent the spread of errors from the top boundary downward into the domain where non-trivial values reside (see figure). With this fix now single column setups with 1M and 2M are numerically stable (tested for several days).

## To-do
Resolve `q_tot` fluctuations related to fast varying `ar`. This is possibly due to not using any upwinding scheme is in sgs mass flux computations.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
