### PR TITLE
Clean up the cloud fraction computation

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -230,7 +230,7 @@ precip_model:
   help: "Precipitation model [`nothing` (default), `0M`, `1M`]"
   value: ~
 cloud_model:
-  help: "Cloud model [`grid_scale`, `quadrature` (default), `quadrature_sgs`]"
+  help: "Cloud model [`grid_scale`, `quadrature` (default)]"
   value: "quadrature"
 implicit_noneq_cloud_formation:
   help: "Whether to treat the nonequilibrium cloud condensate tendency implicitly [`true`, `false` (default)]"

--- a/config/longrun_configs/amip_target_diagedmf.yml
+++ b/config/longrun_configs/amip_target_diagedmf.yml
@@ -1,6 +1,5 @@
 dt_save_state_to_disk: "30days"
 moist: "equil"
-cloud_model: "quadrature_sgs"
 precip_model: "0M"
 rad: "allskywithclear"
 dt_rad: "1hours"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml
@@ -1,7 +1,6 @@
 t_end: "240days"
 dt_save_state_to_disk: "30days"
 moist: "equil"
-cloud_model: "quadrature_sgs"
 rad: "allskywithclear"
 dt_rad: "1hours"
 dt_cloud_fraction: "1hours"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet.yml
@@ -10,7 +10,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 3hours
 reproducibility_test: true

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -11,7 +11,6 @@ edmfx_sgs_diffusive_flux: true
 edmfx_sgsflux_upwinding: "vanleer_limiter"
 edmfx_tracer_upwinding: "vanleer_limiter"
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 12hours
 toml: [toml/diagnostic_edmfx_0M.toml]

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -13,7 +13,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: "equil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "box"
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -13,7 +13,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -14,7 +14,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box

--- a/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
+++ b/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
@@ -27,7 +27,6 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 moist: equil
 toml: [toml/diagnostic_edmfx_era5_ic.toml]

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -11,7 +11,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: box
 x_max: 1e8

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -13,7 +13,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: box

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -12,7 +12,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
 config: box

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -11,7 +11,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
 config: box

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -12,7 +12,6 @@ edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 moist: equil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "0M"
 config: box

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -23,7 +23,6 @@ implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 1hours
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
@@ -26,7 +26,6 @@ use_dense_jacobian: true
 update_jacobian_every: dt
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 40mins
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -25,7 +25,6 @@ implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 1hours
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_dense_autodiff.yml
@@ -27,7 +27,6 @@ update_jacobian_every: dt
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 1hours
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu_sparse_autodiff.yml
@@ -28,7 +28,6 @@ debug_jacobian: true
 approximate_linear_solve_iters: 2
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 1hours
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
@@ -27,7 +27,6 @@ update_jacobian_every: dt
 debug_jacobian: true
 max_newton_iters_ode: 3
 moist: equil
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 t_end: 40mins
 dt_save_state_to_disk: 600secs

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "equil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 3e3

--- a/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
@@ -13,7 +13,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 3e3

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -39,7 +39,6 @@ perturb_initstate: false
 dt: "50secs"
 dt_rad: "10mins"
 t_end: "30hours"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 toml: [toml/prognostic_edmfx_calibrated.toml]
 netcdf_output_at_levels: true

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: equil
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: column
 hyperdiff: false

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "nonequil"
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: "column"

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -27,7 +27,6 @@ dt: "10secs"
 dt_rad: "30mins"
 t_end: "6hours"
 dt_save_state_to_disk: "6hours"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage : true
 toml: [toml/prognostic_edmfx_gcmdriven.toml]
 netcdf_output_at_levels: true

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "nonequil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_rico_column_2M.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column_2M.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "nonequil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "2M"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
@@ -21,7 +21,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: "nonequil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 precip_model: "1M"
 config: "column"

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -15,7 +15,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: false
 moist: "equil"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 config: "column"
 z_max: 4e3

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -16,7 +16,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: column

--- a/config/model_configs/prognostic_edmfx_trmm_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_sparse_autodiff.yml
@@ -23,7 +23,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: column

--- a/config/model_configs/prognostic_edmfx_trmm_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_implicit_column.yml
@@ -22,7 +22,6 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 moist: nonequil
-cloud_model: "quadrature_sgs"
 precip_model: "1M"
 call_cloud_diagnostics_per_stage: true
 config: column

--- a/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
+++ b/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
@@ -30,7 +30,6 @@ perturb_initstate: false
 dt: "10secs"
 dt_rad: "10mins"
 t_end: "30hours"
-cloud_model: "quadrature_sgs"
 call_cloud_diagnostics_per_stage: true
 toml: [toml/prognostic_edmfx_calibrated.toml]
 netcdf_output_at_levels: true

--- a/config/perf_configs/bm_aquaplanet_diagedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_diagedmf.yml
@@ -16,6 +16,5 @@ edmfx_detr_model: "Generalized"
 edmfx_nh_pressure: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 toml: [toml/diagnostic_edmfx.toml]

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -24,6 +24,5 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 toml: [toml/prognostic_edmfx.toml]

--- a/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
@@ -27,6 +27,5 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 toml: [toml/prognostic_edmfx.toml]

--- a/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
@@ -28,6 +28,5 @@ edmfx_vertical_diffusion: true
 edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
-cloud_model: "quadrature_sgs"
 precip_model: 0M
 toml: [toml/prognostic_edmfx.toml]

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -529,13 +529,13 @@ NVTX.@annotate function set_explicit_precomputed_quantities!(Y, p, t)
             ᶜgradᵥ(ᶠinterp(TD.liquid_ice_pottemp(thermo_params, ᶜts)))
     end
 
-    # The buoyancy gradient depends on the cloud fraction, and the cloud fraction 
-    # depends on the mixing length, which depends on the buoyancy gradient. 
-    # We break this circular dependency by using cloud fraction from the previous time step in the 
-    # buoyancy gradient calculation. This breaks reproducible restart in general, 
+    # The buoyancy gradient depends on the cloud fraction, and the cloud fraction
+    # depends on the mixing length, which depends on the buoyancy gradient.
+    # We break this circular dependency by using cloud fraction from the previous time step in the
+    # buoyancy gradient calculation. This breaks reproducible restart in general,
     # but we support reproducible restart with grid-scale cloud by recalculating the cloud fraction here.
-    if p.atmos.cloud_model isa GridScaleCloud
-        set_cloud_fraction!(Y, p, p.atmos.moisture_model, p.atmos.cloud_model)
+    if cloud_model isa GridScaleCloud
+        set_cloud_fraction!(Y, p, moisture_model, cloud_model)
     end
 
     if turbconv_model isa PrognosticEDMFX

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -364,8 +364,6 @@ function get_cloud_model(parsed_args)
         GridScaleCloud()
     elseif cloud_model == "quadrature"
         QuadratureCloud(SGSQuadrature(FT))
-    elseif cloud_model == "quadrature_sgs"
-        SGSQuadratureCloud(SGSQuadrature(FT))
     else
         error("Invalid cloud_model $(cloud_model)")
     end

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -76,23 +76,12 @@ struct GridScaleCloud <: AbstractCloudModel end
 """
     QuadratureCloud
 
-Compute the cloud fraction by sampling over the quadrature points, but without
-the EDMF sub-grid scale model.
+Compute the cloud fraction by sampling over the quadrature points.
 """
 struct QuadratureCloud{SGQ <: AbstractSGSamplingType} <: AbstractCloudModel
     SG_quad::SGQ
 end
 
-"""
-    SGSQuadratureCloud
-
-Compute the cloud fraction as a sum of the EDMF environment and updraft
-contributions. The EDMF environment cloud fraction is computed by sampling over
-the quadrature points.
-"""
-struct SGSQuadratureCloud{SGQ <: AbstractSGSamplingType} <: AbstractCloudModel
-    SG_quad::SGQ
-end
 
 abstract type AbstractSST end
 struct ZonallySymmetricSST <: AbstractSST end
@@ -816,7 +805,7 @@ The default AtmosModel provides:
 ## AtmosWater
 - `moisture_model`: DryModel(), EquilMoistModel(), NonEquilMoistModel()
 - `microphysics_model`: NoPrecipitation(), Microphysics0Moment(), Microphysics1Moment(), Microphysics2Moment()
-- `cloud_model`: GridScaleCloud(), QuadratureCloud(), SGSQuadratureCloud()
+- `cloud_model`: GridScaleCloud(), QuadratureCloud()
 - `noneq_cloud_formation_mode`: Explicit(), Implicit()
 - `call_cloud_diagnostics_per_stage`: nothing or CallCloudDiagnosticsPerStage()
 


### PR DESCRIPTION
This PR:
- Removes the  `quadrature_sgs` option for computing cloud fraction. The remaining options are `grid_scale` and `quadrature` (default). The functionality of `quadrature_sgs` is retained via `quadrature` option and the `turbconv_model` choice. I.e. if the user is running with a `turbconv_model` and `quadrature` cloud, they will get the `quadrature_sgs` behavior.
- Deletes the multiple dispatch options for `set_cloud_fraction!` that were based on `turbconv_model`. I think this was duplicating the code for doing the quadratures and adding updraft contributions. To me the flow for all `quadrature` options is similar. The small differences arising from assuming environment area to be one and storing updraft properties in `precomputed` vs `state` structs can be handled by `if/else` within one function. AFAIK they will be handled at compile time and should not affect the performance. 

I kept the quadrature summation separate, even though it is only used once. Just in case we will want to re-use it in other parts of the code. 