### PR TITLE
rft: split Smagorinsky diffusive model to horizontal and vertical components

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -170,7 +170,7 @@ c_amd:
   help: "Model coefficient for AMD-LES closure (TODO: Move to parameters.toml)"
   value: 0.29
 smagorinsky_lilly:
-  help: "Smagorinsky-Lilly diffusive closure [`nothing` (default), `UVW`]"
+  help: "Smagorinsky-Lilly diffusive closure [`nothing` (default), `UVW`, `UV`, `W`, `UV_W_decoupled`]"
   value: ~
 bubble:
   help: "Enable bubble correction for more accurate surface areas"

--- a/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
+++ b/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
@@ -75,6 +75,9 @@ function set_smagorinsky_lilly_precomputed_quantities!(Y, p, model)
     ᶜfb = lilly_stratification_correction(p, ᶜS)
     if is_smagorinsky_UVW_coupled(model)
         ᶜL_h = ᶜL_v = @. lazy(c_smag * cbrt(Δx * Δy * ᶜΔz) * ᶜfb)
+    else
+        ᶜL_h = @. lazy(c_smag * Δx)
+        ᶜL_v = @. lazy(c_smag * ᶜΔz * ᶜfb)
     end
 
     # Cache strain rate norms for diagnostics

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -176,12 +176,15 @@ Get the Smagorinsky-Lilly turbulence model based on `parsed_args["smagorinsky_li
 
 The possible model configurations flags are:
 - `UVW`: Applies the model to all spatial directions.
+- `UV`: Applies the model to the horizontal direction only.
+- `W`: Applies the model to the vertical direction only.
+- `UV_W`: Applies the model to the horizontal and vertical directions separately.
 """
 function get_smagorinsky_lilly_model(parsed_args)
     smag = parsed_args["smagorinsky_lilly"]
     isnothing(smag) && return nothing
     smag_symbol = Symbol(smag)
-    @assert smag_symbol in (:UVW,)
+    @assert smag_symbol in (:UVW, :UV, :W, :UV_W)
     return SmagorinskyLilly{smag_symbol}()
 end
 

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -248,13 +248,14 @@ Smagorinsky-Lilly eddy viscosity model.
 - `:UVW` (all axes)
 - `:UV` (horizontal axes)
 - `:W` (vertical axis)
+- `:UV_W` (horizontal and vertical axes treated separately).
 """
 struct SmagorinskyLilly{AXES} <: AbstractEddyViscosityModel end
 
 """
     is_smagorinsky_UVW_coupled(model)
 
-Check if the Smagorinsky model is coupled in all directions.
+Check if the Smagorinsky model is coupled along all axes.
 """
 is_smagorinsky_UVW_coupled(::SmagorinskyLilly{AXES}) where {AXES} = AXES == :UVW
 is_smagorinsky_UVW_coupled(::Nothing) = false
@@ -262,23 +263,23 @@ is_smagorinsky_UVW_coupled(::Nothing) = false
 """
     is_smagorinsky_vertical(model)
 
-Check if the Smagorinsky model is applied in the vertical direction.
+Check if the Smagorinsky model is applied along the vertical axis.
 
 See also [`is_smagorinsky_horizontal`](@ref).
 """
 is_smagorinsky_vertical(::SmagorinskyLilly{AXES}) where {AXES} =
-    AXES == :UVW
+    AXES == :UVW || AXES == :W || AXES == :UV_W
 is_smagorinsky_vertical(::Nothing) = false
 
 """
     is_smagorinsky_horizontal(model)
 
-Check if the Smagorinsky model is applied in the horizontal directions.
+Check if the Smagorinsky model is applied along the horizontal axes.
 
 See also [`is_smagorinsky_vertical`](@ref).
 """
 is_smagorinsky_horizontal(::SmagorinskyLilly{AXES}) where {AXES} =
-    AXES == :UVW
+    AXES == :UVW || AXES == :UV || AXES == :UV_W
 is_smagorinsky_horizontal(::Nothing) = false
 
 struct AnisotropicMinimumDissipation{FT} <: AbstractEddyViscosityModel


### PR DESCRIPTION
This pull request extends the configurability of the Smagorinsky-Lilly turbulence model by allowing users to specify whether the model should be applied in the horizontal direction only, vertical direction only, both together, or each separately. This enhancement is reflected in configuration options, documentation, and the underlying implementation.

**Smagorinsky-Lilly model configurability:**

* Added support for new configuration options for the Smagorinsky-Lilly model: `UV` (horizontal only), `W` (vertical only), and `UV_W` (horizontal and vertical treated separately), in addition to the existing `UVW` (all directions). (`config/default_configs/default_config.yml`, `src/solver/model_getters.jl`, `src/solver/types.jl`) [[1]](diffhunk://#diff-a507a5b1b0f8375040a7694778c1ce9ad5ec72a4465b76b7ba5d2aa693dcb574L173-R173) [[2]](diffhunk://#diff-ab240b0d863b064ad1bd28f7844952c3809af57b3424ed31794a4835f6349e47R179-R187) [[3]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66R249-R251)
* Updated the assertion in `get_smagorinsky_lilly_model` to allow the new configuration symbols. (`src/solver/model_getters.jl`)
* Improved documentation for the Smagorinsky-Lilly model to describe all possible configuration flags and their effects. (`src/solver/model_getters.jl`, `src/solver/types.jl`) [[1]](diffhunk://#diff-ab240b0d863b064ad1bd28f7844952c3809af57b3424ed31794a4835f6349e47R179-R187) [[2]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66R249-R251)

**Implementation logic:**

* Updated logic in `set_smagorinsky_lilly_precomputed_quantities!` to correctly compute horizontal and vertical length scales (`ᶜL_h`, `ᶜL_v`) depending on the chosen model configuration. (`src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl`)
* Modified the `is_smagorinsky_vertical` and `is_smagorinsky_horizontal` helper functions to recognize the new configuration options. (`src/solver/types.jl`) [[1]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66L268-R271) [[2]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66L279-R282)