### PR TITLE
ADD emdfx_tracer_upwinding flag, set it to first_order

### DIFF
--- a/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
@@ -6,7 +6,6 @@ turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 rayleigh_sponge: true
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "PiGroups"

--- a/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
@@ -7,7 +7,6 @@ implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 1
-edmfx_upwinding: "first_order"
 rayleigh_sponge: true
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "PiGroups"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -166,7 +166,7 @@ hyperdiff:
 amd_les:
   help: "AMD LES closure [`true`, `false` (default)]"
   value: false
-c_amd: 
+c_amd:
   help: "Model coefficient for AMD-LES closure (TODO: Move to parameters.toml)"
   value: 0.29
 smagorinsky_lilly:
@@ -238,7 +238,7 @@ viscous_sponge:
 tracer_upwinding:
   help: "Tracer upwinding mode [`none`, `first_order` , `third_order`, `boris_book`, `zalesak`, `vanleer_limiter` (default)]"
   value: vanleer_limiter
-energy_upwinding:
+energy_q_tot_upwinding:
   help: "Energy upwinding mode [`none`, `first_order` , `third_order`, `boris_book`, `zalesak`, `vanleer_limiter` (default)]"
   value: vanleer_limiter
 orographic_gravity_wave:
@@ -390,9 +390,12 @@ edmfx_entr_model:
 edmfx_detr_model:
   help: "EDMFX detrainment closure.  [`nothing` (default), `PiGroups`, `Generalized`]"
   value: ~
-edmfx_upwinding:
-  help: "EDMFX upwinding mode [`none` (default), `first_order`, `third_order`]"
-  value: none
+edmfx_mse_q_tot_upwinding:
+  help: "EDMFX upwinding mode [`none`, `first_order` (default), `third_order`]"
+  value: first_order
+edmfx_tracer_upwinding:
+  help: "EDMFX tracer upwinding mode [`none`, `first_order` (default)]"
+  value: first_order
 edmfx_sgsflux_upwinding:
   help: "EDMFX SGS mass flux upwinding mode [`none` (default), `first_order`, `third_order`]"
   value: none

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -13,7 +13,6 @@ prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05",
 surface_setup: "DefaultMoninObukhov"
 turbconv: "diagnostic_edmfx"
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -8,7 +8,6 @@ dt_cloud_fraction: "1hours"
 surface_setup: "DefaultMoninObukhov"
 turbconv: "diagnostic_edmfx"
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_0M.yml
@@ -14,7 +14,6 @@ dt_cloud_fraction: "1hours"
 surface_setup: "DefaultMoninObukhov"
 turbconv: "prognostic_edmfx"
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -5,7 +5,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: diagnostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -4,7 +4,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: diagnostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -7,7 +7,6 @@ turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_stretched_box.yml
@@ -7,7 +7,6 @@ turbconv: "diagnostic_edmfx"
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -7,7 +7,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_explicit_box.yml
@@ -5,7 +5,6 @@ rad: DYCOMS
 surface_setup: DYCOMS_RF01
 turbconv: diagnostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -4,10 +4,10 @@ scm_coriolis: DYCOMS_RF02
 rad: DYCOMS
 surface_setup: DYCOMS_RF02
 turbconv: diagnostic_edmfx
+tracer_upwinding: first_order
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
+++ b/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
@@ -23,7 +23,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -5,7 +5,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -3,10 +3,10 @@ subsidence: Rico
 ls_adv: Rico
 surface_setup: Rico
 turbconv: diagnostic_edmfx
+tracer_upwinding: first_order
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -2,10 +2,10 @@ initial_condition: TRMM_LBA
 rad: TRMM_LBA
 surface_setup: TRMM_LBA
 turbconv: diagnostic_edmfx
+tracer_upwinding: first_order
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -5,7 +5,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -6,7 +6,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_adv_test_column.yml
+++ b/config/model_configs/prognostic_edmfx_adv_test_column.yml
@@ -1,7 +1,6 @@
 initial_condition: "MoistAdiabaticProfileEDMFX"
 advection_test: true
 turbconv: "prognostic_edmfx"
-edmfx_upwinding: "first_order"
 config: "column"
 moist: "equil"
 z_max: 5.5e4

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -8,7 +8,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
@@ -10,7 +10,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -10,7 +10,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
@@ -10,7 +10,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
@@ -10,7 +10,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
@@ -10,7 +10,6 @@ rad: clearsky
 co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/prognostic_edmfx_bomex_box.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_box.yml
@@ -8,7 +8,6 @@ implicit_diffusion: true
 implicit_sgs_advection: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -7,7 +7,6 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
@@ -15,7 +15,6 @@ max_newton_iters_ode: 3
 use_auto_jacobian: true
 update_jacobian_every: dt
 debug_jacobian: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
@@ -4,7 +4,6 @@ scm_coriolis: "Bomex"
 ls_adv: "Bomex"
 surface_setup: "Bomex"
 turbconv: "prognostic_edmfx"
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -12,7 +12,6 @@ implicit_sgs_vertdiff: true
 implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_pigroup_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_pigroup_column.yml
@@ -4,7 +4,6 @@ scm_coriolis: "Bomex"
 ls_adv: "Bomex"
 surface_setup: "Bomex"
 turbconv: "prognostic_edmfx"
-edmfx_upwinding: first_order
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "PiGroups"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_stretched_column.yml
@@ -7,7 +7,6 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -18,10 +18,7 @@ implicit_sgs_nh_pressure: true
 implicit_sgs_vertdiff: false
 
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_sgsflux_upwinding: first_order
-tracer_upwinding: vanleer_limiter
-energy_upwinding: vanleer_limiter
 rayleigh_sponge: true
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "PiGroups"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -7,7 +7,6 @@ turbconv: prognostic_edmfx
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -4,9 +4,9 @@ scm_coriolis: DYCOMS_RF02
 rad: DYCOMS
 surface_setup: DYCOMS_RF02
 turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
 implicit_diffusion: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column_sparse_autodiff.yml
@@ -4,6 +4,7 @@ scm_coriolis: DYCOMS_RF02
 rad: DYCOMS
 surface_setup: DYCOMS_RF02
 turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: true
 implicit_sgs_entr_detr: true
@@ -15,7 +16,6 @@ max_newton_iters_ode: 3
 use_auto_jacobian: true
 update_jacobian_every: dt
 debug_jacobian: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -5,7 +5,6 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
@@ -13,7 +13,6 @@ max_newton_iters_ode: 3
 use_auto_jacobian: true
 update_jacobian_every: dt
 debug_jacobian: true
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -7,7 +7,6 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 rayleigh_sponge: true
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -3,10 +3,10 @@ subsidence: "Rico"
 ls_adv: "Rico"
 surface_setup: "Rico"
 turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_rico_column_2M.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column_2M.yml
@@ -3,10 +3,10 @@ subsidence: "Rico"
 ls_adv: "Rico"
 surface_setup: "Rico"
 turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
@@ -3,6 +3,7 @@ subsidence: "Rico"
 ls_adv: "Rico"
 surface_setup: "Rico"
 turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: true
 implicit_sgs_entr_detr: true
@@ -10,7 +11,6 @@ implicit_nh_pressure: true
 implicit_sgs_vertdiff: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -6,7 +6,6 @@ implicit_diffusion: false
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "SmoothArea"
 edmfx_sgs_mass_flux: false

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -6,7 +6,6 @@ implicit_diffusion: true
 implicit_sgs_advection: true
 implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
-edmfx_upwinding: "first_order"
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "SmoothArea"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -3,10 +3,10 @@ initial_condition: TRMM_LBA
 rad: TRMM_LBA
 surface_setup: TRMM_LBA
 turbconv: prognostic_edmfx
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -10,7 +10,6 @@ implicit_sgs_vertdiff: true
 implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
-edmfx_upwinding: first_order
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "SmoothArea"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_trmm_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_sparse_autodiff.yml
@@ -2,6 +2,7 @@ initial_condition: TRMM_LBA
 rad: TRMM_LBA
 surface_setup: TRMM_LBA
 turbconv: prognostic_edmfx
+tracer_upwinding: first_order
 implicit_diffusion: true
 implicit_sgs_advection: true
 implicit_sgs_entr_detr: true
@@ -13,7 +14,6 @@ max_newton_iters_ode: 3
 use_auto_jacobian: true
 update_jacobian_every: dt
 debug_jacobian: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_sgs_mass_flux: true

--- a/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
+++ b/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
@@ -9,10 +9,7 @@ turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
-edmfx_upwinding: first_order
 edmfx_sgsflux_upwinding: first_order
-tracer_upwinding: vanleer_limiter
-energy_upwinding: vanleer_limiter
 rayleigh_sponge: true
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "PiGroups"

--- a/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_box_diagnostic_edmfx.yml
@@ -8,7 +8,6 @@ turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -5,7 +5,6 @@ co2_model: fixed
 turbconv: diagnostic_edmfx
 insolation: rcemipii
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/perf_configs/bm_aquaplanet_diagedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_diagedmf.yml
@@ -11,7 +11,6 @@ dt_rad: 1hours
 dt_cloud_fraction: 1hours
 turbconv: diagnostic_edmfx
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -17,7 +17,6 @@ dt_cloud_fraction: 1hours
 turbconv: prognostic_edmfx
 max_newton_iters_ode: 3
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
@@ -20,7 +20,6 @@ dt_cloud_fraction: 1hours
 turbconv: prognostic_edmfx
 max_newton_iters_ode: 3
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
@@ -21,7 +21,6 @@ dt_cloud_fraction: 1hours
 turbconv: prognostic_edmfx
 max_newton_iters_ode: 3
 prognostic_tke: true
-edmfx_upwinding: first_order
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -39,7 +39,7 @@ function edmfx_sgs_mass_flux_tendency!(
 )
 
     n = n_mass_flux_subdomains(turbconv_model)
-    (; edmfx_sgsflux_upwinding, tracer_upwinding) = p.atmos.numerics
+    (; edmfx_sgsflux_upwinding, edmfx_tracer_upwinding) = p.atmos.numerics
     (; ᶠu³) = p.precomputed
     (; ᶠu³ʲs, ᶜKʲs, ᶜρʲs) = p.precomputed
     (; ᶠu³⁰, ᶜK⁰, ᶜts⁰, ᶜts) = p.precomputed
@@ -153,7 +153,7 @@ function edmfx_sgs_mass_flux_tendency!(
                         ᶠu³ʲs.:($j),
                         ᶜa_scalar,
                         dt,
-                        tracer_upwinding,
+                        edmfx_tracer_upwinding,
                     )
                     ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
                     @. ᶜρχₜ += vtt
@@ -172,7 +172,7 @@ function edmfx_sgs_mass_flux_tendency!(
                     ᶠu³⁰,
                     ᶜa_scalar,
                     dt,
-                    tracer_upwinding,
+                    edmfx_tracer_upwinding,
                 )
                 ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
                 @. ᶜρχₜ += vtt
@@ -194,7 +194,7 @@ function edmfx_sgs_mass_flux_tendency!(
     turbconv_params = CAP.turbconv_params(p.params)
     a_max = CAP.max_area(turbconv_params)
     n = n_mass_flux_subdomains(turbconv_model)
-    (; edmfx_sgsflux_upwinding, tracer_upwinding) = p.atmos.numerics
+    (; edmfx_sgsflux_upwinding, edmfx_tracer_upwinding) = p.atmos.numerics
     (; ᶠu³) = p.precomputed
     (; ᶜρaʲs, ᶜρʲs, ᶠu³ʲs, ᶜKʲs, ᶜmseʲs, ᶜq_totʲs, ᶜts) = p.precomputed
     (; dt) = p
@@ -305,7 +305,7 @@ function edmfx_sgs_mass_flux_tendency!(
                         ᶠu³ʲs.:($j),
                         ᶜa_scalar,
                         dt,
-                        tracer_upwinding,
+                        edmfx_tracer_upwinding,
                     )
                     ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
                     @. ᶜρχₜ += vtt

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -729,7 +729,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
             (; ᶜgradᵥ_ᶠΦ) = p.core
             (; ᶜρʲs, ᶠu³ʲs, ᶜtsʲs, ᶜKʲs, bdmr_l, bdmr_r, bdmr) = p.precomputed
             is_third_order =
-                p.atmos.numerics.edmfx_upwinding == Val(:third_order)
+                p.atmos.numerics.edmfx_mse_q_tot_upwinding == Val(:third_order)
             ᶠupwind = is_third_order ? ᶠupwind3 : ᶠupwind1
             ᶠset_upwind_bcs = Operators.SetBoundaryOperator(;
                 top = Operators.SetValue(zero(CT3{FT})),

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -195,14 +195,14 @@ function get_numerics(parsed_args, FT)
         parsed_args["test_dycore_consistency"] ? TestDycoreConsistency() :
         nothing
 
-    energy_upwinding = Val(Symbol(parsed_args["energy_upwinding"]))
+    energy_q_tot_upwinding = Val(Symbol(parsed_args["energy_q_tot_upwinding"]))
     tracer_upwinding = Val(Symbol(parsed_args["tracer_upwinding"]))
 
     # Compat
     if !(pkgversion(ClimaCore) ≥ v"0.14.22") &&
-       energy_upwinding == Val(:vanleer_limiter)
-        energy_upwinding = Val(:none)
-        @warn "energy_upwinding=vanleer_limiter is not supported for ClimaCore $(pkgversion(ClimaCore)), please upgrade. Setting energy_upwinding to :none"
+       energy_q_tot_upwinding == Val(:vanleer_limiter)
+        energy_q_tot_upwinding = Val(:none)
+        @warn "energy_q_tot_upwinding=vanleer_limiter is not supported for ClimaCore $(pkgversion(ClimaCore)), please upgrade. Setting energy_q_tot_upwinding to :none"
     end
     if !(pkgversion(ClimaCore) ≥ v"0.14.22") &&
        tracer_upwinding == Val(:vanleer_limiter)
@@ -210,9 +210,11 @@ function get_numerics(parsed_args, FT)
         @warn "tracer_upwinding=vanleer_limiter is not supported for ClimaCore $(pkgversion(ClimaCore)), please upgrade. Setting tracer_upwinding to :none"
     end
 
-    edmfx_upwinding = Val(Symbol(parsed_args["edmfx_upwinding"]))
+    edmfx_mse_q_tot_upwinding = Val(Symbol(parsed_args["edmfx_mse_q_tot_upwinding"]))
     edmfx_sgsflux_upwinding =
         Val(Symbol(parsed_args["edmfx_sgsflux_upwinding"]))
+    edmfx_tracer_upwinding =
+        Val(Symbol(parsed_args["edmfx_tracer_upwinding"]))
 
     limiter = parsed_args["apply_limiter"] ? CA.QuasiMonotoneLimiter() : nothing
 
@@ -222,10 +224,11 @@ function get_numerics(parsed_args, FT)
     hyperdiff = get_hyperdiffusion_model(parsed_args, FT)
 
     numerics = AtmosNumerics(;
-        energy_upwinding,
+        energy_q_tot_upwinding,
         tracer_upwinding,
-        edmfx_upwinding,
+        edmfx_mse_q_tot_upwinding,
         edmfx_sgsflux_upwinding,
+        edmfx_tracer_upwinding,
         limiter,
         test_dycore_consistency = test_dycore,
         diff_mode,

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -348,7 +348,7 @@ end
 
 """
     ExternalDrivenTVForcing
-    
+
 Forcing specified by external forcing file.
 """
 struct ExternalDrivenTVForcing{FT}
@@ -511,13 +511,14 @@ struct SmoothMinimumBlending <: AbstractScaleBlendingMethod end
 struct HardMinimumBlending <: AbstractScaleBlendingMethod end
 Base.broadcastable(x::AbstractScaleBlendingMethod) = tuple(x)
 
-Base.@kwdef struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, TDC, LIM, DM, HD}
+Base.@kwdef struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, ED_TR_UP, TDC, LIM, DM, HD}
 
     """Enable specific upwinding schemes for specific equations"""
-    energy_upwinding::EN_UP
+    energy_q_tot_upwinding::EN_UP
     tracer_upwinding::TR_UP
-    edmfx_upwinding::ED_UP
+    edmfx_mse_q_tot_upwinding::ED_UP
     edmfx_sgsflux_upwinding::SG_UP
+    edmfx_tracer_upwinding::ED_TR_UP
 
     """Add NaNs to certain equations to track down problems"""
     test_dycore_consistency::TDC
@@ -773,9 +774,9 @@ end
 
 Create an AtmosModel with sensible defaults.
 
-This constructor provides sensible defaults for a minimal dry atmospheric model with full customization through keyword arguments. 
+This constructor provides sensible defaults for a minimal dry atmospheric model with full customization through keyword arguments.
 
-All model components are automatically organized into appropriate grouped sub-structs 
+All model components are automatically organized into appropriate grouped sub-structs
 internally:
 - [`AtmosWater`](@ref)
 - [`SCMSetup`](@ref)
@@ -804,9 +805,9 @@ model = AtmosModel()  # Creates a basic dry atmospheric model
 ```julia
 model = AtmosModel(;
     radiation_mode = HeldSuarezForcing(),
-    hyperdiff = ClimaHyperdiffusion(; 
-        ν₄_vorticity_coeff = 1e15, 
-        ν₄_scalar_coeff = 1e15, 
+    hyperdiff = ClimaHyperdiffusion(;
+        ν₄_vorticity_coeff = 1e15,
+        ν₄_scalar_coeff = 1e15,
         divergence_damping_factor = 1.0
     )
 )
@@ -866,7 +867,7 @@ Internal testing and calibration components for single-column setups:
 - `amd_les`: nothing or AnisotropicMinimumDissipation()
 
 ## AtmosGravityWave
-- `non_orographic_gravity_wave`: nothing or NonOrographicGravityWave()  
+- `non_orographic_gravity_wave`: nothing or NonOrographicGravityWave()
 - `orographic_gravity_wave`: nothing or OrographicGravityWave()
 
 ## AtmosSponge
@@ -879,13 +880,13 @@ Internal testing and calibration components for single-column setups:
 - `surface_albedo`: ConstantAlbedo(), RegressionFunctionAlbedo(), CouplerAlbedo()
 
 ## AtmosNumerics
-- `energy_upwinding`, `tracer_upwinding`, `edmfx_upwinding`, `edmfx_sgsflux_upwinding`: Val() upwinding schemes
+- `energy_q_tot_upwinding`, `tracer_upwinding`, `edmfx_mse_q_tot_upwinding`, `edmfx_sgsflux_upwinding`, `edmfx_tracer_upwinding`: Val() upwinding schemes
 - `test_dycore_consistency`: nothing or TestDycoreConsistency() for debugging
 - `limiter`: nothing or QuasiMonotoneLimiter()
 - `diff_mode`: Explicit(), Implicit() timestepping mode for diffusion
 - `hyperdiff`: nothing or ClimaHyperdiffusion()
 
-## Top-level Options  
+## Top-level Options
 - `vertical_diffusion`: nothing, VerticalDiffusion(), DecayWithHeightDiffusion()
 - `disable_surface_flux_tendency`: Bool
 """
@@ -964,10 +965,11 @@ const _DEFAULT_ATMOS_MODEL_KWARGS = (
     insolation = IdealizedInsolation(),
 
     # AtmosNumerics defaults
-    energy_upwinding = Val(:first_order),
-    tracer_upwinding = Val(:first_order),
-    edmfx_upwinding = Val(:first_order),
+    energy_q_tot_upwinding = Val(:vanleer_limiter),
+    tracer_upwinding = Val(:vanleer_limiter),
+    edmfx_mse_q_tot_upwinding = Val(:first_order),
     edmfx_sgsflux_upwinding = Val(:none),
+    edmfx_tracer_upwinding = Val(:first_order),
     test_dycore_consistency = nothing,
     limiter = nothing,
     diff_mode = Explicit(),


### PR DESCRIPTION
`vanleer_limiter` upwinding option does not compile on GPUs for microphysics tracers in EDMF. See https://github.com/CliMA/ClimaAtmos.jl/issues/4046

This PR tries to cleanup the logic of upwinding flags and give us different configuration options untill we solve the underlying GPU compiler issue.

For the atmos runs without EDMF we will now have `energy_q_tot_upwinding` and `tracer_upwinding`. They should both be set to `vanleer_limiter` unless there is a good reason not to.

For atmos runs with EDMF ideally we would do the same. But because right now we can't I have:
- `energy_q_tot_upwinding` set to `vanleer_limiter` but `tracer_upwinding` set to `first_order`
- `edmfx_mse_q_tot_upwinding` and `edmfx_tracer_upwinding` set to `first_order`.


One "behavioral change" is that `tracer_upwinding` was affecting `q_tot` and microphysics tracers on the grid mean. But from all our discussions it seems like we want to group energy and total water together. I don't think it should make any changes in behavior because those two flags are usually set to the same value anyway. 