### PR TITLE
Add options for monthly, weekly, and daily for the period

### DIFF
--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -44,6 +44,20 @@ The default `writer` is NetCDF. If `writer` is `nc` or `netcdf`, the output is
 remapped non-conservatively on a Cartesian grid and saved to a NetCDF file.
 Currently, only 3D fields on cubed spheres are supported.
 
+!!! note "Did you know?"
+    For the `period`, you can also specify `"monthly"`, `"weekly"`, and
+    `"daily"`. These options align the reductions to start at the beginning of
+    each month, week, and day, respectively.
+
+    For example:
+    - If `period: monthly` and `reduction_time: average` are used, and the
+      simulation begins on `2010-01-15`, then the first time saved represents
+      the time average of the second half of January.
+    - The next time saved represents the time average of the data for February,
+      and so on.
+
+    This is useful to account for spinup.
+
 #### Writing in pressure coordinates
 
 !!! compat "Compatibility"


### PR DESCRIPTION
This PR adds the option for passing "monthly", "weekly", and "daily" for the period. This is useful for accounting for spinup when the spinup is not exactly the same units as the period (e.g. 1 week spinup and n months of simulation).

For example, if `period: monthly`, `reduction_time: average` are used, and the simulation begins on `2010-01-15`, then the first time saved represent the time average of the second half of January, the second time saved represents the time average of February, and so on.