### PR TITLE
Water conservation fix

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -18,6 +18,7 @@ import ClimaUtilities.TimeVaryingInputs: evaluate!
 
 
 include("callback_helpers.jl")
+include("precipitation_surface_flux_correction.jl")
 
 function flux_accumulation!(integrator)
     Y = integrator.u

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -503,6 +503,18 @@ function get_callbacks(config, sim_info, atmos, params, Y, p)
         callbacks = (callbacks..., conservation_checking_callback()...)
     end
 
+    # Precipitation flux correction (corrects sfc.water for IMEX Newton asymmetry)
+    if atmos.surface_model isa SlabOceanSST &&
+       !(atmos.moisture_model isa DryModel)
+        callbacks = (
+            callbacks...,
+            call_every_n_steps(
+                correct_precipitation_surface_fluxes!;
+                call_at_end = true,
+            ),
+        )
+    end
+
     # External forcing
     if parsed_args["external_forcing"] in
        ["ReanalysisTimeVarying", "ReanalysisMonthlyAveragedDiurnal"] &&

--- a/src/callbacks/precipitation_surface_flux_correction.jl
+++ b/src/callbacks/precipitation_surface_flux_correction.jl
@@ -1,0 +1,51 @@
+"""
+    correct_precipitation_surface_fluxes!(integrator)
+
+Post-step callback that corrects `Y.sfc.water` to account for the IMEX
+Newton asymmetry in precipitation fluxes.
+
+The IMEX solver extracts implicit tendencies via `(U - temp)/dtγ` (residual),
+which gives atmospheric variables a Newton-corrected tendency but leaves
+`sfc.water` with the tendency evaluated at the prediction `U₀`. This creates
+an O(dt) per-step mismatch between the sedimentation leaving `ρq_tot` and
+the precipitation entering `sfc.water`.
+
+This callback recomputes the bottom-face precipitation flux from the
+converged post-step `Y_{n+1}` and corrects `sfc.water` by:
+
+    sfc.water += dt * (flux(Y_{n+1}) - flux(Y_n))
+
+where `flux(Y_n)` is the stale precomputed value used during the step
+(stored in `p.precomputed.surface_rain_flux` and `surface_snow_flux`).
+
+After correction, the precomputed fluxes are updated to the new values
+so the correction applies cumulatively across steps.
+"""
+function correct_precipitation_surface_fluxes!(integrator)
+    Y = integrator.u
+    p = integrator.p
+    dt = integrator.dt
+    FT = Spaces.undertype(axes(Y.c))
+
+    # Only applies to SlabOceanSST with moisture
+    p.atmos.surface_model isa SlabOceanSST || return nothing
+    p.atmos.moisture_model isa DryModel && return nothing
+
+    (; surface_rain_flux, surface_snow_flux) = p.precomputed
+
+    # Store old fluxes before recomputation
+    old_total_flux = @. surface_rain_flux + surface_snow_flux
+
+    # Recompute fluxes from converged Y_{n+1}
+    set_precipitation_surface_fluxes!(
+        Y,
+        p,
+        p.atmos.microphysics_model,
+    )
+
+    # Correction: replace stale flux with post-step flux
+    new_total_flux = @. surface_rain_flux + surface_snow_flux
+    @. Y.sfc.water += FT(dt) * (new_total_flux - old_total_flux)
+
+    return nothing
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Corrects the water flux from precipitation through the lower boundary by computing a post-timestep correction via a callback, to get an accurate accounting of water fluxes into and out of the domain.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Currently, this makes the conservation checks worse; unclear why
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
