### PR TITLE
Modify Buildkite pipeline to ignore .tar artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -457,9 +457,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/plane_no_topography_float64_test.yml
           --job_id gpu_plane_no_topography_float64_test
-
-          rm gpu_plane_no_topography_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_plane_no_topography_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_plane_no_topography_float64_test/output_active/*.pdf"
+          - "gpu_plane_no_topography_float64_test/output_active/*.yml"
+          - "gpu_plane_no_topography_float64_test/output_active/*.toml"
+          - "gpu_plane_no_topography_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -470,9 +472,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/plane_cosine_hills_float64_test.yml
           --job_id gpu_plane_cosine_hills_float64_test
-
-          rm gpu_plane_cosine_hills_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_plane_cosine_hills_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_plane_cosine_hills_float64_test/output_active/*.pdf"
+          - "gpu_plane_cosine_hills_float64_test/output_active/*.yml"
+          - "gpu_plane_cosine_hills_float64_test/output_active/*.toml"
+          - "gpu_plane_cosine_hills_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -483,9 +487,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/extruded_plane_cosine_hills_float64_test.yml
           --job_id gpu_extruded_plane_cosine_hills_float64_test
-
-          rm gpu_extruded_plane_cosine_hills_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_extruded_plane_cosine_hills_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_extruded_plane_cosine_hills_float64_test/output_active/*.pdf"
+          - "gpu_extruded_plane_cosine_hills_float64_test/output_active/*.yml"
+          - "gpu_extruded_plane_cosine_hills_float64_test/output_active/*.toml"
+          - "gpu_extruded_plane_cosine_hills_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -497,9 +503,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/box_cosine_hills_float64_test.yml
           --job_id gpu_box_cosine_hills_float64_test
-
-          rm gpu_box_cosine_hills_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_box_cosine_hills_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_box_cosine_hills_float64_test/output_active/*.pdf"
+          - "gpu_box_cosine_hills_float64_test/output_active/*.yml"
+          - "gpu_box_cosine_hills_float64_test/output_active/*.toml"
+          - "gpu_box_cosine_hills_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -511,9 +519,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/plane_agnesi_mountain_float64_test.yml
           --job_id gpu_plane_agnesi_mountain_float64_test
-
-          rm gpu_plane_agnesi_mountain_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_plane_agnesi_mountain_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_plane_agnesi_mountain_float64_test/output_active/*.pdf"
+          - "gpu_plane_agnesi_mountain_float64_test/output_active/*.yml"
+          - "gpu_plane_agnesi_mountain_float64_test/output_active/*.toml"
+          - "gpu_plane_agnesi_mountain_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -524,9 +534,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/plane_schar_mountain_float64_test.yml
           --job_id gpu_plane_schar_mountain_float64_test
-
-          rm gpu_plane_schar_mountain_float64_test/output_active/nc_files.tar
-        artifact_paths: "gpu_plane_schar_mountain_float64_test/output_active/*"
+        artifact_paths:
+          - "gpu_plane_schar_mountain_float64_test/output_active/*.pdf"
+          - "gpu_plane_schar_mountain_float64_test/output_active/*.yml"
+          - "gpu_plane_schar_mountain_float64_test/output_active/*.toml"
+          - "gpu_plane_schar_mountain_float64_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -537,9 +549,11 @@ steps:
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
           --config_file $CONFIG_PATH/plane_schar_mountain_float32_test.yml
           --job_id gpu_plane_schar_mountain_float32_test
-
-          rm gpu_plane_schar_mountain_float32_test/output_active/nc_files.tar
-        artifact_paths: "gpu_plane_schar_mountain_float32_test/output_active/*"
+        artifact_paths:
+          - "gpu_plane_schar_mountain_float32_test/output_active/*.pdf"
+          - "gpu_plane_schar_mountain_float32_test/output_active/*.yml"
+          - "gpu_plane_schar_mountain_float32_test/output_active/*.toml"
+          - "gpu_plane_schar_mountain_float32_test/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -1112,9 +1126,11 @@ steps:
           --config_file $COMMON_CONFIG_PATH/numerics_sphere_he6ze31.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_era5_initial_condition.yml
           --job_id diagnostic_edmfx_era5_initial_condition
-
-          rm diagnostic_edmfx_era5_initial_condition/output_active/nc_files.tar
-        artifact_paths: "diagnostic_edmfx_era5_initial_condition/output_active/*"
+        artifact_paths:
+          - "diagnostic_edmfx_era5_initial_condition/output_active/*.pdf"
+          - "diagnostic_edmfx_era5_initial_condition/output_active/*.yml"
+          - "diagnostic_edmfx_era5_initial_condition/output_active/*.toml"
+          - "diagnostic_edmfx_era5_initial_condition/output_active/*.dat"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:


### PR DESCRIPTION
Uploading the nc_files.tar and hdf5_files.tar can
cause some buildkite jobs to fail. This makes them only upload .pdf, .dat, .toml, and .yml files.

This is a follow up to #4241 . Instead of deleting the large files, it ignores them. 


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
