### PR TITLE
fix sgs mass flux of microphysics tracers in diagnostic edmf

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -258,7 +258,10 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
 
     # Full vertical advection of passive tracers (like liq, rai, etc) ...
     # If sgs_mass_flux is true, the advection term is computed from the sum of SGS fluxes
-    if p.atmos.edmfx_model.sgs_mass_flux isa Val{false}
+    if !(
+        p.atmos.turbconv_model isa PrognosticEDMFX &&
+        p.atmos.edmfx_model.sgs_mass_flux isa Val{true}
+    )
         foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
             if !(ρχ_name in (@name(ρe_tot), @name(ρq_tot)))
                 ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds back the grid-mean advection of microphysics tracers in diagnostic EDMF and uses the difference for sgs mass flux. Also removes the j loop for microphysics tracers as we always use the first updraft for the tracers, so it is a bit misleading.

Note: This is just one way to fix it. I chose this so it is similar to qt flux. But it is different from how we calculate flux in prognostic EDMF. We can change it to a different way if we think it is better.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
