### PR TITLE
entr/detr min and area threshold

### DIFF
--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -250,7 +250,7 @@ function edmfx_filter_tendency!(Y, p, t, turbconv_model::PrognosticEDMFX)
 
             # clip updraft area fraction to zero if the cell-averaged velocity is negligible.
             @. Y.c.sgsʲs.:($$j).ρa = ifelse(
-                ᶜinterp(Y.f.sgsʲs.:($$j).u₃.components.data.:1) <= eps(FT),
+                ᶜinterp(Y.f.sgsʲs.:($$j).u₃.components.data.:1) < eps(FT),
                 0,
                 Y.c.sgsʲs.:($$j).ρa,
             )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR:
- ensures that minimum entrainment and detrainment rates are equal to their invariant time scales (`entr_inv_tau` and `detr_inv_tau`),
- Changes entrainment and detrainment area fraction threshold to eps to allow area growth when it's smaller than a_min

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
