### PR TITLE
move tke out of sgs variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaAtmos.jl Release Notes
 
 main
 -------
+- PR [#4191](https://github.com/CliMA/ClimaAtmos.jl/pull/4191) renames ρatke to ρtke and move it out of sgs⁰.
+
 - PR [#4175](https://github.com/CliMA/ClimaAtmos.jl/pull/4175) adds support for lazy diagnostics,
 as introduced in [`ClimaDiagnostics.jl`](https://github.com/CliMA/ClimaDiagnostics.jl) v0.2.13.
 

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-291
+292
 
 # **README**
 #
@@ -20,6 +20,10 @@
 
 
 #=
+292
+- Rename ρatke to ρtke and move it outside of sgs⁰ and fix a bug that there is no
+hyperdiffusion of TKE when using EDOnlyEDMFX.
+
 291
 - Use grid-mean velocity in the advection of TKE
 

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -499,7 +499,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
     ᶜe_tot = @. lazy(specific(Y.c.ρe_tot, Y.c.ρ))
     ᶜh_tot = @. lazy(TD.total_specific_enthalpy(thermo_params, ᶜts, ᶜe_tot))
 
-    ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
 
     for i in 2:Spaces.nlevels(axes(Y.c))
         ρ_level = Fields.field_values(Fields.level(Y.c.ρ, i))
@@ -660,7 +660,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                     Fields.field_values(Fields.level(ᶜSᵖ_snow, i - 1))
             end
 
-            tke_prev_level = Fields.field_values(Fields.level(ᶜtke⁰, i - 1))
+            tke_prev_level = Fields.field_values(Fields.level(ᶜtke, i - 1))
 
             @. entrʲ_prev_level = entrainment(
                 thermo_params,
@@ -1337,7 +1337,7 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
     (; ᶜu, ᶜts, ᶠu³) = p.precomputed
     (; ustar) = p.precomputed.sfc_conditions
     (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-    (; ρatke_flux) = p.precomputed
+    (; ρtke_flux) = p.precomputed
     turbconv_params = CAP.turbconv_params(params)
     thermo_params = CAP.thermodynamics_params(params)
     ᶜlg = Fields.local_geometry_field(Y.c)
@@ -1364,13 +1364,13 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_env_closures!
     ᶜstrain_rate = compute_strain_rate_center_vertical(ᶠu)
     @. ᶜstrain_rate_norm = norm_sqr(ᶜstrain_rate)
 
-    ρatke_flux_values = Fields.field_values(ρatke_flux)
+    ρtke_flux_values = Fields.field_values(ρtke_flux)
     ρ_int_values = Fields.field_values(Fields.level(Y.c.ρ, 1))
     ustar_values = Fields.field_values(ustar)
     sfc_local_geometry_values = Fields.field_values(
         Fields.level(Fields.local_geometry_field(Y.f), half),
     )
-    @. ρatke_flux_values = surface_flux_tke(
+    @. ρtke_flux_values = surface_flux_tke(
         turbconv_params,
         ρ_int_values,
         ustar_values,

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -194,7 +194,7 @@ function precomputed_quantities(Y, atmos)
     advective_sgs_quantities =
         atmos.turbconv_model isa PrognosticEDMFX ?
         (;
-            ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
+            ρtke_flux = similar(Fields.level(Y.f, half), C3{FT}),
             bdmr_l = similar(Y.c, BidiagonalMatrixRow{FT}),
             bdmr_r = similar(Y.c, BidiagonalMatrixRow{FT}),
             bdmr = similar(Y.c, BidiagonalMatrixRow{FT}),
@@ -209,7 +209,7 @@ function precomputed_quantities(Y, atmos)
 
     edonly_quantities =
         atmos.turbconv_model isa EDOnlyEDMFX ?
-        (; ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),) : (;)
+        (; ρtke_flux = similar(Fields.level(Y.f, half), C3{FT}),) : (;)
 
     sgs_quantities = (;
         ᶜgradᵥ_q_tot = Fields.Field(C3{FT}, cspace),
@@ -244,7 +244,7 @@ function precomputed_quantities(Y, atmos)
             ᶠu³⁰ = similar(Y.f, CT3{FT}),
             ᶜu⁰ = similar(Y.c, C123{FT}),
             ᶜK⁰ = similar(Y.c, FT),
-            ρatke_flux = similar(Fields.level(Y.f, half), C3{FT}),
+            ρtke_flux = similar(Fields.level(Y.f, half), C3{FT}),
             precipitation_sgs_quantities...,
             diagnostic_precipitation_sgs_quantities...,
         ) : (;)
@@ -488,7 +488,7 @@ NVTX.@annotate function set_implicit_precomputed_quantities!(Y, p, t)
         # circular dependency will prevent us from computing the exact value of
         # ᶜK. For now, we will make the anelastic approximation ᶜρ⁰ ≈ ᶜρʲ ≈ ᶜρ.
         # add_sgs_ᶜK!(ᶜK, Y, ᶜρa⁰, ᶠu₃⁰, turbconv_model)
-        # @. ᶜK += Y.c.sgs⁰.ρatke / Y.c.ρ
+        # @. ᶜK += Y.c.ρtke / Y.c.ρ
         # TODO: We should think more about these increments before we use them.
     end
     @. ᶜts = ts_gs(thermo_args..., Y.c, ᶜK, ᶜΦ, Y.c.ρ)

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -23,10 +23,10 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
     (; ᶜp, ᶜK) = p.precomputed
     (; ᶠu₃⁰, ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶜts⁰) = p.precomputed
 
-    ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
     set_sgs_ᶠu₃!(u₃⁰, ᶠu₃⁰, Y, turbconv_model)
     set_velocity_quantities!(ᶜu⁰, ᶠu³⁰, ᶜK⁰, ᶠu₃⁰, Y.c.uₕ, ᶠuₕ³)
-    # @. ᶜK⁰ += ᶜtke⁰
+    # @. ᶜK⁰ += ᶜtke
     ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
 
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)
@@ -176,7 +176,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     n = n_mass_flux_subdomains(turbconv_model)
 
     (; ᶜu, ᶜp, ᶠu³, ᶜts, ᶠu³⁰, ᶜts⁰) = p.precomputed
-    (; ᶜlinear_buoygrad, ᶜstrain_rate_norm, ρatke_flux) = p.precomputed
+    (; ᶜlinear_buoygrad, ᶜstrain_rate_norm, ρtke_flux) = p.precomputed
     (;
         ᶜuʲs,
         ᶜtsʲs,
@@ -196,7 +196,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     ᶜlg = Fields.local_geometry_field(Y.c)
     ᶠlg = Fields.local_geometry_field(Y.f)
     ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
-    ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
 
     ᶜvert_div = p.scratch.ᶜtemp_scalar
     ᶜmassflux_vert_div = p.scratch.ᶜtemp_scalar_2
@@ -217,7 +217,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             get_physical_w(ᶜu, ᶜlg),
             TD.relative_humidity(thermo_params, ᶜts⁰),
             FT(0),
-            max(ᶜtke⁰, 0),
+            max(ᶜtke, 0),
             p.atmos.edmfx_model.entr_model,
         )
 
@@ -258,7 +258,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             ᶜvert_div,
             ᶜmassflux_vert_div,
             ᶜw_vert_div,
-            ᶜtke⁰,
+            ᶜtke,
             p.atmos.edmfx_model.detr_model,
         )
 
@@ -319,13 +319,13 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     ᶜstrain_rate = compute_strain_rate_center_vertical(ᶠu)
     @. ᶜstrain_rate_norm = norm_sqr(ᶜstrain_rate)
 
-    ρatke_flux_values = Fields.field_values(ρatke_flux)
+    ρtke_flux_values = Fields.field_values(ρtke_flux)
     ρa_sfc_values = Fields.field_values(Fields.level(ᶜρa⁰, 1)) # TODO: replace by surface value
     ustar_values = Fields.field_values(ustar)
     sfc_local_geometry_values = Fields.field_values(
         Fields.level(Fields.local_geometry_field(Y.f), half),
     )
-    @. ρatke_flux_values = surface_flux_tke(
+    @. ρtke_flux_values = surface_flux_tke(
         turbconv_params,
         ρa_sfc_values,
         ustar_values,

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -1376,7 +1376,7 @@ add_diagnostic_variable!(
 )
 
 ###
-# Environment turbulent kinetic energy (3d)
+# Turbulent kinetic energy (3d)
 ###
 compute_tke!(out, state, cache, time) =
     compute_tke!(out, state, cache, time, cache.atmos.turbconv_model)
@@ -1398,7 +1398,7 @@ function compute_tke!(
     end
 
     ᶜtke = @. lazy(
-        specific(state.c.sgs⁰.ρatke, state.c.ρ),
+        specific(state.c.ρtke, state.c.ρ),
     )
     if isnothing(out)
         return Base.materialize(ᶜtke)
@@ -1570,14 +1570,11 @@ function compute_edt!(
     (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = cache.precomputed
     (; params) = cache
 
-    ᶜρa⁰ =
-        turbconv_model isa PrognosticEDMFX ?
-        (@. lazy(ρa⁰(state.c.ρ, state.c.sgsʲs, turbconv_model))) : state.c.ρ
-    ᶜtke⁰ = @. lazy(
-        specific(state.c.sgs⁰.ρatke, state.c.ρ),
+    ᶜtke = @. lazy(
+        specific(state.c.ρtke, state.c.ρ),
     )
     ᶜmixing_length_field = ᶜmixing_length(state, cache)
-    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke⁰, ᶜmixing_length_field))
+    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
     ᶜprandtl_nvec = @. lazy(
         turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
     )
@@ -1659,14 +1656,11 @@ function compute_evu!(
 )
     turbconv_params = CAP.turbconv_params(cache.params)
 
-    ᶜρa⁰ =
-        turbconv_model isa PrognosticEDMFX ?
-        (@. lazy(ρa⁰(state.c.ρ, state.c.sgsʲs, turbconv_model))) : state.c.ρ
-    ᶜtke⁰ = @. lazy(
-        specific(state.c.sgs⁰.ρatke, state.c.ρ),
+    ᶜtke = @. lazy(
+        specific(state.c.ρtke, state.c.ρ),
     )
     ᶜmixing_length_field = ᶜmixing_length(state, cache)
-    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke⁰, ᶜmixing_length_field))
+    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
 
     if isnothing(out)
         return Base.materialize(ᶜK_u)

--- a/src/initial_conditions/atmos_state.jl
+++ b/src/initial_conditions/atmos_state.jl
@@ -163,14 +163,14 @@ function turbconv_center_variables(
 )
     n = n_mass_flux_subdomains(turbconv_model)
     a_draft = ls.turbconv_state.draft_area
-    sgs⁰ = (; ρatke = ls.ρ * (1 - a_draft) * ls.turbconv_state.tke)
+    ρtke = ls.ρ * ls.turbconv_state.tke
     ρa = ls.ρ * a_draft / n
     mse =
         TD.specific_enthalpy(ls.thermo_params, ls.thermo_state) +
         CAP.grav(ls.params) * ls.geometry.coordinates.z
     q_tot = TD.total_specific_humidity(ls.thermo_params, ls.thermo_state)
     sgsʲs = ntuple(_ -> (; ρa = ρa, mse = mse, q_tot = q_tot), Val(n))
-    return (; sgs⁰, sgsʲs)
+    return (; ρtke = ρtke, sgsʲs)
 end
 function turbconv_center_variables(
     ls,
@@ -182,7 +182,7 @@ function turbconv_center_variables(
     # TODO - Instead of dispatching, should we unify this with the above function?
     n = n_mass_flux_subdomains(turbconv_model)
     a_draft = ls.turbconv_state.draft_area
-    sgs⁰ = (; ρatke = ls.ρ * (1 - a_draft) * ls.turbconv_state.tke)
+    ρtke = ls.ρ * ls.turbconv_state.tke
     ρa = ls.ρ * a_draft / n
     mse =
         TD.specific_enthalpy(ls.thermo_params, ls.thermo_state) +
@@ -223,7 +223,7 @@ function turbconv_center_variables(
             Val(n),
         )
     end
-    return (; sgs⁰, sgsʲs)
+    return (; ρtke = ρtke, sgsʲs)
 end
 
 function turbconv_center_variables(
@@ -233,8 +233,8 @@ function turbconv_center_variables(
     _,
     gs_vars,
 )
-    sgs⁰ = (; ρatke = ls.ρ * ls.turbconv_state.tke)
-    return (; sgs⁰)
+    ρtke = ls.ρ * ls.turbconv_state.tke
+    return (; ρtke = ρtke)
 end
 
 turbconv_face_variables(ls, ::Nothing) = (;)

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -746,9 +746,9 @@ function overwrite_initial_conditions!(
             ) .* Y.c.ρ
     end
 
-    if hasproperty(Y.c, :sgs⁰) && hasproperty(Y.c.sgs⁰, :ρatke)
+    if hasproperty(Y.c, :ρtke)
         # NOTE: This is not the most consistent, but it is better than NaNs
-        fill!(Y.c.sgs⁰.ρatke, 0)
+        fill!(Y.c.ρtke, 0)
     end
 
     return nothing
@@ -879,9 +879,9 @@ function _overwrite_initial_conditions_from_file!(
             ) .* Y.c.ρ
     end
 
-    if hasproperty(Y.c, :sgs⁰) && hasproperty(Y.c.sgs⁰, :ρatke)
+    if hasproperty(Y.c, :ρtke)
         # NOTE: This is not the most consistent, but it is better than NaNs
-        fill!(Y.c.sgs⁰.ρatke, 0)
+        fill!(Y.c.ρtke, 0)
     end
 
     return nothing

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -410,8 +410,8 @@ function ᶜmixing_length(Y, p, property::Val{P} = Val{:master}()) where {P}
     z_sfc = Fields.level(Fields.coordinate_field(Y.f).z, Fields.half)
     ᶜdz = Fields.Δz_field(axes(Y.c))
 
-    ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
-    sfc_tke = Fields.level(ᶜtke⁰, 1)
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
+    sfc_tke = Fields.level(ᶜtke, 1)
 
     ᶜprandtl_nvec = p.scratch.ᶜtemp_scalar_5
     @. ᶜprandtl_nvec =
@@ -426,7 +426,7 @@ function ᶜmixing_length(Y, p, property::Val{P} = Val{:master}()) where {P}
             ᶜdz,
             sfc_tke,
             ᶜlinear_buoygrad,
-            ᶜtke⁰,
+            ᶜtke,
             obukhov_length,
             ᶜstrain_rate_norm,
             ᶜprandtl_nvec,

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -9,7 +9,7 @@
  to the prognostic variables.
 
  This function calculates and applies the changes in the environment TKE
- (`Yₜ.c.sgs⁰.ρatke`) due to various processes within the EDMFX framework,
+ (`Yₜ.c.ρtke`) due to various processes within the EDMFX framework,
  including shear production, buoyancy production, entrainment, detrainment,
  turbulent entrainment, pressure work, and dissipation.
 
@@ -29,19 +29,19 @@ function edmfx_tke_tendency!(Yₜ, Y, p, t, turbconv_model::EDOnlyEDMFX)
     (; params) = p
     (; ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
     turbconv_params = CAP.turbconv_params(p.params)
-    ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
     ᶜmixing_length_field = p.scratch.ᶜtemp_scalar
     ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke⁰, ᶜmixing_length_field))
+    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
     ᶜprandtl_nvec = @. lazy(
         turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
     )
     ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
 
     # shear production
-    @. Yₜ.c.sgs⁰.ρatke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
+    @. Yₜ.c.ρtke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
     # buoyancy production
-    @. Yₜ.c.sgs⁰.ρatke -= Y.c.ρ * ᶜK_h * ᶜlinear_buoygrad
+    @. Yₜ.c.ρtke -= Y.c.ρ * ᶜK_h * ᶜlinear_buoygrad
 end
 
 function edmfx_tke_tendency!(
@@ -62,9 +62,9 @@ function edmfx_tke_tendency!(
         ᶠz = Fields.coordinate_field(Y.f).z
         ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2
         ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
         ᶜK_u = @. lazy(
-            eddy_viscosity(turbconv_params, ᶜtke⁰, ᶜmixing_length_field),
+            eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field),
         )
         ᶜprandtl_nvec = @. lazy(
             turbulent_prandtl_number(
@@ -76,14 +76,14 @@ function edmfx_tke_tendency!(
         ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
 
         # shear production
-        @. Yₜ.c.sgs⁰.ρatke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
+        @. Yₜ.c.ρtke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
         # buoyancy production
-        @. Yₜ.c.sgs⁰.ρatke -= Y.c.ρ * ᶜK_h * ᶜlinear_buoygrad
+        @. Yₜ.c.ρtke -= Y.c.ρ * ᶜK_h * ᶜlinear_buoygrad
         for j in 1:n
             ᶜρaʲ =
                 turbconv_model isa PrognosticEDMFX ? Y.c.sgsʲs.:($j).ρa :
                 p.precomputed.ᶜρaʲs.:($j)
-            @. Yₜ.c.sgs⁰.ρatke -=
+            @. Yₜ.c.ρtke -=
                 ᶜρaʲ * adjoint(CT3(ᶜinterp(ᶠu³ʲs.:($$j) - ᶠu³))) *
                 (ᶜρʲs.:($$j) - Y.c.ρ) *
                 ᶜgradᵥ(CAP.grav(p.params) * ᶠz) / ᶜρʲs.:($$j)
@@ -93,7 +93,7 @@ function edmfx_tke_tendency!(
             ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
             (; ᶜts⁰) = p.precomputed
             ᶜρ⁰ = @. lazy(TD.air_density(thermo_params, ᶜts⁰))
-            @. Yₜ.c.sgs⁰.ρatke -=
+            @. Yₜ.c.ρtke -=
                 ᶜρa⁰ * adjoint(CT3(ᶜinterp(ᶠu³⁰ - ᶠu³))) *
                 (ᶜρ⁰ - Y.c.ρ) *
                 ᶜgradᵥ(CAP.grav(p.params) * ᶠz) / ᶜρ⁰
@@ -103,24 +103,24 @@ function edmfx_tke_tendency!(
 end
 
 """
-    tke_dissipation(turbconv_params, ρatke, tke, mixing_length)
+    tke_dissipation(turbconv_params, ρtke, tke, mixing_length)
 
 Returns a scalar value representing the TKE dissipation rate
 per unit volume, ρ * ε_d [kg m^-1 s^-3].
 
 The physical dissipation is calculated as:
-  ρ * ε_d = c_d * ρatke * sqrt(abs(tke)) / mixing_length
+  ρ * ε_d = c_d * ρtke * sqrt(abs(tke)) / mixing_length
 where `c_d` is a parameter.
 
 Arguments:
 - `turbconv_params`: Turbulence and convection model parameters.
-- `ρatke`: ρ_area_weighted * tke [kg m^-2 s^-2].
+- `ρtke`: ρ_area_weighted * tke [kg m^-2 s^-2].
 - `tke`: Turbulent kinetic energy [m^2 s^-2].
 - `mixing_length`: Turbulent mixing length [m].
 """
-function tke_dissipation(turbconv_params, ρatke, tke, mixing_length)
+function tke_dissipation(turbconv_params, ρtke, tke, mixing_length)
     FT = typeof(tke)
     c_d = CAP.tke_diss_coeff(turbconv_params)
-    dissipation_rate_vol = c_d * ρatke * sqrt(abs(tke)) / mixing_length
+    dissipation_rate_vol = c_d * ρtke * sqrt(abs(tke)) / mixing_length
     return dissipation_rate_vol
 end

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -72,9 +72,9 @@ function hyperdiffusion_cache(
             ᶜ∇²q_totʲs = similar(Y.c, NTuple{n, FT}),
             moisture_sgs_quantities...,
         ) : (;)
-    maybe_ᶜ∇²tke⁰ =
-        use_prognostic_tke(turbconv_model) ? (; ᶜ∇²tke⁰ = similar(Y.c, FT)) : (;)
-    sgs_quantities = (; sgs_quantities..., maybe_ᶜ∇²tke⁰...)
+    maybe_ᶜ∇²tke =
+        use_prognostic_tke(turbconv_model) ? (; ᶜ∇²tke = similar(Y.c, FT)) : (;)
+    sgs_quantities = (; sgs_quantities..., maybe_ᶜ∇²tke...)
     quantities = (; gs_quantities..., sgs_quantities...)
     if do_dss(axes(Y.c))
         quantities = (;
@@ -113,9 +113,9 @@ NVTX.@annotate function prep_hyperdiffusion_tendency!(Yₜ, Y, p, t)
     @. ᶜ∇²specific_energy = wdivₕ(gradₕ(specific(Y.c.ρe_tot, Y.c.ρ) + ᶜp / Y.c.ρ - ᶜh_ref))
 
     if diffuse_tke
-        ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
-        (; ᶜ∇²tke⁰) = p.hyperdiff
-        @. ᶜ∇²tke⁰ = wdivₕ(gradₕ(ᶜtke⁰))
+        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
+        (; ᶜ∇²tke) = p.hyperdiff
+        @. ᶜ∇²tke = wdivₕ(gradₕ(ᶜtke))
     end
 
     # Sub-grid scale hyperdiffusion
@@ -150,7 +150,7 @@ NVTX.@annotate function apply_hyperdiffusion_tendency!(Yₜ, Y, p, t)
         (; ᶜ∇²uₕʲs, ᶜ∇²uᵥʲs, ᶜ∇²uʲs, ᶜ∇²mseʲs) = p.hyperdiff
     end
     if use_prognostic_tke(turbconv_model)
-        (; ᶜ∇²tke⁰) = p.hyperdiff
+        (; ᶜ∇²tke) = p.hyperdiff
     end
 
     if turbconv_model isa PrognosticEDMFX
@@ -168,10 +168,10 @@ NVTX.@annotate function apply_hyperdiffusion_tendency!(Yₜ, Y, p, t)
 
     @. Yₜ.c.ρe_tot -= ν₄_scalar * wdivₕ(ᶜρ * gradₕ(ᶜ∇²specific_energy))
 
-    # Sub-grid scale hyperdiffusion continued
-    if (turbconv_model isa PrognosticEDMFX) && diffuse_tke
-        @. Yₜ.c.sgs⁰.ρatke -= ν₄_vorticity * wdivₕ(ᶜρa⁰ * gradₕ(ᶜ∇²tke⁰))
+    if (turbconv_model isa AbstractEDMF) && diffuse_tke
+        @. Yₜ.c.ρtke -= ν₄_vorticity * wdivₕ(ᶜρ * gradₕ(ᶜ∇²tke))
     end
+    # Sub-grid scale hyperdiffusion continued
     if turbconv_model isa PrognosticEDMFX
         for j in 1:n
             if point_type <: Geometry.Abstract3DPoint
@@ -182,10 +182,6 @@ NVTX.@annotate function apply_hyperdiffusion_tendency!(Yₜ, Y, p, t)
             # Note: It is more correct to have ρa inside and outside the divergence
             @. Yₜ.c.sgsʲs.:($$j).mse -= ν₄_scalar * wdivₕ(gradₕ(ᶜ∇²mseʲs.:($$j)))
         end
-    end
-
-    if turbconv_model isa DiagnosticEDMFX && diffuse_tke
-        @. Yₜ.c.sgs⁰.ρatke -= ν₄_vorticity * wdivₕ(ᶜρ * gradₕ(ᶜ∇²tke⁰))
     end
 end
 
@@ -198,13 +194,13 @@ function dss_hyperdiffusion_tendency_pairs(p)
         (; ᶜ∇²uₕʲs, ᶜ∇²uᵥʲs, ᶜ∇²mseʲs) = p.hyperdiff
     end
     if use_prognostic_tke(turbconv_model)
-        (; ᶜ∇²tke⁰) = p.hyperdiff
+        (; ᶜ∇²tke) = p.hyperdiff
     end
 
     core_dynamics_pairs = (
         ᶜ∇²u => buffer.ᶜ∇²u,
         ᶜ∇²specific_energy => buffer.ᶜ∇²specific_energy,
-        (diffuse_tke ? (ᶜ∇²tke⁰ => buffer.ᶜ∇²tke⁰,) : ())...,
+        (diffuse_tke ? (ᶜ∇²tke => buffer.ᶜ∇²tke,) : ())...,
     )
     tc_dynamics_pairs =
         turbconv_model isa PrognosticEDMFX ?

--- a/src/prognostic_equations/implicit/auto_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/auto_sparse_jacobian.jl
@@ -140,12 +140,12 @@ function jacobian_cache(alg::AutoSparseJacobian, Y, atmos; verbose = true)
         elseif (
             (
                 block_row_name in uₕ_component_names &&
-                block_column_name in (mass_names..., @name(c.sgs⁰.ρatke)) ||
+                block_column_name in (mass_names..., @name(c.ρtke)) ||
                 block_row_name == @name(c.ρe_tot) &&
                 block_column_name in (
                     mass_names...,
                     condensate_names...,
-                    @name(c.sgs⁰.ρatke),
+                    @name(c.ρtke),
                     @name(c.sgsʲs.:(1).q_tot),
                 ) ||
                 block_row_name == @name(c.sgsʲs.:(1).ρa) &&
@@ -159,9 +159,9 @@ function jacobian_cache(alg::AutoSparseJacobian, Y, atmos; verbose = true)
             # Missing off-diagonal blocks whose entries typically have
             # magnitudes that are larger than (or similar to) diagonal blocks in
             # the same rows:
-            # - ‖∂ᶜuᵢₜ/∂ᶜρ‖, ‖∂ᶜuᵢₜ/∂ᶜρaʲ‖ ≳ ‖∂ᶜuᵢₜ/∂ᶜuᵢ‖, and ‖∂ᶜuᵢₜ/∂ᶜρatke⁰‖
+            # - ‖∂ᶜuᵢₜ/∂ᶜρ‖, ‖∂ᶜuᵢₜ/∂ᶜρaʲ‖ ≳ ‖∂ᶜuᵢₜ/∂ᶜuᵢ‖, and ‖∂ᶜuᵢₜ/∂ᶜρtke‖
             #   where uᵢ is either u₁ or u₂, as long as ‖δᶜρ‖, ‖δᶜρaʲ‖ and
-            #   ‖δᶜρatke⁰‖ are relatively smaller than ‖δᶜuᵢ‖.
+            #   ‖δᶜρtke‖ are relatively smaller than ‖δᶜuᵢ‖.
             # - ‖∂ᶜρe_totₜ/∂ᶜρ‖, ‖∂ᶜρe_totₜ/∂ᶜχ‖, and ‖∂ᶜρe_totₜ/∂ᶜρχ‖ ≳
             #   ‖∂ᶜρe_totₜ/∂ᶜρe_tot‖ when χ is any scalar of order unity, as
             #   long as ‖δᶜρ‖ and ‖δᶜχ‖ are relatively smaller than ‖δᶜρe_tot‖.

--- a/src/prognostic_equations/implicit/autodiff_utils.jl
+++ b/src/prognostic_equations/implicit/autodiff_utils.jl
@@ -123,8 +123,8 @@ end
 # Set the derivative of sqrt(x) to iszero(x) ? zero(x) : inv(2 * sqrt(x)) in
 # order to properly handle derivatives of x * sqrt(x). Without this change, the
 # derivative of the turbulent kinetic energy dissipation tendency, which is a
-# linear function of ᶜtke⁰ * sqrt(ᶜtke⁰), evaluates to NaN at every point where
-# tke⁰ = 0. In general, this change is valid if all functions of sqrt(x) can be
+# linear function of ᶜtke * sqrt(ᶜtke), evaluates to NaN at every point where
+# tke = 0. In general, this change is valid if all functions of sqrt(x) can be
 # expanded around x = 0 with a leading term of the form c * x^p * sqrt(x), where
 # c and p are constants and p ≥ 1/2. For example, this will be the case for any
 # linear function of f(x) * sqrt(x), where f(x) has a non-constant Taylor

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -143,11 +143,11 @@ function edmfx_vertical_diffusion_tendency!(
         )
 
         (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-        ᶜtke⁰ = @. lazy(specific(Y.c.sgs⁰.ρatke, Y.c.ρ))
+        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
         # scratch to prevent GPU Kernel parameter memory error
         ᶜmixing_length_field = p.scratch.ᶜtemp_scalar
         ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke⁰, ᶜmixing_length_field))
+        ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
         ᶜprandtl_nvec = @. lazy(
             turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
         )

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -154,9 +154,9 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     rst_uₕ = rayleigh_sponge_tendency_uₕ(ᶜuₕ, rayleigh_sponge)
 
     if use_prognostic_tke(turbconv_model)
-        rst_ρatke =
-            rayleigh_sponge_tendency_sgs_tracer(Y.c.sgs⁰.ρatke, rayleigh_sponge)
-        @. Yₜ.c.sgs⁰.ρatke += rst_ρatke
+        rst_ρtke =
+            rayleigh_sponge_tendency_sgs_tracer(Y.c.ρtke, rayleigh_sponge)
+        @. Yₜ.c.ρtke += rst_ρtke
     end
     if turbconv_model isa PrognosticEDMFX
         ᶜmse = @. lazy(ᶜh_tot - ᶜK)

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -7,15 +7,15 @@ import LinearAlgebra: norm_sqr
 using Dates: DateTime, @dateformat_str
 import StaticArrays: SVector, SMatrix
 
-is_energy_var(symbol) = symbol in (:ρe_tot, :ρae_tot)
-is_momentum_var(symbol) = symbol in (:uₕ, :ρuₕ, :u₃, :ρw)
-is_turbconv_var(symbol) = symbol in (:turbconv, :sgsʲs, :sgs⁰)
+is_energy_var(symbol) = symbol in (:ρe_tot,)
+is_momentum_var(symbol) = symbol in (:uₕ, :u₃)
+is_sgs_var(symbol) = symbol in (:sgsʲs,)
 is_tracer_var(symbol) = !(
     symbol == :ρ ||
-    symbol == :ρa ||
+    symbol == :ρtke ||
     is_energy_var(symbol) ||
     is_momentum_var(symbol) ||
-    is_turbconv_var(symbol)
+    is_sgs_var(symbol)
 )
 
 # we may be hitting a slow path:

--- a/src/utils/variable_manipulations.jl
+++ b/src/utils/variable_manipulations.jl
@@ -73,11 +73,11 @@ end
     gs_tracer_names(Y)
 
 `Tuple` of `@name`s for the grid-scale tracers in the center field `Y.c`
-(excluding `ρ`, `ρe_tot`, velocities, and SGS fields).
+(excluding `ρ`, `ρe_tot`, `ρtke`, velocities, and SGS fields).
 """
 gs_tracer_names(Y) =
     unrolled_filter(MatrixFields.top_level_names(Y.c)) do name
-        is_ρ_weighted_name(name) && !(name in (@name(ρ), @name(ρe_tot)))
+        is_ρ_weighted_name(name) && !(name in (@name(ρ), @name(ρe_tot), @name(ρtke)))
     end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Rename ρatke to ρtke and move it out of sgs⁰, so it is clear that it's a grid-mean variable. Also fixes a bug that rhoa is used instead of rho in tke hyperdiffuion. Fixes a bug that there is no tke hyperdiffusion for EDOnlyEDMFX case.

Closes #4090 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
