### PR TITLE
ft: rcemipii vertical mesh

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -27,6 +27,9 @@ z_elem:
 z_max:
   help: "Model top height. Default: 30km"
   value: 30000.0
+vertical_mesh:
+  help: "Predefined vertical mesh [`~` (default), `rcemipii`]"
+  value: ~
 vorticity_hyperdiffusion_coefficient:
   help: "Hyperdiffusion coefficient for vorticity (m s-1)"
   value: 0.1857

--- a/config/model_configs/rcemipii_box_CRM_1M.yml
+++ b/config/model_configs/rcemipii_box_CRM_1M.yml
@@ -23,20 +23,26 @@ energy_q_tot_upwinding: vanleer_limiter  # is default (alt: `first_order`)
 reproducibility_test: true
 
 # microphysics
+### 0M+Equil option
+# moist: equil
+# precip_model: 0M
 ### !! 1M and 2M !!
 cloud_model: grid_scale   # Ultimately wanted when `moist: nonequil`
 moist: nonequil
 precip_model: 1M
+
 ### spatial discretization ###
-x_max: 96000.0  # 96km
-y_max: 96000.0  # 96km
-# x_max: 6000000.0  # 6000km
-# y_max: 400000.0  # 400km
-z_max: 30000.0  # 30km
 nh_poly: 3  # hor. poly deg -> # quad pts in 1D in a h. elem is Nq = nh + 1
-# z_elem: 43  # Note: Set sponge height (`zd_viscous`) in toml file to cover top ~5 points
-z_elem: 86
-dz_bottom: 30.0
+## RCE_small
+x_max: 96000  # 96km
+y_max: 96000  # 96km
+## RCE_large
+# x_max: 6000000  # 6000km
+# y_max: 400000  # 400km
+## Vertical mesh
+z_max: 33000  # 33km
+z_elem: 74
+vertical_mesh: rcemipii
 
 #~8km grid
 x_elem: 4

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -914,6 +914,7 @@ function get_grid(parsed_args, params, context)
         z_max = parsed_args["z_max"],
         z_stretch = parsed_args["z_stretch"],
         dz_bottom = parsed_args["dz_bottom"],
+        vertical_mesh = parsed_args["vertical_mesh"],
     )
 
     # Add topography parameters for non-column grids


### PR DESCRIPTION
This pull request introduces support for selecting a predefined vertical mesh in the model configuration, specifically enabling the use of the "rcemipii" vertical mesh. The changes allow users to specify a vertical mesh type in the configuration files, and the codebase is updated to construct the appropriate mesh based on this setting.

**Vertical mesh configuration and support:**

* Added a new `vertical_mesh` configuration option in `default_config.yml` to allow users to select the predefined "rcemipii" mesh.
* Updated the `rcemipii_box_CRM_1M.yml` model configuration to use the new `vertical_mesh: rcemipii` option, and adjusted related vertical grid parameters (`z_max`, `z_elem`) to match the new mesh.

**Codebase enhancements for mesh construction:**

* Modified the `BoxGrid` function in `grids.jl` to accept a `vertical_mesh` argument and construct the "rcemipii" mesh when specified, using a hardcoded boundary layer and uniform spacing in the free atmosphere.
* Updated the `get_grid` function in `type_getters.jl` to pass the `vertical_mesh` parameter from parsed arguments to the grid constructor.