### PR TITLE
Add RCEMIPII analytic sounding initial condition

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -168,6 +168,17 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: ":computer: CRM rcemipii in a box with 1M"
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $CONFIG_PATH/rcemipii_box_CRM_1M.yml
+          --job_id rcemipii_box_CRM_1M
+
+          julia --color=yes --project=.buildkite reproducibility_tests/test_mse.jl
+          --job_id rcemipii_box_CRM_1M
+          --out_dir rcemipii_box_CRM_1M/output_active
+        artifact_paths: "rcemipii_box_CRM_1M/output_active/*"
+
       - label: ":genie: LES ISDAC in a box"
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl

--- a/config/model_configs/rcemipii_box_CRM_1M.yml
+++ b/config/model_configs/rcemipii_box_CRM_1M.yml
@@ -1,0 +1,89 @@
+reference_job_id: les_box  # for plotting
+surface_setup: DefaultMoninObukhov
+surface_temperature: RCEMIPII
+insolation: rcemipii
+initial_condition: RCEMIPIIProfile_300
+config: box
+rad: allskywithclear
+co2_model: fixed
+approximate_linear_solve_iters: 2  # only valid when implicit_diffusion=true
+rayleigh_sponge: true  # set sponge level in toml file
+smagorinsky_lilly: "UV"
+implicit_diffusion: true
+
+reproducibility_test: true
+
+# Reference diffusion setup
+vert_diff: "DecayWithHeightDiffusion"
+hyperdiff: "false"
+
+# microphysics
+### !! 1M and 2M !!
+cloud_model: grid_scale   # Ultimately wanted when `moist: nonequil`
+moist: nonequil
+precip_model: 1M
+### spatial discretization ###
+x_max: 96000.0  # 96km
+y_max: 96000.0  # 96km
+# x_max: 6000000.0  # 6000km
+# y_max: 400000.0  # 400km
+z_max: 30000.0  # 30km
+nh_poly: 3  # hor. poly deg -> # quad pts in 1D in a h. elem is Nq = nh + 1
+# z_elem: 43  # Note: Set sponge height (`zd_viscous`) in toml file to cover top ~5 points
+z_elem: 86
+dz_bottom: 30.0
+
+#~8km grid
+x_elem: 4
+y_elem: 4
+dt: 10secs
+# ~4km grid
+# x_elem: 8
+# y_elem: 8
+# dt: 5secs
+# ~2km grid
+# x_elem: 16
+# y_elem: 16
+# dt: 2secs
+# ~1km grid
+# x_elem: 32
+# y_elem: 32
+# dt: 1secs
+
+t_end: 10hours
+# t_end: 2days
+# t_end: 1days
+# t_end: 21days
+
+## >> During debugging, reduce these as appropriate
+dt_save_state_to_disk: 1days
+dt_rad: 1hours  # same as `dt_save_state_to_disk` for reproducibility
+check_nan_every: 1024  # for debugging: set to check NaNs every `n` iterations
+log_to_file: true
+## <<
+
+toml: [toml/rcemipii_box.toml]
+
+# enable_diagnostics: false
+output_default_diagnostics: false  # adds various 1h diagnostics. Only use if `dt_save_state_to_disk` is a multiple of 1hr
+diagnostics:
+  - short_name: [
+      wa, ua, va, ta, thetaa, ha, # dynamics & thermodynamics
+      hus, hur, cl, clw, cli,  # liquid
+      pr,  # precipitation
+      ke,  # kinetic energy for spectrum
+      # Smagorinsky diagnostics
+      Dh_smag, strainh_smag,  # horizontal
+      # Dv_smag, strainv_smag,  # vertical
+      # DecayWithHeight diffusion coefficient
+      edt,
+    ]
+    # period: 10mins
+    period: 1hours
+  ## 1M microphsics
+  - short_name: [husra, hussn]
+    # period: 10mins
+    period: 1hours
+  # 2M microphysics
+  # - short_name: [cdnc, ncra]
+  #   period: 10mins

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -41,6 +41,7 @@ ClimaAtmos.InitialConditions.TRMM_LBA
 ClimaAtmos.InitialConditions.LifeCycleTan2018
 ClimaAtmos.InitialConditions.Bomex
 ClimaAtmos.InitialConditions.Soares
+ClimaAtmos.InitialConditions.RCEMIPIIProfile
 ```
 
 ### Helper

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-279
+280
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+280
+- Add 1M Cloud Resolving Model (CRM) RCEMIPII in a box test
+
 279
 - Use partial cloud fraction in buoyancy gradient calculation
 

--- a/reproducibility_tests/reproducibility_test_job_ids.jl
+++ b/reproducibility_tests/reproducibility_test_job_ids.jl
@@ -7,4 +7,5 @@ reproducibility_test_job_ids() = [
     "diagnostic_edmfx_aquaplanet",
     "single_column_hydrostatic_balance_ft64",
     "prognostic_edmfx_aquaplanet",
+    "rcemipii_box_CRM_1M",
 ]

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -414,6 +414,9 @@ function get_initial_condition(parsed_args, atmos)
         "DryDensityCurrentProfile",
         "RisingThermalBubbleProfile",
         "PrecipitatingColumn",
+        "RCEMIPIIProfile_295",
+        "RCEMIPIIProfile_300",
+        "RCEMIPIIProfile_305",
     ]
         return getproperty(ICs, Symbol(parsed_args["initial_condition"]))()
     elseif isfile(parsed_args["initial_condition"])

--- a/toml/rcemipii_box.toml
+++ b/toml/rcemipii_box.toml
@@ -1,0 +1,34 @@
+# toml/rcemipii_box.toml
+
+[c_smag]
+value = 1.0
+
+[condensation_evaporation_timescale]
+value = 50
+
+[sublimation_deposition_timescale]
+value = 50
+
+[angular_velocity_planet_rotation]
+value = 0
+
+[idealized_ocean_albedo]
+value = 0.07
+
+[mean_sea_level_pressure]
+value = 101480
+
+[D_0_diffusion]
+value = 5
+
+[H_diffusion]
+value = 800
+
+[SST_mean]
+value = 300
+
+[SST_delta]
+value = 1.25
+
+[SST_wavelength]
+value = 6e6


### PR DESCRIPTION
In this PR I am adding the initial sounding from the Wing et. al. (2018) RCEMIP paper. This sounding should be used for RCEMIP simulations. There are three options for initial temps of 295K, 300K, and 305K. This PR also adds an option for a cloud resolving model (CRM) setup of RCEMIP with 1M and noneq to ci.

See here the analytic profile derived from an observation from Wing et. al. (2018) (left) and the Julia implementation (right).
<img width="988" height="558" alt="Screenshot 2025-12-02 at 11 48 28 AM" src="https://github.com/user-attachments/assets/347f192d-1680-44f8-abf7-134f294f0edb" />
