### PR TITLE
Update updraft buoyancy and edmf filters

### DIFF
--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -14,8 +14,7 @@ implicit_sgs_advection: true
 implicit_sgs_mass_flux: true
 implicit_sgs_entr_detr: true
 implicit_sgs_nh_pressure: true
-# unstable with implicit vertical diffusion
-implicit_sgs_vertdiff: false
+implicit_sgs_vertdiff: true
 
 approximate_linear_solve_iters: 2
 edmfx_sgsflux_upwinding: first_order
@@ -25,7 +24,7 @@ edmfx_detr_model: "PiGroups"
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 edmfx_nh_pressure: true
-edmfx_vertical_diffusion: false
+edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
 precip_model: "0M"
@@ -39,6 +38,7 @@ perturb_initstate: false
 dt: "50secs"
 dt_rad: "10mins"
 t_end: "30hours"
+ode_algo: "ARS222"
 toml: [toml/prognostic_edmfx_calibrated.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]

--- a/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_implicit_column.yml
@@ -30,7 +30,7 @@ y_elem: 2
 z_elem: 100
 z_stretch: false
 perturb_initstate: false
-dt: "60secs"
+dt: "120secs"
 t_end: "24hours"
 dt_save_state_to_disk: "60mins"
 toml: [toml/prognostic_edmfx_1M.toml]

--- a/config/model_configs/prognostic_edmfx_trmm_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_implicit_column.yml
@@ -28,7 +28,7 @@ config: column
 z_max: 16400
 z_elem: 82
 z_stretch: false
-dt: 150secs
+dt: 120secs
 t_end: 12hours
 dt_save_state_to_disk: 60mins
 toml: [toml/prognostic_edmfx_1M.toml]

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-313
+314
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+314
+ - PEDMF: precompute sgs buoyancy; apply edmf filter as a callback; mix unphysical sgs with grid mean
+
 313
  - Change microphysics to using bulk microphysics tendencies, with limiters on total 
    tendencies (rather than individual species tendencies).

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -271,6 +271,7 @@ function precomputed_quantities(Y, atmos)
             ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜturb_entrʲs = similar(Y.c, NTuple{n, FT}),
+            ᶠρ_diffʲs = similar(Y.f, NTuple{n, FT}),
             ᶠnh_pressure₃_buoyʲs = similar(Y.f, NTuple{n, C3{FT}}),
             precipitation_sgs_quantities...,
         ) : (;)

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -251,6 +251,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
         ᶜentrʲs,
         ᶜdetrʲs,
         ᶜturb_entrʲs,
+        ᶠρ_diffʲs,
         ᶠnh_pressure₃_buoyʲs,
     ) = p.precomputed
     (; ustar, obukhov_length) = p.precomputed.sfc_conditions
@@ -408,6 +409,8 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
         else
             @. detr_int_val = limit_detrainment(detr_int_val, entr_int_val, ᶜaʲ_int_val, dt)
         end
+
+        @. ᶠρ_diffʲs.:($$j) = min(0, ᶠinterp(ᶜρʲs.:($$j) - Y.c.ρ)) / ᶠinterp(ᶜρʲs.:($$j))
 
         # The buoyancy term in the nonhydrostatic pressure closure is always applied
         # for prognostic edmf. The tendency is combined with the buoyancy term in the

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -161,6 +161,20 @@ NVTX.@annotate function nogw_model_callback!(integrator)
     return nothing
 end
 
+NVTX.@annotate function edmfx_filter_callback!(integrator)
+    Y = integrator.u
+    p = integrator.p
+    t = integrator.t
+
+    edmfx_filter_tendency!(
+        Y,
+        p,
+        t,
+        p.atmos.turbconv_model,
+    )
+    return nothing
+end
+
 #Uniform insolation, magnitudes from Wing et al. (2018)
 #Note that the TOA downward shortwave fluxes won't be the same as the values in the paper if add_isothermal_boundary_layer is true
 function set_insolation_variables!(Y, p, t, ::RCEMIPIIInsolation)

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -497,6 +497,11 @@ function nogw_callback(
     return (call_every_dt(nogw_model_callback!, dt_nogw_seconds),)
 end
 
+function edmfx_filter_callback(
+    dt,
+)
+    return call_every_dt(edmfx_filter_callback!, dt)
+end
 
 function get_callbacks(config, sim_info, atmos, params, Y, p)
     (; parsed_args, comms_ctx) = config
@@ -572,6 +577,12 @@ function get_callbacks(config, sim_info, atmos, params, Y, p)
         )...,
     )
 
+    # EDMFX filter
+    callbacks = (
+        callbacks...,
+        edmfx_filter_callback(dt),
+    )
+
     return callbacks
 end
 
@@ -645,6 +656,12 @@ function default_model_callbacks(gravity_wave::AtmosGravityWave;
         t_end,
         checkpoint_frequency;
     )
+end
+
+# EDMFX filter callbacks
+function default_model_callbacks(turbconv_model::PrognosticEDMFX;
+    dt)
+    return edmfx_filter_callback(dt)
 end
 
 function default_model_callbacks(water::AtmosWater;

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -358,7 +358,7 @@ function edmfx_sgs_vertical_advection_tendency!(
     n = n_prognostic_mass_flux_subdomains(turbconv_model)
     (; dt) = p
     (; edmfx_mse_q_tot_upwinding, edmfx_tracer_upwinding) = p.atmos.numerics
-    (; ᶠu³ʲs, ᶠKᵥʲs, ᶜρʲs) = p.precomputed
+    (; ᶠu³ʲs, ᶠKᵥʲs, ᶜρʲs, ᶠρ_diffʲs) = p.precomputed
     (; ᶠgradᵥ_ᶜΦ) = p.core
 
     FT = eltype(p.params)
@@ -382,8 +382,7 @@ function edmfx_sgs_vertical_advection_tendency!(
         # and calcuate the buoyancy term relative to the grid-mean density.
         # We also include the buoyancy term in the nonhydrostatic pressure closure here.
         @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-            (1 - α_b) * (ᶠinterp(ᶜρʲs.:($$j) - Y.c.ρ) * ᶠgradᵥ_ᶜΦ) /
-            ᶠinterp(ᶜρʲs.:($$j)) + ᶠgradᵥ(ᶜKᵥʲ)
+            (1 - α_b) * ᶠρ_diffʲs.:($$j) * ᶠgradᵥ_ᶜΦ + ᶠgradᵥ(ᶜKᵥʲ)
 
         # buoyancy term in mse equation
         @. Yₜ.c.sgsʲs.:($$j).mse +=

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -140,10 +140,11 @@ function entrainment(
 )
     FT = eltype(thermo_params)
     entr_inv_tau = CAP.entr_inv_tau(turbconv_params)
+    a_min = CAP.min_area(turbconv_params)
     limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
     # Entrainment is not well-defined if updraft area is negligible.
     # Fix at limit_inv_tau to ensure some mixing with the environment.
-    if ᶜaʲ <= eps(FT)
+    if ᶜaʲ <= a_min
         return limit_inv_tau
     end
 
@@ -217,7 +218,7 @@ function entrainment(
 
     # Entrainment is not well-defined if updraft area is negligible,
     # as some limiters depend on ᶜaʲ.
-    if ᶜaʲ <= eps(FT) && min_area_limiter_scale == FT(0) # If no area and no base min_area_limiter
+    if ᶜaʲ <= a_min && min_area_limiter_scale == FT(0) # If no area and no base min_area_limiter
         return limit_inv_tau
     end
 
@@ -336,11 +337,12 @@ function detrainment(
     ::PiGroupsDetrainment,
 )
     FT = eltype(thermo_params)
+    a_min = CAP.min_area(turbconv_params)
     limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
 
     # If ᶜaʲ (updraft area fraction) is negligible, detrainment is considered
     # to be fixed at limit_inv_tau. This also protects division by ᶜρaʲ later.
-    if ᶜaʲ <= eps(FT)
+    if ᶜaʲ <= a_min
         return limit_inv_tau
     end
 
@@ -414,12 +416,13 @@ function detrainment(
         CAP.detr_massflux_vertdiv_coeff(turbconv_params)
     max_area_limiter_scale = CAP.max_area_limiter_scale(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
+    a_min = CAP.min_area(turbconv_params)
     a_max = CAP.max_area(turbconv_params)
     limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
 
     # If ᶜaʲ (updraft area fraction) is negligible, detrainment is not well defined.
     # Fix at limit_inv_tau to ensure some mixing with the environment.
-    if ᶜaʲ <= eps(FT)
+    if ᶜaʲ <= a_min
         return limit_inv_tau
     end
 
@@ -460,9 +463,10 @@ function detrainment(
     ::SmoothAreaDetrainment,
 )
     FT = eltype(thermo_params)
+    a_min = CAP.min_area(turbconv_params)
     limit_inv_tau = CAP.entr_detr_limit_inv_tau(turbconv_params)
     # If ᶜaʲ is negligible detrainment is fixed at limit_inv_tau.
-    if (ᶜaʲ <= eps(FT)) # Consistent check for ᶜaʲ
+    if (ᶜaʲ <= a_min) # Consistent check for ᶜaʲ
         detr = limit_inv_tau
         # If vertical velocity divergence term is non-negative detrainment is zero.
     elseif (ᶜw_vert_div >= 0)

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -260,12 +260,6 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                 )...,
                 MatrixFields.unrolled_map(
                     name ->
-                        (@name(f.sgsʲs.:(1).u₃), name) =>
-                            similar(Y.f, BidiagonalRow_C3),
-                    available_sgs_condensate_mass_names,
-                )...,
-                MatrixFields.unrolled_map(
-                    name ->
                         (@name(c.sgsʲs.:(1).mse), name) => similar(Y.c, DiagonalRow),
                     available_sgs_condensate_mass_names,
                 )...,
@@ -275,10 +269,6 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                     similar(Y.c, TridiagonalRow),
                 (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).mse)) =>
                     similar(Y.c, TridiagonalRow),
-                (@name(f.sgsʲs.:(1).u₃), @name(c.sgsʲs.:(1).q_tot)) =>
-                    similar(Y.f, BidiagonalRow_C3),
-                (@name(f.sgsʲs.:(1).u₃), @name(c.sgsʲs.:(1).mse)) =>
-                    similar(Y.f, BidiagonalRow_C3),
                 (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) =>
                     similar(Y.f, TridiagonalRow_C3xACT3),
             )
@@ -1016,16 +1006,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                     dtγ * ᶜadvdivᵥ_matrix() ⋅
                     (ᶠbidiagonal_matrix_ct3 - ᶠbidiagonal_matrix_ct3_2)
 
-                # ∂ᶠu₃ʲ_err_∂ᶜqʲ through ρʲ variations in updraft buoyancy eq
-                ∂ᶠu₃ʲ_err_∂ᶜqʲ = matrix[@name(f.sgsʲs.:(1).u₃), qʲ_name]
-                @. ∂ᶠu₃ʲ_err_∂ᶜqʲ =
-                    dtγ * DiagonalMatrixRow(
-                        (1 - α_b) * ᶠgradᵥ_ᶜΦ * ᶠinterp(Y.c.ρ) /
-                        (ᶠinterp(ᶜρʲs.:(1)))^2,
-                    ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
-                        (ᶜρʲs.:(1))^2 / ᶜp * ᶜ∂RmT∂qʲ,
-                    )
-
                 # ∂ᶜmseʲ_err_∂ᶜqʲ through ρʲ variations in buoyancy term in mse eq
                 ∂ᶜmseʲ_err_∂ᶜqʲ = matrix[@name(c.sgsʲs.:(1).mse), qʲ_name]
                 @. ∂ᶜmseʲ_err_∂ᶜqʲ =
@@ -1036,16 +1016,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                         )
                     )
             end
-
-            ∂ᶠu₃ʲ_err_∂ᶜmseʲ =
-                matrix[@name(f.sgsʲs.:(1).u₃), @name(c.sgsʲs.:(1).mse)]
-            @. ∂ᶠu₃ʲ_err_∂ᶜmseʲ =
-                dtγ * DiagonalMatrixRow(
-                    (1 - α_b) * ᶠgradᵥ_ᶜΦ * ᶠinterp(Y.c.ρ) /
-                    (ᶠinterp(ᶜρʲs.:(1)))^2,
-                ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
-                    ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp),
-                )
 
             ∂ᶠu₃ʲ_err_∂ᶠu₃ʲ =
                 matrix[@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)]

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -206,33 +206,72 @@ function edmfx_vertical_diffusion_tendency!(
 end
 
 """
-    edmfx_filter_tendency!(Yₜ, Y, p, t, turbconv_model)
+    edmfx_filter_tendency!(Y, p, t, turbconv_model)
 
-Apply EDMF filters:
- - Relax u_3 to zero when it is negative
- - Relax ρa to zero when it is negative
- - Relax ρa to ρ when a is larger than one
-
-This function modifies the tendency `Yₜ` in place based on the current state `Y`,
-parameters `p`, time `t`, and the turbulence convection model `turbconv_model`.
-It specifically targets the vertical velocity (`u₃`) and the product of density and area fraction (`ρa`)
-for each sub-domain in the EDMFX model.
+Apply EDMF physical constraints: immediately mix the updraft with the environment if
+  - area fraction is negative or negligible (smaller than eps)
+  - updraft velocity is negative or negligible
+  - updraft air is heavier than the grid mean (negative buoyancy)
 """
-edmfx_filter_tendency!(Yₜ, Y, p, t, turbconv_model) = nothing
+edmfx_filter_tendency!(Y, p, t, turbconv_model) = nothing
 
-function edmfx_filter_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMFX)
+function edmfx_filter_tendency!(Y, p, t, turbconv_model::PrognosticEDMFX)
 
-    n = n_mass_flux_subdomains(turbconv_model)
-    (; dt) = p
+    (; ᶜh_tot, ᶜK, ᶜρʲs) = p.precomputed
     FT = eltype(p.params)
+    n = n_mass_flux_subdomains(turbconv_model)
+
+    microphysics_tracers = (
+        (@name(c.sgsʲs.:(1).q_liq), @name(c.ρq_liq)),
+        (@name(c.sgsʲs.:(1).q_ice), @name(c.ρq_ice)),
+        (@name(c.sgsʲs.:(1).q_rai), @name(c.ρq_rai)),
+        (@name(c.sgsʲs.:(1).q_sno), @name(c.ρq_sno)),
+        (@name(c.sgsʲs.:(1).n_liq), @name(c.ρn_liq)),
+        (@name(c.sgsʲs.:(1).n_rai), @name(c.ρn_rai)),
+    )
 
     if p.atmos.edmfx_model.filter isa Val{true}
         for j in 1:n
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-                C3(min(Y.f.sgsʲs.:($$j).u₃.components.data.:1, 0)) / dt
-            @. Yₜ.c.sgsʲs.:($$j).ρa -= min(Y.c.sgsʲs.:($$j).ρa, 0) / dt
-            @. Yₜ.c.sgsʲs.:($$j).ρa -=
-                max(Y.c.sgsʲs.:($$j).ρa - p.precomputed.ᶜρʲs.:($$j), 0) / dt
+            # clip updraft velocity and area fraction to zero if they are negative
+            @. Y.c.sgsʲs.:($$j).ρa = max(0, min(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)))
+            @. Y.f.sgsʲs.:($$j).u₃ =
+                C3(max(Y.f.sgsʲs.:($$j).u₃.components.data.:1, 0))
+
+            # clip updraft velocity to zero if the updraft air is heavier than the grid-mean
+            @. Y.f.sgsʲs.:($$j).u₃ =
+                ifelse(ᶠinterp(ᶜρʲs.:($$j) - Y.c.ρ) > 0, C3(0), Y.f.sgsʲs.:($$j).u₃)
+
+            # clip updraft area fraction to zero if the cell-averaged velocity is negligible.
+            @. Y.c.sgsʲs.:($$j).ρa = ifelse(
+                ᶜinterp(Y.f.sgsʲs.:($$j).u₃.components.data.:1) <= eps(FT),
+                0,
+                Y.c.sgsʲs.:($$j).ρa,
+            )
+            # clip updraft velocity to zero if the face-averaged area fraction is negligible.
+            @. Y.f.sgsʲs.:($$j).u₃ =
+                ifelse(ᶠinterp(Y.c.sgsʲs.:($$j).ρa) < eps(FT), C3(0), Y.f.sgsʲs.:($$j).u₃)
+
+            # mix updraft mse and q_tot with the grid mean values if any of the above conditions happened
+            @. Y.c.sgsʲs.:($$j).mse =
+                ifelse(Y.c.sgsʲs.:($$j).ρa < eps(FT), ᶜh_tot - ᶜK, Y.c.sgsʲs.:($$j).mse)
+            @. Y.c.sgsʲs.:($$j).q_tot = ifelse(
+                Y.c.sgsʲs.:($$j).ρa < eps(FT),
+                specific(Y.c.ρq_tot, Y.c.ρ),
+                Y.c.sgsʲs.:($$j).q_tot,
+            )
+
+            # mix the rest of the updraft microphysics tracers
+            MatrixFields.unrolled_foreach(microphysics_tracers) do (χʲ_name, ρχ_name)
+                MatrixFields.has_field(Y, χʲ_name) || return
+                ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
+                ᶜρχ = MatrixFields.get_field(Y, ρχ_name)
+                @. ᶜχʲ = ifelse(
+                    Y.c.sgsʲs.:($$j).ρa < eps(FT),
+                    specific(ᶜρχ, Y.c.ρ),
+                    ᶜχʲ,
+                )
+            end
         end
+        set_precomputed_quantities!(Y, p, t)
     end
 end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -277,7 +277,6 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     if p.atmos.sgs_vertdiff_mode == Explicit()
         edmfx_vertical_diffusion_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
-    edmfx_filter_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     edmfx_tke_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
     # EDMF updraft microphysics tendencies (applied to updraft prognostic variables)

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -53,4 +53,4 @@ value = 100
 value = 100
 
 [entr_detr_limit_inv_tau]
-value = 0.0001
+value = 0.01


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR updates buoyancy equations and edmf filters to make prognostic edmf more stable:
- precompute updraft buyancy; 
- apply edmf filter as a callback; 
- mix updraft with grid-mean when it is unphysical (area fraction or velocity is negative or negligible or when buoyancy is negative)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
