### PR TITLE
remove and modify some single column setup

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -269,7 +269,7 @@ check_steady_state:
   help: "Compare steady-state velocity to analytic solution; only available for certain choices of `topography` [`false` (default), `true`]"
   value: false
 ls_adv:
-  help: "Large-scale advection [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `ARM_SGP`, `GATE_III`]"
+  help: "Large-scale advection [`nothing` (default), `Bomex`, `Rico`]"
   value: ~
 external_forcing:
   help: "External forcing for single column experiments [`nothing` (default), `GCM`, `Reanalysis`, `ReanalysisTimeVarying`, `ReanalysisMonthlyAveragedDiurnal`]"
@@ -290,7 +290,7 @@ era5_diurnal_warming:
   help: Applies a warming scenario by adding a constant temperature offset (in Kelvin). Supported only by the `ReanalysisMonthlyAveragedDiurnal` forcing model. This affects the target surface temperature for the entire simulation, the initial atmospheric temperature profile, and the relaxation temperature profile above `gcmdriven_relaxation_minimum_height`. Specific humidity is increased to hold relative humidity constant in the initial and relaxation profiles.
   value: ~
 subsidence:
-  help: "Subsidence [`nothing` (default), `Bomex`, `LifeCycleTan2018`, `Rico`, `DYCOMS`, `ISDAC`]"
+  help: "Subsidence [`nothing` (default), `Bomex`, `Rico`, `DYCOMS`, `ISDAC`]"
   value: ~
 toml:
   help: "TOML file(s) used to override model parameters"
@@ -381,7 +381,7 @@ implicit_sgs_mass_flux:
   help: "Whether to treat the subgrid-scale mass flux tendency implicitly or explicitly in grid-mean equations. Currently updraft only with Jacobian terms 0. [`false` (default), `true`]. Setting it to true only works if both implicit_sgs_advection and implicit_diffusion are set to true."
   value: false
 scm_coriolis:
-  help: "SCM Coriolis [`nothing` (default), `Bomex`,`LifeCycleTan2018`,`Rico`,`ARM_SGP`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
+  help: "SCM Coriolis [`nothing` (default), `Bomex`, `Rico`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
   value: ~
 edmfx_filter:
   help: "If set to true, it switches on the relaxation of negative velocity in EDMFX.  [`true`, `false` (default)]"
@@ -425,7 +425,7 @@ log_to_file:
   value: false
 use_itime:
   help: "If set to true, ITime (integer time) is used. This should be set to true when precision with time is necessary as floating point time may encounter floating point errors. When converting an ITime back to a float, the float will be Float64. See the examples below where there will be a difference in ITime and Float64:
-  1. Surface conditions that explicitly depend on time (e.g. LifeCycleTan2018, TRMM_LBA, etc.),
+  1. Surface conditions that explicitly depend on time (e.g. TRMM_LBA),
   2. Time dependent forcing/tendencies use time rounded to the nearest unit of time for dt"
   value: false
 prescribed_flow:

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -130,15 +130,6 @@ and Pamnany, K. and Waruszewski, M. and Gibson, T. H. and Kozdon, J. E. and Chur
   doi = {https://doi.org/10.1002/2017MS001162}
 }
 
-@incollection{Nieuwstadt1993,
-  title = {Large-eddy simulation of the convective boundary layer: A comparison of four computer codes},
-  author = {Nieuwstadt, Frans TM and Mason, Paul J and Moeng, Chin-Hoh and Schumann, Ulrich},
-  booktitle = {Turbulent shear flows 8},
-  pages = {343--367},
-  year = {1993},
-  publisher = {Springer}
-}
-
 @article{Soares2004,
   title = {An eddy-diffusivity/mass-flux parametrization for dry and shallow cumulus convection},
   author = {Soares, PMM and Miranda, PMA and Siebesma, AP and Teixeira, J},

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,15 +30,11 @@ ClimaAtmos.InitialConditions.MoistAdiabaticProfileEDMFX
 ### Cases from literature
 
 ```@docs
-ClimaAtmos.InitialConditions.Nieuwstadt
 ClimaAtmos.InitialConditions.GABLS
-ClimaAtmos.InitialConditions.GATE_III
-ClimaAtmos.InitialConditions.ARM_SGP
 ClimaAtmos.InitialConditions.DYCOMS_RF01
 ClimaAtmos.InitialConditions.DYCOMS_RF02
 ClimaAtmos.InitialConditions.Rico
 ClimaAtmos.InitialConditions.TRMM_LBA
-ClimaAtmos.InitialConditions.LifeCycleTan2018
 ClimaAtmos.InitialConditions.Bomex
 ClimaAtmos.InitialConditions.Soares
 ClimaAtmos.InitialConditions.RCEMIPIIProfile

--- a/docs/src/single_column_prospect.md
+++ b/docs/src/single_column_prospect.md
@@ -9,9 +9,6 @@
 | SOARES | Shallow Cumulus Convection | Shallow Cumulus | [Soares et al. (2004)](https://doi.org/10.1256/qj.03.223) |
 | GABLS | GEWEX Atmospheric Boundary Layer Study | Dry Convective Boundary Layer | [Kosović & Curry (2000)](https://doi.org/10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2) |
 | TRMM | Tropical Rainfall Measuring Mission | Deep Convection | [Grabowski et al. (2006)](https://doi.org/10.1256/qj.04.147) |
-| ARM_SGP | Atmospheric Radiation Measurement Southern Great Plains | Continental Shallow Cumulus | [Brown et al. (2002)](https://doi.org/10.1256/qj.01.202) |
-| LifeCycle | Life Cycle of Shallow Cumulus | Shallow Cumulus Life Cycle | [Tan et al. (2018)](https://doi.org/10.1002/2017MS001162) |
-| GATE_III | GARP Atlantic Tropical Experiment | Tropical Deep Convection | [Khairoutdinov et al. (2009)](https://doi.org/10.3894/JAMES.2009.1.15) |
 
 For example, to run the BOMEX test case execute the following:
 ```bash

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -1300,16 +1300,6 @@ function hydrostatic_pressure_profile(;
 end
 
 """
-    Nieuwstadt
-
-The `InitialCondition` described in [Nieuwstadt1993](@cite), but with a
-hydrostatically balanced pressure profile.
-"""
-Base.@kwdef struct Nieuwstadt <: InitialCondition
-    prognostic_tke::Bool = false
-end
-
-"""
     GABLS
 
 The `InitialCondition` described in [Kosovic2000](@cite), but with a hydrostatically
@@ -1319,7 +1309,7 @@ Base.@kwdef struct GABLS <: InitialCondition
     prognostic_tke::Bool = false
 end
 
-for IC in (:Nieuwstadt, :GABLS)
+for IC in (:GABLS,)
     θ_func_name = Symbol(IC, :_θ_liq_ice)
     u_func_name = Symbol(IC, :_u)
     tke_func_name = Symbol(IC, :_tke_prescribed)
@@ -1406,27 +1396,7 @@ Base.@kwdef struct Bomex <: InitialCondition
     prognostic_tke::Bool = false
 end
 
-"""
-    LifeCycleTan2018
-
-The `InitialCondition` described in [Tan2018](@cite), but with a hydrostatically
-balanced pressure profile.
-"""
-Base.@kwdef struct LifeCycleTan2018 <: InitialCondition
-    prognostic_tke::Bool = false
-end
-
-"""
-    ARM_SGP
-
-The `InitialCondition` described in [Brown2002](@cite), but with a
-hydrostatically balanced pressure profile.
-"""
-Base.@kwdef struct ARM_SGP <: InitialCondition
-    prognostic_tke::Bool = false
-end
-
-for IC in (:Soares, :Bomex, :LifeCycleTan2018, :ARM_SGP)
+for IC in (:Soares, :Bomex)
     θ_func_name = Symbol(IC, :_θ_liq_ice)
     q_tot_func_name = Symbol(IC, :_q_tot)
     u_func_name = Symbol(IC, :_u)
@@ -1436,9 +1406,8 @@ for IC in (:Soares, :Bomex, :LifeCycleTan2018, :ARM_SGP)
         FT = eltype(params)
         thermo_params = CAP.thermodynamics_params(params)
         p_0 = FT(
-            $IC <: Bomex || $IC <: LifeCycleTan2018 ? 101500.0 :
+            $IC <: Bomex ? 101500.0 :
             $IC <: Soares ? 100000.0 :
-            $IC <: ARM_SGP ? 97000.0 :
             error("Invalid Initial Condition : $($IC)"),
         )
         θ = APL.$θ_func_name(FT)

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -402,8 +402,6 @@ function get_subsidence_model(parsed_args, radiation_mode, FT)
 
     prof = if subsidence == "Bomex"
         APL.Bomex_subsidence(FT)
-    elseif subsidence == "LifeCycleTan2018"
-        APL.LifeCycleTan2018_subsidence(FT)
     elseif subsidence == "Rico"
         APL.Rico_subsidence(FT)
     elseif subsidence == "DYCOMS"
@@ -425,33 +423,16 @@ function get_large_scale_advection_model(parsed_args, ::Type{FT}) where {FT}
 
     (prof_dTdt₀, prof_dqtdt₀) = if ls_adv == "Bomex"
         (APL.Bomex_dTdt(FT), APL.Bomex_dqtdt(FT))
-    elseif ls_adv == "LifeCycleTan2018"
-        (APL.LifeCycleTan2018_dTdt(FT), APL.LifeCycleTan2018_dqtdt(FT))
     elseif ls_adv == "Rico"
         (APL.Rico_dTdt(FT), APL.Rico_dqtdt(FT))
-    elseif ls_adv == "ARM_SGP"
-        (APL.ARM_SGP_dTdt(FT), APL.ARM_SGP_dqtdt(FT))
-    elseif ls_adv == "GATE_III"
-        (APL.GATE_III_dTdt(FT), APL.GATE_III_dqtdt(FT))
     else
         error("Uncaught case")
     end
     # See https://clima.github.io/AtmosphericProfilesLibrary.jl/dev/
     # for which functions accept which arguments.
-    prof_dqtdt = if ls_adv in ("Bomex", "LifeCycleTan2018", "Rico", "GATE_III")
-        (thermo_params, ᶜts, t, z) -> prof_dqtdt₀(z)
-    elseif ls_adv == "ARM_SGP"
-        (thermo_params, ᶜts, t, z) ->
-            prof_dqtdt₀(TD.exner(thermo_params, ᶜts), t, z)
-    end
-    prof_dTdt = if ls_adv in ("Bomex", "LifeCycleTan2018", "Rico")
-        (thermo_params, ᶜts, t, z) ->
-            prof_dTdt₀(TD.exner(thermo_params, ᶜts), z)
-    elseif ls_adv == "ARM_SGP"
-        (thermo_params, ᶜts, t, z) -> prof_dTdt₀(t, z)
-    elseif ls_adv == "GATE_III"
-        (thermo_params, ᶜts, t, z) -> prof_dTdt₀(z)
-    end
+    prof_dqtdt = (thermo_params, ᶜts, t, z) -> prof_dqtdt₀(z)
+    prof_dTdt = (thermo_params, ᶜts, t, z) ->
+        prof_dTdt₀(TD.exner(thermo_params, ᶜts), z)
 
     return LargeScaleAdvection(prof_dTdt, prof_dqtdt)
 end
@@ -538,12 +519,8 @@ function get_scm_coriolis(parsed_args, ::Type{FT}) where {FT}
     scm_coriolis == nothing && return nothing
     (prof_u, prof_v) = if scm_coriolis == "Bomex"
         (APL.Bomex_geostrophic_u(FT), z -> FT(0))
-    elseif scm_coriolis == "LifeCycleTan2018"
-        (APL.LifeCycleTan2018_geostrophic_u(FT), z -> FT(0))
     elseif scm_coriolis == "Rico"
         (APL.Rico_geostrophic_ug(FT), APL.Rico_geostrophic_vg(FT))
-    elseif scm_coriolis == "ARM_SGP"
-        (z -> FT(10), z -> FT(0))
     elseif scm_coriolis == "DYCOMS_RF01"
         (z -> FT(7), z -> FT(-5.5))
     elseif scm_coriolis == "DYCOMS_RF02"
@@ -556,9 +533,7 @@ function get_scm_coriolis(parsed_args, ::Type{FT}) where {FT}
 
     coriolis_params = Dict()
     coriolis_params["Bomex"] = FT(0.376e-4)
-    coriolis_params["LifeCycleTan2018"] = FT(0.376e-4)
     coriolis_params["Rico"] = FT(4.5e-5)
-    coriolis_params["ARM_SGP"] = FT(8.5e-5)
     coriolis_params["DYCOMS_RF01"] = FT(0) # TODO: check this
     coriolis_params["DYCOMS_RF02"] = FT(0) # TODO: check this
     coriolis_params["GABLS"] = FT(1.39e-4)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -298,13 +298,9 @@ function get_initial_condition(parsed_args, atmos)
             parsed_args["perturb_initstate"],
         )
     elseif parsed_args["initial_condition"] in [
-        "Nieuwstadt",
         "GABLS",
-        "GATE_III",
         "Soares",
         "Bomex",
-        "LifeCycleTan2018",
-        "ARM_SGP",
         "DYCOMS_RF01",
         "DYCOMS_RF02",
         "Rico",

--- a/src/surface_conditions/surface_setups.jl
+++ b/src/surface_conditions/surface_setups.jl
@@ -36,17 +36,6 @@ function (::DefaultExchangeCoefficients)(params)
 end
 
 # All of the following are specific to TC cases
-struct Nieuwstadt end
-function (::Nieuwstadt)(params)
-    FT = eltype(params)
-    T = FT(300)
-    p = FT(1e5)
-    q_vap = FT(0)
-    z0 = FT(0.16)
-    θ_flux = FT(0.06)
-    parameterization = MoninObukhov(; z0, fluxes = θAndQFluxes(; θ_flux))
-    return SurfaceState(; parameterization, T, p, q_vap)
-end
 
 struct GABLS end
 function (::GABLS)(params)
@@ -65,21 +54,6 @@ function (::GABLS)(params)
         )
     end
     return surface_state
-end
-
-# TODO: The paper only specifies that T = 299.88. Where did all of these values
-# come from?
-struct GateIII end
-function (::GateIII)(params)
-    FT = eltype(params)
-    T = FT(299.184)
-    p = FT(101300)
-    q_vap = FT(0.0165)
-    Cd = FT(0.0012)
-    Ch = FT(0.0034337)
-    Cq = FT(0.0034337) # TODO: Add support for Cq to SF.Coefficients.
-    parameterization = ExchangeCoefficients(Cd, Ch)
-    return SurfaceState(; parameterization, T, p, q_vap)
 end
 
 struct Soares end
@@ -112,57 +86,6 @@ function (::Bomex)(params)
     return SurfaceState(; parameterization, T, p, q_vap)
 end
 
-struct LifeCycleTan2018 end
-function (::LifeCycleTan2018)(params)
-    FT = eltype(params)
-    T = FT(300.4)
-    p = FT(101500)
-    q_vap = FT(0.02245)
-    θ_flux0 = FT(8e-3)
-    q_flux0 = FT(5.2e-5)
-    z0 = FT(1e-4)
-    ustar = FT(0.28)
-    function surface_state(surface_coordinates, interior_z, t)
-        _FT = eltype(surface_coordinates) # do not capture FT
-        weight = _FT(0.01) + _FT(0.99) * (cos(2 * _FT(π) * t / 3600) + 1) / 2
-        fluxes =
-            θAndQFluxes(; θ_flux = θ_flux0 * weight, q_flux = q_flux0 * weight)
-        parameterization = MoninObukhov(; z0, fluxes, ustar)
-        return SurfaceState(; parameterization, T, p, q_vap)
-    end
-    return surface_state
-end
-
-struct ARM_SGP end
-function (::ARM_SGP)(params)
-    FT = eltype(params)
-    θ = FT(299)
-    p = FT(97000)
-    q_vap = FT(0.0152)
-    t_data = FT[0, 4, 6.5, 7.5, 10, 12.5, 14.5] .* 3600
-    shf_data = FT[-30, 90, 140, 140, 100, -10, -10]
-    lhf_data = FT[5, 250, 450, 500, 420, 180, 0]
-    z0 = FT(1e-4)
-    ustar = FT(0.28) # 0.28 is taken from Bomex. TODO: Approximate from LES TKE.
-    thermo_params = CAP.thermodynamics_params(params)
-    ts = TD.PhaseNonEquil_pθq(thermo_params, p, θ, TD.PhasePartition(q_vap))
-    T = TD.air_temperature(thermo_params, ts)
-    shf = Intp.extrapolate(
-        Intp.interpolate((t_data,), shf_data, Intp.Gridded(Intp.Linear())),
-        Intp.Flat(),
-    )
-    lhf = Intp.extrapolate(
-        Intp.interpolate(t_data, lhf_data, Intp.Gridded(Intp.Linear())),
-        Intp.Flat(),
-    )
-    function surface_state(surface_coordinates, interior_z, t)
-        fluxes = HeatFluxes(; shf = shf(t), lhf = lhf(t))
-        parameterization = MoninObukhov(; z0, fluxes, ustar)
-        return SurfaceState(; parameterization, T, p, q_vap)
-    end
-    return surface_state
-end
-
 struct DYCOMS_RF01 end
 function (::DYCOMS_RF01)(params)
     FT = eltype(params)
@@ -172,7 +95,8 @@ function (::DYCOMS_RF01)(params)
     z0 = FT(1e-4)
     shf = FT(15)
     lhf = FT(115)
-    parameterization = MoninObukhov(; z0, fluxes = HeatFluxes(; shf, lhf))
+    ustar = FT(0.25) # not specified in the literature, taken from DYCOMS_RF02.
+    parameterization = MoninObukhov(; z0, fluxes = HeatFluxes(; shf, lhf), ustar)
     return SurfaceState(; parameterization, T, p, q_vap)
 end
 
@@ -308,8 +232,7 @@ function (::ISDAC)(params)
     FT = eltype(params)
     T = FT(267)  # K
     p = FT(102000)  # Pa
-    lhf = shf = FT(0)  # neglect heat fluxes
     z0 = FT(4e-4)  # m  surface roughness length
-    parameterization = MoninObukhov(; z0, fluxes = HeatFluxes(; lhf, shf))
+    parameterization = MoninObukhov(; z0)
     return SurfaceState(; parameterization, T, p)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This is the first of a series of PRs that modify ClimaAtmos to use the new SurfaceFluxes. This PR removes some single column setups that are not used or tested. It also prescribes ustar for the cases that prescribe heat fluxes, as only prescribing heat fluxes is not supported anymore.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
