### PR TITLE
Create IC type to allow initializing AMIP with ERA5 on model levels

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -429,7 +429,7 @@ version = "0.5.20"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.35.1"
+version = "0.35.2"
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]
@@ -467,9 +467,9 @@ version = "0.3.18"
 
 [[deps.ClimaDiagnostics]]
 deps = ["Accessors", "ClimaComms", "ClimaCore", "ClimaUtilities", "Dates", "NCDatasets", "NVTX", "OrderedCollections", "SciMLBase"]
-git-tree-sha1 = "ee9609d1c03d43bd09236ff9943df17f37db004c"
+git-tree-sha1 = "34afaa11e04d6d4f746b0d03cdbc83b543f77302"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.ClimaInterpolations]]
 deps = ["DocStringExtensions"]
@@ -1158,9 +1158,9 @@ version = "0.1.0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "6b4d2dc81736fe3980ff0e8879a9fc7c33c44ddf"
+git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.86.2+0"
+version = "2.86.3+0"
 
 [[deps.Graphics]]
 deps = ["Colors", "LinearAlgebra", "NaNMath"]

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -81,6 +81,8 @@ git-tree-sha1 = "789c8dd160b022a6c714a102c1495530c7a9d20c"
 [weather_model_ic]
 git-tree-sha1 = "1c05bc305e79ceaab8c537be4f8c4a26465996a3"
 
+[era5_inst_model_levels]
+git-tree-sha1 = "8aae2d7330f90a029a4891be658a691e4e3362dc"
 
 [cloud_fraction_nn]
 git-tree-sha1 = "c2412372bdf40ba73f496dc0fe427d063e31533b"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,12 @@ ClimaAtmos.jl Release Notes
 main
 -------
 
+v0.35.2
+-------
+
 v0.35.1
 -------
+- [4276](https://github.com/CliMA/ClimaAtmos.jl/pull/4276) Create IC type to allow initializing AMIP with ERA5 on model levels. Add artifact which corresponds to default AMIP start date (Jan 1, 2010). Also removes unused ᶜspecific in the precomputed cache.
 
 v0.35.0
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.35.1"
+version = "0.35.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -10,6 +10,7 @@ edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_sgsflux_upwinding: "vanleer_limiter"
 edmfx_tracer_upwinding: "vanleer_limiter"
+initial_condition: "AMIPFromERA5"
 moist: equil
 precip_model: 0M
 t_end: 12hours

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -37,7 +37,6 @@ function implicit_precomputed_quantities(Y, atmos)
     FT = eltype(Y)
     n = n_mass_flux_subdomains(turbconv_model)
     gs_quantities = (;
-        ᶜspecific = Base.materialize(ᶜspecific_gs_tracers(Y)),
         ᶜu = similar(Y.c, C123{FT}),
         ᶠu³ = similar(Y.f, CT3{FT}),
         ᶠu = similar(Y.f, CT123{FT}),

--- a/src/initial_conditions/InitialConditions.jl
+++ b/src/initial_conditions/InitialConditions.jl
@@ -26,6 +26,7 @@ import ..gcm_height
 import ..gcm_driven_profile_tmean
 import ..constant_buoyancy_frequency_initial_state
 import ..weather_model_data_path
+import ..parse_date
 
 import Thermodynamics.TemperatureProfiles:
     DecayingTemperatureProfile, DryAdiabaticProfile
@@ -40,6 +41,7 @@ import Interpolations as Intp
 import NCDatasets as NC
 import Statistics: mean
 import ClimaUtilities.SpaceVaryingInputs
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import Dates
 
 include("local_state.jl")

--- a/src/initial_conditions/initial_conditions.jl
+++ b/src/initial_conditions/initial_conditions.jl
@@ -210,7 +210,20 @@ struct WeatherModel <: InitialCondition
     era5_initial_condition_dir::Union{Nothing, String}
 end
 
-function (initial_condition::Union{MoistFromFile, WeatherModel})(params)
+"""
+    AMIPFromERA5(start_date)
+
+An `InitialCondition` for AMIP simulations using ERA5 monthly reanalysis data.
+Uses the `amip_era5_ic` artifact containing pre-processed ERA5 data interpolated
+to z-levels, matching the format expected by the WeatherModel machinery.
+
+Expected artifact structure: `amip_era5_ic/era5_init_YYYYMMDD_0000.nc`
+"""
+struct AMIPFromERA5 <: InitialCondition
+    start_date::String
+end
+
+function (initial_condition::Union{MoistFromFile, WeatherModel, AMIPFromERA5})(params)
     function local_state(local_geometry)
         FT = eltype(params)
 
@@ -505,8 +518,7 @@ function correct_surface_pressure_for_topography!(
     grav = thermo_params.grav
 
     ᶠz_model_surface = Fields.level(Fields.coordinate_field(Y.f).z, Fields.half)
-    ᶠΔz = zeros(face_space)
-    @. ᶠΔz = ᶠz_model_surface - ᶠz_surface
+    ᶠΔz = @. ᶠz_model_surface - ᶠz_surface
 
     ᶠR_m = ᶠinterp.(TD.gas_constant_air.(thermo_params, ᶜq_tot))
     ᶠR_m_sfc = Fields.level(ᶠR_m, Fields.half)
@@ -712,6 +724,14 @@ function overwrite_initial_conditions!(
             "`dry` configurations are incompatible with the interpolated initial conditions.",
         )
     end
+
+    if hasproperty(Y.c, :ρq_liq)
+        fill!(Y.c.ρq_liq, 0)
+    end
+    if hasproperty(Y.c, :ρq_ice)
+        fill!(Y.c.ρq_ice, 0)
+    end
+
     if hasproperty(Y.c, :ρq_sno) && hasproperty(Y.c, :ρq_rai)
         Y.c.ρq_sno .=
             SpaceVaryingInputs.SpaceVaryingInput(
@@ -740,7 +760,45 @@ function overwrite_initial_conditions!(
 end
 
 """
-    _overwrite_initial_conditions_from_file!(file_path::String, Y, thermo_params, config)
+    overwrite_initial_conditions!(initial_condition::AMIPFromERA5, Y, thermo_params)
+
+Overwrite the prognostic state `Y` with ERA5-derived initial conditions for AMIP simulations.
+Initial condition corresponds to Jan 1, 2010 at 00Z.
+Uses hydrostatic integration from surface pressure to compute the pressure profile.
+
+Expected variables in the IC file:
+- 3D: `u`, `v`, `w`, `t`, `q`
+- 2D broadcast in `z`: `p` (surface pressure)
+"""
+function overwrite_initial_conditions!(
+    initial_condition::AMIPFromERA5,
+    Y,
+    thermo_params,
+)
+    # Get file path from AMIP artifact
+    dt = parse_date(initial_condition.start_date)
+    start_date_str = Dates.format(dt, "yyyymmdd")
+
+    file_path = joinpath(
+        @clima_artifact("era5_inst_model_levels"),
+        "era5_init_processed_internal_$(start_date_str)_0000.nc",
+    )
+
+    extrapolation_bc = (Intp.Periodic(), Intp.Flat(), Intp.Flat())
+
+    return _overwrite_initial_conditions_from_file!(
+        file_path,
+        extrapolation_bc,
+        Y,
+        thermo_params;
+        regridder_type = :InterpolationsRegridder,
+        interpolation_method = Intp.Linear(),
+    )
+end
+
+"""
+    _overwrite_initial_conditions_from_file!(file_path, extrapolation_bc, Y, thermo_params;
+                                              regridder_type=nothing, interpolation_method=nothing)
 
 Given a prognostic state `Y`, an `initial condition` (specifically, where initial values are
 assigned from interpolations of existing datasets), and `thermo_params`, this function
@@ -755,14 +813,34 @@ We expect the file to contain the following variables:
 - `q`, for humidity,
 - `u, v, w`, for velocity,
 - `cswc, crwc` for snow and rain water content (for 1 moment microphysics).
+
+If the file contains `z_sfc` (surface altitude), a hydrostatic correction is applied
+to account for differences between the file's orography and the model's topography.
+
+Optional keyword arguments:
+- `regridder_type`: The regridder type to use (e.g., `:InterpolationsRegridder`)
+- `interpolation_method`: The interpolation method (e.g., `Intp.Linear()`)
 """
 function _overwrite_initial_conditions_from_file!(
     file_path::String,
     extrapolation_bc,
     Y,
-    thermo_params,
+    thermo_params;
+    regridder_type = nothing,
+    interpolation_method = nothing,
 )
-    regridder_kwargs = isnothing(extrapolation_bc) ? () : (; extrapolation_bc)
+    regridder_kwargs = if isnothing(extrapolation_bc) && isnothing(interpolation_method)
+        ()
+    elseif isnothing(interpolation_method)
+        (; extrapolation_bc)
+    elseif isnothing(extrapolation_bc)
+        (; interpolation_method)
+    else
+        (; extrapolation_bc, interpolation_method)
+    end
+    svi_kwargs =
+        isnothing(regridder_type) ? (; regridder_kwargs) :
+        (; regridder_type, regridder_kwargs)
     isfile(file_path) || error("$(file_path) is not a file")
     @info "Overwriting initial conditions with data from file $(file_path)"
     center_space = Fields.axes(Y.c)
@@ -773,23 +851,42 @@ function _overwrite_initial_conditions_from_file!(
         SpaceVaryingInputs.SpaceVaryingInput(
             file_path,
             "p",
-            face_space,
-            regridder_kwargs = regridder_kwargs,
+            face_space;
+            svi_kwargs...,
         ),
         Fields.half,
     )
     ᶜT = SpaceVaryingInputs.SpaceVaryingInput(
         file_path,
         "t",
-        center_space,
-        regridder_kwargs = regridder_kwargs,
+        center_space;
+        svi_kwargs...,
     )
     ᶜq_tot = SpaceVaryingInputs.SpaceVaryingInput(
         file_path,
         "q",
-        center_space,
-        regridder_kwargs = regridder_kwargs,
+        center_space;
+        svi_kwargs...,
     )
+
+    # Apply hydrostatic surface-pressure correction only if surface altitude is available
+    surface_altitude_var = "z_sfc"
+    has_surface_altitude = NC.NCDataset(file_path) do ds
+        haskey(ds, surface_altitude_var)
+    end
+    if has_surface_altitude
+        correct_surface_pressure_for_topography!(
+            p_sfc,
+            file_path,
+            face_space,
+            Y,
+            ᶜT,
+            ᶜq_tot,
+            thermo_params,
+            regridder_kwargs;
+            surface_altitude_var = surface_altitude_var,
+        )
+    end
 
     # With the known temperature (ᶜT) and moisture (ᶜq_tot) profile,
     # recompute the pressure levels assuming hydrostatic balance is maintained.
@@ -816,20 +913,20 @@ function _overwrite_initial_conditions_from_file!(
             SpaceVaryingInputs.SpaceVaryingInput(
                 file_path,
                 "u",
-                center_space,
-                regridder_kwargs = regridder_kwargs,
+                center_space;
+                svi_kwargs...,
             ),
             SpaceVaryingInputs.SpaceVaryingInput(
                 file_path,
                 "v",
-                center_space,
-                regridder_kwargs = regridder_kwargs,
+                center_space;
+                svi_kwargs...,
             ),
             SpaceVaryingInputs.SpaceVaryingInput(
                 file_path,
                 "w",
-                center_space,
-                regridder_kwargs = regridder_kwargs,
+                center_space;
+                svi_kwargs...,
             ),
         )
     Y.c.uₕ .= C12.(Geometry.UVVector.(vel))
@@ -845,21 +942,46 @@ function _overwrite_initial_conditions_from_file!(
             "`dry` configurations are incompatible with the interpolated initial conditions.",
         )
     end
+
+    if hasproperty(Y.c, :ρq_liq)
+        fill!(Y.c.ρq_liq, 0)
+    end
+    if hasproperty(Y.c, :ρq_ice)
+        fill!(Y.c.ρq_ice, 0)
+    end
     if hasproperty(Y.c, :ρq_sno) && hasproperty(Y.c, :ρq_rai)
-        Y.c.ρq_sno .=
-            SpaceVaryingInputs.SpaceVaryingInput(
-                file_path,
-                "cswc",
-                center_space,
-                regridder_kwargs = regridder_kwargs,
-            ) .* Y.c.ρ
-        Y.c.ρq_rai .=
-            SpaceVaryingInputs.SpaceVaryingInput(
-                file_path,
-                "crwc",
-                center_space,
-                regridder_kwargs = regridder_kwargs,
-            ) .* Y.c.ρ
+        has_microphysics_vars = NC.NCDataset(file_path) do ds
+            haskey(ds, "cswc") && haskey(ds, "crwc")
+        end
+        if has_microphysics_vars
+            Y.c.ρq_sno .=
+                SpaceVaryingInputs.SpaceVaryingInput(
+                    file_path,
+                    "cswc",
+                    center_space;
+                    svi_kwargs...,
+                ) .* Y.c.ρ
+            Y.c.ρq_rai .=
+                SpaceVaryingInputs.SpaceVaryingInput(
+                    file_path,
+                    "crwc",
+                    center_space;
+                    svi_kwargs...,
+                ) .* Y.c.ρ
+        else
+            fill!(Y.c.ρq_sno, 0)
+            fill!(Y.c.ρq_rai, 0)
+        end
+    end
+    # Initialize prognostic EDMF 0M subdomains if present
+    if hasproperty(Y.c, :sgsʲs)
+        ᶜmse = TD.enthalpy.(thermo_params, ᶜT, ᶜq_tot) .+ e_pot
+        for name in propertynames(Y.c.sgsʲs)
+            s = getproperty(Y.c.sgsʲs, name)
+            hasproperty(s, :ρa) && fill!(s.ρa, 0)
+            hasproperty(s, :mse) && (s.mse .= ᶜmse)
+            hasproperty(s, :q_tot) && (s.q_tot .= ᶜq_tot)
+        end
     end
 
     if hasproperty(Y.c, :ρtke)

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -436,6 +436,8 @@ function get_initial_condition(parsed_args, atmos)
             parsed_args["start_date"],
             parsed_args["era5_initial_condition_dir"],
         )
+    elseif parsed_args["initial_condition"] == "AMIPFromERA5"
+        return ICs.AMIPFromERA5(parsed_args["start_date"])
     elseif parsed_args["initial_condition"] == "ShipwayHill2012"
         return ICs.ShipwayHill2012()
     else


### PR DESCRIPTION
Create IC type to allow initializing AMIP with ERA5 on model levels. Add artifact which corresponds to default AMIP start date (Jan 1, 2010). Enables change of default IC for nightly and longruns in Coupler: https://github.com/CliMA/ClimaCoupler.jl/pull/1712
Also removes unused `ᶜspecific` in the precomputed cache.
        