### PR TITLE
Update RCE configs

### DIFF
--- a/config/model_configs/prognostic_edmfx_rcemip_column.yml
+++ b/config/model_configs/prognostic_edmfx_rcemip_column.yml
@@ -1,0 +1,42 @@
+initial_condition: RCEMIPIIProfile_300
+surface_setup: DefaultMoninObukhov
+surface_temperature: RCEMIPII
+insolation: rcemipii
+turbconv: "prognostic_edmfx"
+tracer_upwinding: first_order
+implicit_diffusion: true
+implicit_sgs_advection: false
+approximate_linear_solve_iters: 2
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+edmfx_vertical_diffusion: true
+edmfx_filter: true
+prognostic_tke: true
+moist: "nonequil"
+call_cloud_diagnostics_per_stage: true
+precip_model: "1M"
+config: "column"
+z_max: 30000.0  # 30km
+x_elem: 2
+y_elem: 2
+z_elem: 86
+dz_bottom: 30.0
+z_stretch: false
+perturb_initstate: false
+dt: "5secs"
+t_end: "24hours"
+dt_save_state_to_disk: "60mins"
+toml: [toml/rcemip_SCM_prognostic_edmfx_1M.toml]
+netcdf_interpolation_num_points: [8, 8, 100]
+diagnostics:
+  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
+    period: 10mins
+  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [husra, hussn]
+    period: 10mins

--- a/config/model_configs/rcemipii_box_CRM_1M.yml
+++ b/config/model_configs/rcemipii_box_CRM_1M.yml
@@ -7,14 +7,20 @@ config: box
 rad: allskywithclear
 approximate_linear_solve_iters: 2  # only valid when implicit_diffusion=true
 rayleigh_sponge: true  # set sponge level in toml file
-smagorinsky_lilly: "UV"
-implicit_diffusion: true
+
+# Diffusion
+hyperdiff: "false"
+implicit_diffusion: false
+smagorinsky_lilly: "UV_W"  # horizontal + vertical
+# smagorinsky_lilly: "UV"  # horizontal
+# vert_diff: "DecayWithHeightDiffusion"  # vertical
+# implicit_diffusion: true
+
+# Upwinding mode
+tracer_upwinding: vanleer_limiter  # is default (alt: `first_order`)
+energy_q_tot_upwinding: vanleer_limiter  # is default (alt: `first_order`)
 
 reproducibility_test: true
-
-# Reference diffusion setup
-vert_diff: "DecayWithHeightDiffusion"
-hyperdiff: "false"
 
 # microphysics
 ### !! 1M and 2M !!
@@ -73,9 +79,9 @@ diagnostics:
       ke,  # kinetic energy for spectrum
       # Smagorinsky diagnostics
       Dh_smag, strainh_smag,  # horizontal
-      # Dv_smag, strainv_smag,  # vertical
+      Dv_smag, strainv_smag  # vertical
       # DecayWithHeight diffusion coefficient
-      edt
+      # edt
     ]
     # period: 10mins
     period: 1hours

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-301
+302
 
 # **README**
 #
@@ -20,6 +20,8 @@
 
 
 #=
+302
+- Changing the diffusion used for the RCEMIPII CRM box test changes behavior.
 
 301
 - Using spacefillingcurve in SphereGrid changes order of operations, which

--- a/toml/rcemip_SCM_prognostic_edmfx_1M.toml
+++ b/toml/rcemip_SCM_prognostic_edmfx_1M.toml
@@ -1,0 +1,62 @@
+[zd_rayleigh]
+value = 40000.0
+
+[zd_viscous]
+value = 40000.0
+
+[EDMF_surface_area]
+value = 0.1
+
+[EDMF_min_area]
+value = 1.0e-5
+
+[EDMF_max_area]
+value = 0.7
+
+[entr_inv_tau]
+value = 0.0001
+
+[entr_coeff]
+value = 0.1
+
+[min_area_limiter_scale]
+value = 0
+
+[detr_inv_tau]
+value = 0.0001
+
+[detr_coeff]
+value = 0
+
+[detr_buoy_coeff]
+value = 0
+
+[detr_vertdiv_coeff]
+value = 0
+
+[detr_massflux_vertdiv_coeff]
+value = 1
+
+[max_area_limiter_scale]
+value = 0
+
+[pressure_normalmode_drag_coeff]
+value = 40.0
+
+[tracer_vertical_diffusion_factor]
+value = 0
+
+[condensation_evaporation_timescale]
+value = 50
+
+[sublimation_deposition_timescale]
+value = 50
+
+[SST_mean]
+value = 300
+
+[SST_delta]
+value = 0
+
+[SST_wavelength]
+value = 6e6

--- a/toml/rcemipii_box.toml
+++ b/toml/rcemipii_box.toml
@@ -1,7 +1,7 @@
 # toml/rcemipii_box.toml
 
 [c_smag]
-value = 1.0
+value = 0.2
 
 [condensation_evaporation_timescale]
 value = 50


### PR DESCRIPTION
This PR updates the RCEMIPII ci test to use the most up to date diffusion, and also adds a config (not to ci) to run a single column RCEMIP setting with prognostic edmf + 1M. The SCM is considered to be RCEMIP but not RCEMIPII because RCEMIPII did not accept SCMs.
