### PR TITLE
nullbroadcasted example

### DIFF
--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -282,7 +282,8 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         )
         vtt = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, FT(dt), energy_q_tot_upwinding)
         vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, FT(dt), Val(:none))
-        @. Yₜ.c.ρe_tot += vtt - vtt_central
+        vtt_fake = NullBroadcasted()
+        @. Yₜ.c.ρe_tot += vtt - vtt_central + vtt_fake
     end
 
     if !(p.atmos.moisture_model isa DryModel) && energy_q_tot_upwinding != Val(:none)


### PR DESCRIPTION
In #4095, we observed that the addition of a new term `vtt_bc` in `advection.jl`, as follows:

```julia
if !(p.atmos.moisture_model isa DryModel) && energy_q_tot_upwinding != Val(:none)
    ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
    vtt = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, FT(dt), energy_q_tot_upwinding)
    vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, FT(dt), Val(:none))
    vtt_bc = ᶜρq_tot_vertical_transport_bc(prescribed_flow, thermo_params, t, ᶠu³)
    @. Yₜ.c.ρq_tot += vtt - vtt_central + vtt_bc
end
```
where `vtt_bc = ᶜρq_tot_vertical_transport_bc(prescribed_flow, thermo_params, t, ᶠu³)` returns either a `@. lazy` field or `NullBroadcasted()`.

In the buildkite test `:fire: Flame graph: perf target (Callbacks)`, where `vtt_bc` should evaluate to `NullBroadcasted()`, we observed ~10% more allocations, which exceeded the `flame_callbacks` threshold.

We hypothesize that the expression was not correctly inferred, which led to the (potential) simulation slowdown