### PR TITLE
Add GHA to trigger buildkite on comment

### DIFF
--- a/buildkite-trigger.yml
+++ b/buildkite-trigger.yml
@@ -1,0 +1,45 @@
+name: Buildkite External PR Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-buildkite:
+    # Only run on PR comments with the trigger phrase and when the commenter is an org member
+    if: |
+      github.event.issue.pull_request && 
+      startsWith(github.event.comment.body, '/buildkite run') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('base', pr.data.base.ref);
+            return pr.data;
+            
+      - name: Trigger Buildkite
+        uses: buildkite/trigger-pipeline-action@v2.4.1
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_API_TOKEN }}
+          pipeline: "your-org/your-pipeline"
+          branch: ${{ steps.pr.outputs.ref }}
+          commit: ${{ steps.pr.outputs.sha }}
+          message: "Triggered by @${{ github.actor }} via comment"
+          # Needed to ensure buildkite associated this build with the PR
+          send_pull_request: true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds a github action to trigger the climaatmos-ci buildkite pipeline via commenting "/buildkite run" on a PR. To get this fully working, we will need to update the slurm-buildkite checkout hook.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
