### PR TITLE
rft: clean up surface code

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -496,13 +496,8 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
 
     # integral
     ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
 
     ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
 

--- a/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
+++ b/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
@@ -129,13 +129,8 @@ function horizontal_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipat
     @. Yₜ.f.u₃ -= C3(wdivₕ(ᶠρ * ᶠτ_amd) / ᶠρ)
 
     ## Total energy tendency
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     ∇h_tot = @. lazy(Geometry.project(axis_uvw, gradₕ(ᶜh_tot)))
     ∂̂h_tot = @. lazy(Δ_h * ∇h_tot)
     ᶜD_amd = @. ᶜtemp_scalar = max(
@@ -311,13 +306,8 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     @. Yₜ.f.u₃ -= C3(ᶠdivᵥ(Y.c.ρ * ᶜτ_amd) / ᶠρ)
 
     ## Total energy tendency
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     # TODO: Fix @lazy broadcast (components access)
     ∇h_tot = @. lazy(Geometry.project(axis_uvw, ᶠgradᵥ_scalar(ᶜh_tot)))
     ∂̂h_tot = @. lazy(ᶠΔ_z * ∇h_tot)

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -52,13 +52,8 @@ NVTX.@annotate function horizontal_dynamics_tendency!(Yₜ, Y, p, t)
         end
     end
 
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     @. Yₜ.c.ρe_tot -= wdivₕ(Y.c.ρ * ᶜh_tot * ᶜu)
 
     if p.atmos.turbconv_model isa PrognosticEDMFX
@@ -297,13 +292,8 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     # ... and upwinding correction of energy and total water.
     # (The central advection of energy and total water is done implicitly.)
     if energy_q_tot_upwinding != Val(:none)
-        ᶜh_tot = @. lazy(
-            TD.total_specific_enthalpy(
-                thermo_params,
-                ᶜts,
-                specific(Y.c.ρe_tot, Y.c.ρ),
-            ),
-        )
+        ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+        ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
         vtt = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, dt, energy_q_tot_upwinding)
         vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, dt, Val(:none))
         @. Yₜ.c.ρe_tot += vtt - vtt_central

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -637,13 +637,8 @@ function edmfx_first_interior_entr_tendency!(
         Fields.local_geometry_field(Fields.level(Y.f, Fields.half)),
     )
 
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     ᶜh_tot_int_val = Fields.field_values(Fields.level(ᶜh_tot, 1))
     ᶜK_int_val = Fields.field_values(Fields.level(ᶜK, 1))
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -57,13 +57,8 @@ function edmfx_sgs_mass_flux_tendency!(
         # [best after removal of precomputed quantities]
         ᶠu³_diff = p.scratch.ᶠtemp_CT3
         ᶜa_scalar = p.scratch.ᶜtemp_scalar
-        ᶜh_tot = @. lazy(
-            TD.total_specific_enthalpy(
-                thermo_params,
-                ᶜts,
-                specific(Y.c.ρe_tot, Y.c.ρ),
-            ),
-        )
+        ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+        ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
         for j in 1:n
             @. ᶠu³_diff = ᶠu³ʲs.:($$j) - ᶠu³
             @. ᶜa_scalar =
@@ -202,13 +197,8 @@ function edmfx_sgs_mass_flux_tendency!(
     if p.atmos.edmfx_model.sgs_mass_flux isa Val{true}
         thermo_params = CAP.thermodynamics_params(p.params)
         # energy
-        ᶜh_tot = @. lazy(
-            TD.total_specific_enthalpy(
-                thermo_params,
-                ᶜts,
-                specific(Y.c.ρe_tot, Y.c.ρ),
-            ),
-        )
+        ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+        ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
         ᶠu³_diff = p.scratch.ᶠtemp_CT3
         ᶜa_scalar = p.scratch.ᶜtemp_scalar
         for j in 1:n
@@ -422,13 +412,8 @@ function edmfx_sgs_diffusive_flux_tendency!(
             top = Operators.SetValue(C3(FT(0))),
             bottom = Operators.SetValue(C3(FT(0))),
         )
-        ᶜh_tot = @. lazy(
-            TD.total_specific_enthalpy(
-                thermo_params,
-                ᶜts,
-                specific(Y.c.ρe_tot, Y.c.ρ),
-            ),
-        )
+        ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+        ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
         @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠρaK_h * ᶠgradᵥ(ᶜh_tot)))
 
         if use_prognostic_tke(turbconv_model)

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -354,13 +354,8 @@ function external_forcing_tendency!(
     @. ᶜuₕ_nudge = C12(Geometry.UVVector(ᶜu_nudge, ᶜv_nudge), ᶜlg)
     @. Yₜ.c.uₕ -= (Y.c.uₕ - ᶜuₕ_nudge) * ᶜinv_τ_wind
 
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     # nudging tendency
     ᶜdTdt_nudging = p.scratch.ᶜtemp_scalar
     ᶜdqtdt_nudging = p.scratch.ᶜtemp_scalar_2

--- a/src/prognostic_equations/forcing/subsidence.jl
+++ b/src/prognostic_equations/forcing/subsidence.jl
@@ -99,13 +99,8 @@ function subsidence_tendency!(Yₜ, Y, p, t, ::Subsidence)
         subsidence_profile(ᶠz) * CT3(unit_basis_vector_data(CT3, ᶠlg))
 
     # LS Subsidence
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
     subsidence!(Yₜ.c.ρe_tot, Y.c.ρ, ᶠsubsidence³, ᶜh_tot, Val{:first_order}())
     subsidence!(Yₜ.c.ρq_tot, Y.c.ρ, ᶠsubsidence³, ᶜq_tot, Val{:first_order}())

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -115,13 +115,8 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     (; ᶠu³, ᶜp, ᶜts) = p.precomputed
     thermo_params = CAP.thermodynamics_params(params)
     cp_d = CAP.cp_d(params)
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
 
     @. Yₜ.c.ρ -= ᶜdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠu³)
 

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -147,13 +147,8 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     thermo_params = CAP.thermodynamics_params(params)
     (; ᶜp, sfc_conditions, ᶜts, ᶜK) = p.precomputed
 
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     vst_uₕ = viscous_sponge_tendency_uₕ(ᶜuₕ, viscous_sponge)
     vst_u₃ = viscous_sponge_tendency_u₃(ᶠu₃, viscous_sponge)
     vst_ρe_tot = viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, viscous_sponge)

--- a/src/prognostic_equations/surface_flux.jl
+++ b/src/prognostic_equations/surface_flux.jl
@@ -110,18 +110,12 @@ function surface_flux_tendency!(Yₜ, Y, p, t)
     thermo_params = CAP.thermodynamics_params(params)
 
     if !disable_momentum_vertical_diffusion(p.atmos.vertical_diffusion)
-        btt =
-            boundary_tendency_momentum(Y.c.ρ, Y.c.uₕ, sfc_conditions.ρ_flux_uₕ)
+        btt = boundary_tendency_momentum(Y.c.ρ, Y.c.uₕ, sfc_conditions.ρ_flux_uₕ)
         @. Yₜ.c.uₕ -= btt
     end
 
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
     btt = boundary_tendency_scalar(ᶜh_tot, sfc_conditions.ρ_flux_h_tot)
     @. Yₜ.c.ρe_tot -= btt
 

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -114,15 +114,9 @@ function vertical_diffusion_boundary_layer_tendency!(
         top = Operators.SetValue(C3(0)),
         bottom = Operators.SetValue(C3(0)),
     )
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
-    @. Yₜ.c.ρe_tot -=
-        ᶜdivᵥ_ρe_tot(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜh_tot)))
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
+    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜh_tot)))
 
     ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar_2
     ᶜK_h_scaled = p.scratch.ᶜtemp_scalar_3

--- a/src/surface_conditions/surface_state.jl
+++ b/src/surface_conditions/surface_state.jl
@@ -43,25 +43,9 @@ SurfaceState(;
     v::FTN5 = nothing,
     gustiness::FTN6 = nothing,
     beta::FTN7 = nothing,
-) where {
-    SFP <: SurfaceParameterization,
-    FTN1,
-    FTN2,
-    FTN3,
-    FTN4,
-    FTN5,
-    FTN6,
-    FTN7,
-} =
+) where {SFP <: SurfaceParameterization, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7} =
     SurfaceState{float_type(SFP), SFP, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7}(
-        parameterization,
-        T,
-        p,
-        q_vap,
-        u,
-        v,
-        gustiness,
-        beta,
+        parameterization, T, p, q_vap, u, v, gustiness, beta,
     )
 
 """
@@ -71,8 +55,7 @@ Container for heat fluxes
  - shf: Sensible heat flux
  - lhf: Latent heat flux
 """
-Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <:
-                   PrescribedFluxes{FT}
+Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     shf::FT
     lhf::FTN = nothing
 end
@@ -82,8 +65,7 @@ end
 
 Container for quantities used to calculate sensible and latent heat fluxes.
 """
-Base.@kwdef struct θAndQFluxes{FT, FTN <: Union{FT, Nothing}} <:
-                   PrescribedFluxes{FT}
+Base.@kwdef struct θAndQFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     θ_flux::FT
     q_flux::FTN = nothing
 end
@@ -133,11 +115,8 @@ struct MoninObukhov{
 end
 
 function MoninObukhov(;
-    z0 = nothing,
-    z0m = nothing,
-    z0b = nothing,
-    fluxes = nothing,
-    ustar = nothing,
+    z0 = nothing, z0m = nothing, z0b = nothing,
+    fluxes = nothing, ustar = nothing,
 )
     if !isnothing(z0)
         if isnothing(z0m) && isnothing(z0b)

--- a/src/utils/variable_manipulations.jl
+++ b/src/utils/variable_manipulations.jl
@@ -437,13 +437,8 @@ function ᶜspecific_env_mse(Y, p)
     turbconv_model = p.atmos.turbconv_model
     (; ᶜK, ᶜts) = p.precomputed
     thermo_params = CAP.thermodynamics_params(p.params)
-    ᶜh_tot = @. lazy(
-        TD.total_specific_enthalpy(
-            thermo_params,
-            ᶜts,
-            specific(Y.c.ρe_tot, Y.c.ρ),
-        ),
-    )
+    ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
+    ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
 
     # grid-scale moist static energy density `ρ * mse`.
     ᶜρmse = @. lazy(Y.c.ρ * (ᶜh_tot - ᶜK))


### PR DESCRIPTION
This pull request primarily refactors and cleans up the code in the surface conditions and surface flux modules, focusing on improving readability and maintainability without changing core logic. The changes involve consolidating multi-line expressions into single lines, improving destructuring and broadcasting, and removing unnecessary variables. There are no significant algorithmic or behavioral changes.

Key refactoring and cleanup changes:

**Surface conditions module (`src/surface_conditions/surface_conditions.jl`):**
- Consolidated multi-line variable assignments and function calls into single lines throughout, improving readability [[1]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L25-R30) [[2]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L100-R92) [[3]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L113-R102) [[4]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L140-R128) [[5]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L182-R168) [[6]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L193-R178) [[7]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L219-R200) [[8]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L234-R216) [[9]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L250-R228) [[10]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L305-R281) [[11]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L325-R303) [[12]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L459-R409).
- Improved destructuring of external forcing inputs for clarity.
- Used `cospi` for surface temperature calculation, simplifying trigonometric expressions.
- Removed unused variables and unnecessary comments for conciseness.
- Cleaned up struct construction and field assignment for surface conditions [[1]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L493-R443) [[2]](diffhunk://#diff-114b793ba758c79301c98a4931b2b71e3b6a9e691b39fd85870693d2cc635760L427-R393).

**Surface state module (`src/surface_conditions/surface_state.jl`):**
- Reformatted struct definitions and constructors to single lines for conciseness [[1]](diffhunk://#diff-eddb5efe356e217f120a6d12b850cad9dcd1dc05dbc8784f400af528b1dbe5ebL46-R48) [[2]](diffhunk://#diff-eddb5efe356e217f120a6d12b850cad9dcd1dc05dbc8784f400af528b1dbe5ebL74-R58) [[3]](diffhunk://#diff-eddb5efe356e217f120a6d12b850cad9dcd1dc05dbc8784f400af528b1dbe5ebL85-R68) [[4]](diffhunk://#diff-eddb5efe356e217f120a6d12b850cad9dcd1dc05dbc8784f400af528b1dbe5ebL136-R119).

**Surface flux tendency (`src/prognostic_equations/surface_flux.jl`):**
- Refactored calculation of total specific enthalpy for clarity and efficiency.

These changes are focused on code style and maintainability, making the codebase easier to read and modify without altering its functionality.