### PR TITLE
Add cloud fraction threshold for noneq

### DIFF
--- a/src/cache/cloud_fraction.jl
+++ b/src/cache/cloud_fraction.jl
@@ -208,7 +208,7 @@ NVTX.@annotate function set_cloud_fraction!(
         q_ice = @. lazy(specific(Y.c.ρq_ice, Y.c.ρ))
         @. p.precomputed.cloud_diagnostics_tuple =
             make_cloud_fraction_named_tuple(
-                ifelse(q_liq + q_ice > 0, FT(1), FT(0)),
+                ifelse(TD.has_condensate(thermo_params, ᶜts), FT(1), FT(0)),
                 q_liq,
                 q_ice,
             )


### PR DESCRIPTION
This PR changes the default threshold for condensate to be considered a cloud from 0 to a tunable parameter when running with NonEq. This is necessary because as is, we have very high cloud fraction in regions with very small mass due to the prevalence of small positives throughout the domain and into the stratosphere. This PR is still very rough and I would love input on:

- As of now, cloud fraction is computed by calculating whether cli + clw > 0. Therefore, when there is very negative clw but positive cli, cl = 0. Do we want to consider adding a negative mask when computing this fraction rather than just adding them together?
- The default value for this threshold is currently set to a constant 1e-8. Other models like CESM make the threshold a function dependent on qv and qsi. Do we want to consider doing that, or is a constant okay for our purposes?
- Where I'm actually putting this in parameters - I placed this with a previous cloud fraction parameter from Julian. Should these be located outside of turbulence and convection parameters?
- Naming convention of parameter. I'm using a parameter that used to be in ClimaParams I created for the cloud top diagnostic that has yet to be added -- should I revisit that parameter?

Thanks for your input!
