### PR TITLE
some more cleanup of surface conditions

### DIFF
--- a/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
@@ -30,7 +30,7 @@ y_elem: 2
 z_elem: 100
 z_stretch: false
 perturb_initstate: false
-dt: "80secs"
+dt: "60secs"
 t_end: "24hours"
 dt_save_state_to_disk: "60mins"
 toml: [toml/prognostic_edmfx_1M.toml]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Some more cleanup before changing to the new SurfaceFluxes.
- Remove deardorff gustiness specification in ClimaAtmos. This will be set in the new SurfaceFluxes
- Remove the option that sets surface thermo state with prescribed surface pressure. The new SurfaceFluxes doesn't require a surface thermo state, and sets surface density internally.

Note these changes the behavior of some EDMF cases slightly, but I think it's ok.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
