### PR TITLE
nonnegativity element limiter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ ClimaAtmos.jl Release Notes
 
 main
 -------
+- [#4211](https://github.com/CliMA/ClimaAtmos.jl/pull/4211) 
+  add experimental methods to remove negative microphysical condensate values
+
 v0.34.0
 -------
 - [#4198](https://github.com/CliMA/ClimaAtmos.jl/pull/4198) [badge-💥breaking] modifies surface conditions

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -175,9 +175,15 @@ constant_horizontal_diffusion:
 smagorinsky_lilly:
   help: "Smagorinsky-Lilly diffusive closure [`nothing` (default), `UVW`, `UV`, `W`, `UV_W_decoupled`]"
   value: ~
-moisture_fixer:
-  help: "A flag to switch on a grid mean tendency that moves mass from vapor to adjust small negative tracer values [false (default), true]"
-  value: false
+tracer_nonnegativity_method:
+  help: |
+    Optionally constrain microphysical condensate tracers (q_liq, q_rai, q_ice, q_sno) to be nonnegative. Options:
+    - `elementwise_constraint`: Enforce nonnegativity by instantaneously redistributing tracer mass within an element
+    - `vapor_constraint`: Enforce nonnegativity by instantaneously redistributing tracer mass between vapor (q_tot) and each tracer
+    - `vapor_tendency`: Weakly enforce nonnegativity by applying a tendency to each tracer to redistribute tracer mass between vapor (q_tot) and each tracer
+    - `~` (default): Do not enforce nonnegativity
+    Note: append `_qtot` to the method name to enforce nonnegativity of q_tot as well.
+  value: ~
 bubble:
   help: "Enable bubble correction for more accurate surface areas"
   value: false

--- a/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 initial_condition: "MoistBaroclinicWave"
 t_end: "5days"
 moist: "nonequil"
-moisture_fixer: true
+tracer_nonnegativity_method: "vapor_tendency"
 surface_setup: DefaultMoninObukhov
 prognostic_surface: "SlabOceanSST"
 rad: "clearsky"

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -32,7 +32,7 @@ device = ClimaComms.device(config.comms_ctx)
         "T_imp!",
         "T_exp_T_lim!",
         # "lim!",
-        "dss!",
+        "dss!",  # TODO: Rename to constrain_state! once ClimaTimeSteppers.jl updates its API
         "cache!",
         "cache_imp!",
         "step!",

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -151,7 +151,7 @@ include(joinpath("cache", "temporary_quantities.jl"))
 include(joinpath("cache", "tracer_cache.jl"))
 include(joinpath("cache", "cache.jl"))
 include(joinpath("cache", "eddy_diffusivity_coefficient.jl"))
-include(joinpath("prognostic_equations", "dss.jl"))
+include(joinpath("prognostic_equations", "constrain_state.jl"))
 include(joinpath("prognostic_equations", "limited_tendencies.jl"))
 
 include(joinpath("callbacks", "callbacks.jl"))

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -126,7 +126,16 @@ function build_cache(
         Limiters.QuasiMonotoneLimiter(similar(Y.c, FT))
     end
 
-    numerics = (; limiter)
+    nonneg_lim = atmos.water.tracer_nonnegativity_method
+    tracer_nonnegativity_limiter = if nonneg_lim isa TracerNonnegativityElementConstraint
+        Limiters.QuasiMonotoneLimiter(similar(Y.c.ρq_tot, FT);
+            convergence_stats = Limiters.NoConvergenceStats(),
+        )
+    else
+        nothing
+    end
+
+    numerics = (; limiter, tracer_nonnegativity_limiter)
 
     sfc_local_geometry =
         Fields.level(Fields.local_geometry_field(Y.f), Fields.half)

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -474,8 +474,7 @@ NVTX.@annotate function set_implicit_precomputed_quantities!(Y, p, t)
 
     @. ᶠuₕ³ = $compute_ᶠuₕ³(Y.c.uₕ, Y.c.ρ)
 
-    # TODO: We might want to move this to dss! (and rename dss! to something
-    # like enforce_constraints!).
+    # TODO: We might want to move this to constrain_state!
     if !(p.atmos.prescribed_flow isa PrescribedFlow)
         set_velocity_at_surface!(Y, ᶠuₕ³, turbconv_model)
         set_velocity_at_top!(Y, turbconv_model)

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -28,15 +28,6 @@ function limit(q, dt, n::Int)
     return q / dt / n
 end
 
-function moisture_fixer(q, qᵥ, dt)
-    FT = eltype(q)
-    return triangle_inequality_limiter(
-        -min(FT(0), q / dt),
-        limit(qᵥ, dt, 5),
-        FT(0),
-    )
-end
-
 """
     cloud_sources(cm_params, thp, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, Tₐ, dt)
 

--- a/src/parameterized_tendencies/microphysics/moisture_fixer.jl
+++ b/src/parameterized_tendencies/microphysics/moisture_fixer.jl
@@ -1,35 +1,30 @@
 import ClimaCore.MatrixFields as MF
 import CloudMicrophysics.ThermodynamicsInterface as TDI
 
-moisture_fixer_tendency!(Yₜ, Y, p, t, _, _) = nothing
+function tracer_nonnegativity_vapor_tendency(q, qᵥ, dt)
+    FT = eltype(q)
+    return triangle_inequality_limiter(-min(FT(0), q / dt), limit(qᵥ, dt, 5), FT(0))
+end
 
-function moisture_fixer_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    ::NonEquilMoistModel,
-    ::Union{Microphysics1Moment, Microphysics2Moment},
+tracer_nonnegativity_vapor_tendency!(Yₜ, Y, p, t, _, _) = nothing
+
+function tracer_nonnegativity_vapor_tendency!(Yₜ, Y, p, t,
+    ::NonEquilMoistModel, ::Union{Microphysics1Moment, Microphysics2Moment},
 )
-    if p.atmos.water.moisture_fixer
-        moisture_species = (
-            MF.@name(c.ρq_liq), MF.@name(c.ρq_ice),
-            MF.@name(c.ρq_rai), MF.@name(c.ρq_sno),
-        )
-        qᵥ = @. lazy(
-            specific(
-                TDI.q_vap(Y.c.ρq_tot, Y.c.ρq_liq, Y.c.ρq_ice, Y.c.ρq_rai, Y.c.ρq_sno),
-                Y.c.ρ,
-            ),
-        )
+    p.atmos.water.tracer_nonnegativity_method isa TracerNonnegativityVaporTendency || return
 
-        MF.unrolled_foreach(moisture_species) do (ρq_name)
-            ᶜρq = MF.get_field(Y, ρq_name)
-            ᶜρqₜ = MF.get_field(Yₜ, ρq_name)
-            ᶜq = @. lazy(specific(ᶜρq, Y.c.ρ))
-            # Increase the grid mean small tracers if negative,
-            # using mass from grid mean vapor.
-            @. ᶜρqₜ += Y.c.ρ * moisture_fixer(ᶜq, qᵥ, p.dt)
-        end
+    moisture_species = (
+        MF.@name(ρq_liq), MF.@name(ρq_ice),
+        MF.@name(ρq_rai), MF.@name(ρq_sno),
+    )
+    ρqᵥ = @. lazy(TDI.q_vap(Y.c.ρq_tot, Y.c.ρq_liq, Y.c.ρq_ice, Y.c.ρq_rai, Y.c.ρq_sno))
+    qᵥ = @. lazy(specific(ρqᵥ, Y.c.ρ))
+
+    MF.unrolled_foreach(moisture_species) do ρq_name
+        ᶜρq = MF.get_field(Y.c, ρq_name)
+        ᶜρqₜ = MF.get_field(Yₜ.c, ρq_name)
+        ᶜq = @. lazy(specific(ᶜρq, Y.c.ρ))
+        # Increase the grid mean small tracers if negative, using mass from grid mean vapor.
+        @. ᶜρqₜ += Y.c.ρ * tracer_nonnegativity_vapor_tendency(ᶜq, qᵥ, p.dt)
     end
 end

--- a/src/prognostic_equations/constrain_state.jl
+++ b/src/prognostic_equations/constrain_state.jl
@@ -13,6 +13,26 @@ using ClimaCore.Utilities: half
 import ClimaCore.Fields: ColumnField
 
 """
+    constrain_state!(Y, p, t)
+
+Apply constraints to the state `Y`.
+
+This function contains constraints that may be applied to the state `Y`,
+in order to ensure that the state satisfies certain physical properties.
+
+Currently, these include
+- `prescribe_flow!`: used for 'kinematic driver'-like simulations
+- `tracer_nonnegativity_constraint!`: used to ensure that tracer fields are non-negative
+- `dss!`: used to ensure that fields are continuous at element boundaries
+"""
+NVTX.@annotate function constrain_state!(Y, p, t)
+    prescribe_flow!(Y, p, t, p.atmos.prescribed_flow)
+    tracer_nonnegativity_constraint!(Y, p, t, p.atmos.water.tracer_nonnegativity_method)
+    dss!(Y, p, t)
+    return nothing
+end
+
+"""
     dss!(Y, p, t)
 
 Perform a weighted Direct Stiffness Summation (DSS) on components of the state `Y`.
@@ -76,13 +96,44 @@ dss!(Y_state, params, t_current)
 # with DSS applied, ensuring continuity across distributed elements.
 ```
 """
-
-NVTX.@annotate function dss!(Y, p, t)  # TODO: Rename to e.g. `apply_constraints!`
-    prescribe_flow!(Y, p, t, p.atmos.prescribed_flow)
+NVTX.@annotate function dss!(Y, p, t)
     if do_dss(axes(Y.c))
         Spaces.weighted_dss!(Y.c => p.ghost_buffer.c, Y.f => p.ghost_buffer.f)
     end
     return nothing
+end
+
+tracer_nonnegativity_constraint!(Y, p, t, _) = nothing
+function tracer_nonnegativity_constraint!(Y, p, t,
+    tracer_nonnegativity::TracerNonnegativityConstraint{constrain_qtot},
+) where {constrain_qtot}
+    (; tracer_nonnegativity_limiter) = p.numerics
+    (; ᶜtemp_scalar) = p.scratch
+    ᶜρ = Y.c.ρ
+    ᶜρq_tot = Y.c.ρq_tot
+
+    tracer_mass_names = (
+        @name(ρq_liq), @name(ρq_rai), @name(ρq_ice), @name(ρq_sno),
+        @name(ρq_tot),
+    )
+
+    for name in tracer_mass_names
+        MatrixFields.has_field(Y.c, name) || continue
+        name == @name(ρq_tot) && !constrain_qtot && continue
+        # Compute clipped version of ᶜρq
+        ᶜρq = MatrixFields.get_field(Y.c, name)
+
+        if tracer_nonnegativity isa TracerNonnegativityElementConstraint
+            ᶜρq_lim = @. ᶜtemp_scalar = max(0, ᶜρq)
+            Limiters.compute_bounds!(tracer_nonnegativity_limiter, ᶜρq_lim, ᶜρ)  # bounds are `extrema(ᶜρq_lim) = (0, max(ᶜρq))`
+            Limiters.apply_limiter!(ᶜρq, ᶜρ, tracer_nonnegativity_limiter)  # ᶜρq is clipped to bounds, effectively ensuring `0 ≤ ᶜρq`
+        elseif tracer_nonnegativity isa TracerNonnegativityVaporConstraint
+            # If `ρq` is negative, set it to 0 (as long as `ρq_tot` is positive), otherwise keep it as is
+            @. ᶜρq = ifelse(ᶜρq_tot > 0, max(0, ᶜρq), ᶜρq)
+        end
+
+    end
+
 end
 
 prescribe_flow!(_, _, _, ::Nothing) = nothing

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -356,7 +356,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
     # Optional tendency to bring negative small tracers back from negative
     # at the cost of water vapor.
-    moisture_fixer_tendency!(Yₜ, Y, p, t, moisture_model, microphysics_model)
+    tracer_nonnegativity_vapor_tendency!(Yₜ, Y, p, t, moisture_model, microphysics_model)
 
     # NOTE: This will zero out all momentum tendencies in the EDMFX advection test,
     # where velocities do not evolve

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -139,7 +139,7 @@ function get_atmos(config::AtmosConfig, params)
         noneq_cloud_formation_mode = implicit_noneq_cloud_formation ?
                                      Implicit() : Explicit(),
         call_cloud_diagnostics_per_stage,
-        moisture_fixer = parsed_args["moisture_fixer"],
+        tracer_nonnegativity_method = get_tracer_nonnegativity_method(parsed_args),
 
         # SCMSetup - Single-Column Model components
         subsidence = get_subsidence_model(parsed_args, radiation_mode, FT),
@@ -845,7 +845,7 @@ function args_integrator(Y, p, tspan, ode_algo, callback,
         tendency_function = CTS.ClimaODEFunction(;
             T_exp_T_lim!, T_imp!,
             cache! = set_precomputed_quantities!, cache_imp!,
-            lim! = limiters_func!, dss!,
+            lim! = limiters_func!, dss! = constrain_state!,  # TODO: Rename ClimaODEFunction kwarg to `constrain_state!`
         )
     end
     problem = SciMLBase.ODEProblem(tendency_function, Y, tspan, p)


### PR DESCRIPTION
This pull request introduces improvements to how scalar nonnegativity is enforced. The main focus is on ensuring that condensate mass variables remain physically valid (non-negative) throughout computations.

**Naming convention update**
- `dss.jl` is renamed to `constrain_state.jl` to reflect its broader usage
- New top-level function `constrain_state!` is added, which is the function that is passed to ClimaTimeSteppers (TODO: Update CTS with new keyword argument for clarity)

**Physical Constraints Enforcement:**

* A new function `preserve_scalar_nonnegativity!` is introduced in `constrain_state!` (`src/prognostic_equations/constrain_state.jl`) to explicitly enforce nonnegativity for condensate mass fields (e.g., `ρq_liq`, `ρq_rai`, `ρq_ice`, `ρq_sno`, `ρq_tot`). This function clips negative values to zero and applies the limiter, ensuring physically meaningful results for these quantities.
* The call to `preserve_scalar_nonnegativity!` is added to the main `constrain_state!` routine, so nonnegativity is enforced every time `constrain_state!` runs.