### PR TITLE
ci: JET v0.10, v0.11 in .buildkite compat

### DIFF
--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -40,11 +40,15 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
+[sources]
+ClimaAtmos = {path = ".."}
+PrecompileCI = {path = "PrecompileCI"}
+
 [compat]
 CairoMakie = "0.11 - 0.15"
 ClimaCoreSpectra = "0.1"
 ClimaCoreTempestRemap = "0.3"
-JET = "0.9"
+JET = "0.9, 0.10, 0.11"
 PrettyTables = "2"
 ProfileCanvas = "0.1"
 SnoopCompileCore = "3"


### PR DESCRIPTION
- this enables support for Julia v1.12
- retain JET v0.9 to support Julia v1.11
