### PR TITLE
Advection kernel splits

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-304
+305
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+305
+- Remove grid-scale thermo state from precomputed quantities and uses new thermodynamics functions.
+(Fix main branch that is still breaking)
 
 304
 - Remove grid-scale thermo state from precomputed quantities and uses new thermodynamics functions.


### PR DESCRIPTION
## Purpose 
Improve GPU performance of AMIP with 1 moment precip based on profiling without changing behavior

## Content
Pull out common subexpression and store in shared memory; split one kernel into three.
All kernels in update_jacobian are now less than 1.2% of total step time.

----
- [X] I have read and checked the items on the review checklist.
