### PR TITLE
rft: separate vertical and full strain

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -1376,8 +1376,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
     # TODO: Currently the shear production only includes vertical gradients
     ᶠu = p.scratch.ᶠtemp_C123
     @. ᶠu = C123(ᶠinterp(Y.c.uₕ)) + C123(ᶠu³)
-    ᶜstrain_rate = p.scratch.ᶜtemp_UVWxUVW
-    ᶜstrain_rate .= compute_strain_rate_center(ᶠu)
+    ᶜstrain_rate = compute_strain_rate_center_vertical(ᶠu)
     @. ᶜstrain_rate_norm = norm_sqr(ᶜstrain_rate)
 
     ρatke_flux_values = Fields.field_values(ρatke_flux)

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -451,8 +451,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     # TODO: Currently the shear production only includes vertical gradients
     ᶠu = p.scratch.ᶠtemp_C123
     @. ᶠu = C123(ᶠinterp(Y.c.uₕ)) + C123(ᶠu³)
-    ᶜstrain_rate = p.scratch.ᶜtemp_UVWxUVW
-    ᶜstrain_rate .= compute_strain_rate_center(ᶠu)
+    ᶜstrain_rate = compute_strain_rate_center_vertical(ᶠu)
     @. ᶜstrain_rate_norm = norm_sqr(ᶜstrain_rate)
 
     ρatke_flux_values = Fields.field_values(ρatke_flux)

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -499,8 +499,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
         end
 
         # Momentum diffusion
-        ᶠstrain_rate = p.scratch.ᶠtemp_UVWxUVW
-        ᶠstrain_rate .= compute_strain_rate_face(ᶜu⁰)
+        ᶠstrain_rate = compute_strain_rate_face_vertical(ᶜu⁰)
         @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(-(2 * ᶠρaK_u * ᶠstrain_rate)) / Y.c.ρ)
     end
     return nothing
@@ -625,8 +624,7 @@ function edmfx_sgs_diffusive_flux_tendency!(
         end
 
         # Momentum diffusion
-        ᶠstrain_rate = p.scratch.ᶠtemp_UVWxUVW
-        ᶠstrain_rate .= compute_strain_rate_face(ᶜu)
+        ᶠstrain_rate = compute_strain_rate_face_vertical(ᶜu)
         @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(-(2 * ᶠρaK_u * ᶠstrain_rate)) / Y.c.ρ)
     end
 

--- a/src/prognostic_equations/gm_sgs_closures.jl
+++ b/src/prognostic_equations/gm_sgs_closures.jl
@@ -84,8 +84,7 @@ NVTX.@annotate function compute_gm_mixing_length(Y, p)
     # TODO: move strain rate calculation to separate function
     ᶠu = p.scratch.ᶠtemp_C123
     @. ᶠu = C123(ᶠinterp(Y.c.uₕ)) + C123(ᶠu³)
-    ᶜstrain_rate = p.scratch.ᶜtemp_UVWxUVW
-    ᶜstrain_rate .= compute_strain_rate_center(ᶠu)
+    ᶜstrain_rate = compute_strain_rate_center_vertical(ᶠu)
     @. ᶜstrain_rate_norm = norm_sqr(ᶜstrain_rate)
 
     ᶜprandtl_nvec = p.scratch.ᶜtemp_scalar_2

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -104,8 +104,7 @@ function vertical_diffusion_boundary_layer_tendency!(
     end
 
     if !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
-        ᶠstrain_rate = p.scratch.ᶠtemp_UVWxUVW
-        ᶠstrain_rate .= compute_strain_rate_face(ᶜu)
+        ᶠstrain_rate = compute_strain_rate_face_vertical(ᶜu)
         @. Yₜ.c.uₕ -= C12(
             ᶜdivᵥ(-2 * ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠstrain_rate) / Y.c.ρ,
         ) # assumes ᶜK_u = ᶜK_h


### PR DESCRIPTION
This pull request refactors the computation of strain rate tensors throughout the codebase to clarify the distinction between vertical-only and full (vertical + horizontal) strain rate calculations. It introduces new, more explicit utility functions for these computations, updates all relevant usages to call the appropriate function, and adds improved documentation to guide future development.

Key changes include:

**Refactoring and API Improvements:**

* Introduced `compute_strain_rate_center_vertical` and `compute_strain_rate_face_vertical` functions to explicitly compute strain rate tensors using only vertical gradients, replacing the more generic `compute_strain_rate_center` and `compute_strain_rate_face` in all relevant locations. [[1]](diffhunk://#diff-a10d64c3d8b32e25ab8ccf092795daf458729f66806dea4194ed1587ce1e0bbaL85-R210) [[2]](diffhunk://#diff-c40362df68b4fff9a33bde60b63f84cdb1c323bb7e94236d6af305dae6d8e827L1379-R1379) [[3]](diffhunk://#diff-43813dbcf4657b2bc39334da18fb7f4df140e1bc0cff776af167a6ce029d9a33L454-R454) [[4]](diffhunk://#diff-2a4cb71f47cc00b2b728d951d7dc3da0061b2952d3d2e5291a150f02562efa8eL87-R87) [[5]](diffhunk://#diff-6211880f7b3bcc4739f6e2525b27f3fc9b4aa208fecf78e004f63c94669a29dfL502-R502) [[6]](diffhunk://#diff-6211880f7b3bcc4739f6e2525b27f3fc9b4aa208fecf78e004f63c94669a29dfL628-R627) [[7]](diffhunk://#diff-e3561a9af3ea9efb1a9df157311a7989580811ed8569202132564cef68e2ec30L107-R107)

* Added new functions `compute_strain_rate_center_full!` and `compute_strain_rate_face_full!` to compute the full strain rate tensor (including both vertical and horizontal gradients) at cell centers and faces, respectively, with detailed documentation and guidance for use.

**Documentation and Usability:**

* Expanded and clarified docstrings for all strain rate computation functions, making it clear which functions use only vertical gradients and which compute the full tensor, and providing usage notes and references for future developers.

* Added a new `strain_rate_norm` utility function to compute the norm of the strain rate tensor, with optional projection onto specific axes.

These changes improve code clarity, ensure correct usage of strain rate computations, and provide a stronger foundation for future development and maintenance.