### PR TITLE
pedmf boundary conditions

### DIFF
--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -30,7 +30,7 @@ z_elem: 82
 z_stretch: false
 dz_bottom: 30
 dt: 150secs
-t_end: 6hours
+t_end: 12hours
 toml: [toml/prognostic_edmfx_implicit_scm_calibrated_5_cases_shallow_deep_v1.toml]
 netcdf_interpolation_num_points: [8, 8, 82]
 diagnostics:

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-275
+276
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+276
+- Update prognostic EDMF boundary conditions: apply equal surface fluxes to the
+  updraft and grid mean, and enable entrainment of buoyant air in the first cell.
+
 275
 - Change order of GPU calculations for better performance, but it
   results in slightly different floating point rounding.  Artifacts

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -556,9 +556,7 @@ NVTX.@annotate function set_explicit_precomputed_quantities_part1!(Y, p, t)
             ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts)))
     end
 
-    if turbconv_model isa PrognosticEDMFX
-        set_prognostic_edmf_precomputed_quantities_bottom_bc!(Y, p, t)
-    elseif turbconv_model isa DiagnosticEDMFX
+    if turbconv_model isa DiagnosticEDMFX
         set_diagnostic_edmf_precomputed_quantities_bottom_bc!(Y, p, t)
     elseif !(isnothing(turbconv_model))
         # Do nothing for other turbconv models for now

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -206,6 +206,7 @@ end
 Apply EDMF filters:
  - Relax u_3 to zero when it is negative
  - Relax ρa to zero when it is negative
+ - Relax ρa to ρ when a is larger than one
 
 This function modifies the tendency `Yₜ` in place based on the current state `Y`,
 parameters `p`, time `t`, and the turbulence convection model `turbconv_model`.
@@ -225,6 +226,8 @@ function edmfx_filter_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMFX)
             @. Yₜ.f.sgsʲs.:($$j).u₃ -=
                 C3(min(Y.f.sgsʲs.:($$j).u₃.components.data.:1, 0)) / FT(dt)
             @. Yₜ.c.sgsʲs.:($$j).ρa -= min(Y.c.sgsʲs.:($$j).ρa, 0) / FT(dt)
+            @. Yₜ.c.sgsʲs.:($$j).ρa -=
+                max(Y.c.sgsʲs.:($$j).ρa - p.precomputed.ᶜρʲs.:($$j), 0) / FT(dt)
         end
     end
 end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -284,6 +284,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     if p.atmos.sgs_entr_detr_mode == Explicit()
         edmfx_entr_detr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
+    edmfx_first_interior_entr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     if p.atmos.sgs_mf_mode == Explicit()
         edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR updates the treatment of boundary conditions for prognostic EDMF:
1- Apply surface fluxes to both grid-mean and updraft fields equally.
2- Seed a small updraft area fraction in the first cell when the surface buoyancy flux is positive, allowing it to grow even if initially zero.
3- Instead of overwriting the first-cell area fraction, increase the entrainment rate when buoyancy flux is positive, ensuring the area reaches the prescribed value in one timestep. This ensures that tracer masses are conserved.
4- Instead of overwriting mse and q_tot, assume a near-surface entrainment in the first cell, with tracer values of the entraining fluid provided by the function `sgs_scalar_first_interior_bc` (mean + perturbation).


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
