### PR TITLE
Refactor atmospheric gases

### DIFF
--- a/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_diagnostic.yml
@@ -23,7 +23,6 @@ z_elem: 60
 z_stretch: true
 dz_bottom: 30
 rad: allskywithclear
-co2_model: fixed
 insolation: "gcmdriven"
 dt: "100secs"
 t_end: "72hours"

--- a/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
+++ b/calibration/experiments/gcm_driven_scm/model_config_prognostic.yml
@@ -25,7 +25,6 @@ z_elem: 60
 z_stretch: true
 dz_bottom: 30
 rad: allskywithclear
-co2_model: fixed
 insolation: "gcmdriven"
 perturb_initstate: false
 dt: "10secs"

--- a/calibration/test/model_config.yml
+++ b/calibration/test/model_config.yml
@@ -8,7 +8,6 @@ output_dir: calibration_end_to_end_test
 output_default_diagnostics: false
 dt_rad: 6hours
 rad: clearsky
-co2_model: fixed
 diagnostics:
   - reduction_time: average
     short_name: rsut

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -337,17 +337,14 @@ deep_atmosphere:
 restart_file:
   help: "Path to HDF5 file to use as simulation starting point"
   value: ~
-prescribe_ozone:
-  help: "Prescribe time and spatially varying ozone from a file [`false` (default), `true`]"
-  value: false
-co2_model:
-  help: "What CO2 concentration to use for RRTGMP. When fixed, it is set to 397.547 parts per million. Otherwise, it is read from the MaunaLoa measuraments. [`nothing` (default), `Fixed`, `MaunaLoa`]"
-  value: ~
 detect_restart_file:
   help: "When true, try finding a restart file and use it to restart the simulation. Only works with ActiveLink."
   value: false
 prescribed_aerosols:
   help: "Which aerosols to add. List of keys from the data file (e.g., CB1, CB2)."
+  value: []
+time_varying_trace_gases:
+  help: "Trace gases that vary in time, e.g. [`CO2`, `O3`]. This setting is only relevant when using RRTMGP. Currently, only `CO2` and `O3` are supported. All other trace gases set fixed to default values from ClimaParams."
   value: []
 # TODO: remove once https://github.com/CliMA/ClimaAtmos.jl/issues/2873 is closed
 call_cloud_diagnostics_per_stage:

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_diag_1process.yml
@@ -2,7 +2,6 @@ dt_save_state_to_disk: 12hours
 moist: equil
 precip_model: 0M
 rad: allskywithclear
-co2_model: fixed
 idealized_insolation: false
 dt_rad: 1hours
 vert_diff: "DecayWithHeightDiffusion"
@@ -14,6 +13,6 @@ output_default_diagnostics: false
 diagnostics:
   - short_name: ["pfull", "wa", "va", "rv", "ke"]
     period: "12hours"
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ss.yml
@@ -10,6 +10,6 @@ vert_diff: "DecayWithHeightDiffusion"
 surface_setup: "DefaultMoninObukhov"
 t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_summer.yml
@@ -11,7 +11,7 @@ edmfx_sgs_diffusive_flux: true
 surface_setup: "DefaultMoninObukhov"
 t_end: "1hours"
 toml: [toml/longrun_aquaplanet.toml]
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 start_date: "20160801"

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_1process.yml
@@ -10,6 +10,6 @@ vert_diff: "DecayWithHeightDiffusion"
 surface_setup: "DefaultMoninObukhov"
 t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_2process.yml
@@ -11,6 +11,6 @@ vert_diff: "DecayWithHeightDiffusion"
 surface_setup: "DefaultMoninObukhov"
 t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
+++ b/config/gpu_configs/gpu_aquaplanet_dyamond_ws_4process.yml
@@ -13,6 +13,6 @@ vert_diff: "DecayWithHeightDiffusion"
 surface_setup: "DefaultMoninObukhov"
 t_end: "1days"
 toml: [toml/longrun_aquaplanet.toml]
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -6,8 +6,7 @@ rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"
 insolation: "timevarying"
-co2_model: maunaloa
-prescribe_ozone: true
+time_varying_trace_gases: ["CO2", "O3"]
 aerosol_radiation: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 surface_setup: "DefaultMoninObukhov"

--- a/config/longrun_configs/amip_target_edonly.yml
+++ b/config/longrun_configs/amip_target_edonly.yml
@@ -5,8 +5,7 @@ rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"
 insolation: "timevarying"
-co2_model: maunaloa
-prescribe_ozone: true
+time_varying_trace_gases: ["CO2", "O3"]
 aerosol_radiation: true
 edmfx_sgs_diffusive_flux: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]

--- a/config/model_configs/aquaplanet_nonequil_allsky_gw_res.yml
+++ b/config/model_configs/aquaplanet_nonequil_allsky_gw_res.yml
@@ -14,7 +14,7 @@ insolation: "timevarying"
 non_orographic_gravity_wave: true
 orographic_gravity_wave: "gfdl_restart"
 surface_setup: "DefaultMoninObukhov"
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 reproducibility_test: true
 prescribed_aerosols: ["SO4", "CB1", "OC1", "DST01", "SSLT01"]
 toml: [toml/sphere_aquaplanet_1M.toml]

--- a/config/model_configs/aquaplanet_nonequil_allsky_gw_res_2M.yml
+++ b/config/model_configs/aquaplanet_nonequil_allsky_gw_res_2M.yml
@@ -13,7 +13,7 @@ insolation: "timevarying"
 non_orographic_gravity_wave: true
 orographic_gravity_wave: "gfdl_restart"
 surface_setup: "DefaultMoninObukhov"
-prescribe_ozone: true
+time_varying_trace_gases: ["O3"]
 reproducibility_test: true
 prescribed_aerosols: ["SO4", "CB1", "OC1", "DST01", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 diagnostics:

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -2,7 +2,6 @@ dt: 120secs
 viscous_sponge: false
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: diagnostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -1,7 +1,6 @@
 dt: 120secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: diagnostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
+++ b/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
@@ -18,7 +18,6 @@ vorticity_hyperdiffusion_coefficient: 0.1857
 insolation: "timevarying"
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
-co2_model: fixed
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2

--- a/config/model_configs/edonly_edmfx_aquaplanet.yml
+++ b/config/model_configs/edonly_edmfx_aquaplanet.yml
@@ -1,7 +1,6 @@
 dt: 120secs
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
-co2_model: fixed
 edmfx_sgs_diffusive_flux: true
 turbconv: edonly_edmfx
 moist: equil

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -5,7 +5,6 @@ dz_bottom: 500.0
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
@@ -7,7 +7,6 @@ viscous_sponge: false
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -7,7 +7,6 @@ viscous_sponge: false
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
@@ -7,7 +7,6 @@ viscous_sponge: false
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
@@ -7,7 +7,6 @@ viscous_sponge: false
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
@@ -7,7 +7,6 @@ viscous_sponge: false
 dt: 20secs
 surface_setup: DefaultMoninObukhov
 rad: clearsky
-co2_model: fixed
 turbconv: prognostic_edmfx
 prognostic_tke: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -29,7 +29,6 @@ edmfx_vertical_diffusion: false
 edmfx_filter: true
 prognostic_tke: true
 precip_model: "0M"
-prescribe_ozone: false
 moist: "equil"
 config: "column"
 z_max: 60e3

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -34,7 +34,6 @@ netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
 output_default_diagnostics: false
 rad: allskywithclear
-co2_model: fixed
 insolation: "gcmdriven"
 diagnostics:
   - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]

--- a/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
+++ b/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
@@ -20,7 +20,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 precip_model: "0M"
-prescribe_ozone: false
 moist: "equil"
 config: "column"
 z_max: 45e3

--- a/config/model_configs/rcemipii_box_CRM_1M.yml
+++ b/config/model_configs/rcemipii_box_CRM_1M.yml
@@ -5,7 +5,6 @@ insolation: rcemipii
 initial_condition: RCEMIPIIProfile_300
 config: box
 rad: allskywithclear
-co2_model: fixed
 approximate_linear_solve_iters: 2  # only valid when implicit_diffusion=true
 rayleigh_sponge: true  # set sponge level in toml file
 smagorinsky_lilly: "UV"

--- a/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
+++ b/config/model_configs/rcemipii_sphere_diagnostic_edmfx.yml
@@ -1,7 +1,6 @@
 surface_setup: DefaultMoninObukhov
 surface_temperature: RCEMIPII
 rad: allskywithclear
-co2_model: fixed
 turbconv: diagnostic_edmfx
 insolation: rcemipii
 prognostic_tke: true

--- a/docs/src/tracers.md
+++ b/docs/src/tracers.md
@@ -1,13 +1,13 @@
 # Aerosols
 
-`ClimaAtmos` implements two modes for ozone profiles. These are only relevant
-for the radiation transfer, and only when RRTMGP is used.
+# Trace Gases
+`ClimaAtmos` implements two modes for each ozone and carbon dioxide: one time varying and one time invariant. These are only relevant for the radiation transfer, and only when RRTMGP is used. All other atmospheric gases are held fixed with default values from RRTMPG that can be changed in the toml file.
 
-### Idealized Ozone Profile
+### Time Invariant Ozone Profile
 
-The `IdealizedOzone` type of ozone uses the `idealized_ozone` function to
-compute an idealized ozone profile based on the work of `Wing2018`. This
-profile is not time-varying.
+The time invariant type of ozone uses the `idealized_ozone` function to
+compute an idealized ozone profile based on the work of `Wing2018`.
+This option is default.
 
 The `idealized_ozone` function returns the ozone concentration in volume mixing
 ratio (VMR) at a given altitude `z`.
@@ -26,34 +26,28 @@ ozone = ClimaAtmos.idealized_ozone.(z)
 lines(ozone, z)
 ```
 
-### Prescribed Ozone Profile
+### Time Varying Ozone Profile
 
-The `PrescribedOzone` type of ozone uses CMIP6 forcing data to prescribe ozone
+The time varying ozone profile uses CMIP6 forcing data to prescribe ozone
 as read from files. A high-resolution, multi-year file is available in the
 `ozone_concentrations` artifact. This file is not small, so you have to obtain
 independently. Please, refer to `ClimaArtifacts` for more information. If the
 file is not found, a low-resolution, single-year version is used. This is not
-advised for production simulations.
+advised for production simulations. This option is enabled with by adding `"O3"`
+to the `time_varying_gases` config argument list, ie: `time_varying_gases: ["O3"]`.
 
 We interpolate the data from file in time every time radiation is called. The
 interpolation used is the `LinerPeriodFilling` from `ClimaUtilities`. This is a
 linear period-aware interpolation that preserves the annual cycle.
 
-### Prescribed CO2 Profile
+### Time Invariant CO2
 
-In addition to ozone, `ClimaAtmos` can prescribe CO2 concentration using data
+By default, CO2 concentrations are set to 397.547 ppm. The number can be altered
+by changing the `CO2_fixed_value` parameter in the toml file.
+
+### Time Varying CO2
+
+`ClimaAtmos` can prescribe CO2 concentration using data
 from [Mauna Loa CO2 measurements](https://gml.noaa.gov/ccgg/trends/data.html).
-This option is enabled with `MaunaLoaCO2`. Alternatively, `FixedCO2`
-utilizes a constant value that can be prescribed (by default, 397.547 ppm).
-
-### More docstrings
-
-```@docs
-ClimaAtmos.AbstractOzone
-ClimaAtmos.IdealizedOzone
-ClimaAtmos.PrescribedOzone
-
-ClimaAtmos.AbstractCO2
-ClimaAtmos.FixedCO2
-ClimaAtmos.MaunaLoaCO2
-```
+This option is enabled with by adding `"CO2"` to the `time_varying_gases`
+config argument list, ie: `time_varying_gases: ["CO2"]`.

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-286
+287
 
 # **README**
 #
@@ -20,6 +20,11 @@
 
 
 #=
+287
+- Moving fixed trace gas parameters to params resulted in small changes to radiation,
+likely due to slightly different float values. Additionally, added fixed trace gas
+values to the RCE ci case as per Wing et. al. (2018).
+
 286 
 - We don't know why, but a few (not all) cases seemed to not reproduce the reference.
   Maybe some files were not moved correctly.

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -90,6 +90,7 @@ function build_cache(
     surface_setup,
     sim_info,
     aerosol_names,
+    time_varying_trace_gas_names,
     steady_state_velocity,
 )
     (; dt, start_date, output_dir) = sim_info
@@ -169,9 +170,8 @@ function build_cache(
         (
             start_date,
             params,
-            atmos.ozone,
-            atmos.co2,
             aerosol_names,
+            time_varying_trace_gas_names,
             atmos.insolation,
         ) : ()
 
@@ -179,7 +179,7 @@ function build_cache(
     non_orographic_gravity_wave = non_orographic_gravity_wave_cache(Y, atmos)
     orographic_gravity_wave = orographic_gravity_wave_cache(Y, atmos)
     radiation = radiation_model_cache(Y, atmos, radiation_args...)
-    tracers = tracer_cache(Y, atmos, aerosol_names, start_date)
+    tracers = tracer_cache(Y, aerosol_names, time_varying_trace_gas_names, start_date)
 
     args = (
         dt,

--- a/src/cache/tracer_cache.jl
+++ b/src/cache/tracer_cache.jl
@@ -4,8 +4,7 @@ import ClimaUtilities.TimeVaryingInputs
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, LinearInterpolation
 import Interpolations as Intp
 
-ozone_cache(_, _, _) = (;)
-function ozone_cache(::PrescribedOzone, Y, start_date)
+function ozone_cache(Y, start_date)
     o3 = similar(Y.c.ρ)
     extrapolation_bc = (Intp.Periodic(), Intp.Flat(), Intp.Flat())
     prescribed_o3_timevaryinginput = TimeVaryingInput(
@@ -20,8 +19,7 @@ function ozone_cache(::PrescribedOzone, Y, start_date)
     return (; o3, prescribed_o3_timevaryinginput)
 end
 
-co2_cache(_, _, _) = (;)
-function co2_cache(::MaunaLoaCO2, Y, start_date)
+function co2_cache(Y, start_date)
     FT = Spaces.undertype(axes(Y.c))
     # ClimaUtilities < v0.1.21 can only write to Arrays that are on the same
     # device as the space
@@ -57,7 +55,7 @@ function co2_cache(::MaunaLoaCO2, Y, start_date)
     return (; co2, prescribed_co2_timevaryinginput)
 end
 
-function tracer_cache(Y, atmos, prescribed_aerosol_names, start_date)
+function tracer_cache(Y, prescribed_aerosol_names, time_varying_trace_gases, start_date)
     if !isempty(prescribed_aerosol_names)
         target_space = axes(Y.c)
 
@@ -104,7 +102,9 @@ function tracer_cache(Y, atmos, prescribed_aerosol_names, start_date)
     else
         aerosol_cache = (;)
     end
-    o3_cache = ozone_cache(atmos.ozone, Y, start_date)
-    co2_cache_nt = co2_cache(atmos.co2, Y, start_date)
+
+    o3_cache = :O3 ∈ Symbol.(time_varying_trace_gases) ? ozone_cache(Y, start_date) : (;)
+    co2_cache_nt = :CO2 ∈ Symbol.(time_varying_trace_gases) ? co2_cache(Y, start_date) : (;)
+
     return (; aerosol_cache..., o3_cache..., co2_cache_nt...)
 end

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -39,18 +39,6 @@ radiation_tendency!(Yₜ, Y, p, t, ::Union{Nothing, HeldSuarezForcing}) = nothin
 ##### RRTMGP Radiation
 #####
 
-#########
-# Ozone #
-#########
-
-function center_vmr_o3(::IdealizedOzone, ᶜz)
-    ᶜvolume_mixing_ratio_o3_field = idealized_ozone.(ᶜz)
-    return Fields.field2array(ᶜvolume_mixing_ratio_o3_field)
-end
-
-# Initialized in callback
-center_vmr_o3(::PrescribedOzone, _) = NaN
-
 """
     idealized_ozone(z::FT)
 
@@ -90,20 +78,8 @@ function idealized_ozone(z::FT) where {FT}
     return g1 * p^g2 * exp(-p / g3) * PPMV_TO_VMR
 end
 
-#######
-# CO2 #
-#######
-
-center_vmr_co2(co2::FixedCO2) = co2.value
-
-# Initialized in callback
-center_vmr_co2(::MaunaLoaCO2) = NaN
-
-function rrtmgp_model_kwargs(
+function rrtmgp_model_kwargs_gray_radiation(
     space,
-    radiation_mode::RRTMGPI.GrayRadiation,
-    ozone::AbstractOzone,
-    co2::AbstractCO2,
     include_z::Bool,
 )
     ᶜspace = Spaces.center_space(space)
@@ -141,156 +117,159 @@ end
 
 function rrtmgp_model_kwargs(
     space,
+    trace_gas_params,
+    time_varying_trace_gases,
     radiation_mode::RRTMGPI.AbstractRRTMGPMode,
-    ozone::AbstractOzone,
-    co2::AbstractCO2,
     include_z::Bool,
 )
     ᶜspace = Spaces.center_space(space)
     ᶠspace = Spaces.face_space(space)
     FT = Spaces.undertype(space)
 
-    bottom_coords = Fields.coordinate_field(Spaces.level(ᶜspace, 1))
     ᶜΔz = Fields.Δz_field(ᶜspace)
     ᶜz = Fields.coordinate_field(ᶜspace).z
     ᶠz = Fields.coordinate_field(ᶠspace).z
     if ᶜspace.grid.global_geometry isa Geometry.AbstractSphericalGlobalGeometry
         planet_radius = ᶜspace.grid.global_geometry.radius
     end
-    latitude = if eltype(bottom_coords) <: Geometry.LatLongZPoint
-        Fields.field2array(bottom_coords.lat)
-    else
-        Fields.field2array(zero(bottom_coords.z)) # flat space is on Equator
-    end
     kwargs = NamedTuple()
     (; aerosol_radiation) = radiation_mode
-    NC.Dataset(RRTMGP.ArtifactPaths.get_input_filename(:gas, :lw)) do input_data
-        center_volume_mixing_ratio_o3 = center_vmr_o3(ozone, ᶜz)
 
-        # FT is needed in case FixedCO2 is being used with an inconsistent
-        # floating point type
-        center_volume_mixing_ratio_co2 = FT(center_vmr_co2(co2))
+    center_volume_mixing_ratio_o3 =
+        :O3 in Symbol.(time_varying_trace_gases) ? NaN :
+        Fields.field2array(idealized_ozone.(ᶜz))
 
-        # the first value for each global mean volume mixing ratio is the
-        # present-day value
-        input_vmr(name) =
-            input_data[name][1] * parse(FT, input_data[name].attrib["units"])
-        kwargs = (;
-            use_global_means_for_well_mixed_gases = true,
-            center_volume_mixing_ratio_h2o = NaN, # initialize in tendency
-            center_relative_humidity = NaN, # initialized in callback
-            center_volume_mixing_ratio_o3,
-            volume_mixing_ratio_co2 = center_volume_mixing_ratio_co2,
-            volume_mixing_ratio_n2o = input_vmr("nitrous_oxide_GM"),
-            volume_mixing_ratio_co = input_vmr("carbon_monoxide_GM"),
-            volume_mixing_ratio_ch4 = input_vmr("methane_GM"),
-            volume_mixing_ratio_o2 = input_vmr("oxygen_GM"),
-            volume_mixing_ratio_n2 = input_vmr("nitrogen_GM"),
-            volume_mixing_ratio_ccl4 = input_vmr("carbon_tetrachloride_GM"),
-            volume_mixing_ratio_cfc11 = input_vmr("cfc11_GM"),
-            volume_mixing_ratio_cfc12 = input_vmr("cfc12_GM"),
-            volume_mixing_ratio_cfc22 = input_vmr("hcfc22_GM"),
-            volume_mixing_ratio_hfc143a = input_vmr("hfc143a_GM"),
-            volume_mixing_ratio_hfc125 = input_vmr("hfc125_GM"),
-            volume_mixing_ratio_hfc23 = input_vmr("hfc23_GM"),
-            volume_mixing_ratio_hfc32 = input_vmr("hfc32_GM"),
-            volume_mixing_ratio_hfc134a = input_vmr("hfc134a_GM"),
-            volume_mixing_ratio_cf4 = input_vmr("cf4_GM"),
-            volume_mixing_ratio_no2 = 0, # not available in input_data
-            latitude,
+    trace_gas_names = (
+        :CO2,
+        :N2O,
+        :CO,
+        :CH4,
+        :O2,
+        :N2,
+        :CCL4,
+        :CFC11,
+        :CFC12,
+        :CFC22,
+        :HFC143A,
+        :HFC125,
+        :HFC23,
+        :HFC32,
+        :HFC134A,
+        :CF4,
+        :NO2,
+    )
+    trace_gas_vmr_names =
+        map(
+            gas_name -> Symbol(:volume_mixing_ratio_, lowercase(String(gas_name))),
+            trace_gas_names,
         )
-        if !(radiation_mode isa RRTMGPI.ClearSkyRadiation)
-            kwargs = (; kwargs..., ice_roughness = 2)
-            if radiation_mode.idealized_clouds # icy cloud on top and wet cloud on bottom
-                # TODO: can we avoid using DataLayouts with this?
-                #     `ᶜis_bottom_cloud = similar(ᶜz, Bool)`
-                ᶜis_bottom_cloud = Fields.Field(
-                    DataLayouts.replace_basetype(Fields.field_values(ᶜz), Bool),
-                    ᶜspace,
-                ) # need to fix several ClimaCore bugs in order to simplify this
-                ᶜis_top_cloud = similar(ᶜis_bottom_cloud)
-                @. ᶜis_bottom_cloud = ᶜz > 1e3 && ᶜz < 1.5e3
-                @. ᶜis_top_cloud = ᶜz > 4e3 && ᶜz < 5e3
-                kwargs = (;
-                    kwargs...,
-                    center_cloud_liquid_effective_radius = 12,
-                    center_cloud_ice_effective_radius = 25,
-                    center_cloud_liquid_water_path = Fields.field2array(
-                        @. ifelse(ᶜis_bottom_cloud, FT(0.002) * ᶜΔz, FT(0))
-                    ),
-                    center_cloud_ice_water_path = Fields.field2array(
-                        @. ifelse(ᶜis_top_cloud, FT(0.001) * ᶜΔz, FT(0))
-                    ),
-                    center_cloud_fraction = Fields.field2array(
-                        @. ifelse(
-                            ᶜis_bottom_cloud | ᶜis_top_cloud,
-                            FT(1),
-                            0 * ᶜΔz,
-                        )
-                    ),
-                )
-            else
-                kwargs = (;
-                    kwargs...,
-                    center_cloud_liquid_water_path = NaN, # initialized in callback
-                    center_cloud_ice_water_path = NaN, # initialized in callback
-                    center_cloud_fraction = NaN, # initialized in callback
-                    center_cloud_liquid_effective_radius = NaN, # initialized in callback
-                    center_cloud_ice_effective_radius = NaN, # initialized in callback
-                )
-            end
+    trace_gas_vmrs = map(trace_gas_names) do gas_name
+        if gas_name in Symbol.(time_varying_trace_gases)
+            NaN
+        else
+            getfield(trace_gas_params, Symbol(gas_name, :_fixed_value))
         end
+    end
+    kwargs = (;
+        kwargs...,
+        use_global_means_for_well_mixed_gases = true,
+        center_volume_mixing_ratio_h2o = NaN, # initialize in tendency
+        center_relative_humidity = NaN, # initialized in callback
+        center_volume_mixing_ratio_o3,
+        NamedTuple{trace_gas_vmr_names}(trace_gas_vmrs)...,
+    )
 
-        if aerosol_radiation
+    if !(radiation_mode isa RRTMGPI.ClearSkyRadiation)
+        kwargs = (; kwargs..., ice_roughness = 2)
+        if radiation_mode.idealized_clouds # icy cloud on top and liquid cloud on bottom
+            # TODO: can we avoid using DataLayouts with this?
+            #     `ᶜis_bottom_cloud = similar(ᶜz, Bool)`
+            ᶜis_bottom_cloud = Fields.Field(
+                DataLayouts.replace_basetype(Fields.field_values(ᶜz), Bool),
+                ᶜspace,
+            ) # need to fix several ClimaCore bugs in order to simplify this
+            ᶜis_top_cloud = similar(ᶜis_bottom_cloud)
+            @. ᶜis_bottom_cloud = ᶜz > 1e3 && ᶜz < 1.5e3
+            @. ᶜis_top_cloud = ᶜz > 4e3 && ᶜz < 5e3
             kwargs = (;
                 kwargs...,
-                aod_sw_extinction = NaN,
-                aod_sw_scattering = NaN,
-                # assuming fixed aerosol radius
-                center_dust1_radius = 0.55,
-                center_dust2_radius = 1.4,
-                center_dust3_radius = 2.4,
-                center_dust4_radius = 4.5,
-                center_dust5_radius = 8,
-                center_ss1_radius = 0.55,
-                center_ss2_radius = 1.4,
-                center_ss3_radius = 2.4,
-                center_ss4_radius = 4.5,
-                center_ss5_radius = 8,
-                center_dust1_column_mass_density = NaN, # initialized in callback
-                center_dust2_column_mass_density = NaN, # initialized in callback
-                center_dust3_column_mass_density = NaN, # initialized in callback
-                center_dust4_column_mass_density = NaN, # initialized in callback
-                center_dust5_column_mass_density = NaN, # initialized in callback
-                center_ss1_column_mass_density = NaN, # initialized in callback
-                center_ss2_column_mass_density = NaN, # initialized in callback
-                center_ss3_column_mass_density = NaN, # initialized in callback
-                center_ss4_column_mass_density = NaN, # initialized in callback
-                center_ss5_column_mass_density = NaN, # initialized in callback
-                center_so4_column_mass_density = NaN, # initialized in callback
-                center_bcpi_column_mass_density = NaN, # initialized in callback
-                center_bcpo_column_mass_density = NaN, # initialized in callback
-                center_ocpi_column_mass_density = NaN, # initialized in callback
-                center_ocpo_column_mass_density = NaN, # initialized in callback
+                center_cloud_liquid_effective_radius = 12,
+                center_cloud_ice_effective_radius = 25,
+                center_cloud_liquid_water_path = Fields.field2array(
+                    @. ifelse(ᶜis_bottom_cloud, FT(0.002) * ᶜΔz, FT(0))
+                ),
+                center_cloud_ice_water_path = Fields.field2array(
+                    @. ifelse(ᶜis_top_cloud, FT(0.001) * ᶜΔz, FT(0))
+                ),
+                center_cloud_fraction = Fields.field2array(
+                    @. ifelse(
+                        ᶜis_bottom_cloud | ᶜis_top_cloud,
+                        FT(1),
+                        0 * ᶜΔz,
+                    )
+                ),
+            )
+        else
+            kwargs = (;
+                kwargs...,
+                center_cloud_liquid_water_path = NaN, # initialized in callback
+                center_cloud_ice_water_path = NaN, # initialized in callback
+                center_cloud_fraction = NaN, # initialized in callback
+                center_cloud_liquid_effective_radius = NaN, # initialized in callback
+                center_cloud_ice_effective_radius = NaN, # initialized in callback
             )
         end
+    end
 
-        if include_z
-            if ᶜspace.grid.global_geometry isa
-               Geometry.AbstractSphericalGlobalGeometry
-                kwargs = (;
-                    kwargs...,
-                    center_z = Fields.field2array(ᶜz),
-                    face_z = Fields.field2array(ᶠz),
-                    planet_radius = planet_radius,
-                )
-            else
-                kwargs = (;
-                    kwargs...,
-                    center_z = Fields.field2array(ᶜz),
-                    face_z = Fields.field2array(ᶠz),
-                )
-            end
+    if aerosol_radiation
+        kwargs = (;
+            kwargs...,
+            aod_sw_extinction = NaN,
+            aod_sw_scattering = NaN,
+            # assuming fixed aerosol radius
+            center_dust1_radius = 0.55,
+            center_dust2_radius = 1.4,
+            center_dust3_radius = 2.4,
+            center_dust4_radius = 4.5,
+            center_dust5_radius = 8,
+            center_ss1_radius = 0.55,
+            center_ss2_radius = 1.4,
+            center_ss3_radius = 2.4,
+            center_ss4_radius = 4.5,
+            center_ss5_radius = 8,
+            center_dust1_column_mass_density = NaN, # initialized in callback
+            center_dust2_column_mass_density = NaN, # initialized in callback
+            center_dust3_column_mass_density = NaN, # initialized in callback
+            center_dust4_column_mass_density = NaN, # initialized in callback
+            center_dust5_column_mass_density = NaN, # initialized in callback
+            center_ss1_column_mass_density = NaN, # initialized in callback
+            center_ss2_column_mass_density = NaN, # initialized in callback
+            center_ss3_column_mass_density = NaN, # initialized in callback
+            center_ss4_column_mass_density = NaN, # initialized in callback
+            center_ss5_column_mass_density = NaN, # initialized in callback
+            center_so4_column_mass_density = NaN, # initialized in callback
+            center_bcpi_column_mass_density = NaN, # initialized in callback
+            center_bcpo_column_mass_density = NaN, # initialized in callback
+            center_ocpi_column_mass_density = NaN, # initialized in callback
+            center_ocpo_column_mass_density = NaN, # initialized in callback
+        )
+    end
+
+    if include_z
+        if ᶜspace.grid.global_geometry isa
+           Geometry.AbstractSphericalGlobalGeometry
+            kwargs = (;
+                kwargs...,
+                center_z = Fields.field2array(ᶜz),
+                face_z = Fields.field2array(ᶠz),
+                planet_radius = planet_radius,
+            )
+        else
+            kwargs = (;
+                kwargs...,
+                center_z = Fields.field2array(ᶜz),
+                face_z = Fields.field2array(ᶠz),
+            )
         end
     end
     return kwargs
@@ -301,9 +280,8 @@ function radiation_model_cache(
     radiation_mode::RRTMGPI.AbstractRRTMGPMode,
     start_date,
     params,
-    ozone,
-    co2,
     aerosol_names,
+    time_varying_trace_gas_names,
     insolation_mode;
     interpolation = RRTMGPI.BestFit(),
     bottom_extrapolation = RRTMGPI.SameAsInterpolation(),
@@ -344,8 +322,15 @@ function radiation_model_cache(
         RRTMGPI.requires_z(interpolation) ||
         RRTMGPI.requires_z(bottom_extrapolation)
 
-    kwargs =
-        rrtmgp_model_kwargs(axes(Y.c), radiation_mode, ozone, co2, include_z)
+    if radiation_mode isa RRTMGPI.GrayRadiation
+        kwargs = rrtmgp_model_kwargs_gray_radiation(axes(Y.c), include_z)
+    else
+        trace_gas_params = CAP.trace_gas_params(params)
+        kwargs = rrtmgp_model_kwargs(
+            axes(Y.c), trace_gas_params, time_varying_trace_gas_names, radiation_mode,
+            include_z,
+        )
+    end
 
     cos_zenith = weighted_irradiance = NaN # initialized in callback
 

--- a/src/parameterized_tendencies/radiation/update_inputs.jl
+++ b/src/parameterized_tendencies/radiation/update_inputs.jl
@@ -4,7 +4,6 @@ import ClimaCore.Operators
 import ClimaUtilities.TimeVaryingInputs: evaluate!
 import CloudMicrophysics as CM
 import ..Parameters as CAP
-import ..PrescribedOzone, ..MaunaLoaCO2
 import ..PrescribedCloudInRadiation
 import ..lazy
 
@@ -125,11 +124,10 @@ Update volume mixing ratios.
 """
 function update_volume_mixing_ratios!((; u, p, t)::I) where {I}
     (; rrtmgp_model) = p.radiation
-    # If we have prescribed ozone or aerosols, we need to update them
-    update_o3!(p, t, p.atmos.ozone)
-    update_co2!(p, t, p.atmos.co2)
 
     if :o3 in propertynames(p.tracers)
+        evaluate!(p.tracers.o3, p.tracers.prescribed_o3_timevaryinginput, t)
+
         ᶜvmr_o3 = Fields.array2field(
             rrtmgp_model.center_volume_mixing_ratio_o3,
             axes(u.c),
@@ -137,6 +135,8 @@ function update_volume_mixing_ratios!((; u, p, t)::I) where {I}
         @. ᶜvmr_o3 = p.tracers.o3
     end
     if :co2 in propertynames(p.tracers)
+        evaluate!(p.tracers.co2, p.tracers.prescribed_co2_timevaryinginput, t)
+
         if pkgversion(ClimaUtilities) < v"0.1.21"
             rrtmgp_model.volume_mixing_ratio_co2 .= p.tracers.co2
         else
@@ -144,18 +144,6 @@ function update_volume_mixing_ratios!((; u, p, t)::I) where {I}
         end
     end
 
-    return nothing
-end
-
-update_o3!(_, _, _) = nothing
-function update_o3!(p, t, ::PrescribedOzone)
-    evaluate!(p.tracers.o3, p.tracers.prescribed_o3_timevaryinginput, t)
-    return nothing
-end
-
-update_co2!(_, _, _) = nothing
-function update_co2!(p, t, ::MaunaLoaCO2)
-    evaluate!(p.tracers.co2, p.tracers.prescribed_co2_timevaryinginput, t)
     return nothing
 end
 

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -65,6 +65,7 @@ Base.@kwdef struct ClimaAtmosParameters{
     FT,
     TP,
     RP,
+    TG,
     IP,
     MPC,
     MP0M,
@@ -79,6 +80,7 @@ Base.@kwdef struct ClimaAtmosParameters{
 } <: ACAP
     thermodynamics_params::TP
     rrtmgp_params::RP
+    trace_gas_params::TG
     insolation_params::IP
     microphysics_cloud_params::MPC
     microphysics_0m_params::MP0M

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -35,6 +35,9 @@ function ClimaAtmosParameters(
     rrtmgp_params = RRTMGPParameters(toml_dict)
     RP = typeof(rrtmgp_params)
 
+    trace_gas_params = trace_gas_parameters(toml_dict)
+    TG = typeof(trace_gas_params)
+
     insolation_params = InsolationParameters(toml_dict)
     IP = typeof(insolation_params)
 
@@ -81,6 +84,7 @@ function ClimaAtmosParameters(
         FT,
         TP,
         RP,
+        TG,
         IP,
         MPC,
         MP0M,
@@ -96,6 +100,7 @@ function ClimaAtmosParameters(
         parameters...,
         thermodynamics_params,
         rrtmgp_params,
+        trace_gas_params,
         insolation_params,
         microphysics_cloud_params,
         microphysics_0m_params,
@@ -256,6 +261,19 @@ function prescribed_aerosol_parameters(toml_dict)
         :mam3_stdev_accum => :sulfate_std,
     )
     return CP.get_parameter_values(toml_dict, name_map, "ClimaAtmos")
+end
+
+function trace_gas_parameters(toml_dict)
+    names = (
+        "CO2_fixed_value", "N2O_fixed_value", "CO_fixed_value", "CH4_fixed_value",
+        "O2_fixed_value", "N2_fixed_value", "CF4_fixed_value", "NO2_fixed_value",
+        "CCL4_fixed_value", "CFC11_fixed_value", "CFC12_fixed_value",
+        "CFC22_fixed_value",
+        "HFC143A_fixed_value", "HFC125_fixed_value", "HFC23_fixed_value",
+        "HFC32_fixed_value",
+        "HFC134A_fixed_value",
+    )
+    return CP.get_parameter_values(toml_dict, names, "ClimaAtmos")
 end
 
 to_svec(x::AbstractArray) = SA.SVector{length(x)}(x)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -46,26 +46,10 @@ function get_atmos(config::AtmosConfig, params)
         parsed_args["implicit_noneq_cloud_formation"]
     @assert implicit_noneq_cloud_formation in (true, false)
 
-    ozone = get_ozone(parsed_args)
     radiation_mode = get_radiation_mode(parsed_args, FT)
     forcing_type = get_forcing_type(parsed_args)
     call_cloud_diagnostics_per_stage =
         get_call_cloud_diagnostics_per_stage(parsed_args)
-
-    if isnothing(ozone) && radiation_mode isa RRTMGPI.AbstractRRTMGPMode
-        @warn "prescribe_ozone is set to nothing with an RRTMGP model. Resetting to IdealizedOzone. This behavior will stop being supported in some future release"
-        ozone = IdealizedOzone()
-    end
-    co2 = get_co2(parsed_args)
-    with_rrtmgp = radiation_mode isa RRTMGPI.AbstractRRTMGPMode
-    if with_rrtmgp && isnothing(co2)
-        @warn (
-            "co2_model set to nothing with an RRTMGP model. Resetting to FixedCO2"
-        )
-        co2 = FixedCO2()
-    end
-    (!isnothing(co2) && !with_rrtmgp) &&
-        @warn ("$(co2) does nothing if RRTMGP is not used")
 
     # HeldSuarezForcing can be set via radiation_mode or legacy forcing option for now
     final_radiation_mode =
@@ -142,8 +126,6 @@ function get_atmos(config::AtmosConfig, params)
 
         # AtmosRadiation
         radiation_mode = final_radiation_mode,
-        ozone,
-        co2,
         insolation = get_insolation_form(parsed_args),
 
         # AtmosTurbconv - Turbulence & Convection
@@ -906,6 +888,7 @@ function get_simulation(config::AtmosConfig)
             surface_setup,
             sim_info,
             tracers.aerosol_names,
+            tracers.time_varying_trace_gas_names,
             steady_state_velocity,
         )
     end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -110,70 +110,6 @@ struct GCMDrivenInsolation <: AbstractInsolation end
 struct ExternalTVInsolation <: AbstractInsolation end
 
 """
-    AbstractOzone
-
-Describe how ozone concentration should be set.
-"""
-abstract type AbstractOzone end
-
-"""
-    IdealizedOzone
-
-Implement a static (not varying in time) idealized ozone profile as described by
-`idealized_ozone`.
-"""
-struct IdealizedOzone <: AbstractOzone end
-
-"""
-    PrescribedOzone
-
-Implement a time-varying ozone profile as read from disk.
-
-The CMIP6 forcing dataset is used. For production runs, you should acquire the
-high-resolution, multi-year `ozone_concentrations` artifact. If this is not available, a low
-resolution, single-year version will be used.
-
-Refer to ClimaArtifacts for more information on how to obtain the artifact.
-"""
-struct PrescribedOzone <: AbstractOzone end
-
-"""
-    AbstractCO2
-
-Describe how CO2 concentration should be set.
-"""
-abstract type AbstractCO2 end
-
-"""
-    FixedCO2
-
-Implement a static CO2 profile as read from disk.
-
-The data used is the one distributed with `RRTMGP.jl`.
-
-By default, this is 397.547 parts per million.
-
-This is the volume mixing ratio.
-"""
-struct FixedCO2{FT} <: AbstractCO2
-    value::FT
-
-    function FixedCO2(; FT = Float64, value = FT(397.547e-6))
-        return new{FT}(value)
-    end
-end
-
-"""
-    MuanaLoaCO2
-
-Implement a time-varying CO2 profile as read from disk.
-
-The data from the Mauna Loa CO2 measurements is used. It is a assumed that the
-concentration is constant.
-"""
-struct MaunaLoaCO2 <: AbstractCO2 end
-
-"""
     AbstractCloudInRadiation
 
 Describe how cloud properties should be set in radiation.
@@ -659,10 +595,8 @@ end
 
 Groups radiation-related models and types.
 """
-Base.@kwdef struct AtmosRadiation{RM, OZ, CO2, IN}
+Base.@kwdef struct AtmosRadiation{RM, IN}
     radiation_mode::RM = nothing
-    ozone::OZ = nothing
-    co2::CO2 = nothing
     insolation::IN = nothing
 end
 
@@ -865,8 +799,6 @@ model = AtmosModel(;
     moisture_model = EquilMoistModel(),
     microphysics_model = Microphysics0Moment(),
     radiation_mode = RRTMGPI.AllSkyRadiation(),
-    ozone = IdealizedOzone(),
-    co2 = FixedCO2()
 )
 ```
 
@@ -901,8 +833,6 @@ Internal testing and calibration components for single-column setups:
   - Global radiation: RRTMGPI.ClearSkyRadiation(), RRTMGPI.AllSkyRadiation()
   - Atmospheric forcing: HeldSuarezForcing() (for idealized dynamics)
   - SCM-specific: RadiationDYCOMS(), RadiationISDAC(), RadiationTRMM_LBA()
-- `ozone`: IdealizedOzone(), PrescribedOzone()
-- `co2`: FixedCO2(), MaunaLoaCO2()
 - `insolation`: IdealizedInsolation(), TimeVaryingInsolation(), etc.
 
 ## AtmosTurbconv
@@ -1131,8 +1061,6 @@ function EquilMoistAtmosModel(; kwargs...)
         surface_model = PrescribedSST(),
         sfc_temperature = ZonallySymmetricSST(),
         insolation = IdealizedInsolation(),
-        ozone = IdealizedOzone(),
-        co2 = FixedCO2(),
     )
     return AtmosModel(; defaults..., kwargs...)
 end
@@ -1151,8 +1079,6 @@ function NonEquilMoistAtmosModel(; kwargs...)
         surface_model = PrescribedSST(),
         sfc_temperature = ZonallySymmetricSST(),
         insolation = IdealizedInsolation(),
-        ozone = IdealizedOzone(),
-        co2 = FixedCO2(),
     )
     return AtmosModel(; defaults..., kwargs...)
 end

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -402,7 +402,6 @@ if MANYTESTS
                             "rayleigh_sponge" => true,
                             "insolation" => "timevarying",
                             "rad" => radiation,
-                            "co2_model" => "fixed",
                             "dt_rad" => "1secs",
                             "surface_setup" => "DefaultMoninObukhov",
                             "call_cloud_diagnostics_per_stage" => true,  # Needed to ensure that cloud variables are computed

--- a/test/solver/atmos_model_constructor.jl
+++ b/test/solver/atmos_model_constructor.jl
@@ -45,8 +45,6 @@ end
 
             # Advanced physics defaults (should be nothing/disabled)
             :radiation_mode => nothing,
-            :ozone => nothing,
-            :co2 => nothing,
             :turbconv_model => nothing,
             :non_orographic_gravity_wave => nothing,
             :orographic_gravity_wave => nothing,
@@ -76,8 +74,6 @@ end
                 false,
                 false,
             ),
-            ozone = CA.IdealizedOzone(),
-            co2 = CA.FixedCO2(),
             hyperdiff = CA.ClimaHyperdiffusion(;
                 ν₄_vorticity_coeff = 1e15,
                 ν₄_scalar_coeff = 1e15,
@@ -91,8 +87,6 @@ end
         @test model.microphysics_model isa CA.Microphysics1Moment
         @test model.cloud_model isa CA.QuadratureCloud
         @test model.radiation_mode isa RRTMGPI.ClearSkyRadiation
-        @test model.ozone isa CA.IdealizedOzone
-        @test model.co2 isa CA.FixedCO2
         @test model.hyperdiff isa CA.ClimaHyperdiffusion
         @test model.numerics.hyperdiff isa CA.ClimaHyperdiffusion
         @test model.disable_surface_flux_tendency == true
@@ -140,13 +134,10 @@ end
                 false,
                 false,
             ),
-            ozone = CA.IdealizedOzone(),
-            co2 = CA.FixedCO2(),
         )
         @test moist_model.moisture_model isa CA.EquilMoistModel
         @test moist_model.microphysics_model isa CA.Microphysics0Moment
         @test moist_model.radiation_mode isa RRTMGPI.ClearSkyRadiation
-        @test moist_model.ozone isa CA.IdealizedOzone
 
         # Test HeldSuarezForcing as radiation mode
         held_suarez_model =

--- a/toml/rcemipii_box.toml
+++ b/toml/rcemipii_box.toml
@@ -15,6 +15,27 @@ value = 0
 [idealized_ocean_albedo]
 value = 0.07
 
+[CO2_fixed_value]
+value = 348e-6
+
+[CH4_fixed_value]
+value = 1650e-9
+
+[N2O_fixed_value]
+value = 306e-9
+
+[CFC11_fixed_value]
+value = 0
+
+[CFC12_fixed_value]
+value = 0
+
+[CFC22_fixed_value]
+value = 0
+
+[CCL4_fixed_value]
+value = 0
+
 [mean_sea_level_pressure]
 value = 101480
 


### PR DESCRIPTION
This PR refactors the way atmospheric gases are treated in the code. Namely, it:

- gives all atmospheric gases two options: either to be time varying or fixed. Only two gases have time varying implementations currently -- ozone and co2
- sets fixed values for atmospheric gases from values given in toml, rather than from RRTMGP artifact
- removes individual model structs for ozone and co2