### PR TITLE
Fix plotting in KID

### DIFF
--- a/config/model_configs/kinematic_driver.yml
+++ b/config/model_configs/kinematic_driver.yml
@@ -4,10 +4,10 @@ initial_condition: ShipwayHill2012
 surface_setup: ShipwayHill2012
 energy_q_tot_upwinding: first_order
 tracer_upwinding: first_order
-# moist: "nonequil"
-# precip_model: "1M"
-moist: "equil"
-precip_model: "0M"
+moist: "nonequil"
+precip_model: "1M"
+#moist: "equil"
+#precip_model: "0M"
 cloud_model: "grid_scale"
 call_cloud_diagnostics_per_stage: true
 config: "column"

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -594,7 +594,7 @@ function make_plots(::ColumnPlots, output_paths::Vector{<:AbstractString})
     short_names = ["ta", "wa"]
     vars = map_comparison(simdirs, short_names) do simdir, short_name
         var = get(simdir; short_name)
-        # For vertical-only (FiniteDifferenceGrid) spaces, the data may have 
+        # For vertical-only (FiniteDifferenceGrid) spaces, the data may have
         # extra singleton dimensions. Check and squeeze if needed.
         if haskey(var.dims, "x") && length(var.dims["x"]) == 1
             var = slice(var; x = var.dims["x"][1])
@@ -1575,7 +1575,7 @@ function make_plots(::Val{:kinematic_driver}, output_paths::Vector{<:AbstractStr
     ]
     short_names = short_names ∩ collect(keys(simdirs[1].vars))
     vars = map_comparison(simdirs, short_names) do simdir, short_name
-        var = slice(get(simdir; short_name), x = 0, y = 0)
+        var = get(simdir; short_name)
         if short_name in ["hus", "clw", "husra", "cli", "hussn"]
             var.data .= var.data .* 1000
             var.attributes["units"] = "g/kg"
@@ -1589,7 +1589,7 @@ function make_plots(::Val{:kinematic_driver}, output_paths::Vector{<:AbstractStr
     short_names_lines = ["lwp", "rwp", "pr"]
     short_names_lines = short_names_lines ∩ collect(keys(simdirs[1].vars))
     vars_lines = map_comparison(simdirs, short_names_lines) do simdir, short_name
-        var = slice(get(simdir; short_name), x = 0, y = 0)
+        var = get(simdir; short_name)
         return rescale_time_to_min(var)
     end
     make_plots_generic(output_paths, vars_lines; summary_files = [file_contour])


### PR DESCRIPTION
This pull request updates the kinematic driver ci plotting script to fix a bug introduced in #4095 in which it is assumed that output diagnostics have x- and y- dimensions. Currently, the kinematic driver is only run in a "single column" configuration, so these dimensions do not exist.