### PR TITLE
Store all parameters in arrays

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,7 @@ steps:
 
       - echo "--- Instantiate .buildkite"
       - "julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.precompile(;strict=true); using CUDA; CUDA.precompile_runtime(); Pkg.status()'"
+      - "julia --project=.buildkite -e 'using Pkg; Pkg.add(; url=\"https://github.com/CliMA/ClimaCore.jl\", rev=\"dy/nonuniform_structs\")'"
 
     agents:
       slurm_cpus_per_task: 8

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -15,6 +15,38 @@ include("compat.jl")
 include(joinpath("parameters", "Parameters.jl"))
 import .Parameters as CAP
 
+# Base.@propagate_inbounds CAP.CC.Operators.get_node(
+#     _,
+#     field::CAP.CC.Fields.Field{V},
+#     _::CartesianIndex{1},
+#     _,
+# ) where {V <: CAP.CC.DataLayouts.DataF{<:CAP.ACAP}} = field[]
+# Base.@propagate_inbounds CAP.CC.Operators.get_node(
+#     _,
+#     field::CAP.CC.Fields.Field{V},
+#     _::CartesianIndex{2},
+#     _,
+# ) where {V <: CAP.CC.DataLayouts.DataF{<:CAP.ACAP}} = field[]
+Base.@propagate_inbounds CAP.CC.Operators.get_node(
+    _,
+    field::CAP.CC.Fields.PointField,
+    _::CartesianIndex{1},
+    _,
+) = field[]
+Base.@propagate_inbounds CAP.CC.Operators.get_node(
+    _,
+    field::CAP.CC.Fields.PointField,
+    _::CartesianIndex{2},
+    _,
+) = field[]
+Base.@propagate_inbounds CAP.CC.Operators.get_node(
+    _,
+    data::CAP.CC.DataLayouts.DataF{<:CAP.ACAP},
+    _,
+    _,
+) = data[]
+
+
 include(joinpath("utils", "abbreviations.jl"))
 include(joinpath("utils", "gpu_compat.jl"))
 include(joinpath("solver", "types.jl"))

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -151,6 +151,11 @@ function build_cache(
     sfc_local_geometry =
         Fields.level(Fields.local_geometry_field(Y.f), Fields.half)
 
+    param_field = Fields.Field(
+        Fields.DataLayouts.DataF(params),
+        Fields.column(Fields.level(axes(Y.c), 1), 1, 1, 1),
+    )
+
     core = (
         ᶜΦ,
         ᶠgradᵥ_ᶜΦ = ᶠgradᵥ.(ᶜΦ),
@@ -162,7 +167,7 @@ function build_cache(
             unit_basis_vector_data.(CT3, sfc_local_geometry),
         ),
     )
-    external_forcing = external_forcing_cache(Y, atmos, params, start_date)
+    external_forcing = external_forcing_cache(Y, atmos, param_field, start_date)
     sfc_setup = surface_setup(params)
     scratch = temporary_quantities(Y, atmos)
 
@@ -170,7 +175,7 @@ function build_cache(
     precomputing_arguments = (;
         atmos,
         core,
-        params,
+        params = param_field,
         sfc_setup,
         precomputed,
         scratch,
@@ -189,7 +194,7 @@ function build_cache(
         atmos.radiation_mode isa RRTMGPI.AbstractRRTMGPMode ?
         (
             start_date,
-            params,
+            param_field,
             aerosol_names,
             time_varying_trace_gas_names,
             atmos.insolation,
@@ -204,7 +209,7 @@ function build_cache(
         dt,
         atmos,
         numerics,
-        params,
+        param_field,
         core,
         sfc_setup,
         ghost_buffer,

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -136,7 +136,7 @@ function set_precipitation_velocities!(
     (; ᶜwₗʲs, ᶜwᵢʲs, ᶜwᵣʲs, ᶜwₛʲs, ᶜTʲs, ᶜρʲs) = p.precomputed
     (; ᶜT⁰, ᶜq_tot_safe⁰, ᶜq_liq_rai⁰, ᶜq_ice_sno⁰) = p.precomputed
 
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     cmc = CAP.microphysics_cloud_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
     thp = CAP.thermodynamics_params(p.params)
@@ -435,7 +435,7 @@ function set_precipitation_velocities!(
     cm1p = CAP.microphysics_1m_params(p.params)
     cm2p = CAP.microphysics_2m_params(p.params)
     thp = CAP.thermodynamics_params(p.params)
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
 
     ᶜρ⁰ = @. lazy(TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_safe⁰, ᶜq_liq_rai⁰, ᶜq_ice_sno⁰))
     ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
@@ -1449,7 +1449,7 @@ function set_precipitation_surface_fluxes!(
     # update surface precipitation fluxes in cache for coupler's use
     thermo_params = CAP.thermodynamics_params(p.params)
     T_freeze = TD.Parameters.T_freeze(thermo_params)
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     ᶜ3d_rain = @. lazy(ifelse(ᶜT >= T_freeze, ᶜρ_dq_tot_dt, FT(0)))
     ᶜ3d_snow = @. lazy(ifelse(ᶜT < T_freeze, ᶜρ_dq_tot_dt, FT(0)))
     Operators.column_integral_definite!(surface_rain_flux, ᶜ3d_rain)

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -626,7 +626,7 @@ NVTX.@annotate function set_explicit_precomputed_quantities!(Y, p, t)
     (; turbconv_model, cloud_model, microphysics_model) = p.atmos
 
     thermo_params = CAP.thermodynamics_params(p.params)
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
 
     if !isnothing(p.sfc_setup)
         SurfaceConditions.update_surface_conditions!(Y, p, FT(t))

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -195,7 +195,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     thermo_params = CAP.thermodynamics_params(params)
     turbconv_params = CAP.turbconv_params(params)
 
-    FT = eltype(params)
+    FT = CAP.float_type(params)
     n = n_mass_flux_subdomains(turbconv_model)
 
     (; ᶜu, ᶜp, ᶠu³, ᶜT, ᶜq_liq_rai, ᶜq_ice_sno) = p.precomputed

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -23,7 +23,7 @@ function flux_accumulation!(integrator)
     Y = integrator.u
     p = integrator.p
     Δt = integrator.dt
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     if !isnothing(p.atmos.radiation_mode)
         (; ᶠradiation_flux) = p.radiation
         (; net_energy_flux_toa, net_energy_flux_sfc) = p
@@ -278,7 +278,7 @@ end
 NVTX.@annotate function save_state_to_disk_func(integrator, output_dir)
     (; t, u, p) = integrator
     Y = u
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
 
     # TODO: Use ITime here
     t = FT(t)

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -318,7 +318,7 @@ Dispatches on `microphysics_model` and `cloud_model`:
 For EDMF turbulence models, updraft contributions are added to the environment values.
 """
 NVTX.@annotate function set_cloud_fraction!(Y, p, ::DryModel, _)
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     p.precomputed.ᶜcloud_fraction .= FT(0)
 end
 NVTX.@annotate function set_cloud_fraction!(
@@ -328,7 +328,7 @@ NVTX.@annotate function set_cloud_fraction!(
     ::GridScaleCloud,
 )
     (; ᶜq_liq_rai, ᶜq_ice_sno) = p.precomputed
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     @. p.precomputed.ᶜcloud_fraction =
         ifelse(TD.has_condensate(ᶜq_liq_rai + ᶜq_ice_sno), FT(1), FT(0))
 end

--- a/src/parameterized_tendencies/radiation/held_suarez.jl
+++ b/src/parameterized_tendencies/radiation/held_suarez.jl
@@ -12,7 +12,7 @@ import ClimaCore.Fields as Fields
 #####
 
 function held_suarez_ΔT_y_T_equator(params, microphysics_model::DryModel)
-    FT = eltype(params)
+    FT = CAP.float_type(params)
     ΔT_y = FT(CAP.ΔT_y_dry(params))
     T_equator = FT(CAP.T_equator_dry(params))
     return ΔT_y, T_equator
@@ -22,7 +22,7 @@ function held_suarez_ΔT_y_T_equator(
     params,
     microphysics_model::T,
 ) where {T <: MoistMicrophysics}
-    FT = eltype(params)
+    FT = CAP.float_type(params)
     ΔT_y = FT(CAP.ΔT_y_wet(params))
     T_equator = FT(CAP.T_equator_wet(params))
     return ΔT_y, T_equator

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -8,6 +8,7 @@ import SurfaceFluxes as SF
 
 abstract type AbstractClimaAtmosParameters end
 const ACAP = AbstractClimaAtmosParameters
+const ACAPField = CC.Fields.Field{<:CC.DataLayouts.DataF{<:ACAP}}
 
 abstract type AbstractTurbulenceConvectionParameters end
 const ATCP = AbstractTurbulenceConvectionParameters
@@ -178,10 +179,14 @@ end
 
 Base.eltype(::ClimaAtmosParameters{FT}) where {FT} = FT
 
+float_type(ps::ACAPField) =
+    first(Base.promote_op(Val ∘ eltype, eltype(ps)).parameters)
+
 # Forward TurbulenceConvection parameters
 const TCPS = TurbulenceConvectionParameters
 for var in fieldnames(TCPS)
     @eval $var(ps::ACAP) = $var(turbconv_params(ps))
+    @eval $var(ps::ACAPField) = $var(turbconv_params(ps[]))
 end
 for fn in fieldnames(TCPS)
     @eval $(fn)(ps::ATCP) = ps.$(fn)
@@ -189,21 +194,27 @@ end
 
 for var in fieldnames(TD.Parameters.ThermodynamicsParameters)
     @eval $var(ps::ACAP) = TD.Parameters.$var(thermodynamics_params(ps))
+    @eval $var(ps::ACAPField) = TD.Parameters.$var(thermodynamics_params(ps[]))
 end
 # Thermodynamics derived parameters
 for var in [:Rv_over_Rd, :kappa_d, :e_int_v0, :e_int_i0, :cv_v, :cv_l, :cv_d]
     @eval $var(ps::ACAP) = TD.Parameters.$var(thermodynamics_params(ps))
+    @eval $var(ps::ACAPField) = TD.Parameters.$var(thermodynamics_params(ps[]))
 end
 
 # Forwarding SurfaceFluxes parameters
 von_karman_const(ps::ACAP) =
     SF.Parameters.von_karman_const(surface_fluxes_params(ps))
+von_karman_const(ps::ACAPField) =
+    SF.Parameters.von_karman_const(surface_fluxes_params(ps[]))
 
 # ------ MOST (Monin–Obukhov) stability-function coefficients ------
 
 # Insolation parameters
 day(ps::ACAP) = IP.day(insolation_params(ps))
+day(ps::ACAPField) = IP.day(insolation_params(ps[]))
 tot_solar_irrad(ps::ACAP) = IP.tot_solar_irrad(insolation_params(ps))
+tot_solar_irrad(ps::ACAPField) = IP.tot_solar_irrad(insolation_params(ps[]))
 
 # Forward External Forcing parameters
 efp_fields = [
@@ -215,11 +226,13 @@ efp_fields = [
 
 for fn_efp in efp_fields
     @eval $(fn_efp)(ps::ACAP) = external_forcing_params(ps).$(fn_efp)
+    @eval $(fn_efp)(ps::ACAPField) = external_forcing_params(ps[]).$(fn_efp)
 end
 
 # Define parameters as functions
 for var in fieldnames(ClimaAtmosParameters)
     @eval $var(ps::ACAP) = ps.$var
+    @eval $var(ps::ACAPField) = eltype(ps.$var) <: Number ? ps.$var[] : ps.$var
 end
 
 end

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -360,7 +360,7 @@ function edmfx_sgs_vertical_advection_tendency!(
     (; ᶠu³ʲs, ᶠKᵥʲs, ᶜρʲs, ᶠρ_diffʲs) = p.precomputed
     (; ᶠgradᵥ_ᶜΦ) = p.core
 
-    FT = eltype(p.params)
+    FT = CAP.float_type(params)
     turbconv_params = CAP.turbconv_params(params)
     α_b = CAP.pressure_normalmode_buoy_coeff1(turbconv_params)
     ᶠz = Fields.coordinate_field(Y.f).z

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -554,7 +554,7 @@ function edmfx_first_interior_entr_tendency!(
     (; params, dt) = p
     (; ᶜK, ᶜρʲs, ᶜentrʲs) = p.precomputed
 
-    FT = eltype(params)
+    FT = CAP.float_type(params)
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
     thermo_params = CAP.thermodynamics_params(params)
     turbconv_params = CAP.turbconv_params(params)

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -54,7 +54,7 @@ function edmfx_tke_tendency!(
     n = n_mass_flux_subdomains(turbconv_model)
     (; ᶠu³, ᶠu³ʲs, ᶠu³⁰, ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
     turbconv_params = CAP.turbconv_params(p.params)
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     thermo_params = CAP.thermodynamics_params(p.params)
 
     if use_prognostic_tke(turbconv_model)

--- a/src/prognostic_equations/forcing/external_forcing.jl
+++ b/src/prognostic_equations/forcing/external_forcing.jl
@@ -491,7 +491,10 @@ function external_forcing_cache(
         Fields.level(Y.f.u₃, ClimaCore.Utilities.half),
         NamedTuple{
             Tuple(surface_variable_names_as_symbols),
-            NTuple{length(surface_variable_names_as_symbols), eltype(params)},
+            NTuple{
+                length(surface_variable_names_as_symbols),
+                CAP.float_type(params),
+            },
         },
     )
 

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -295,7 +295,7 @@ NVTX.@annotate function apply_tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
 
     # Rescale the hyperdiffusivity for precipitating species.
     (; ν₄_scalar) = ν₄(hyperdiff, Y)
-    ν₄_scalar_for_precip = CAP.α_hyperdiff_tracer(p.params) * ν₄_scalar
+    ν₄_scalar_for_precip = CAP.α_hyperdiff_tracer(p.params[]) * ν₄_scalar
 
     n = n_mass_flux_subdomains(turbconv_model)
     (; ᶜ∇²specific_tracers) = p.hyperdiff

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -661,7 +661,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
     if use_derivative(diffusion_flag)
         (; turbconv_model) = p.atmos
         turbconv_params = CAP.turbconv_params(params)
-        FT = eltype(params)
+        FT = CAP.float_type(params)
         (; vertical_diffusion, smagorinsky_lilly) = p.atmos
         (; ᶜp) = p.precomputed
         ᶜK_u = p.scratch.ᶜtemp_scalar_4

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -142,7 +142,7 @@ function edmfx_vertical_diffusion_tendency!(
     if p.atmos.edmfx_model.vertical_diffusion isa Val{true}
         (; params) = p
         (; ᶜρʲs) = p.precomputed
-        FT = eltype(p.params)
+        FT = CAP.float_type(params)
         turbconv_params = CAP.turbconv_params(params)
         n = n_mass_flux_subdomains(turbconv_model)
         ᶜdivᵥ_mse = Operators.DivergenceF2C(
@@ -226,7 +226,7 @@ edmfx_filter_tendency!(Y, p, t, turbconv_model) = nothing
 function edmfx_filter_tendency!(Y, p, t, turbconv_model::PrognosticEDMFX)
 
     (; ᶜh_tot, ᶜK, ᶜρʲs) = p.precomputed
-    FT = eltype(p.params)
+    FT = CAP.float_type(p.params)
     n = n_mass_flux_subdomains(turbconv_model)
 
     microphysics_tracers = (

--- a/src/prognostic_equations/zero_velocity.jl
+++ b/src/prognostic_equations/zero_velocity.jl
@@ -100,7 +100,7 @@ Arguments:
 function set_identity_matrix_entry!(matrix_entry, row_name, col_name)
     identity_matrix_entry_value = if row_name == col_name
         # TODO: Add a method for one(::Axis2Tensor) to simplify this.
-        T = eltype(eltype(matrix_entry))
+        T = CAP.float_type(matrix_entry)
         tensor_data = UniformScaling(one(eltype(T)))
         -DiagonalMatrixRow(Geometry.AxisTensor(axes(T), tensor_data))
     else

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -16,9 +16,9 @@ function update_surface_conditions!(Y, p, t)
         Fields.field_values(Fields.level(Fields.local_geometry_field(Y.c), 1))
     (; ᶜT, ᶜq_tot_safe, ᶜq_liq_rai, ᶜq_ice_sno, ᶜu, sfc_conditions) = p.precomputed
     (; params, sfc_setup, atmos) = p
-    thermo_params = CAP.thermodynamics_params(params)
-    surface_fluxes_params = CAP.surface_fluxes_params(params)
-    surface_temp_params = CAP.surface_temp_params(params)
+    thermo_params = Fields.field_values(CAP.thermodynamics_params(params))
+    surface_fluxes_params = Fields.field_values(CAP.surface_fluxes_params(params))
+    surface_temp_params = Fields.field_values(CAP.surface_temp_params(params))
     int_T_values = Fields.field_values(Fields.level(ᶜT, 1))
     int_ρ_values = Fields.field_values(Fields.level(Y.c.ρ, 1))
     int_q_tot_values = Fields.field_values(Fields.level(ᶜq_tot_safe, 1))
@@ -88,7 +88,7 @@ surface_state(
 function set_dummy_surface_conditions!(p)
     (; params, atmos) = p
     (; sfc_conditions) = p.precomputed
-    FT = eltype(params)
+    FT = CAP.float_type(params)
     @. sfc_conditions.T_sfc = FT(300)
     @. sfc_conditions.q_vap_sfc = FT(0)
     @. sfc_conditions.ustar = FT(0.2)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR adds arrays for storing parameters, so that they can be loaded into GPU kernels from constant memory instead of parameter memory.

## To-do
Update the `DataLayouts` module in ClimaCore.jl to handle nonuniform data types. This is necessary because the parameters for Insolation.jl contain an integer `DateTime`, which cannot currently be stored in a `CuArray`-backed `DataF` of floating-point values.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
