### PR TITLE
Trim trailing whitespace in `parameterized_tendencies`

### DIFF
--- a/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
@@ -331,7 +331,7 @@ function non_orographic_gravity_wave_forcing(
     ᶜv_p1 = p.scratch.ᶜtemp_scalar_4
     ᶜbf_p1 = p.scratch.ᶜtemp_scalar_5
 
-    FT = eltype(ᶜρ) # Define the floating point type 
+    FT = eltype(ᶜρ) # Define the floating point type
 
     # Using interpolate operator, generate the field of ρ,u,v,z with on level shifted up
     ρ_endlevel = Fields.level(ᶜρ, Spaces.nlevels(axes(ᶜρ)))
@@ -375,8 +375,10 @@ function non_orographic_gravity_wave_forcing(
 
     mask_u = StaticBitVector{nc}(_ -> true)
     mask_v = StaticBitVector{nc}(_ -> true)
-    #We use StaticBitVector here because the unrolled_reduce function in Julia can cause memory allocation issues when the mask has more than 32 elements。 
-    #StaticBitVector stores 8 boolean values in a UInt8, allowing efficient storage for up to 256 gravity wave break data.
+    # We use StaticBitVector here because the unrolled_reduce function in Julia can
+    # cause memory allocation issues when the mask has more than 32 elements.
+    # StaticBitVector stores 8 boolean values in a UInt8, allowing efficient storage
+    # for up to 256 gravity wave break data.
     level_end = Spaces.nlevels(axes(ᶜρ))
 
     # Collect all required fields in a broadcasted object

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
@@ -73,12 +73,12 @@ end
 
 """
     calc_velocity_potential(elev, lon, lat, earth_radius)
-    
+
     Calculate velocity potential
     - elev: surface elevation
     - lon: longitude
     - lat: latitude
-    - earth_radius: radius of the Earth 
+    - earth_radius: radius of the Earth
 """
 function calc_velocity_potential(elev, lon, lat, earth_radius)
     FT = eltype(elev)

--- a/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
+++ b/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
@@ -10,7 +10,7 @@ import LinearAlgebra: tr
 """
     set_amd_precomputed_quantities!(Y, p)
 
-Placeholder for precomputed quantities in the Anisotropic-Minimum-Dissipation method. 
+Placeholder for precomputed quantities in the Anisotropic-Minimum-Dissipation method.
 Returns `nothing`. This function is included for simple extensions in debugging workflows.
 """
 function set_amd_precomputed_quantities!(Y, p)
@@ -107,7 +107,7 @@ function horizontal_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipat
     ᶜ∂ₗuₘ∂ₗuₘ = @. lazy(CA.norm_sqr(∇ᶜu_uvw))
 
     # AMD eddy viscosity
-    # no defined trace method in climacore for axistensors? 
+    # no defined trace method in climacore for axistensors?
     ᶜνₜ = @. ᶜtemp_scalar = max(
         FT(0),
         -c_amd *
@@ -264,7 +264,7 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     ᶜS = @. ᶜtemp_strain = (∇ᶜu_uvw + adjoint(∇ᶜu_uvw)) / 2
     ᶠS = @. ᶠtemp_strain = (∇ᶠu_uvw + adjoint(∇ᶠu_uvw)) / 2
 
-    # Do we need scratch variables at all? 
+    # Do we need scratch variables at all?
     # Scaled Derivatives ∂̂ᵢ = Δ₍ᵢ₎∂ᵢ
     ᶜ∂̂u_uvw = @.ᶜtemp_UVWxUVW = Δ_h * Geometry.project(axis_uvw, gradₕ(ᶜu_uvw))
     @. ᶜ∂̂u_uvw += ᶜΔ_z * Geometry.project(axis_uvw, ᶜgradᵥ(ᶠu_uvw))
@@ -280,7 +280,7 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     ᶠS = @. ᶠtemp_strain = (∇ᶠu_uvw + adjoint(∇ᶠu_uvw)) / 2
 
     # AMD eddy viscosity
-    # no defined trace method in climacore for axistensors? 
+    # no defined trace method in climacore for axistensors?
     ᶜνₜ = @. ᶜtemp_scalar = max(
         FT(0),
         -c_amd *

--- a/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
+++ b/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
@@ -9,7 +9,7 @@ import ClimaCore: Geometry
 """
     lilly_stratification_correction(p, ᶜS)
 
-Return a lazy representation of the Lilly stratification correction factor 
+Return a lazy representation of the Lilly stratification correction factor
     based on the local Richardson number.
 
 # Arguments
@@ -36,13 +36,13 @@ end
 """
     set_smagorinsky_lilly_precomputed_quantities!(Y, p)
 
-Compute the Smagorinsky-Lilly horizontal and vertical quantities needed for 
+Compute the Smagorinsky-Lilly horizontal and vertical quantities needed for
     subgrid-scale diffusive tendencies
 
-The subgrid-scale momentum flux tensor is defined by `τ = -2 νₜ ∘ S`, 
-where `νₜ` is the Smagorinsky-Lilly eddy viscosity and `S` is the strain rate tensor. 
+The subgrid-scale momentum flux tensor is defined by `τ = -2 νₜ ∘ S`,
+where `νₜ` is the Smagorinsky-Lilly eddy viscosity and `S` is the strain rate tensor.
 
-The turbulent diffusivity is defined as `D = νₜ / Pr_t`, 
+The turbulent diffusivity is defined as `D = νₜ / Pr_t`,
 where `Pr_t` is the turbulent Prandtl number for neutral stratification.
 
 This method precomputes and stores in `p.precomputed` the following quantities:

--- a/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
+++ b/src/parameterized_tendencies/radiation/RRTMGPInterface.jl
@@ -33,10 +33,10 @@ struct AllSkyRadiation{ACR <: AbstractCloudInRadiation} <: AbstractRRTMGPMode
     add_isothermal_boundary_layer::Bool
     aerosol_radiation::Bool
     """
-    Reset the RNG seed before calling RRTMGP to a known value (the timestep number). 
-    When modeling cloud optics, RRTMGP uses a random number generator. 
-    Resetting the seed every time RRTMGP is called to a deterministic value ensures that 
-    the simulation is fully reproducible and can be restarted in a reproducible way. 
+    Reset the RNG seed before calling RRTMGP to a known value (the timestep number).
+    When modeling cloud optics, RRTMGP uses a random number generator.
+    Resetting the seed every time RRTMGP is called to a deterministic value ensures that
+    the simulation is fully reproducible and can be restarted in a reproducible way.
     Disable this option when running production runs.
     """
     reset_rng_seed::Bool
@@ -51,10 +51,10 @@ struct AllSkyRadiationWithClearSkyDiagnostics{
     add_isothermal_boundary_layer::Bool
     aerosol_radiation::Bool
     """
-    Reset the RNG seed before calling RRTMGP to a known value (the timestep number). 
-    When modeling cloud optics, RRTMGP uses a random number generator. 
-    Resetting the seed every time RRTMGP is called to a deterministic value ensures that 
-    the simulation is fully reproducible and can be restarted in a reproducible way. 
+    Reset the RNG seed before calling RRTMGP to a known value (the timestep number).
+    When modeling cloud optics, RRTMGP uses a random number generator.
+    Resetting the seed every time RRTMGP is called to a deterministic value ensures that
+    the simulation is fully reproducible and can be restarted in a reproducible way.
     Disable this option when running production runs.
     """
     reset_rng_seed::Bool
@@ -787,8 +787,8 @@ function _RRTMGPModel(
         set_and_save!(z_lev, "face_z", t..., dict)
         if radiation_mode.deep_atmosphere && :planet_radius in keys(dict)
             planet_radius = pop!(dict, :planet_radius)
-            # Area ratio appears in denominator of RRTMGP scaling functions, 
-            # we therefore pass the multiplicative inverse from ClimaAtmos to 
+            # Area ratio appears in denominator of RRTMGP scaling functions,
+            # we therefore pass the multiplicative inverse from ClimaAtmos to
             # use mult ops instead of div in RRTMGP GPU kernels.
             metric_scaling .=
                 inv.(((z_lev .+ planet_radius) ./ planet_radius) .^ (FT(2)))
@@ -900,7 +900,7 @@ NVTX.@annotate function update_fluxes!(model, seedval)
     model.radiation_mode.add_isothermal_boundary_layer &&
         update_boundary_layer!(model)
     clip_values!(model)
-    # TODO : update_concentrations as part of update_atmospheric_state! 
+    # TODO : update_concentrations as part of update_atmospheric_state!
     update_concentrations!(model.radiation_mode, model)
     update_lw_fluxes!(model.radiation_mode, model)
     update_sw_fluxes!(model.radiation_mode, model)
@@ -948,9 +948,9 @@ update_views(f, mode, outs, ins, others, out_range, in_range1, in_range2) = f(
 
 """
     update_boundary_layer!(model)
-    
-Adds an isothermal boundary layer above the domain and extension (the pressure at the top of this layer 
-is the minimum pressure supported by RRTMGP, while the temperature and volume mixing ratios in this layer 
+
+Adds an isothermal boundary layer above the domain and extension (the pressure at the top of this layer
+is the minimum pressure supported by RRTMGP, while the temperature and volume mixing ratios in this layer
 are the same as in the layer below it)
 """
 function update_boundary_layer!(model)

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -423,7 +423,7 @@ function radiation_tendency!(Yₜ, Y, p, t, ::RRTMGPI.AbstractRRTMGPMode)
     @. Yₜ.c.ρe_tot -= ᶜdivᵥ(ᶠradiation_flux)
     # Apply radiation tendency to updrafts in prognostic EDMF. We use the
     # grid-mean radiation as an approximation for updraft radiation.
-    # Note: Radiation is not applied to updrafts in diagnostic EDMF because updrafts 
+    # Note: Radiation is not applied to updrafts in diagnostic EDMF because updrafts
     # are typically absent in the stratosphere where radiation is more important.
     if turbconv_model isa PrognosticEDMFX
         (; ᶜρʲs) = p.precomputed

--- a/src/parameterized_tendencies/radiation/update_inputs.jl
+++ b/src/parameterized_tendencies/radiation/update_inputs.jl
@@ -19,7 +19,7 @@ end
 function update_atmospheric_state!(radiation_mode::R, integrator) where {R}
     # update temperature & pressure
     update_temperature_pressure!(integrator)
-    # update relative humidity 
+    # update relative humidity
     update_relative_humidity!(integrator)
     # update gas concentrations (volume mixing ratios)
     update_volume_mixing_ratios!(integrator)
@@ -68,7 +68,7 @@ end
 """
     update_relative_humidity!(integrator)
 
-Update relative humidity `ᶜrh`. 
+Update relative humidity `ᶜrh`.
 """
 function update_relative_humidity!((; u, p, t)::I) where {I}
     (; radiation_mode) = p.atmos
@@ -150,7 +150,7 @@ end
 """
     update_aerosol_concentrations!((; u, p, t)::I) where {I}
 
-Updates aerosol concentrations for supported aerosol names (dust (5 types), 
+Updates aerosol concentrations for supported aerosol names (dust (5 types),
 sea-salt (5 types), sulfates, black-carbon (2 types), organic-carbon (2 types))
 """
 function update_aerosol_concentrations!((; u, p, t)::I) where {I}
@@ -225,7 +225,7 @@ Updates aerosol properties for the following supported symbols:
     seasalt_names = [:SSLT01, :SSLT02, :SSLT03, :SSLT04, :SSLT05]
     dust_names = [:DST01, :DST02, :DST03, :DST04, :DST05]
     SO4_names = [:SO4]
-When prescribed cloud fields are used, time-varying interpolation is applied using 
+When prescribed cloud fields are used, time-varying interpolation is applied using
 `ClimaUtilities` functions.
 No updates are applied when `radiation_mode.idealized_clouds` is true.
 """


### PR DESCRIPTION
The purpose here is to not obscure the diff in #4186 and future-proof against similar issues. I assume these aren't meaningful since they're mostly trailing single spaces, and Julia only respects trailing double spaces as new line indicators in docstrings?