### PR TITLE
Fix times of diagnostics when restarting

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -56,6 +56,7 @@ function get_diagnostics(
         num_points = num_netcdf_points;
         z_sampling_method,
         sync_schedule = CAD.EveryStepSchedule(),
+        init_time = t_start,
         maybe_add_start_date...,
     )
 
@@ -77,6 +78,7 @@ function get_diagnostics(
             num_points = num_netcdf_points;
             z_sampling_method,
             sync_schedule = CAD.EveryStepSchedule(),
+            init_time = t_start,
             maybe_add_start_date...,
         )
     end

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -39,6 +39,7 @@ function setup_diagnostics_and_writers(
         num_points = ClimaDiagnostics.Writers.default_num_points(axes(Y.c));
         z_sampling_method = CAD.LevelsMethod(),  # TODO: Could make this configurable
         sync_schedule = CAD.EveryStepSchedule(),
+        init_time = t_start,
         start_date,
     )
 


### PR DESCRIPTION
Before, the diagnostics handler wasn't aware of the time that the simulation started at. This leads to the first time of the diagnostics of a restarted simulation being 0.0. This PR fixes it by passing `t_start` to the diagnostics handler.