### PR TITLE
Fix initialization of EveryCalendarDtSchedule for diagnostics

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -120,13 +120,20 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, output_dir)
                     CA.promote_period.(Dates.Second(period_seconds))
             end
 
+            (; start_date, t_start) = sim_info
+            date_last =
+                t_start isa ITime ?
+                ClimaUtilities.TimeManager.date(t_start) :
+                start_date + Dates.Second(t_start)
             output_schedule = CAD.EveryCalendarDtSchedule(
                 period_dates;
                 reference_date = start_date,
+                date_last = date_last,
             )
             compute_schedule = CAD.EveryCalendarDtSchedule(
                 period_dates;
                 reference_date = start_date,
+                date_last = date_last,
             )
 
             if isnothing(output_name)
@@ -166,7 +173,8 @@ function get_diagnostics(parsed_args, atmos_model, Y, p, sim_info, output_dir)
                 sim_info.dt isa ITime ?
                 ITime(time_to_seconds(parsed_args["t_end"])) - t_start :
                 FT(time_to_seconds(parsed_args["t_end"]) - t_start),
-                start_date;
+                start_date,
+                sim_info.t_start;
                 output_writer = netcdf_writer,
                 topography = has_topography(axes(Y.c)),
             )...,

--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -6,6 +6,8 @@
 #   conceptually related. The dictionary `ALL_DIAGNOSTICS` should be considered an
 #   implementation detail.
 
+import ClimaUtilities
+import Dates
 
 const ALL_DIAGNOSTICS = Dict{String, DiagnosticVariable}()
 

--- a/src/diagnostics/standard_diagnostic_frequencies.jl
+++ b/src/diagnostics/standard_diagnostic_frequencies.jl
@@ -1,220 +1,224 @@
 """
-    monthly_maxs(FT, short_names...; output_writer, start_date)
+    monthly_maxs(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly max for the given variables.
 """
-monthly_maxs(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Month(1), max, output_writer, start_date, short_names...)
+monthly_maxs(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Month(1), max, output_writer, start_date, t_start, short_names...)
 """
-    monthly_max(FT, short_names; output_writer, start_date)
+    monthly_max(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the monthly max for the given variable.
 """
-monthly_max(FT, short_names; output_writer, start_date) =
-    monthly_maxs(FT, short_names; output_writer, start_date)[1]
+monthly_max(FT, short_names; output_writer, start_date, t_start) =
+    monthly_maxs(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    monthly_mins(short_names...; output_writer, start_date)
+    monthly_mins(short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly min for the given variables.
 """
-monthly_mins(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Month(1), min, output_writer, start_date, short_names...)
+monthly_mins(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Month(1), min, output_writer, start_date, t_start, short_names...)
 """
-    monthly_min(FT, short_names; output_writer, start_date)
+    monthly_min(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the monthly min for the given variable.
 """
-monthly_min(FT, short_names; output_writer, start_date) =
-    monthly_mins(FT, short_names; output_writer, start_date)[1]
+monthly_min(FT, short_names; output_writer, start_date, t_start) =
+    monthly_mins(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    monthly_averages(FT, short_names...; output_writer, start_date)
+    monthly_averages(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the monthly average for the given variables.
 """
 # An average is just a sum with a normalization before output
-monthly_averages(FT, short_names...; output_writer, start_date) =
+monthly_averages(FT, short_names...; output_writer, start_date, t_start) =
     common_diagnostics(
         Month(1),
         (+),
         output_writer,
         start_date,
+        t_start,
         short_names...,
         ;
         pre_output_hook! = average_pre_output_hook!,
     )
 
 """
-    monthly_average(FT, short_names; output_writer, start_date)
+    monthly_average(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that compute the monthly average for the given variable.
 """
 # An average is just a sum with a normalization before output
-monthly_average(FT, short_names; output_writer, start_date) =
-    monthly_averages(FT, short_names; output_writer, start_date)[1]
+monthly_average(FT, short_names; output_writer, start_date, t_start) =
+    monthly_averages(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    tendaily_maxs(FT, short_names...; output_writer, start_date)
+    tendaily_maxs(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the max over ten days for the given variables.
 """
-tendaily_maxs(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Day(10), max, output_writer, start_date, short_names...)
+tendaily_maxs(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Day(10), max, output_writer, start_date, t_start, short_names...)
 """
-    tendaily_max(FT, short_names; output_writer, start_date)
+    tendaily_max(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the max over ten days for the given variable.
 """
-tendaily_max(FT, short_names; output_writer, start_date) =
-    tendaily_maxs(FT, short_names; output_writer, start_date)[1]
+tendaily_max(FT, short_names; output_writer, start_date, t_start) =
+    tendaily_maxs(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    tendaily_mins(FT, short_names...; output_writer, start_date)
+    tendaily_mins(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the min over ten days for the given variables.
 """
-tendaily_mins(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Day(10), min, output_writer, start_date, short_names...)
+tendaily_mins(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Day(10), min, output_writer, start_date, t_start, short_names...)
 """
-    tendaily_min(FT, short_names; output_writer, start_date)
+    tendaily_min(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the min over ten days for the given variable.
 """
-tendaily_min(FT, short_names; output_writer, start_date) =
-    tendaily_mins(FT, short_names; output_writer, start_date)[1]
+tendaily_min(FT, short_names; output_writer, start_date, t_start) =
+    tendaily_mins(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    tendaily_averages(FT, short_names...; output_writer, start_date)
+    tendaily_averages(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the average over ten days for the given variables.
 """
 # An average is just a sum with a normalization before output
-tendaily_averages(FT, short_names...; output_writer, start_date) =
+tendaily_averages(FT, short_names...; output_writer, start_date, t_start) =
     common_diagnostics(
         Day(10),
         (+),
         output_writer,
         start_date,
+        t_start,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    tendaily_average(FT, short_names; output_writer, start_date)
+    tendaily_average(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that compute the average over ten days for the given variable.
 """
 # An average is just a sum with a normalization before output
-tendaily_average(FT, short_names; output_writer, start_date) =
-    tendaily_averages(FT, short_names; output_writer, start_date)[1]
+tendaily_average(FT, short_names; output_writer, start_date, t_start) =
+    tendaily_averages(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    daily_maxs(FT, short_names...; output_writer, start_date)
+    daily_maxs(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the daily max for the given variables.
 """
-daily_maxs(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Day(1), max, output_writer, start_date, short_names...)
+daily_maxs(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Day(1), max, output_writer, start_date, t_start, short_names...)
 """
-    daily_max(FT, short_names; output_writer, start_date)
+    daily_max(FT, short_names; output_writer, start_date, t_start)
 
 
 Return a `ScheduledDiagnostics` that computes the daily max for the given variable.
 """
-daily_max(FT, short_names; output_writer, start_date) =
-    daily_maxs(FT, short_names; output_writer, start_date)[1]
+daily_max(FT, short_names; output_writer, start_date, t_start) =
+    daily_maxs(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    daily_mins(FT, short_names...; output_writer, start_date)
+    daily_mins(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the daily min for the given variables.
 """
-daily_mins(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Day(1), min, output_writer, start_date, short_names...)
+daily_mins(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Day(1), min, output_writer, start_date, t_start, short_names...)
 """
-    daily_min(FT, short_names; output_writer, start_date)
+    daily_min(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the daily min for the given variable.
 """
-daily_min(FT, short_names; output_writer, start_date) =
-    daily_mins(FT, short_names; output_writer, start_date)[1]
+daily_min(FT, short_names; output_writer, start_date, t_start) =
+    daily_mins(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    daily_averages(FT, short_names...; output_writer, start_date)
+    daily_averages(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the daily average for the given variables.
 """
 # An average is just a sum with a normalization before output
-daily_averages(FT, short_names...; output_writer, start_date) =
+daily_averages(FT, short_names...; output_writer, start_date, t_start) =
     common_diagnostics(
         Day(1),
         (+),
         output_writer,
         start_date,
+        t_start,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 """
-    daily_average(FT, short_names; output_writer, start_date)
+    daily_average(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that compute the daily average for the given variable.
 """
 # An average is just a sum with a normalization before output
-daily_average(FT, short_names; output_writer, start_date) =
-    daily_averages(FT, short_names; output_writer, start_date)[1]
+daily_average(FT, short_names; output_writer, start_date, t_start) =
+    daily_averages(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    hourly_maxs(FT, short_names...; output_writer, start_date)
+    hourly_maxs(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly max for the given variables.
 """
-hourly_maxs(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Hour(1), max, output_writer, start_date, short_names...)
+hourly_maxs(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Hour(1), max, output_writer, start_date, t_start, short_names...)
 
 """
-    hourly_max(FT, short_names; output_writer, start_date)
+    hourly_max(FT, short_names; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the hourly max for the given variable.
 """
-hourly_max(FT, short_names; output_writer, start_date) =
-    hourly_maxs(FT, short_names; output_writer, start_date)[1]
+hourly_max(FT, short_names; output_writer, start_date, t_start) =
+    hourly_maxs(FT, short_names; output_writer, start_date, t_start)[1]
 
 """
-    hourly_mins(FT, short_names...; output_writer, start_date)
+    hourly_mins(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly min for the given variables.
 """
-hourly_mins(FT, short_names...; output_writer, start_date) =
-    common_diagnostics(Hour(1), min, output_writer, start_date, short_names...)
+hourly_mins(FT, short_names...; output_writer, start_date, t_start) =
+    common_diagnostics(Hour(1), min, output_writer, start_date, t_start, short_names...)
 """
-    hourly_mins(FT, short_names...; output_writer, start_date)
+    hourly_mins(FT, short_names...; output_writer, start_date, t_start)
 
 
 Return a `ScheduledDiagnostics` that computes the hourly min for the given variable.
 """
-hourly_min(FT, short_names; output_writer, start_date) =
-    hourly_mins(FT, short_names; output_writer, start_date)[1]
+hourly_min(FT, short_names; output_writer, start_date, t_start) =
+    hourly_mins(FT, short_names; output_writer, start_date, t_start)[1]
 
 # An average is just a sum with a normalization before output
 """
-    hourly_averages(FT, short_names...; output_writer, start_date)
+    hourly_averages(FT, short_names...; output_writer, start_date, t_start)
 
 Return a list of `ScheduledDiagnostics` that compute the hourly average for the given variables.
 """
-hourly_averages(FT, short_names...; output_writer, start_date) =
+hourly_averages(FT, short_names...; output_writer, start_date, t_start) =
     common_diagnostics(
         Hour(1),
         (+),
         output_writer,
         start_date,
+        t_start,
         short_names...;
         pre_output_hook! = average_pre_output_hook!,
     )
 
 """
-    hourly_average(FT, short_names...; output_writer, start_date)
+    hourly_average(FT, short_names...; output_writer, start_date, t_start)
 
 Return a `ScheduledDiagnostics` that computes the hourly average for the given variable.
 """
-hourly_average(FT, short_names; output_writer, start_date) =
-    hourly_averages(FT, short_names; output_writer, start_date)[1]
+hourly_average(FT, short_names; output_writer, start_date, t_start) =
+    hourly_averages(FT, short_names; output_writer, start_date, t_start)[1]


### PR DESCRIPTION
closes #4188 - This PR fixes the initialization of `EveryCalendarDtSchedule`. Without this fix, the times and dates of the diagnostics after a restart would be off by a single timestep. Note that the first time and date of the diagnostics produced from a restarted simulation is still wrong, because of a bug in ClimaDiagnostics. See https://github.com/CliMA/ClimaDiagnostics.jl/issues/149
