### PR TITLE
Fix density oscillations

### DIFF
--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -66,7 +66,7 @@ function column_indefinite_integral(
     f::Function,
     ϕ₀::FT,
     zspan::Tuple{FT, FT};
-    nelems = 100, # sets resolution for integration
+    nelems = 1000, # sets resolution for integration
 ) where {FT <: Real}
     # --- Make a space for integration:
     z_domain = Domains.IntervalDomain(

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -361,6 +361,7 @@ function edmfx_sgs_vertical_advection_tendency!(
     ᶠz = Fields.coordinate_field(Y.f).z
     ᶜu₃ʲ = p.scratch.ᶜtemp_C3
     ᶜKᵥʲ = p.scratch.ᶜtemp_scalar_2
+    ᶠρ_diff = p.scratch.ᶠtemp_scalar
     ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
 
     for j in 1:n
@@ -371,12 +372,20 @@ function edmfx_sgs_vertical_advection_tendency!(
             ᶜleft_bias(ᶠKᵥʲs.:($$j)),
             ᶜright_bias(ᶠKᵥʲs.:($$j)),
         )
+        # Use downwind density for buoyancy forcing.
+        # This ensures that the velocity perturbation responds with the correct phase
+        # to oppose density anomalies, preventing spurious growth of grid-scale modes.
+        # (Upwind choice would reinforce the anomaly and cause instability.)
+        @. ᶠρ_diff = ifelse(
+            Y.f.sgsʲs.:($$j).u₃.components.data.:1 < 0,
+            ᶠleft_bias((ᶜρʲs.:($$j) - Y.c.ρ) / ᶜρʲs.:($$j)),
+            ᶠright_bias((ᶜρʲs.:($$j) - Y.c.ρ) / ᶜρʲs.:($$j)),
+        )
         # For the updraft u_3 equation, we assume the grid-mean to be hydrostatic
         # and calcuate the buoyancy term relative to the grid-mean density.
         # We also include the buoyancy term in the nonhydrostatic pressure closure here.
         @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-            (1 - α_b) * (ᶠinterp(ᶜρʲs.:($$j) - Y.c.ρ) * ᶠgradᵥ_ᶜΦ) /
-            ᶠinterp(ᶜρʲs.:($$j)) + ᶠgradᵥ(ᶜKᵥʲ)
+            (1 - α_b) * (ᶠρ_diff * ᶠgradᵥ_ᶜΦ) + ᶠgradᵥ(ᶜKᵥʲ)
 
         # buoyancy term in mse equation
         @. Yₜ.c.sgsʲs.:($$j).mse +=

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -41,6 +41,7 @@ const ᶜsubdivᵥ = Operators.DivergenceF2C(
 # Precipitation has no flux at the top, but it has free outflow at the bottom.
 const ᶜprecipdivᵥ = Operators.DivergenceF2C(top = Operators.SetValue(CT3(0)))
 
+const ᶠleft_bias = Operators.LeftBiasedC2F()
 const ᶠright_bias = Operators.RightBiasedC2F() # for free outflow in ᶜprecipdivᵥ
 const ᶜleft_bias = Operators.LeftBiasedF2C()
 const ᶜright_bias = Operators.RightBiasedF2C()


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fix density fluctuations by using downwind density info in updraft buoyancy eq

Here are `\rho^j - \rho` plots after 1hr simulation of the single column trmm with prognostic EDMF when updating the updraft velocity by using density:
- upwind of the flow,
- interpolating the two sides,
- downwind of the flow,
respectively:

<img width="1144" height="660" alt="Screenshot 2025-10-03 at 3 15 45 PM" src="https://github.com/user-attachments/assets/dcbb15f7-e24f-4863-8148-70e197816330" />

<img width="1142" height="652" alt="Screenshot 2025-10-03 at 3 12 44 PM" src="https://github.com/user-attachments/assets/702a266a-1a58-4eb4-9333-5006e1389cbf" />

<img width="1093" height="647" alt="Screenshot 2025-10-03 at 3 14 20 PM" src="https://github.com/user-attachments/assets/ab55db80-2efa-4173-9f54-c9f8ee69d4dd" />

