### PR TITLE
Updated the yaml output to reference the toml file in the output

### DIFF
--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -988,12 +988,16 @@ function get_simulation(config::AtmosConfig)
     output_dir = sim_info.output_dir
     @info "Simulation info" job_id output_dir
 
+    output_toml_file = joinpath(output_dir, "$(job_id)_parameters.toml")
     CP.log_parameter_information(
         config.toml_dict,
-        joinpath(output_dir, "$(job_id)_parameters.toml"),
+        output_toml_file,
         strict = config.parsed_args["strict_params"],
     )
-    YAML.write_file(joinpath(output_dir, "$job_id.yml"), config.parsed_args)
+
+    output_args = copy(config.parsed_args)
+    output_args["toml"] = [abspath(output_toml_file)]
+    YAML.write_file(joinpath(output_dir, "$job_id.yml"), output_args)
 
     if sim_info.restart
         s = @timed_str begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,8 @@ if TEST_GROUP in ("infrastructure", "all")
     @safetestset "Variable manipulations" begin @time include("variable_manipulations_tests.jl") end
     @safetestset "Parameter tests" begin @time include("parameter_tests.jl") end
 
+    @safetestset "Check TOML path" begin @time include("test_output_yaml_path.jl") end
+
     # Interface tests
     @safetestset "Radiation interface tests" begin @time include("rrtmgp_interface.jl") end
     @safetestset "Coupler compatibility" begin @time include("coupler_compatibility.jl") end

--- a/test/test_output_yaml_path.jl
+++ b/test/test_output_yaml_path.jl
@@ -1,0 +1,39 @@
+import ClimaAtmos as CA
+import YAML
+using Test
+
+@testset "Output YAML Path Test" begin
+    mktempdir() do output_dir
+        job_id = "test_yaml_path_fix"
+
+        input_toml_path = joinpath(@__DIR__, "..", "toml", "bomex_box_rhoe.toml")
+
+        config_dict = Dict(
+            "job_id" => job_id,
+            "output_dir" => output_dir,
+            "config" => "box",
+            "toml" => [input_toml_path],
+            "x_elem" => 2,
+            "y_elem" => 2,
+            "z_elem" => 4,
+            "dt" => "1s",
+            "t_end" => "2s",
+            "dt_save_state_to_disk" => "2s",
+        )
+
+        config = CA.AtmosConfig(config_dict; job_id)
+
+        simulation = CA.get_simulation(config)
+        real_output_dir = simulation.output_dir
+
+        output_yaml_path = joinpath(real_output_dir, "$(job_id).yml")
+        output_toml_path = joinpath(real_output_dir, "$(job_id)_parameters.toml")
+
+        @test isfile(output_yaml_path)
+        @test isfile(output_toml_path)
+
+        yaml_data = YAML.load_file(output_yaml_path)
+        @test yaml_data["toml"] == [abspath(output_toml_path)]
+        @test yaml_data["toml"] != [input_toml_path]
+    end
+end


### PR DESCRIPTION
directory to prevent restart failures when original files are moved

## Purpose 
This PR addresses issue #4040. Currently, the output YAML file generated after a simulation references the paths of the original input TOML files. If those original files are moved or deleted, restarting the simulation from the output YAML fails.

This change ensures that the output YAML points to the absolute path of the parameters TOML file that is automatically saved in the output directory ( <job_id>_parameters.toml ). This makes the output folder self-contained and allows for robust restarts even if the original input files are modified or removed.


## To-do
- Modify `get_simulation` in type_getters.jl to update the toml path in output config
- use abspath to ensure the path is unambiguous regardless of the execution directory


## Content
The fix is implemented in `type_getters.jl` withing the get_simulation function.
Prior to writing the output YAML file, I created a copy of config.parsed_args to avoid modifying the runtime configuration object (which seemed safer than in-place mutation). In this copy, I updated the toml key to be a list containing the absolute path to the local `*_parameters.toml` file.

As suggested by @haakon-e and @nefrathenrici , I used the full absolute path (abspath(...)) for the new TOML entry. This avoids potential ambiguity with relative paths depending on where the Julia process is launched.

## Verification Step:
I verified this manually using a small "box" simulation configuration:


1. Ran a simulation using an existing TOML file ( box_density_current_test.toml ) as input.
2. Verified that the generated output YAML now points to the file in the output directory instead of the original input file.
3. Renamed the original input TOML file to simulate deletion.
4. Successfully restarted the simulation using the generated output YAML 

Let me know if any adjustment are needed, or if you want any test script.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
