### PR TITLE
change default timestepper to ARS222

### DIFF
--- a/config/common_configs/numerics_column_ze63.yml
+++ b/config/common_configs/numerics_column_ze63.yml
@@ -3,5 +3,5 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: false

--- a/config/common_configs/numerics_column_ze63.yml
+++ b/config/common_configs/numerics_column_ze63.yml
@@ -3,5 +3,5 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: false

--- a/config/common_configs/numerics_sphere_he16ze63.yml
+++ b/config/common_configs/numerics_sphere_he16ze63.yml
@@ -5,7 +5,7 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/common_configs/numerics_sphere_he16ze63.yml
+++ b/config/common_configs/numerics_sphere_he16ze63.yml
@@ -5,7 +5,7 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/common_configs/numerics_sphere_he30ze43.yml
+++ b/config/common_configs/numerics_sphere_he30ze43.yml
@@ -5,6 +5,6 @@ z_elem: 43
 z_max: 30000.0
 dz_bottom: 30.0
 dt: 90secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: ClimaHyperdiffusion
 max_newton_iters_ode: 1

--- a/config/common_configs/numerics_sphere_he30ze43.yml
+++ b/config/common_configs/numerics_sphere_he30ze43.yml
@@ -5,6 +5,6 @@ z_elem: 43
 z_max: 30000.0
 dz_bottom: 30.0
 dt: 90secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: ClimaHyperdiffusion
 max_newton_iters_ode: 1

--- a/config/common_configs/numerics_sphere_he30ze63.yml
+++ b/config/common_configs/numerics_sphere_he30ze63.yml
@@ -5,7 +5,7 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 90secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/common_configs/numerics_sphere_he30ze63.yml
+++ b/config/common_configs/numerics_sphere_he30ze63.yml
@@ -5,7 +5,7 @@ z_elem: 63
 z_max: 60000.0
 dz_bottom: 30.0
 dt: 90secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/common_configs/numerics_sphere_he6ze10.yml
+++ b/config/common_configs/numerics_sphere_he6ze10.yml
@@ -5,7 +5,7 @@ z_elem: 10
 z_max: 30000.0
 dz_bottom: 500.0
 dt: 400secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: false
 viscous_sponge: false

--- a/config/common_configs/numerics_sphere_he6ze10.yml
+++ b/config/common_configs/numerics_sphere_he6ze10.yml
@@ -5,7 +5,7 @@ z_elem: 10
 z_max: 30000.0
 dz_bottom: 500.0
 dt: 400secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: false
 viscous_sponge: false

--- a/config/common_configs/numerics_sphere_he6ze31.yml
+++ b/config/common_configs/numerics_sphere_he6ze31.yml
@@ -5,7 +5,7 @@ z_elem: 31
 z_max: 60000.0
 dz_bottom: 50.0
 dt: 400secs
-ode_algo: ARS222
+ode_algo: ARS232
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/common_configs/numerics_sphere_he6ze31.yml
+++ b/config/common_configs/numerics_sphere_he6ze31.yml
@@ -5,7 +5,7 @@ z_elem: 31
 z_max: 60000.0
 dz_bottom: 50.0
 dt: 400secs
-ode_algo: ARS343
+ode_algo: ARS222
 hyperdiff: ClimaHyperdiffusion
 rayleigh_sponge: true
 viscous_sponge: true

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -75,8 +75,8 @@ max_newton_iters_ode:
   help: "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)"
   value: 1
 ode_algo:
-  help: "ODE algorithm [`ARS222` (default), `SSP333`, `IMKG343a`, etc.]"
-  value: "ARS222"
+  help: "ODE algorithm [`ARS232` (default), `SSP333`, `IMKG343a`, etc.]"
+  value: "ARS232"
 krylov_rtol:
   help: "Relative tolerance of the Krylov method (only for ClimaTimeSteppers.jl; only used if `use_krylov_method` is `true`)"
   value: 0.1

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -75,8 +75,8 @@ max_newton_iters_ode:
   help: "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)"
   value: 1
 ode_algo:
-  help: "ODE algorithm [`ARS343` (default), `SSP333`, `IMKG343a`, etc.]"
-  value: "ARS343"
+  help: "ODE algorithm [`ARS222` (default), `SSP333`, `IMKG343a`, etc.]"
+  value: "ARS222"
 krylov_rtol:
   help: "Relative tolerance of the Krylov method (only for ClimaTimeSteppers.jl; only used if `use_krylov_method` is `true`)"
   value: 0.1

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -147,7 +147,7 @@ function AtmosSimulation{FT}(;
     t_start = 0,
     t_end = 86400 * 10,  # 10 days
     ode_config = CTS.IMEXAlgorithm(
-        CTS.ARS222(),
+        CTS.ARS232(),
         CTS.NewtonsMethod(;
             max_iters = 1,
             update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -147,7 +147,7 @@ function AtmosSimulation{FT}(;
     t_start = 0,
     t_end = 86400 * 10,  # 10 days
     ode_config = CTS.IMEXAlgorithm(
-        CTS.ARS343(),
+        CTS.ARS222(),
         CTS.NewtonsMethod(;
             max_iters = 1,
             update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
From @sajjadazimi:)

> ARS222 is stiffly accurate; the solution that is found in Newton is used as the initial condition of the next step. Based on the reference paper being stiffly accurate helps with extremely stiff problems. The accuracy is the same for both. So I think I like ARS222 better.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
