### PR TITLE
Defuse advection kernels

### DIFF
--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -41,6 +41,7 @@ function temporary_quantities(Y, atmos)
     return (;
         ᶠtemp_scalar = Fields.Field(FT, face_space), # ᶠp, ᶠρK_h
         ᶠtemp_scalar_2 = Fields.Field(FT, face_space), # ᶠρK_u
+        ᶠtemp_scalar_3 = Fields.Field(FT, face_space),
         ᶜtemp_scalar = Fields.Field(FT, center_space), # ᶜ1
         ᶜtemp_scalar_2 = Fields.Field(FT, center_space), # ᶜtke_exch
         ᶜtemp_scalar_3 = Fields.Field(FT, center_space),
@@ -132,6 +133,20 @@ function temporary_quantities(Y, atmos)
             },
         ),
         ᶠbidiagonal_matrix_ct3_2 = similar(Y.f, BidiagonalMatrixRow{CT3{FT}}),
+        ᶠbidiagonal_matrix_ct3xct12 = similar(
+            Y.f,
+            BidiagonalMatrixRow{
+                ClimaCore.Geometry.AxisTensor{
+                    FT,
+                    2,
+                    Tuple{
+                        ClimaCore.Geometry.ContravariantAxis{(3,)},
+                        ClimaCore.Geometry.ContravariantAxis{(1, 2)},
+                    },
+                    SMatrix{1, 2, FT, 2},
+                },
+            },
+        ),
         ᶜbidiagonal_matrix_scalar = similar(Y.c, BidiagonalMatrixRow{FT}),
         ᶜadvection_matrix = similar(
             Y.c,

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -430,17 +430,14 @@ function edmfx_sgs_vertical_advection_tendency!(
             (; ᶜTʲs) = p.precomputed
             ᶜ∂ρ∂t_sed = p.scratch.ᶜtemp_scalar_3
             @. ᶜ∂ρ∂t_sed = 0
-
-            ᶜinv_ρ̂ = (@. lazy(
-                specific(
-                    FT(1),
-                    Y.c.sgsʲs.:($$j).ρa,
-                    FT(0),
-                    ᶜρʲs.:($$j),
-                    turbconv_model,
-                ),
-            ))
-
+            ᶜinv_ρ̂ = p.scratch.ᶜtemp_scalar_4
+            @. ᶜinv_ρ̂ = specific(
+                FT(1),
+                Y.c.sgsʲs.:($$j).ρa,
+                FT(0),
+                ᶜρʲs.:($$j),
+                turbconv_model,
+            )
             # Sedimentation
             # TODO - lazify ᶜwₗʲs computation. No need to cache it.
             sgs_microphysics_tracers = (
@@ -468,7 +465,10 @@ function edmfx_sgs_vertical_advection_tendency!(
                 @. ᶜqʲₜ += va
 
                 # Flux form sedimentation of tracers
-                vtt = updraft_sedimentation(
+                vtt = p.scratch.ᶜtemp_scalar_5
+                updraft_sedimentation!(
+                    vtt,
+                    p,
                     ᶜρʲs.:($j),
                     ᶜwʲ,
                     ᶜa,
@@ -491,11 +491,14 @@ function edmfx_sgs_vertical_advection_tendency!(
                 else
                     error("Unsupported moisture tracer variable")
                 end
-                vtt = updraft_sedimentation(
+                ᶜχ_lazy = @. lazy(ᶜqʲ * ᶜmse_li)
+                updraft_sedimentation!(
+                    vtt,
+                    p,
                     ᶜρʲs.:($j),
                     ᶜwʲ,
                     ᶜa,
-                    ᶜqʲ .* ᶜmse_li,
+                    ᶜχ_lazy,
                     ᶠJ,
                 )
                 @. Yₜ.c.sgsʲs.:($$j).mse +=
@@ -548,7 +551,10 @@ function edmfx_sgs_vertical_advection_tendency!(
                 @. ᶜχʲₜ += va
 
                 # Flux form sedimentation of tracers
-                vtt = updraft_sedimentation(
+                vtt = p.scratch.ᶜtemp_scalar_5
+                updraft_sedimentation!(
+                    vtt,
+                    p,
                     ᶜρʲs.:($j),
                     ᶜwʲ,
                     ᶜa,
@@ -565,40 +571,43 @@ function edmfx_sgs_vertical_advection_tendency!(
 end
 
 """
-    updraft_sedimentation(ᶜρ, ᶜw, ᶜa, ᶜχ, ᶠJ)
+    updraft_sedimentation!(vtt, p, ᶜρ, ᶜw, ᶜa, ᶜχ, ᶠJ)
 
-Compute the sedimentation tendency of tracer `χ` within an updraft, including lateral 
+Compute the sedimentation tendency of tracer `χ` within an updraft, including lateral
 detrainment when the updraft area increases with height.
 
 # Description
-Sedimenting particles fall with velocity `w` through an updraft of fractional area `a(z)`.  
-The vertical flux divergence gives a tendency of ``∂(ρ w a χ)/∂z``.  
-When `∂a/∂z > 0`, some sedimenting mass exits laterally through the expanding sides, 
-producing a detrainment tendency of ``-ρ w χ ∂a/∂z``.  
+Sedimenting particles fall with velocity `w` through an updraft of fractional area `a(z)`.
+The vertical flux divergence gives a tendency of ``∂(ρ w a χ)/∂z``.
+When `∂a/∂z > 0`, some sedimenting mass exits laterally through the expanding sides,
+producing a detrainment tendency of ``-ρ w χ ∂a/∂z``.
 The resulting net tendency in this case is ``a * ∂(ρ w χ)/∂z``.
 
 # Equation
-The lateral flux through the updraft side surface `S` within one grid column is  
-``F_side = ∫_S (ρ χ (w · n)) dS ≈ ρ χ (w · n) A_side,``  
-where `n` is the outward unit normal and `A_side` the side area.  
-For predominantly vertical sedimentation,  
-``w·n A_side ≈ w A_grid [a(z+Δz) - a(z)] = w A_grid Δa.``  
-Dividing by the grid column volume `A_grid·Δz` gives the flux divergence (tendency):  
-``tendency ≈ ρ χ w ∂a/∂z.``  
-A negative sign is applied to represent the loss (detrainment) from the updraft:  
+The lateral flux through the updraft side surface `S` within one grid column is
+``F_side = ∫_S (ρ χ (w · n)) dS ≈ ρ χ (w · n) A_side,``
+where `n` is the outward unit normal and `A_side` the side area.
+For predominantly vertical sedimentation,
+``w·n A_side ≈ w A_grid [a(z+Δz) - a(z)] = w A_grid Δa.``
+Dividing by the grid column volume `A_grid·Δz` gives the flux divergence (tendency):
+``tendency ≈ ρ χ w ∂a/∂z.``
+A negative sign is applied to represent the loss (detrainment) from the updraft:
 ``Dₛ = -ρ w χ ∂a/∂z.``
 
 # Arguments
-- `ᶜρ`: air density  
-- `ᶜw`: sedimentation velocity (positive downward)  
-- `ᶜa`: updraft area fraction  
-- `ᶜχ`: tracer mixing ratio  
+- `vtt` : output field
+- `p`: cache containing scratch spaces
+- `ᶜρ`: air density
+- `ᶜw`: sedimentation velocity (positive downward)
+- `ᶜa`: updraft area fraction
+- `ᶜχ`: tracer mixing ratio
 - `ᶠJ`: face Jacobian (grid geometry)
 
-# Returns
-Tracer tendency due to sedimentation and lateral detrainment.
+`vtt` gets filled with Tracer tendency due to sedimentation and lateral detrainment.
 """
-function updraft_sedimentation(
+function updraft_sedimentation!(
+    vtt,
+    p,
     ᶜρ,
     ᶜw,
     ᶜa,
@@ -606,18 +615,22 @@ function updraft_sedimentation(
     ᶠJ,
 )
     ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
-    ∂a∂z = @. lazy(ᶜprecipdivᵥ(ᶠinterp(ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(ᶜa))))
-    return @. lazy(
-        ifelse(
-            ∂a∂z < 0,
-            -(ᶜprecipdivᵥ(
-                ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(-(ᶜw)) * ᶜa * ᶜχ),
-            )),
-            -(
-                ᶜa * ᶜprecipdivᵥ(
-                    ᶠinterp(ᶜρ * ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(-(ᶜw)) * ᶜχ),
-                )
-            ),
+    # use output as a scratch field
+    ∂a∂z = vtt
+    @. ∂a∂z = ᶜprecipdivᵥ(ᶠinterp(ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(ᶜa)))
+    @. p.scratch.ᶠtemp_scalar = ᶠinterp(ᶜρ * ᶜJ) / ᶠJ
+    @. p.scratch.ᶠtemp_scalar_3 = ᶠright_bias(-(ᶜw) * ᶜa * ᶜχ)
+    @. p.scratch.ᶠtemp_scalar_2 = ᶠright_bias(-(ᶜw) * ᶜχ)
+    @. vtt = ifelse(
+        ∂a∂z < 0,
+        -(ᶜprecipdivᵥ(
+            p.scratch.ᶠtemp_scalar * Geometry.WVector(p.scratch.ᶠtemp_scalar_3),
+        )),
+        -(
+            ᶜa * ᶜprecipdivᵥ(
+                p.scratch.ᶠtemp_scalar * Geometry.WVector(p.scratch.ᶠtemp_scalar_2),
+            )
         ),
     )
+    return
 end

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -502,12 +502,12 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
 
     @. ᶜadvection_matrix =
         -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(ᶠinterp(ᶜρ * ᶜJ) / ᶠJ)
-
+    @. p.scratch.ᶠbidiagonal_matrix_ct3xct12 =
+        ᶠwinterp_matrix(ᶜJ * ᶜρ) ⋅ DiagonalMatrixRow(g³ʰ(ᶜgⁱʲ))
     if use_derivative(topography_flag)
         ∂ᶜρ_err_∂ᶜuₕ = matrix[@name(c.ρ), @name(c.uₕ)]
         @. ∂ᶜρ_err_∂ᶜuₕ =
-            dtγ * ᶜadvection_matrix ⋅ ᶠwinterp_matrix(ᶜJ * ᶜρ) ⋅
-            DiagonalMatrixRow(g³ʰ(ᶜgⁱʲ))
+            dtγ * ᶜadvection_matrix ⋅ p.scratch.ᶠbidiagonal_matrix_ct3xct12
     end
     ∂ᶜρ_err_∂ᶠu₃ = matrix[@name(c.ρ), @name(f.u₃)]
     @. ∂ᶜρ_err_∂ᶠu₃ = dtγ * ᶜadvection_matrix ⋅ DiagonalMatrixRow(g³³(ᶠgⁱʲ))
@@ -522,7 +522,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
             ∂ᶜρχ_err_∂ᶜuₕ = matrix[ρχ_name, @name(c.uₕ)]
             @. ∂ᶜρχ_err_∂ᶜuₕ =
                 dtγ * ᶜadvection_matrix ⋅ DiagonalMatrixRow(ᶠinterp(ᶜχ)) ⋅
-                ᶠwinterp_matrix(ᶜJ * ᶜρ) ⋅ DiagonalMatrixRow(g³ʰ(ᶜgⁱʲ))
+                p.scratch.ᶠbidiagonal_matrix_ct3xct12
         end
 
         ∂ᶜρχ_err_∂ᶠu₃ = matrix[ρχ_name, @name(f.u₃)]
@@ -1524,7 +1524,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
 
                         ∂ᶜρχ_err_∂ᶠu₃ʲ =
                             matrix[ρχ_name, @name(f.sgsʲs.:(1).u₃)]
-                        # pull out and store in shmem for kernel performance
+                        # pull out and store in cache for kernel performance
                         @. p.scratch.ᶠtemp_CT3_2 = ᶠset_tracer_upwind_bcs(
                             ᶠtracer_upwind(CT3(sign(ᶠu³⁰_data)),
                                 ᶜχ⁰ * draft_area(ᶜρa⁰, ᶜρ⁰),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

I took a look at a prognostic EDMF simulation with 1M microphysics and noticed that there are some easy performance improvements in the advection code (at the cost of readability)

## To-do
- Unrelated to this PR, but I need to document guidelines on code patterns for atmos developers to avoid for performance reasons

## Content
- fix inaccurate comment in `update_jacobian`
- cache expensive ` ᶠwinterp_matrix(ᶜJ * ᶜρ) ⋅ DiagonalMatrixRow(g³ʰ(ᶜgⁱʲ))` in `update_jacobian`
- change `updraft_sedimentation` to an in-place eager computation
- defuses advection code



With the following config options, this PR improves SYPD from 0.11 to 0.124
```
aerosol_radiation: true
approximate_linear_solve_iters: 2
cloud_model: "quadrature"
dt_cloud_fraction: "1hours"
dt_save_state_to_disk: "30days"
dz_bottom: 30.0
edmfx_detr_model: "Generalized"
edmfx_entr_model: "Generalized"
edmfx_filter: true
edmfx_nh_pressure: true
edmfx_sgs_diffusive_flux: true
edmfx_sgs_mass_flux: true
edmfx_upwinding: "first_order"
edmfx_vertical_diffusion: true
h_elem: 16
implicit_diffusion: true
implicit_sgs_advection: true
implicit_sgs_entr_detr: true
implicit_sgs_mass_flux: true
implicit_sgs_nh_pressure: true
implicit_sgs_vertdiff: true
insolation: "timevarying"
max_newton_iters_ode: 3
moist: "nonequil"
netcdf_output_at_levels: true
precip_model: "1M"
prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
prognostic_tke: true
rad: "allskywithclear"
rayleigh_sponge: true
t_end: "120days"
time_varying_trace_gases: ["CO2", "O3"]
toml: [toml/longrun_aquaplanet_diagedmf.toml]
turbconv: "prognostic_edmfx"
viscous_sponge: true
z_elem: 63
z_max: 60000.0

FLOAT_TYPE: "Float32"
albedo_model: "CouplerAlbedo"
atmos_config_file: "config/atmos_configs/climaatmos_progedmf_1m.yml"
checkpoint_dt: "366days"
coupler_toml: ["toml/amip_progedmf_1m.toml"]
dt: "30secs"
dt_cpl: "30secs"
dt_rad: "600secs"
energy_check: false
land_model: "integrated"
mode_name: "amip"
radiation_reset_rng_seed: true
start_date: "20100101"
surface_setup: "PrescribedSurface"
topo_smoothing: true
topography: "Earth"
```



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
