### PR TITLE
use grid-mean u for TKE advection

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-290
+291
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+291
+- Use grid-mean velocity in the advection of TKE
+
 290
 - Change jacobians related to the derivative of pressure with respect to density
 and fix a bug in EDMF mass flux jacobian.

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -1344,11 +1344,8 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
 
     if p.atmos.turbconv_model isa DiagnosticEDMFX
         (; ᶠu³⁰, ᶜu⁰) = p.precomputed
-    elseif p.atmos.turbconv_model isa EDOnlyEDMFX
-        ᶠu³⁰ = p.precomputed.ᶠu³
-        ᶜu⁰ = ᶜu
-    end
-    @. ᶜu⁰ = C123(Y.c.uₕ) + ᶜinterp(C123(ᶠu³⁰))  # Set here, but used in a different function
+        @. ᶜu⁰ = C123(Y.c.uₕ) + ᶜinterp(C123(ᶠu³⁰))
+    end  # Set here, but used in a different function
 
     @. ᶜlinear_buoygrad = buoyancy_gradients(
         BuoyGradMean(),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I forgot to change environment u to grid-mean u when changing environment TKE to grid-mean TKE.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
