### PR TITLE
Tr/kernel fission 1

### DIFF
--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -1,5 +1,8 @@
 using ClimaCore: Fields
 using ClimaCore.Utilities: half
+using ClimaCore.MatrixFields
+using ClimaCore
+import StaticArrays: SMatrix
 
 # Fields used to store variables that only need to be used in a single function
 # but cannot be computed on the fly. Unlike the precomputed quantities, these
@@ -35,6 +38,7 @@ function temporary_quantities(Y, atmos)
         ᶜtemp_scalar_3 = Fields.Field(FT, center_space),
         ᶜtemp_scalar_4 = Fields.Field(FT, center_space),
         ᶜtemp_scalar_5 = Fields.Field(FT, center_space),
+        ᶜtemp_scalar_6 = Fields.Field(FT, center_space),
         ᶠtemp_field_level = Fields.level(Fields.Field(FT, face_space), half),
         temp_field_level = Fields.level(Fields.Field(FT, center_space), 1),
         temp_field_level_2 = Fields.level(Fields.Field(FT, center_space), 1),
@@ -57,11 +61,16 @@ function temporary_quantities(Y, atmos)
         ᶜtemp_CT3 = Fields.Field(CT3{FT}, center_space), # ᶜω³, ᶜ∇Φ³
         ᶜtemp_CT123 = Fields.Field(CT123{FT}, center_space),
         ᶠtemp_CT3 = Fields.Field(CT3{FT}, face_space), # ᶠuₕ³
+        ᶠtemp_CT3_2 = Fields.Field(CT3{FT}, face_space),
         ᶠtemp_CT12 = Fields.Field(CT12{FT}, face_space), # ᶠω¹²
         ᶠtemp_CT12ʲs = Fields.Field(
             NTuple{n_mass_flux_subdomains(atmos.turbconv_model), CT12{FT}},
             face_space,
         ), # ᶠω¹²ʲs
+        ᶜbidiagonal_adjoint_matrix_c3 = Fields.Field(
+            BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
+            center_space,
+        ),
         ᶠtemp_C123 = Fields.Field(C123{FT}, face_space), # χ₁₂₃
         ᶜtemp_UVW = Fields.Field(typeof(uvw_vec), center_space), # UVW(ᶜu)
         ᶠtemp_UVW = Fields.Field(typeof(uvw_vec), face_space), # UVW(ᶠu³)
@@ -76,7 +85,30 @@ function temporary_quantities(Y, atmos)
         ∂ᶜK_∂ᶠu₃ = similar(Y.c, BidiagonalMatrixRow{Adjoint{FT, CT3{FT}}}),
         ᶠp_grad_matrix = similar(Y.f, BidiagonalMatrixRow{C3{FT}}),
         ᶠbidiagonal_matrix_ct3 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
+        ᶠband_matrix_wvec = similar(
+            Y.f,
+            ClimaCore.MatrixFields.BandMatrixRow{
+                ClimaCore.Utilities.PlusHalf{Int64}(0),
+                1,
+                ClimaCore.Geometry.WVector{FT},
+            },
+        ),
+        ᶠdiagonal_matrix_ct3xct3 = similar(
+            Y.f,
+            DiagonalMatrixRow{
+                ClimaCore.Geometry.AxisTensor{
+                    FT,
+                    2,
+                    Tuple{
+                        ClimaCore.Geometry.ContravariantAxis{(3,)},
+                        ClimaCore.Geometry.ContravariantAxis{(3,)},
+                    },
+                    SMatrix{1, 1, FT, 1},
+                },
+            },
+        ),
         ᶠbidiagonal_matrix_ct3_2 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
+        ᶜbidiagonal_matrix_scalar = similar(Y.c, BidiagonalMatrixRow{FT}),
         ᶜadvection_matrix = similar(
             Y.c,
             BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

closes #4092


## To-do

Make better names for intermediates. 

I made new scratch variables when old scratch vars could be used.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

For he16ze63 longrun_aquaplanet_allsky_progedmf_0M:
NSYS report shows that `update_jacobian` is responsible for 242 ms of the 498 ms that the current `step_u` takes on device.

Each call to `update_jacobian` currently takes 27 ms.

After these changes, each call takes 9 ms.

Expected change in step time = (256 + 242 * 0.33 )/(498) -1= -0.32 = 32% faster
Expected sypd improvement = (1/(256 + 242 * 0.33)) / (1/498) - 1 = .48 = 48% increase = 1/(1 + Expected change in step time)

SYPD before: 0.237
SYPD after: 0.162
SYPD improvement:  0.237/0.162 - 1 = 0.463 = 46% increase

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
