### PR TITLE
pedmf bugfix; entr at the boundary

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-307
+308
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+308
+ - PEDMF bugfix: return entr_detr_lim_tau for entr at the boundary when area fraction is negative
+
 307
 - Update to Insolation v1.1, with a small change in clipping of solar zenith angle.
 Also change TOA flux and zenith angle for idealized insolation.

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -364,7 +364,8 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
         detr_int_val = Fields.field_values(Fields.level(ᶜdetrʲs.:($j), 1))
         @. entr_int_val = limit_entrainment(
             ifelse(
-                buoyancy_flux_val < 0 || ᶜaʲ_int_val >= $(FT(turbconv_params.surface_area)),
+                buoyancy_flux_val < 0 || ᶜaʲ_int_val <= 0 ||
+                ᶜaʲ_int_val >= $(FT(turbconv_params.surface_area)),
                 entr_int_val,
                 detr_int_val +
                 ($(FT(turbconv_params.surface_area)) / ᶜaʲ_int_val - 1) / dt,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
When `a` is negative, `entr` at the boundary becomes zero. This differs from our expectation that we set a limit value for entr/detr when a is below eps. This PR sets `entr` at the boundary equal to `detr` when `a` is negative to allow some mixing (both are equal to `entr_detr_limit_entr_tau`).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
