### PR TITLE
remove unused cache in prognostic edmf

### DIFF
--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -86,7 +86,6 @@ function implicit_precomputed_quantities(Y, atmos)
             ᶜq_liq_raiʲs = similar(Y.c, NTuple{n, FT}),
             ᶜq_ice_snoʲs = similar(Y.c, NTuple{n, FT}),
             ᶜρʲs = similar(Y.c, NTuple{n, FT}),
-            ᶠnh_pressure₃_dragʲs = similar(Y.f, NTuple{n, C3{FT}}),
         ) : (;)
     return (;
         gs_quantities...,
@@ -265,14 +264,10 @@ function precomputed_quantities(Y, atmos)
         atmos.turbconv_model isa PrognosticEDMFX ?
         (;
             ρtke_flux = similar(Fields.level(Y.f, half), C3{FT}),
-            bdmr_l = similar(Y.c, BidiagonalMatrixRow{FT}),
-            bdmr_r = similar(Y.c, BidiagonalMatrixRow{FT}),
-            bdmr = similar(Y.c, BidiagonalMatrixRow{FT}),
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜturb_entrʲs = similar(Y.c, NTuple{n, FT}),
             ᶠρ_diffʲs = similar(Y.f, NTuple{n, FT}),
-            ᶠnh_pressure₃_buoyʲs = similar(Y.f, NTuple{n, C3{FT}}),
             precipitation_sgs_quantities...,
         ) : (;)
 
@@ -576,7 +571,6 @@ NVTX.@annotate function set_implicit_precomputed_quantities!(Y, p, t)
     if turbconv_model isa PrognosticEDMFX
         set_prognostic_edmf_precomputed_quantities_draft!(Y, p, ᶠuₕ³, t)
         set_prognostic_edmf_precomputed_quantities_environment!(Y, p, ᶠuₕ³, t)
-        set_prognostic_edmf_precomputed_quantities_implicit_closures!(Y, p, t)
     elseif !(isnothing(turbconv_model))
         # Do nothing for other turbconv models for now
     end

--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -87,6 +87,9 @@ function temporary_quantities(Y, atmos)
             BidiagonalMatrixRow{Adjoint{FT, C3{FT}}},
             center_space,
         ),
+        ᶜtemp_bdmr = similar(Y.c, BidiagonalMatrixRow{FT}),
+        ᶜtemp_bdmr_2 = similar(Y.c, BidiagonalMatrixRow{FT}),
+        ᶜtemp_bdmr_3 = similar(Y.c, BidiagonalMatrixRow{FT}),
         ᶠtemp_C123 = Fields.Field(C123{FT}, face_space), # χ₁₂₃
         ᶜtemp_UVW = Fields.Field(typeof(uvw_vec), center_space), # UVW(ᶜu)
         ᶠtemp_UVW = Fields.Field(typeof(uvw_vec), face_space), # UVW(ᶠu³)

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -805,9 +805,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                 ᶜq_liq_raiʲs,
                 ᶜq_ice_snoʲs,
                 ᶜKʲs,
-                bdmr_l,
-                bdmr_r,
-                bdmr,
             ) = p.precomputed
 
             # upwinding options for q_tot and mse
@@ -1021,10 +1018,15 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                 matrix[@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)]
             ᶜu₃ʲ = p.scratch.ᶜtemp_C3
             @. ᶜu₃ʲ = ᶜinterp(Y.f.sgsʲs.:(1).u₃)
-            @. bdmr_l = convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix())
-            @. bdmr_r = convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix())
-            @. bdmr = ifelse(ᶜu₃ʲ.components.data.:1 > 0, bdmr_l, bdmr_r)
-            @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) ⋅ bdmr
+            @. p.scratch.ᶜtemp_bdmr = convert(BidiagonalMatrixRow{FT}, ᶜleft_bias_matrix())
+            @. p.scratch.ᶜtemp_bdmr_2 =
+                convert(BidiagonalMatrixRow{FT}, ᶜright_bias_matrix())
+            @. p.scratch.ᶜtemp_bdmr_3 = ifelse(
+                ᶜu₃ʲ.components.data.:1 > 0,
+                p.scratch.ᶜtemp_bdmr,
+                p.scratch.ᶜtemp_bdmr_2,
+            )
+            @. ᶠtridiagonal_matrix_c3 = -(ᶠgradᵥ_matrix()) ⋅ p.scratch.ᶜtemp_bdmr_3
             if rs isa RayleighSponge
                 @. ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ =
                     dtγ * (

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -111,10 +111,21 @@ function edmfx_nh_pressure_drag_tendency!(
     t,
     turbconv_model::PrognosticEDMFX,
 )
-    (; ᶠnh_pressure₃_dragʲs) = p.precomputed
-    n = n_mass_flux_subdomains(turbconv_model)
-    for j in 1:n
-        @. Yₜ.f.sgsʲs.:($$j).u₃ -= ᶠnh_pressure₃_dragʲs.:($$j)
+    if p.atmos.edmfx_model.nh_pressure isa Val{true}
+        (; params) = p
+        n = n_mass_flux_subdomains(turbconv_model)
+        (; ᶠu₃⁰) = p.precomputed
+        ᶠlg = Fields.local_geometry_field(Y.f)
+        scale_height = CAP.R_d(params) * CAP.T_surf_ref(params) / CAP.grav(params)
+        for j in 1:n
+            @. Yₜ.f.sgsʲs.:($$j).u₃ -= ᶠupdraft_nh_pressure_drag(
+                params,
+                ᶠlg,
+                Y.f.sgsʲs.:($$j).u₃,
+                ᶠu₃⁰,
+                scale_height,
+            )
+        end
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
ᶠnh_pressure₃_buoyʲs is not used anymore after TKE is changed to grid-mean. ᶠnh_pressure_dragʲs is only used in the nh pressure tendency, so we don't need to cache it. This PR removes them.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
