### PR TITLE
Improve GPU performance of update_jacobian by pulling out subexpressions

### DIFF
--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -92,6 +92,16 @@ function temporary_quantities(Y, atmos)
                 ClimaCore.Geometry.WVector{FT},
             },
         ),
+        ᶠsed_tracer_advection = similar(
+            Y.f,
+            ClimaCore.MatrixFields.BandMatrixRow{
+                ClimaCore.Utilities.PlusHalf{Int64}(0),
+                1,
+                ClimaCore.Geometry.WVector{FT},
+            },
+        ),
+        ᶠtracer_advection = similar(Y.f, BidiagonalMatrixRow{Adjoint{FT, C3{FT}}}),
+        ᶠtracer_advection_upwind = similar(Y.f, TridiagonalMatrixRow{FT}),
         ᶠdiagonal_matrix_ct3xct3 = similar(
             Y.f,
             DiagonalMatrixRow{
@@ -109,6 +119,10 @@ function temporary_quantities(Y, atmos)
         ᶠbidiagonal_matrix_ct3_2 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
         ᶜbidiagonal_matrix_scalar = similar(Y.c, BidiagonalMatrixRow{FT}),
         ᶜadvection_matrix = similar(
+            Y.c,
+            BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
+        ),
+        ᶜadvection_matrix_2 = similar(
             Y.c,
             BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
         ),


### PR DESCRIPTION
Sedimentation and the microphysics tracers loop were affected. Three new scratch variables were introduced.

## To-do
Profile the advection kernels from manual_sparse_jacobian.jl:1041 and 1051 to see
what can be done to speed those up.


## Content
nsys profiling revealed that four kernels were taking up over 25% of the total time running
prognostic 1M.  With these changes, they account for a few percent of the changes, and overall
step times dropped about 33%.
Because this is just a performance rewrite, there is no new functionality, and no new tests
are needed.


----
- [X] I have read and checked the items on the review checklist.
