### PR TITLE
Remove duplicate calc + reduce baro-wave + AMD test time for ci

### DIFF
--- a/config/model_configs/baroclinic_wave_equil_amd.yml
+++ b/config/model_configs/baroclinic_wave_equil_amd.yml
@@ -2,9 +2,9 @@ precip_model: "0M"
 dt_save_state_to_disk: "2days"
 reproducibility_test: true
 initial_condition: "MoistBaroclinicWave"
-dt: "300secs"
+dt: "360secs"
 amd_les: true
-t_end: "10days"
+t_end: "8days"
 moist: "equil"
 disable_surface_flux_tendency: true
 diagnostics:

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-296
+297
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+297
+- Add new dataset to reproducibility bundle : `baroclinic_wave_equil_amd/prog_state.hdf5`.
+
 296
 - Fix ρa tendencies due to vertical diffusion and hyperdiffusion of q_totʲ for PEDMF
 

--- a/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
+++ b/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
@@ -107,7 +107,6 @@ function horizontal_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipat
     ᶜ∂ₗuₘ∂ₗuₘ = @. lazy(CA.norm_sqr(∇ᶜu_uvw))
 
     # AMD eddy viscosity
-    # no defined trace method in climacore for axistensors?
     ᶜνₜ = @. ᶜtemp_scalar = max(
         FT(0),
         -c_amd *
@@ -275,12 +274,8 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     ᶜ∂ₖuᵢ∂ₖuⱼ = @. lazy(ᶜ∂̂u_uvw * adjoint(ᶜ∂̂u_uvw))
     ᶠ∂ₖuᵢ∂ₖuⱼ = @. lazy(ᶠ∂̂u_uvw * adjoint(ᶠ∂̂u_uvw))
     ᶜ∂ₗuₘ∂ₗuₘ = @. lazy(CA.norm_sqr(∇ᶜu_uvw))
-    # Strain rate tensor
-    ᶜS = @. ᶜtemp_strain = (∇ᶜu_uvw + adjoint(∇ᶜu_uvw)) / 2
-    ᶠS = @. ᶠtemp_strain = (∇ᶠu_uvw + adjoint(∇ᶠu_uvw)) / 2
 
     # AMD eddy viscosity
-    # no defined trace method in climacore for axistensors?
     ᶜνₜ = @. ᶜtemp_scalar = max(
         FT(0),
         -c_amd *


### PR DESCRIPTION
Bugfix : Remove duplicate strain rate calculation
Reduce Barowave+AMD ci time with increased dt, reduced t_end. 
