### PR TITLE
fix jacobian terms related to dpdqt

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-282
+283
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+283
+- Change the Jacobian terms related to dp_drhoq_tot
+
 282
 - Use ClimaCore.CommonSpaces constructors for Atmos spaces
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Makes the jacobian terms that related to dp/dqt more consistent with the updraft. These includes ∂ᶠu₃_err_∂ᶜρq_tot and ∂ᶠᶜρe_tot_err_∂ᶜρq_tot. Also fixes a bug we had before in ∂ᶠᶜρe_tot_err_∂ᶜρq_tot.

I think there might be a small error in ∂ᶠᶜρe_tot_err_∂ᶜρ too. I will look at that next.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
