### PR TITLE
rft: add face density method

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -216,6 +216,9 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     point_type = eltype(Fields.coordinate_field(Y.c))
     (; dt) = p
     ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶜρ = Y.c.ρ
+    ᶜρJ = @. lazy(ᶜρ * ᶜJ)
+    ᶠρJ = @. lazy(ᶠinterp(ᶜρJ))
     (; ᶜf³, ᶠf¹²) = p.core
     (; ᶜu, ᶠu³, ᶜK) = p.precomputed
     (; edmfx_mse_q_tot_upwinding) = n > 0 || advect_tke ? p.atmos.numerics : all_nothing
@@ -247,15 +250,13 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     end
     # Without the CT12(), the right-hand side would be a CT1 or CT2 in 2D space.
 
-    ᶜρ = Y.c.ρ
-
     # Full vertical advection of passive tracers (such as liq, rai, etc) with the
     # grid-mean flow. When EDMFX sgs_mass_flux is active, difference-form SGS
     # corrections ρᵏaᵏ(u³ᵏ - u³)(χᵏ - χ) are added on top of this in
     # edmfx_sgs_mass_flux_tendency!.
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
         if !(ρχ_name in (@name(ρe_tot), @name(ρq_tot)))
-            ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+            ᶜχ = @. lazy(specific(ᶜρχ, ᶜρ))
             vtt = vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, tracer_upwinding)
             @. ᶜρχₜ += vtt
         end
@@ -268,9 +269,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
 
     if isnothing(ᶠf¹²)
         # shallow atmosphere
-        @. Yₜ.c.uₕ -=
-            ᶜinterp(ᶠω¹² × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
-            (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.c.uₕ -= ᶜinterp(ᶠω¹² × (ᶠρJ * ᶠu³)) / ᶜρJ + (ᶜf³ + ᶜω³) × CT12(ᶜu)
         @. Yₜ.f.u₃ -= ᶠω¹² × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
@@ -279,9 +278,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         end
     else
         # deep atmosphere
-        @. Yₜ.c.uₕ -=
-            ᶜinterp((ᶠf¹² + ᶠω¹²) × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) /
-            (Y.c.ρ * ᶜJ) + (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.c.uₕ -= ᶜinterp((ᶠf¹² + ᶠω¹²) × (ᶠρJ * ᶠu³)) / ᶜρJ + (ᶜf³ + ᶜω³) × CT12(ᶜu)
         @. Yₜ.f.u₃ -= (ᶠf¹² + ᶠω¹²) × ᶠinterp(CT12(ᶜu)) + ᶠgradᵥ(ᶜK)
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
@@ -520,14 +517,15 @@ function updraft_sedimentation!(
     ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
     # use output as a scratch field
     ∂a∂z = vtt
-    @. ∂a∂z = ᶜprecipdivᵥ(ᶠinterp(ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(ᶜa)))
-    ᶠρ = @. p.scratch.ᶠtemp_scalar = ᶠinterp(ᶜρ * ᶜJ) / ᶠJ
+    @. ∂a∂z = ᶜprecipdivᵥ(ᶠinterp(ᶜJ) / ᶠJ * ᶠright_bias(WVec(ᶜa)))
+    ᶠρ = p.scratch.ᶠtemp_scalar
+    ᶠρ .= ᶠface_density(ᶜρ)
     ᶠwaχ = @. p.scratch.ᶠtemp_scalar_3 = ᶠright_bias(-(ᶜw) * ᶜa * ᶜχ)
     ᶠwχ = @. p.scratch.ᶠtemp_scalar_2 = ᶠright_bias(-(ᶜw) * ᶜχ)
     @. vtt = ifelse(
         ∂a∂z < 0,
-        -(ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwaχ))),
-        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwχ))),
+        -(ᶜprecipdivᵥ(ᶠρ * WVec(ᶠwaχ))),
+        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * WVec(ᶠwχ))),
     )
     return
 end

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -75,28 +75,22 @@ end
 # the implicit tendency function. Since dt >= dtγ, we can safely use dt for now.
 
 function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:none})
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(-(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠu³ * ᶠinterp(ᶜχ))))
+    ᶠρ = ᶠface_density(ᶜρ)
+    return @. lazy(-(ᶜadvdivᵥ(ᶠρ * ᶠu³ * ᶠinterp(ᶜχ))))
 end
 function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:first_order})
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(-(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠupwind1(ᶠu³, ᶜχ))))
+    ᶠρ = ᶠface_density(ᶜρ)
+    return @. lazy(-(ᶜadvdivᵥ(ᶠρ * ᶠupwind1(ᶠu³, ᶜχ))))
 end
 @static if pkgversion(ClimaCore) ≥ v"0.14.22"
     function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:vanleer_limiter})
-        ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-        ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-        return @. lazy(
-            -(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠlin_vanleer(ᶠu³, ᶜχ, dt))),
-        )
+        ᶠρ = ᶠface_density(ᶜρ)
+        return @. lazy(-(ᶜadvdivᵥ(ᶠρ * ᶠlin_vanleer(ᶠu³, ᶜχ, dt))))
     end
 end
 function vertical_transport(ᶜρ, ᶠu³, ᶜχ, dt, ::Val{:third_order})
-    ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ᶠJ = Fields.local_geometry_field(axes(ᶠu³)).J
-    return @. lazy(-(ᶜadvdivᵥ(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠupwind3(ᶠu³, ᶜχ))))
+    ᶠρ = ᶠface_density(ᶜρ)
+    return @. lazy(-(ᶜadvdivᵥ(ᶠρ * ᶠupwind3(ᶠu³, ᶜχ))))
 end
 
 vertical_advection(ᶠu³, ᶜχ, ::Val{:none}) =
@@ -110,8 +104,7 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     (; microphysics_model, turbconv_model, rayleigh_sponge) = p.atmos
     (; params, dt) = p
     n = n_mass_flux_subdomains(turbconv_model)
-    ᶜJ = Fields.local_geometry_field(axes(Y.c)).J
-    ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
+    ᶜρ, ᶠρ = Y.c.ρ, ᶠface_density(Y.c.ρ)
     (; ᶠgradᵥ_ᶜΦ) = p.core
     (; ᶠu³, ᶜp, ᶜh_tot, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
     thermo_params = CAP.thermodynamics_params(params)
@@ -123,18 +116,18 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     # boundaries, and the ρ row of the manual Jacobian is built from
     # ᶜadvdivᵥ_matrix(), so using ᶜadvdivᵥ here keeps the residual, the
     # boundary conditions, and the Jacobian consistent.
-    @. Yₜ.c.ρ -= ᶜadvdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠu³)
+    @. Yₜ.c.ρ -= ᶜadvdivᵥ(ᶠρ * ᶠu³)
 
     # Central vertical advection of active tracers (ρe_tot and ρq_tot).
     # The upwind correction is applied post-Newton via `T_post_imp!`
     # (see `correct_implicit_advection_tendency!`), so that the upwind
     # direction is taken with respect to the Newton-solved velocity rather
     # than the initial guess.
-    vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜh_tot, dt, Val(:none))
+    vtt = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, dt, Val(:none))
     @. Yₜ.c.ρe_tot += vtt
     if !(microphysics_model isa DryModel)
-        ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
-        vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜq_tot, dt, Val(:none))
+        ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, ᶜρ))
+        vtt = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, dt, Val(:none))
         @. Yₜ.c.ρq_tot += vtt
     end
 
@@ -144,65 +137,40 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     # using downward biasing and free outflow bottom boundary condition
     if microphysics_model isa NonEquilibriumMicrophysics
         (; ᶜwₗ, ᶜwᵢ) = p.precomputed
-        @. Yₜ.c.ρq_lcl -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwₗ)) * specific(Y.c.ρq_lcl, Y.c.ρ),
-            ),
-        )
-        @. Yₜ.c.ρq_icl -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwᵢ)) * specific(Y.c.ρq_icl, Y.c.ρ),
-            ),
-        )
+        @. Yₜ.c.ρq_lcl -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwₗ)) * specific(Y.c.ρq_lcl, ᶜρ)))
+        @. Yₜ.c.ρq_icl -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwᵢ)) * specific(Y.c.ρq_icl, ᶜρ)))
     end
     if microphysics_model isa
        NonEquilibriumMicrophysics1M
         (; ᶜwᵣ, ᶜwₛ) = p.precomputed
-        @. Yₜ.c.ρq_rai -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwᵣ)) * specific(Y.c.ρq_rai, Y.c.ρ),
-            ),
-        )
-        @. Yₜ.c.ρq_sno -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwₛ)) * specific(Y.c.ρq_sno, Y.c.ρ),
-            ),
-        )
+        @. Yₜ.c.ρq_rai -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwᵣ)) * specific(Y.c.ρq_rai, ᶜρ)))
+        @. Yₜ.c.ρq_sno -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwₛ)) * specific(Y.c.ρq_sno, ᶜρ)))
     end
     if microphysics_model isa
        NonEquilibriumMicrophysics2M
         (; ᶜwₙₗ, ᶜwₙᵣ, ᶜwᵣ, ᶜwₛ) = p.precomputed
-        @. Yₜ.c.ρn_lcl -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwₙₗ)) * specific(Y.c.ρn_lcl, Y.c.ρ),
-            ),
-        )
-        @. Yₜ.c.ρn_rai -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwₙᵣ)) * specific(Y.c.ρn_rai, Y.c.ρ),
-            ),
-        )
-        @. Yₜ.c.ρq_rai -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwᵣ)) * specific(Y.c.ρq_rai, Y.c.ρ),
-            ),
-        )
-        @. Yₜ.c.ρq_sno -= ᶜprecipdivᵥ(
-            ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠright_bias(
-                Geometry.WVector(-(ᶜwₛ)) * specific(Y.c.ρq_sno, Y.c.ρ),
-            ),
-        )
+        @. Yₜ.c.ρn_lcl -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwₙₗ)) * specific(Y.c.ρn_lcl, ᶜρ)))
+        @. Yₜ.c.ρn_rai -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwₙᵣ)) * specific(Y.c.ρn_rai, ᶜρ)))
+        @. Yₜ.c.ρq_rai -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwᵣ)) * specific(Y.c.ρq_rai, ᶜρ)))
+        @. Yₜ.c.ρq_sno -=
+            ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜwₛ)) * specific(Y.c.ρq_sno, ᶜρ)))
     end
     if microphysics_model isa NonEquilibriumMicrophysics2MP3
-        (; ρ, ρn_ice, ρq_rim, ρb_rim) = Y.c
-        ᶜwnᵢ = @. lazy(Geometry.WVector(p.precomputed.ᶜwnᵢ))
-        ᶜwᵢ = @. lazy(Geometry.WVector(p.precomputed.ᶜwᵢ))
-        ᶠρ = @. lazy(ᶠinterp(ρ * ᶜJ) / ᶠJ)
+        (; ρn_ice, ρq_rim, ρb_rim) = Y.c
+        ᶜwnᵢ = @. lazy(WVec(p.precomputed.ᶜwnᵢ))
+        ᶜwᵢ = @. lazy(WVec(p.precomputed.ᶜwᵢ))
 
         # Note: `ρq_icl` is handled above, in `microphysics_model isa NonEquilibriumMicrophysics`
-        @. Yₜ.c.ρn_ice -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwnᵢ * specific(ρn_ice, ρ)))
-        @. Yₜ.c.ρq_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρq_rim, ρ)))
-        @. Yₜ.c.ρb_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρb_rim, ρ)))
+        @. Yₜ.c.ρn_ice -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwnᵢ * specific(ρn_ice, ᶜρ)))
+        @. Yₜ.c.ρq_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρq_rim, ᶜρ)))
+        @. Yₜ.c.ρb_rim -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(- ᶜwᵢ * specific(ρb_rim, ᶜρ)))
     end
 
     vertical_advection_of_water_tendency!(Yₜ, Y, p, t)

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -569,7 +569,7 @@ function update_advection_jacobian!(matrix, Y, p, dtγ, topography_flag)
     e_int_v0 = FT(CAP.e_int_v0(params))
     thermo_params = CAP.thermodynamics_params(params)
 
-    ᶜρ = Y.c.ρ
+    ᶜρ, ᶠρ = Y.c.ρ, ᶠface_density(Y.c.ρ)
     ᶜuₕ = Y.c.uₕ
     ᶠu₃ = Y.f.u₃
     ᶜJ = Fields.local_geometry_field(Y.c).J
@@ -595,8 +595,7 @@ function update_advection_jacobian!(matrix, Y, p, dtγ, topography_flag)
 
     @. ᶠp_grad_matrix = DiagonalMatrixRow(-1 / ᶠinterp(ᶜρ)) ⋅ ᶠgradᵥ_matrix()
 
-    @. ᶜadvection_matrix =
-        -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ)
+    @. ᶜadvection_matrix = -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠρ)
     @. p.scratch.ᶠbidiagonal_matrix_ct3xct12 =
         ᶠwinterp_matrix(ᶜJ * ᶜρ) ⋅ DiagonalMatrixRow(g³ʰ(ᶜgⁱʲ))
     if use_derivative(topography_flag)

--- a/src/prognostic_equations/water_advection.jl
+++ b/src/prognostic_equations/water_advection.jl
@@ -53,9 +53,6 @@ function vertical_advection_of_water_tendency!(Yₜ, Y, p, t)
     (; ᶜu, ᶜT) = p.precomputed
     thp = CAP.thermodynamics_params(params)
 
-    ᶜJ = Fields.local_geometry_field(Y.c).J
-    ᶠJ = Fields.local_geometry_field(Y.f).J
-
     microphysics_tracers = (
         (@name(ρq_lcl), @name(ᶜwₗ)),
         (@name(ρq_icl), @name(ᶜwᵢ)),
@@ -67,33 +64,23 @@ function vertical_advection_of_water_tendency!(Yₜ, Y, p, t)
         (name == @name(ρq_icl) || name == @name(ρq_sno)) ? TD.internal_energy_ice :
         nothing
 
-    ᶠρ = p.scratch.ᶠtemp_scalar
+    ᶠρ = ᶠface_density(Y.c.ρ)
     ᶜq = p.scratch.ᶜtemp_scalar
     vtt = p.scratch.ᶜtemp_scalar_2
-    @. ᶠρ = ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ
     MatrixFields.unrolled_foreach(microphysics_tracers) do (ρq_name, w_name)
         MatrixFields.has_field(Y.c, ρq_name) || return
 
         ᶜρq = MatrixFields.get_field(Y.c, ρq_name)
         ᶜw = MatrixFields.get_field(p.precomputed, w_name)
         @. ᶜq = specific(ᶜρq, Y.c.ρ)
-        @. vtt =
-            -1 * ᶜprecipdivᵥ(
-                ᶠρ * ᶠright_bias(
-                    Geometry.WVector(-(ᶜw)) * ᶜq,
-                ),
-            )
+        @. vtt = -1 * ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(-(ᶜw)) * ᶜq))
         @. Yₜ.c.ρ += vtt
         @. Yₜ.c.ρq_tot += vtt
 
         e_int_func = internal_energy_func(ρq_name)
         @. p.scratch.ᶜtemp_scalar_3 =
             -(ᶜw) * ᶜq * (e_int_func(thp, ᶜT) + ᶜΦ + $(Kin(ᶜw, ᶜu)))
-        @. Yₜ.c.ρe_tot -= ᶜprecipdivᵥ(
-            ᶠρ * ᶠright_bias(
-                Geometry.WVector(p.scratch.ᶜtemp_scalar_3),
-            ),
-        )
+        @. Yₜ.c.ρe_tot -= ᶜprecipdivᵥ(ᶠρ * ᶠright_bias(WVec(p.scratch.ᶜtemp_scalar_3)))
     end
 
     # For prognostic edmf, augment the energy tendencies with the additional energy contributions
@@ -146,14 +133,13 @@ function vertical_advection_of_water_tendency!(Yₜ, Y, p, t)
             @. p.scratch.ᶜtemp_scalar_3 =
                 e_int_func(thp, ᶜTʲs.:(1)) + $(Kin(ᶜwʲ, ᶜuʲ)) -
                 p.scratch.ᶜtemp_scalar_2
-            @. Yₜ.c.ρe_tot -=
-                ᶜprecipdivᵥ(
-                    ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ * ᶠright_bias(
-                        Geometry.WVector(-(ᶜwʲ)) *
-                        draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)) * ᶜqʲ *
-                        p.scratch.ᶜtemp_scalar_3,
-                    ),
-                )
+            ᶠρʲ = ᶠface_density(ᶜρʲs.:(1))
+            @. Yₜ.c.ρe_tot -= ᶜprecipdivᵥ(
+                ᶠρʲ * ᶠright_bias(
+                    WVec(-(ᶜwʲ)) * draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)) * ᶜqʲ *
+                    p.scratch.ᶜtemp_scalar_3,
+                ),
+            )
             # Environment correction: (e_int⁰ + Kin⁰) - (e_int + Kin). The
             # environment sedimentation velocity is not stored separately
             # (the environment mass flux is the residual ρqw - ρaʲqʲwʲ), so
@@ -164,13 +150,9 @@ function vertical_advection_of_water_tendency!(Yₜ, Y, p, t)
                 e_int_func(thp, ᶜT⁰) + $(Kin(ᶜw, ᶜu⁰)) -
                 p.scratch.ᶜtemp_scalar_2
             ᶜwaq⁰ = @. lazy((ᶜρq * ᶜw - Y.c.sgsʲs.:(1).ρa * ᶜqʲ * ᶜwʲ) / ᶜρ⁰)
+            ᶠρ⁰ = ᶠface_density(ᶜρ⁰)
             @. Yₜ.c.ρe_tot -=
-                ᶜprecipdivᵥ(
-                    ᶠinterp(ᶜρ⁰ * ᶜJ) / ᶠJ * ᶠright_bias(
-                        Geometry.WVector(-(ᶜwaq⁰)) *
-                        p.scratch.ᶜtemp_scalar_3,
-                    ),
-                )
+                ᶜprecipdivᵥ(ᶠρ⁰ * ᶠright_bias(WVec(-(ᶜwaq⁰)) * p.scratch.ᶜtemp_scalar_3))
         end
     end
 

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -286,6 +286,22 @@ function strain_rate_norm(S, axis = Geometry.UVWAxis())
 end
 
 """
+    ᶠface_density(ᶜρ)
+
+Compute the density at cell faces from the density at cell centers.
+
+This reconstruction satisfies a Jacobian-weighted average, see the definition in
+Eq. (104) in Section 5.6 of the dycore paper (Yatunin et al., 2025).
+"""
+function ᶠface_density(ᶜρ)
+    ᶠspace = Spaces.face_space(axes(ᶜρ))
+    ᶠJ = Fields.local_geometry_field(ᶠspace).J
+    ᶜJ = Fields.local_geometry_field(ᶜρ).J
+
+    @. lazy(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ)
+end
+
+"""
     g³³_field(space)
 
 Extracts the value of `g³³`, the 3rd component of the metric terms that convert


### PR DESCRIPTION
Add `ᶠface_density(ᶜρ)`, the Jacobian-weighted face density `ᶠinterp(ᶜρ * ᶜJ) / ᶠJ` (Eq. 104 of the dycore paper), and use it in the vertical advection, sedimentation, and manual sparse Jacobian routines instead of combining cell and face Jacobians and densities at each call site. Also add `WVec` and `UV` as shorthand for `Geometry.WVector` and `Geometry.UVVector` (`UV` has no call site in this PR).

Pure refactor: the substitutions are algebraically identical, so simulations are unaffected.

About two dozen sites use `ᶠinterp(ᶜρ)` without Jacobian weighting. Whether any of them should use `ᶠface_density` instead is left for discussion; such a change would affect results and must be applied to the tendency and the Jacobian together.
