### PR TITLE
Update entr and detr limits for negligible ar

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -445,9 +445,9 @@ weakdeps = ["CUDA"]
 
 [[deps.ClimaParams]]
 deps = ["Dates", "TOML"]
-git-tree-sha1 = "7571dccc41d8489d7fbb4773d243ba6abd8a8c8b"
+git-tree-sha1 = "d2381a8307acf02a94f62e0af39929e0b53f531c"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.ClimaReproducibilityTests]]
 deps = ["OrderedCollections", "PrettyTables"]

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-268
+269
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+269
+- Use the same time scale parameter for entrainment and detrainment when area fraction
+  is negligible
+
 268
 - Updated deps, specifically SurfaceFluxes.jl
 

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -39,6 +39,7 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, VFT1, VFT2} <: ATCP
     pressure_normalmode_drag_coeff::FT
     entr_inv_tau::FT
     entr_coeff::FT
+    entr_detr_limit_inv_tau::FT
     detr_inv_tau::FT
     detr_coeff::FT
     detr_buoy_coeff::FT

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -308,6 +308,7 @@ function TurbulenceConvectionParameters(
             :pressure_normalmode_buoy_coeff1,
         :detr_inv_tau => :detr_inv_tau,
         :entr_inv_tau => :entr_inv_tau,
+        :entr_detr_limit_inv_tau => :entr_detr_limit_inv_tau,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
     parameters = merge(parameters, overrides)

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -140,10 +140,11 @@ function entrainment(
 )
     FT = eltype(thermo_params)
     entr_inv_tau = CAP.entr_inv_tau(turbconv_params)
+    limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
     # Entrainment is not well-defined if updraft area is negligible.
-    # Fix at entr_inv_tau to ensure some mixing with the environment.
+    # Fix at limit_inv_tau to ensure some mixing with the environment.
     if ᶜaʲ <= eps(FT)
-        return entr_inv_tau
+        return limit_inv_tau
     end
 
     elev_above_sfc = ᶜz - z_sfc
@@ -212,11 +213,12 @@ function entrainment(
     min_area_limiter_scale = CAP.min_area_limiter_scale(turbconv_params)
     min_area_limiter_power = CAP.min_area_limiter_power(turbconv_params)
     a_min = CAP.min_area(turbconv_params)
+    limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
 
     # Entrainment is not well-defined if updraft area is negligible,
     # as some limiters depend on ᶜaʲ.
     if ᶜaʲ <= eps(FT) && min_area_limiter_scale == FT(0) # If no area and no base min_area_limiter
-        return entr_inv_tau
+        return limit_inv_tau
     end
 
     min_area_limiter =
@@ -387,13 +389,12 @@ function detrainment(
     ::PiGroupsDetrainment,
 )
     FT = eltype(thermo_params)
-    detr_inv_tau = CAP.detr_inv_tau(turbconv_params)
+    limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
 
-    # If ᶜρaʲ (updraft effective density) is zero or negligible, detrainment is 
-    # considered to be fixed at detr_inv_tau. This also protects division by ᶜρaʲ later.
-    # This condition implies the updraft area (ᶜaʲ) is also likely negligible.
-    if ᶜρaʲ <= eps(FT)
-        return detr_inv_tau
+    # If ᶜaʲ (updraft area fraction) is negligible, detrainment is considered
+    # to be fixed at limit_inv_tau. This also protects division by ᶜρaʲ later.
+    if ᶜaʲ <= eps(FT)
+        return limit_inv_tau
     end
 
     elev_above_sfc = ᶜz - z_sfc
@@ -467,11 +468,12 @@ function detrainment(
     max_area_limiter_scale = CAP.max_area_limiter_scale(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
     a_max = CAP.max_area(turbconv_params)
+    limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
 
-    # If ᶜρaʲ (updraft effective density) is zero or negligible, detrainment is not well defined.
-    # Fix at detr_inv_tau to ensure some mixing with the environment.
-    if ᶜρaʲ <= eps(FT)
-        return detr_inv_tau
+    # If ᶜaʲ (updraft area fraction) is negligible, detrainment is not well defined.
+    # Fix at limit_inv_tau to ensure some mixing with the environment.
+    if ᶜaʲ <= eps(FT)
+        return limit_inv_tau
     end
 
     max_area_limiter =
@@ -511,10 +513,10 @@ function detrainment(
     ::SmoothAreaDetrainment,
 )
     FT = eltype(thermo_params)
-    detr_inv_tau = CAP.detr_inv_tau(turbconv_params)
-    # If ᶜρaʲ is negligible detrainment is fixed at detr_inv_tau.
-    if (ᶜρaʲ <= eps(FT)) # Consistent check for ᶜρaʲ
-        detr = detr_inv_tau
+    limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
+    # If ᶜaʲ is negligible detrainment is fixed at limit_inv_tau.
+    if (ᶜaʲ <= eps(FT)) # Consistent check for ᶜaʲ
+        detr = limit_inv_tau
         # If vertical velocity divergence term is non-negative detrainment is zero.
     elseif (ᶜw_vert_div >= 0)
         detr = FT(0)

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -24,7 +24,6 @@ value = 0
 
 [detr_inv_tau]
 value = 0.0001
-# Set equal to entr_inv_tau to prevent spurious growth of ar at high altitudes (seen in single-column RICO)
 
 [detr_coeff]
 value = 0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Use the same time scale for both entrainment and detrainment when area fraction is negligible.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
