### PR TITLE
chore: add show method for ColumnInterpolatableField

### DIFF
--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -48,6 +48,21 @@ struct ColumnInterpolatableField{F, D}
 end
 (f::ColumnInterpolatableField)(z) = Spaces.undertype(axes(f.f))(f.data(z))
 
+function Base.show(io::IO, x::ColumnInterpolatableField)
+    # Extract z grid from the wrapped column field
+    z = Fields.coordinate_field(x.f).z
+    nz = Spaces.nlevels(z)
+    zmin, zmax = extrema(z)
+    val_eltype = eltype(x.f)
+    # These are fixed by the constructor
+    interp_str = "Linear"
+    extrap_str = "Flat"
+    print(io,
+        "ColumnInterpolatableField(Nz=$nz, z∈[$zmin, $zmax], value_eltype=$val_eltype, ",
+        "interpolation=$interp_str, extrapolation=$extrap_str)",
+    )
+end
+
 import ClimaComms
 import ClimaCore.Domains as Domains
 import ClimaCore.Meshes as Meshes


### PR DESCRIPTION
Looks like:

```julia
ColumnInterpolatableField(Nz=101, z∈[0.0, 30000.0], value_eltype=Float32, interpolation=Linear, extrapolation=Flat)
```
instead of
```julia
ClimaAtmos.InitialConditions.ColumnInterpolatableField{ClimaCore.Fields.Field{ClimaCore.DataLayouts.VF{Float32, 101, Matrix{Float32}}, ClimaCore.Spaces.FiniteDifferenceSpace{ClimaCore.Grids.FiniteDifferenceGrid{ClimaCore.Topologies.IntervalTopology{ClimaComms.SingletonCommsContext{ClimaComms.CPUMultiThreaded}, ClimaCore.Meshes.IntervalMesh{ClimaCore.Meshes.Uniform, ClimaCore.Domains.IntervalDomain{ClimaCore.Geometry.ZPoint{Float32}, Tuple{Symbol, Symbol}}, LinRange{ClimaCore.Geometry.ZPoint{Float32}, Int64}, Nothing}, @NamedTuple{bottom::Int64, top::Int64}}, ClimaCore.Geometry.CartesianGlobalGeometry, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float32}, Float32, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}}, 100, Matrix{Float32}}, ClimaCore.DataLayouts.VF{ClimaCore.Geometry.LocalGeometry{(3,), ClimaCore.Geometry.ZPoint{Float32}, Float32, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.LocalAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.LocalAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.ContravariantAxis{(3,)}, ClimaCore.Geometry.ContravariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}, ClimaCore.Geometry.AxisTensor{Float32, 2, Tuple{ClimaCore.Geometry.CovariantAxis{(3,)}, ClimaCore.Geometry.CovariantAxis{(3,)}}, StaticArraysCore.SMatrix{1, 1, Float32, 1}}}, 101, Matrix{Float32}}}, ClimaCore.Grids.CellFace}}, Interpolations.Extrapolation{Float32, 1, Interpolations.GriddedInterpolation{Float32, 1, Vector{Float32}, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Tuple{Base.ReshapedArray{Float32, 1, SubArray{Float32, 2, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}, Tuple{}}}}, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Interpolations.Flat{Nothing}}}(Float32-valued Field:
  Float32[100700.0, 97312.2, 94005.9, 90780.3, 87650.3, 84613.5, 81667.1, 78808.9, 76036.4, 73347.2  …  1128.48, 1039.37, 955.709, 877.266, 803.806, 735.101, 670.932, 611.086, 555.356, 503.542], 101-element extrapolate(interpolate((reshape(view(::Matrix{Float32}, :, 1:1), 101),), ::Vector{Float32}, Gridded(Linear())), Flat()) with element type Float32:
 100700.0
  97312.24
  94005.86
  90780.266
  87650.336
  84613.47
  81667.14
  78808.91
  76036.38
  73347.25
  70739.26
  68210.21
  65757.98
      ⋮
   1431.0823
   1324.0808
   1223.3019
   1128.4825
   1039.3674
    955.7088
    877.266
    803.80554
    735.1008
    670.93207
    611.08606
    555.3561
    503.54172)
```