### PR TITLE
Fix hyperdiff prandtl to stabilize prog-edmf nightly build

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -32,7 +32,7 @@ vorticity_hyperdiffusion_coefficient:
   value: 0.1857
 hyperdiffusion_prandtl_number:
   help: "Prandtl number for hyperdiffusion. Scalar hyperdiffusion coefficient = vorticity coefficient / Prandtl number."
-  value: 1.0
+  value: 0.2
 # Topography
 topography:
   help: "Define the surface elevation profile [`NoWarp` (default), `Earth`, `DCMIP200`, `Hughes2023`, `Agnesi`, `Schar`, `Cosine2D`, `Cosine3D`]"

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-308
+309
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+309
+ - Stabilize prognostic-EDMF nightly build with reduced hyperdiff Prandtl number. 
+
 308
  - PEDMF bugfix: return entr_detr_lim_tau for entr at the boundary when area fraction is negative
 


### PR DESCRIPTION
Prognostic-EDMF (nightly config) is unstable with reduced scalar hyperdiffusion (compared to CAM_SE config). This PR reduces the hyperdiff prandtl number to provide sufficient hyperdiffusion for stability. 