### PR TITLE
Improve tracer performance in jacobian update

### DIFF
--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -1,5 +1,6 @@
 using ClimaCore: Fields
 using ClimaCore.Utilities: half
+using ClimaCore.MatrixFields
 
 # Fields used to store variables that only need to be used in a single function
 # but cannot be computed on the fly. Unlike the precomputed quantities, these
@@ -62,6 +63,11 @@ function temporary_quantities(Y, atmos)
             NTuple{n_mass_flux_subdomains(atmos.turbconv_model), CT12{FT}},
             face_space,
         ), # ᶠω¹²ʲs
+        # TODO: better names for theis scratch fields
+        ᶜbidiagonal_adjoint_matrix_c3 = Fields.Field(
+            BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
+            center_space,
+        ),
         ᶠtemp_C123 = Fields.Field(C123{FT}, face_space), # χ₁₂₃
         ᶜtemp_UVW = Fields.Field(typeof(uvw_vec), center_space), # UVW(ᶜu)
         ᶠtemp_UVW = Fields.Field(typeof(uvw_vec), face_space), # UVW(ᶠu³)
@@ -76,6 +82,15 @@ function temporary_quantities(Y, atmos)
         ∂ᶜK_∂ᶠu₃ = similar(Y.c, BidiagonalMatrixRow{Adjoint{FT, CT3{FT}}}),
         ᶠp_grad_matrix = similar(Y.f, BidiagonalMatrixRow{C3{FT}}),
         ᶠbidiagonal_matrix_ct3 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
+        # TODO: better names for theis scratch fields
+        ᶠband_matrix_wvec = similar(
+            Y.f,
+            ClimaCore.MatrixFields.BandMatrixRow{
+                ClimaCore.Utilities.PlusHalf{Int64}(0),
+                1,
+                ClimaCore.Geometry.WVector{FT},
+            },
+        ),
         ᶠbidiagonal_matrix_ct3_2 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
         ᶜadvection_matrix = similar(
             Y.c,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Split up a high register pressure broadcast.

closes #4064 

## To-do
- measure sypd in more robust way
- decide if adding to scratch is OK, or if another scratch field could be used (while changing eltype of field)
## Content
It appears that just the broadcast is nearly seven times as fast after the change.


Sypd of numerics_sphere_he30ze63.yml and longrun_aquaplanet_allsky_1M.yml:

before: 0.429
after: 0.476

~11% speedup



BEFORE:
<img width="1286" height="338" alt="Screenshot 2025-10-24 at 11 13 43 AM" src="https://github.com/user-attachments/assets/3f1b4951-1425-4735-88e5-51354dc8d8b3" />


AFTER:
<img width="1555" height="540" alt="Screenshot 2025-10-24 at 11 13 58 AM" src="https://github.com/user-attachments/assets/df149ccc-0ac5-44e6-a073-0a7e1a33bebb" />

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
