### PR TITLE
Reduces default scalar hyperdiffusion coefficent by 5x.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@ thermo state, including ᶜts in p.precomputed.sfc_conditions.
 - [#4211](https://github.com/CliMA/ClimaAtmos.jl/pull/4211) 
   add experimental methods to remove negative microphysical condensate values
 
+- Refactor hyperdiffusion to use Prandtl number parameterization. The scalar hyperdiffusion
+  coefficient is now computed as `ν₄_scalar = ν₄_vorticity / prandtl_number`, replacing the
+  previous direct `ν₄_scalar_coeff` parameter. Configure via `hyperdiffusion_prandtl_number`
+  (default: 1.0). The `CAM_SE` hyperdiffusion configuration maintains a 5x ratio between
+  vorticity and scalar coefficients by using `prandtl_number = 0.2`.
+
 v0.34.0
 -------
 - [#4198](https://github.com/CliMA/ClimaAtmos.jl/pull/4198) [badge-💥breaking] modifies surface conditions

--- a/config/common_configs/numerics_sphere_he16ze63.yml
+++ b/config/common_configs/numerics_sphere_he16ze63.yml
@@ -6,7 +6,7 @@ z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
 ode_algo: ARS343
-hyperdiff: CAM_SE
+hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true

--- a/config/common_configs/numerics_sphere_he30ze43.yml
+++ b/config/common_configs/numerics_sphere_he30ze43.yml
@@ -6,5 +6,5 @@ z_max: 30000.0
 dz_bottom: 30.0
 dt: 90secs
 ode_algo: ARS343
-hyperdiff: CAM_SE
+hyperdiff: ClimaHyperdiffusion
 max_newton_iters_ode: 1

--- a/config/common_configs/numerics_sphere_he30ze63.yml
+++ b/config/common_configs/numerics_sphere_he30ze63.yml
@@ -6,7 +6,7 @@ z_max: 60000.0
 dz_bottom: 30.0
 dt: 90secs
 ode_algo: ARS343
-hyperdiff: CAM_SE
+hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true

--- a/config/common_configs/numerics_sphere_he6ze10.yml
+++ b/config/common_configs/numerics_sphere_he6ze10.yml
@@ -6,6 +6,6 @@ z_max: 30000.0
 dz_bottom: 500.0
 dt: 400secs
 ode_algo: ARS343
-hyperdiff: CAM_SE
+hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: false
 viscous_sponge: false

--- a/config/common_configs/numerics_sphere_he6ze31.yml
+++ b/config/common_configs/numerics_sphere_he6ze31.yml
@@ -6,7 +6,7 @@ z_max: 60000.0
 dz_bottom: 50.0
 dt: 400secs
 ode_algo: ARS343
-hyperdiff: CAM_SE
+hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true
 implicit_diffusion: true

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -30,9 +30,9 @@ z_max:
 vorticity_hyperdiffusion_coefficient:
   help: "Hyperdiffusion coefficient for vorticity (m s-1)"
   value: 0.1857
-scalar_hyperdiffusion_coefficient:
-  help: "Hyperdiffusion coefficient for scalar (m s-1)"
-  value: 0.929738
+hyperdiffusion_prandtl_number:
+  help: "Prandtl number for hyperdiffusion. Scalar hyperdiffusion coefficient = vorticity coefficient / Prandtl number."
+  value: 1.0
 # Topography
 topography:
   help: "Define the surface elevation profile [`NoWarp` (default), `Earth`, `DCMIP200`, `Hughes2023`, `Agnesi`, `Schar`, `Cosine2D`, `Cosine3D`]"
@@ -161,8 +161,8 @@ vert_diff:
   help: "Vertical diffusion [`false` (default), `VerticalDiffusion`, `true` (defaults to `VerticalDiffusion`), `DecayWithHeightDiffusion`]"
   value: "false"
 hyperdiff:
-  help: "Hyperdiffusion. Use `CAM_SE` for sensible default values and ClimaHyperdiffusion for user control. [`CAM_SE` (default), `ClimaHyperdiffusion` (or `true`), `none` (or `false`)]"
-  value: "CAM_SE"
+  help: "Hyperdiffusion. [`ClimaHyperdiffusion` (default), `CAM_SE` (Lauritzen et al. 2018), `none` (or `false`)]"
+  value: "ClimaHyperdiffusion"
 amd_les:
   help: "AMD LES closure [`true`, `false` (default)]"
   value: false

--- a/config/model_configs/baroclinic_wave_hughes2023.yml
+++ b/config/model_configs/baroclinic_wave_hughes2023.yml
@@ -5,7 +5,7 @@ topo_smoothing: false
 moist: equil
 disable_surface_flux_tendency: true
 dt: "200secs"
-t_end: "8days"
+t_end: "4days"
 diagnostics:
   - short_name: [pfull, ua, wa, va, rv, pr, cli, hus, ke]
     period: 1days

--- a/config/model_configs/baroclinic_wave_topography_dcmip_rs.yml
+++ b/config/model_configs/baroclinic_wave_topography_dcmip_rs.yml
@@ -7,7 +7,7 @@ t_end: "6days"
 dt: "200secs"
 hyperdiff: "ClimaHyperdiffusion"
 vorticity_hyperdiffusion_coefficient: 1.5
-scalar_hyperdiffusion_coefficient: 1.5
+hyperdiffusion_prandtl_number: 1.0
 divergence_damping_factor: 1.0
 disable_surface_flux_tendency: true
 netcdf_output_at_levels: false

--- a/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
+++ b/config/model_configs/diagnostic_edmfx_era5_initial_condition.yml
@@ -12,8 +12,8 @@ rayleigh_sponge: true
 
 hyperdiff: ClimaHyperdiffusion
 divergence_damping_factor: 50.0 # large value to damp IC waves
-scalar_hyperdiffusion_coefficient: 0.929738
 vorticity_hyperdiffusion_coefficient: 0.1857
+hyperdiffusion_prandtl_number: 0.2
 insolation: "timevarying"
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-305
+306
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+306
+- Reduce default scalar hyperdiffusion coefficient (apply prandtl number parameter in the default yaml)
+
 305
 - Remove grid-scale thermo state from precomputed quantities and uses new thermodynamics functions.
 (Fix main branch that is still breaking)

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -12,13 +12,15 @@ import ClimaCore.Spaces as Spaces
 A `NamedTuple` of the hyperdiffusivity `ν₄_scalar` and the hyperviscosity
 `ν₄_vorticity`. These quantities are assumed to scale with `h^3`, where `h` is
 the mean nodal distance, following the empirical results of Lauritzen et al.
-(2018, https://doi.org/10.1029/2017MS001257). When `h == 1`, these quantities
-are equal to `hyperdiff.ν₄_scalar_coeff` and `hyperdiff.ν₄_vorticity_coeff`.
+(2018, https://doi.org/10.1029/2017MS001257). The scalar coefficient is computed
+as `ν₄_scalar = ν₄_vorticity / prandtl_number`, where `ν₄_vorticity = ν₄_vorticity_coeff * h^3`.
 """
 function ν₄(hyperdiff, Y)
     h = Spaces.node_horizontal_length_scale(Spaces.horizontal_space(axes(Y.c)))
-    ν₄_scalar = hyperdiff.ν₄_scalar_coeff * h^3
+    # Vorticity coefficient unchanged
     ν₄_vorticity = hyperdiff.ν₄_vorticity_coeff * h^3
+    # Scalar coefficient = vorticity coefficient / Prandtl number
+    ν₄_scalar = ν₄_vorticity / hyperdiff.prandtl_number
     return (; ν₄_scalar, ν₄_vorticity)
 end
 

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -59,12 +59,12 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
     if hyperdiff_name in ("ClimaHyperdiffusion", "true", true)
         ν₄_vorticity_coeff =
             FT(parsed_args["vorticity_hyperdiffusion_coefficient"])
-        ν₄_scalar_coeff = FT(parsed_args["scalar_hyperdiffusion_coefficient"])
         divergence_damping_factor = FT(parsed_args["divergence_damping_factor"])
+        prandtl_number = FT(parsed_args["hyperdiffusion_prandtl_number"])
         return ClimaHyperdiffusion(;
             ν₄_vorticity_coeff,
-            ν₄_scalar_coeff,
             divergence_damping_factor,
+            prandtl_number,
         )
     elseif hyperdiff_name == "CAM_SE"
         # To match hyperviscosity coefficients in:
@@ -73,13 +73,13 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
         # Need to scale by (1.1e5 / (sqrt(4 * pi / 6) * 6.371e6 / (3*30)) )^3  ≈ 1.238
         # These are re-scaled by the grid resolution in function ν₄(hyperdiff, Y)
         ν₄_vorticity_coeff = FT(0.150 * 1.238)
-        ν₄_scalar_coeff = FT(0.751 * 1.238)
         divergence_damping_factor = FT(5)
+        prandtl_number = FT(0.2)  # Maintains CAM_SE 5x scalar/vorticity ratio
         # Ensure the user isn't trying to set the values manually from the config as CAM_SE defines a set of hyperdiffusion coefficients
         coeff_pairs = [
             (ν₄_vorticity_coeff, "vorticity_hyperdiffusion_coefficient"),
-            (ν₄_scalar_coeff, "scalar_hyperdiffusion_coefficient"),
             (divergence_damping_factor, "divergence_damping_factor"),
+            (prandtl_number, "hyperdiffusion_prandtl_number"),
         ]
 
         for (cam_coef, config_coef) in coeff_pairs
@@ -89,8 +89,8 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
         end
         return ClimaHyperdiffusion(;
             ν₄_vorticity_coeff,
-            ν₄_scalar_coeff,
             divergence_damping_factor,
+            prandtl_number,
         )
     elseif hyperdiff_name in ("none", "false", false)
         return nothing

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -174,8 +174,8 @@ end
 abstract type AbstractHyperdiffusion end
 Base.@kwdef struct ClimaHyperdiffusion{FT} <: AbstractHyperdiffusion
     ν₄_vorticity_coeff::FT
-    ν₄_scalar_coeff::FT
     divergence_damping_factor::FT
+    prandtl_number::FT
 end
 
 abstract type AbstractVerticalDiffusion end
@@ -546,8 +546,8 @@ Base.@kwdef struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, ED_TR_UP, TDC, RR, 
     """Hyperdiffusion model: nothing or ClimaHyperdiffusion()"""
     hyperdiff::HD = ClimaHyperdiffusion{Float32}(;
         ν₄_vorticity_coeff = 0.150 * 1.238,
-        ν₄_scalar_coeff = 0.751 * 1.238,
         divergence_damping_factor = 5,
+        prandtl_number = 1.0,
     )
 end
 Base.broadcastable(x::AtmosNumerics) = tuple(x)
@@ -828,8 +828,8 @@ model = AtmosModel(;
     radiation_mode = HeldSuarezForcing(),
     hyperdiff = ClimaHyperdiffusion(;
         ν₄_vorticity_coeff = 1e15,
-        ν₄_scalar_coeff = 1e15,
-        divergence_damping_factor = 1.0
+        divergence_damping_factor = 1.0,
+        prandtl_number = 1.0
     )
 )
 ```
@@ -1049,7 +1049,7 @@ Create a dry atmospheric model with sensible defaults for dry simulations.
 ```julia
 model = DryAtmosModel(;
     radiation_mode = HeldSuarezForcing(),
-    hyperdiff = ClimaHyperdiffusion(; ν₄_vorticity_coeff = 1e15, ν₄_scalar_coeff = 1e15, divergence_damping_factor = 1.0)
+    hyperdiff = ClimaHyperdiffusion(; ν₄_vorticity_coeff = 1e15, divergence_damping_factor = 1.0, prandtl_number = 1.0)
 )
 ```
 """

--- a/test/restart_AtmosSimulation.jl
+++ b/test/restart_AtmosSimulation.jl
@@ -38,8 +38,8 @@ function amip_target_diagedmf(context, output_dir)
     diff_mode = CA.Implicit()
     hyperdiff = CA.ClimaHyperdiffusion{FT}(;
         ν₄_vorticity_coeff = 0.150 * 1.238,
-        ν₄_scalar_coeff = 0.751 * 1.238,
         divergence_damping_factor = 5,
+        prandtl_number = FT(0.2),  # Maintains 5x scalar/vorticity ratio (0.751/0.150)
     )
 
     tracers = (

--- a/test/solver/atmos_model_constructor.jl
+++ b/test/solver/atmos_model_constructor.jl
@@ -76,8 +76,8 @@ end
             ),
             hyperdiff = CA.ClimaHyperdiffusion(;
                 ν₄_vorticity_coeff = 1e15,
-                ν₄_scalar_coeff = 1e15,
                 divergence_damping_factor = 1.0,
+                prandtl_number = 1.0,
             ),
             disable_surface_flux_tendency = true,
         )

--- a/test/solver/model_getters.jl
+++ b/test/solver/model_getters.jl
@@ -11,7 +11,7 @@ import ClimaAtmos as CA
         Dict(
             "hyperdiff" => "CAM_SE",
             "vorticity_hyperdiffusion_coefficient" => 0.1857,
-            "scalar_hyperdiffusion_coefficient" => 0.929738,
+            "hyperdiffusion_prandtl_number" => 0.2,
             "divergence_damping_factor" => 5.0,
         ),
         job_id = "test_hyperdiff_cam_se_args",
@@ -23,11 +23,11 @@ import ClimaAtmos as CA
 
     # Test that CAM_SE returns the correct coefficient values
     cam_se_ν₄_vort = FT(0.150 * 1.238)
-    cam_se_ν₄_scalar = FT(0.751 * 1.238)
+    cam_se_prandtl = FT(0.2)
     cam_se_ν₄_dd = FT(5)
     @test hyperdiff_model isa CA.ClimaHyperdiffusion
     @test hyperdiff_model.ν₄_vorticity_coeff == cam_se_ν₄_vort
-    @test hyperdiff_model.ν₄_scalar_coeff == cam_se_ν₄_scalar
+    @test hyperdiff_model.prandtl_number == cam_se_prandtl
     @test hyperdiff_model.divergence_damping_factor == cam_se_ν₄_dd
 
     @info "Test CAM_SE coefficient validation"
@@ -36,7 +36,7 @@ import ClimaAtmos as CA
         Dict(
             "hyperdiff" => "CAM_SE",
             "vorticity_hyperdiffusion_coefficient" => 0.18571, # deliberately wrong value
-            "scalar_hyperdiffusion_coefficient" => 0.929738,
+            "hyperdiffusion_prandtl_number" => 0.2,
             "divergence_damping_factor" => 5.0,
         ),
         job_id = "test_hyperdiff_cam_se_wrong_args",


### PR DESCRIPTION
Adds hyperdiffusion prandtl number as a config parameter (default 1.0). Default hyperdiffusion changed to `ClimaHyperdiffusion`. 
CAM_SE hyperdiffusion retains the ratio between vorticity and scalar hyperdiffusion coefficients specified in Lauritzen et al. (2018).

Hyperdiffusion coefficient informed by scalar spectra from longruns in 1M configuration. (See also AMIP notes on negative value issues) 

(1M Allsky Aquaplanet at day 50 : Humidity and Temperature spectra, 1500m level)
<img width="1223" height="423" alt="Screenshot 2026-01-28 at 2 09 23 PM" src="https://github.com/user-attachments/assets/986d4908-a9d5-4847-a704-46fbdded4239" />
