### PR TITLE
Cartesian spectra in ci

### DIFF
--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -40,10 +40,12 @@
 
 import CairoMakie
 import CairoMakie.Makie
+import ClimaAtmos as CA
 import ClimaAnalysis
 import ClimaAnalysis: Visualize as viz
 import ClimaAnalysis: SimDir, slice, average_xy, window, average_time
 import ClimaAnalysis.Utils: kwargs as ca_kwargs
+import OrderedCollections: OrderedDict
 
 import ClimaCoreSpectra: power_spectrum_2d
 
@@ -399,6 +401,102 @@ function compute_spectrum(var::ClimaAnalysis.OutputVar; mass_weight = nothing)
     )
 end
 
+import ClimaCoreSpectra.FFTW
+
+"""
+    compute_average_cartesian_spectrum_1d(
+        x::ClimaAnalysis.OutputVar;
+        spectrum_dim::String,
+        average_dims::Tuple = (),
+    )
+
+Compute a 1D power spectrum of `x` along `spectrum_dim`, optionally averaging
+the power over `average_dims`.
+
+# Arguments
+- `spectrum_dim`: The dimension to FFT along (e.g. `"x"` or `"y"`).
+- `average_dims`: Dimensions over which to average the power spectrum
+  (e.g. `["time"]`).  Omit to keep all other dimensions.
+
+Returns a `ClimaAnalysis.OutputVar` with raw (not log-scaled) power
+values.  Apply `log10` during plotting if desired.
+"""
+function compute_average_cartesian_spectrum_1d(
+    x::ClimaAnalysis.OutputVar;
+    spectrum_dim::String,
+    average_dims::Tuple = (),
+)
+    @assert haskey(x.dims, spectrum_dim) LazyString(
+        "Dimension \"", spectrum_dim, "\" not found in OutputVar",
+    )
+    for d in average_dims
+        @assert haskey(x.dims, d) LazyString("Dimension \"", d, "\" not found in OutputVar")
+    end
+
+    # Grid spacing along the spectrum dimension (assumed uniform)
+    grid_vals = x.dims[spectrum_dim]
+    n = length(grid_vals)
+    Δ = abs(grid_vals[end] - grid_vals[1]) / (n - 1)
+
+    # FFT along spectrum_dim
+    spectrum_axis = x.dim2index[spectrum_dim]
+    x̂ = FFTW.rfft(x.data, spectrum_axis)
+
+    # Compute norm using Parseval's theorem, equivalent to `sum(abs2, fft(x.data)) / n`
+    normalization = sum(abs2, x.data; dims = spectrum_axis)
+
+    # Average over requested dimensions
+    average_inds = map(k -> x.dim2index[k], average_dims)
+    power_spectrum = @. abs2(x̂) / normalization
+    avg_power_spectrum = mean(power_spectrum; dims = average_inds)
+
+    # Build output dimensions, dropping averaged dims and replacing
+    # spectrum_dim with the chosen independent variable.
+    unchanged_dims = setdiff(keys(x.dims), (average_dims..., spectrum_dim))
+
+    # Physical wavenumber: rfftfreq(n, 1/Δ) gives cycles per metre (1/m)
+    freq = collect(FFTW.rfftfreq(n, 1 / Δ))
+
+    # Drop the zero-frequency (DC) bin
+    freq = freq[2:end]
+
+    # Slice power to drop the DC bin along the spectrum axis.
+    # We also need to drop singleton dims from averaging.
+    idx = ntuple(ndims(x.data)) do i
+        if i == spectrum_axis
+            2:size(x̂, i)  # remove DC bin
+        elseif i in average_inds
+            1  # removes averaged dimensions
+        else  # `unchanged_dims`
+            1:size(x̂, i)  # keep other dimensions
+        end
+    end
+    avg_power_spectrum_sliced = avg_power_spectrum[idx...]
+
+    # Build output dims OrderedDict
+    # Need to get the right order of dimensions
+    new_dims = typeof(x.dims)()
+    new_dim_attr = typeof(x.dim_attributes)()
+    for d in keys(x.dims)
+        if d == spectrum_dim
+            new_dims["wavenumber"] = freq
+            new_dim_attr["wavenumber"] = Dict("units" => "1/m")
+        elseif d in unchanged_dims
+            new_dims[d] = x.dims[d]
+            new_dim_attr[d] = get(x.dim_attributes, d, Dict("units" => ""))
+        end
+    end
+
+    attr = Dict(
+        "short_name" => "spectrum_" * short_name(x),
+        "long_name" =>
+            "Spectrum along " * spectrum_dim * " of " * long_name(x) *
+            ";\naveraged over " * join(average_dims, ", "),
+        "units" => "(" * x.attributes["units"] * ")^2",
+    )
+
+    return ClimaAnalysis.OutputVar(attr, new_dims, new_dim_attr, avg_power_spectrum_sliced)
+end
 
 """
     map_comparison(func, simdirs, args)
@@ -490,6 +588,79 @@ function plot_spectrum_with_line!(grid_loc, spectrum; exponent = -3.0)
         text = "k^$exponent";
         color,
     )
+
+    return nothing
+end
+
+function plot_1d_spectra_same_axis!(grid_loc, spectra; reference_exponent = -3.0)
+    get_slice_dims(spectrum) = begin
+        slice_keys = filter(
+            k -> startswith(k, "slice_") && !endswith(k, "_units"),
+            keys(spectrum.attributes),
+        )
+        map(Tuple(slice_keys)) do slice_key
+            chop(slice_key; head = 6, tail = 0)
+        end
+    end
+    get_slice_label(spectrum) = begin
+        slice_dims = get_slice_dims(spectrum)
+        join(map(slice_dims) do slice_dim
+                val = spectrum.attributes["slice_" * slice_dim]
+                "$slice_dim = $val"
+            end, "; ")
+    end
+
+    @assert "wavenumber" in spectra[1].index2dim
+    spectrum1, spectra2... = spectra
+    label1 = get_slice_label(spectrum1)
+    slice_dims = get_slice_dims(spectrum1)
+    long_name_fix = long_name(spectrum1)  # loop is big hack to get long_name without slice info (since we add that in the label)
+    for pattern in (" " .* get_slice_dims(spectrum1) .* " = ")
+        long_name_fix = split(long_name_fix, pattern)[1]
+    end
+    more_kwargs = Dict(
+        :axis => Dict(
+            :title => long_name_fix,
+            :xscale => log10, :yscale => log10,
+        ),
+        :plot => Dict(:label => label1),
+    )
+    viz.plot!(grid_loc, spectrum1; more_kwargs)
+    for spectrum in spectra2
+        label = get_slice_label(spectrum)
+        x = spectrum.dims["wavenumber"]
+        CairoMakie.lines!(x, spectrum.data; label)
+    end
+    CairoMakie.axislegend(CairoMakie.current_axis(); position = :lb)
+
+    if reference_exponent isa Real
+        # Short reference power-law line covering the last ~1/3 of the
+        # wavenumber range (in log-space), hovering above the data.
+        wn = spectrum1.dims["wavenumber"]
+
+        # Start 2/3 of the way across the log-spaced range
+        log_k_start = log10(wn[1])
+        log_k_end = log10(wn[end])
+        log_k_ref_start = log_k_start + 3 / 4 * (log_k_end - log_k_start)
+        ref_range = filter(i -> log10(wn[i]) >= log_k_ref_start, eachindex(wn))
+        wn_ref = wn[ref_range]
+
+        # Anchor the line to the first spectrum's value at the start of the range,
+        # shifted up by 5× so it hovers above the data
+        k_anchor = wn_ref[1]
+        p_anchor = spectrum1.data[ref_range[1]]
+        C = 3 * p_anchor / k_anchor^reference_exponent
+        ref_vals = C .* wn_ref .^ reference_exponent
+
+        ax = CairoMakie.current_axis()
+        CairoMakie.lines!(ax, wn_ref, ref_vals; color = :gray, linestyle = :dash)
+
+        # Place label at the midpoint of the reference line
+        mid = length(wn_ref) ÷ 2
+        CairoMakie.text!(ax, wn_ref[mid], ref_vals[mid];
+            text = "k^$(reference_exponent)", color = :gray,
+        )
+    end
 
     return nothing
 end
@@ -1234,7 +1405,11 @@ function make_plots(::LESBoxPlots, output_paths::Vector{<:AbstractString})
         "husra", "hussn", # 1M microphysics
         "cdnc", "ncra",   # 2M microphysics
     ]
+    short_names_spectra = ["ua", "va", "wa"]
+
+    # Filter out variables that are not actually present in the simulations
     short_names_xyzt = short_names_xyzt ∩ collect(keys(simdirs[1].vars))
+    short_names_spectra = short_names_spectra ∩ collect(keys(simdirs[1].vars))
 
     # Window average from instantaneous snapshots?
     function average_t_last2hrs(var)
@@ -1261,9 +1436,38 @@ function make_plots(::LESBoxPlots, output_paths::Vector{<:AbstractString})
     )
 
     summary_file = make_plots_generic(output_paths, vcat(var_groups_tz_avg_xy...);
+        output_name = isempty(short_names_spectra) ? "summary" : "tmp2",
         plot_fn = plot_parsed_attribute_title!,
         summary_files = [tmp_file],
         MAX_NUM_COLS = 2, MAX_NUM_ROWS = 4,
+    )
+
+    isempty(short_names_spectra) && return summary_file
+    # If spectra are available, make additional plots
+
+    # x spectrum, averaged over y and last 7 days at z = 600, 6000, 10_000 m
+    var_groups_x_spectra_zs_comparison =
+        map_comparison(simdirs, short_names_spectra) do simdir, short_name
+            var = get(simdir; short_name, reduction)
+            last_t = last(var.dims["time"])
+            data = window(var, "time"; left = last_t - CA.time_to_seconds("7days"))
+            spectrum_data = compute_average_cartesian_spectrum_1d(
+                data; spectrum_dim = "x", average_dims = ("time", "y"),
+            )
+            [
+                slice(spectrum_data; z = 600),
+                slice(spectrum_data; z = 6000),
+                slice(spectrum_data; z = 10_000),
+            ]
+        end
+
+    make_plots_generic(
+        output_paths,
+        var_groups_x_spectra_zs_comparison;
+        summary_files = [summary_file],
+        plot_fn = plot_1d_spectra_same_axis!,
+        MAX_NUM_COLS = 2,
+        MAX_NUM_ROWS = 4,
     )
 end
 


### PR DESCRIPTION
This pull request enhances the plotting and spectral analysis capabilities in `post_processing/ci_plots.jl` for simulations on Cartesian domains. The major changes include the addition of a new function for computing 1D Cartesian spectra, potentially averaged over other dimensions, and associated plotting logic.

**Spectrum computation improvements:**

* Added a new function `compute_average_cartesian_spectrum_1d` to compute spectra along a spatial dimension using FFTW, optionally averaged along one or more other dimensions; including proper handling of metadata and units.
* formatting updates

----

Looks something like this:
<img width="1279" height="981" alt="image" src="https://github.com/user-attachments/assets/d2cdcabf-48c2-4e97-9e58-30bd4a949fbc" />

