### PR TITLE
Expose ClimaParams strict option

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -289,6 +289,9 @@ subsidence:
 toml:
   help: "TOML file(s) used to override model parameters"
   value: []
+strict_params:
+  help: "Raise an error if any overridden parameters are unused."
+  value: true
 prognostic_tke:
   help: "A flag for prognostic TKE [`false` (default), `true`]"
   value: false

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -780,7 +780,7 @@ function get_simulation(config::AtmosConfig)
     CP.log_parameter_information(
         config.toml_dict,
         joinpath(output_dir, "$(job_id)_parameters.toml"),
-        strict = true,
+        strict = config.parsed_args["strict_params"],
     )
     YAML.write_file(joinpath(output_dir, "$job_id.yml"), config.parsed_args)
 


### PR DESCRIPTION
Expose ClimaParams strict option. Needed for running coupled runs with tomls containing both land and atmosphere parameters in ClimaCoupler.jl. 