### PR TITLE
Support "inst" reduction in yaml diagnostics

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -20,7 +20,8 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, output_dir)
     # NOTE: Everything has to be lowercase in ALLOWED_REDUCTIONS (so that we can match
     # "max" and "Max")
     ALLOWED_REDUCTIONS = Dict(
-        "nothing" => (nothing, nothing), # nothing is: just dump the variable
+        "inst" => (nothing, nothing), # nothing is: just dump the variable
+        "nothing" => (nothing, nothing),
         "max" => (max, nothing),
         "min" => (min, nothing),
         "average" => ((+), CAD.average_pre_output_hook!),


### PR DESCRIPTION
This PR enables `reduction: inst` in yaml diagnostics.
For example:
```yaml
diagnostics:
  - short_name: [hus, thetaa, clw, arup, tke, entr, detr, waup, turbentr]
    period: 10mins
    reduction: inst
```