### PR TITLE
Updated ogw artifacts for naming consistency

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -91,36 +91,36 @@ git-tree-sha1 = "c2412372bdf40ba73f496dc0fe427d063e31533b"
     sha256 = "a0b8b682539d975c1cc331549d0222a0eda121f5b2977cc63486368a7dc07885"
     url = "https://caltech.box.com/shared/static/vdb6r7cv5tj6uhrphn5a4352smsxdqgs.gz"
 
-[ogwd_computed_drag_h6]
-git-tree-sha1 = "bf189454e5cb19962d8324e7e1667b7aa867bff9"
+[ogw_computed_drag_h6]
+git-tree-sha1 = "eda18e3fb3c23e68d5baa1798c654d3b88181c9f"
 lazy = true
 
-    [[ogwd_computed_drag_h6.download]]
-    sha256 = "a54c3ab3c0213e7c6d11fa73ab5fe54f3799e8383c6c3164e98d9c257945a4ef"
+    [[ogw_computed_drag_h6.download]]
+    sha256 = "18ea7cba9518d46e9552bf1a7ca5170882e40bf0755280df86e1f0cdd5354044"
     url = "https://caltech.box.com/shared/static/hrupvak4oceoi2camqey166u61421q25.gz"
 
-[ogwd_computed_drag_h8]
-git-tree-sha1 = "df178b2f3efba5c9670c7f75cd04637f844a8145"
+[ogw_computed_drag_h8]
+git-tree-sha1 = "ea035bd664abf8552a6ccb845f15c6c73c58745d"
 lazy = true
 
-    [[ogwd_computed_drag_h8.download]]
-    sha256 = "8375fd84c2b2b3ef9b333666702c55687f130e299753f4e21e0fd99f04fa355d"
+    [[ogw_computed_drag_h8.download]]
+    sha256 = "f649d2820ec445a5028626432717dc89f0dc0172b9ac1f9b46bf3076e09e2788"
     url = "https://caltech.box.com/shared/static/bmzj3r7b2lez3xjggymi2ifoq5vg6jnq.gz"
 
-[ogwd_computed_drag_h12]
-git-tree-sha1 = "2aa7ab2ca8b562aa8ba92905bd664cc64a976ad2"
+[ogw_computed_drag_h12]
+git-tree-sha1 = "129809607edc23bfa8b4a8f6a1e0addf01d4d96c"
 lazy = true
 
-    [[ogwd_computed_drag_h12.download]]
-    sha256 = "8b3834b9e3ed93bf08c6b7a0bbec83ff418ce357f186f67fc441b0e8d288ae32"
+    [[ogw_computed_drag_h12.download]]
+    sha256 = "d7e9dd1425e1c0708711940c87dde82e4667265f489085be581e159b742e433a"
     url = "https://caltech.box.com/shared/static/p058wvdd42zhidgt3copgn88ijgs2c3a.gz"
 
-[ogwd_computed_drag_h16]
-git-tree-sha1 = "158138fc38c3aa08ce1605ac65ff1983a1a407db"
+[ogw_computed_drag_h16]
+git-tree-sha1 = "2161318478a32f9826c2f1733af280a5ed148f5c"
 lazy = true
 
-    [[ogwd_computed_drag_h16.download]]
-    sha256 = "af9987bf9bf63899014b99b9420536cdd06f7bc05ea44b37f31e42e3b7840ed7"
+    [[ogw_computed_drag_h16.download]]
+    sha256 = "9c617e547526670efdde33c62bfc38f1ee9b9f647783fe8e832aa169d4d985bb"
     url = "https://caltech.box.com/shared/static/imtr9k7ktzm0fff1k32zphb8oybmrsvn.gz"
 
 [ogw_computed_drag_h30]

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -988,7 +988,7 @@ function compute_ogw_drag(
             # Fall back to ClimaArtifacts
             @info "Local file not found, loading from ClimaArtifacts (h_elem=$(h_elem))..."
             artifact_path =
-                AA.ogwd_computed_drag_file_path(; h_elem, context = ClimaComms.context(Y.c))
+                AA.ogw_computed_drag_file_path(; h_elem, context = ClimaComms.context(Y.c))
             @info "Loading from: $(artifact_path)"
             reader = InputOutput.HDF5Reader(artifact_path, ClimaComms.context(Y.c))
             topo_info = InputOutput.read_field(reader, "computed_drag")

--- a/src/utils/AtmosArtifacts.jl
+++ b/src/utils/AtmosArtifacts.jl
@@ -119,17 +119,17 @@ function co2_concentration_file_path(; context = nothing)
 end
 
 """
-    ogwd_computed_drag_file_path(; h_elem::Int, context = nothing)
+    ogw_computed_drag_file_path(; h_elem::Int, context = nothing)
 
-Construct the file path for the pre-computed OGWD topographic drag HDF5 file.
+Construct the file path for the pre-computed OGW topographic drag HDF5 file.
 
 Pre-computed drag tensor fields (t11, t12, t21, t22) and mountain heights
 (hmax, hmin) for the specified horizontal resolution.
 
 Supports h_elem = 6, 8, 12, 16.
 """
-function ogwd_computed_drag_file_path(; h_elem::Int, context = nothing)
-    artifact_name = "ogwd_computed_drag_h$(h_elem)"
+function ogw_computed_drag_file_path(; h_elem::Int, context = nothing)
+    artifact_name = "ogw_computed_drag_h$(h_elem)"
     filename = "computed_drag_Earth_false_1_$(h_elem).hdf5"
     return joinpath(@clima_artifact(artifact_name, context), filename)
 end

--- a/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/ogw_test_utils.jl
+++ b/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/ogw_test_utils.jl
@@ -31,7 +31,7 @@ function load_computed_drag(parsed_args, comms_ctx)
 
     # Fall back to ClimaArtifacts
     @info "Local file not found, loading from ClimaArtifacts..."
-    artifact_path = AA.ogwd_computed_drag_file_path(; h_elem, context = comms_ctx)
+    artifact_path = AA.ogw_computed_drag_file_path(; h_elem, context = comms_ctx)
     @info "Loading from: $(artifact_path)"
     reader = InputOutput.HDF5Reader(artifact_path, comms_ctx)
     drag = InputOutput.read_field(reader, "computed_drag")

--- a/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/test_ogw_baseflux.jl
+++ b/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/test_ogw_baseflux.jl
@@ -59,7 +59,7 @@ function compute_base_flux(ogw_mode::String, comms_ctx, config_file, job_id; h_e
 
     ᶜz = Fields.coordinate_field(Y.c).z
 
-    # Simple latitude-based wind profile (from ogwd_baseflux_gpu.jl / Garner05 Figure 1)
+    # Simple latitude-based wind profile (from ogw_baseflux_gpu.jl / Garner05 Figure 1)
     # Tropics (|lat| <= 23.5): u = -7 m/s, v = 0
     # Extratropics: u = 13 m/s, v = 0
     ᶜlocal_geometry = Fields.local_geometry_field(axes(Y.c))
@@ -85,7 +85,7 @@ function compute_base_flux(ogw_mode::String, comms_ctx, config_file, job_id; h_e
     # Use constant buoyancy frequency N = 0.01
     @. ᶜbuoyancy_frequency = FT(0.01)
 
-    # Use constant density ρ = 1.0 (like ogwd_baseflux_gpu.jl)
+    # Use constant density ρ = 1.0 (like ogw_baseflux_gpu.jl)
     @. Y.c.ρ = FT(1.0)
 
     # Compute base flux


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
* Previously, artifact filenames were ogwd_\* and ogw_\*. We now consistently use ogw_\* everywhere.
* Hashes are updated for the latest ogw_computed_drag artifacts

<!---  
## To-do
list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
