### PR TITLE
Bug fix in non-orographic gravity wave; extended pre-computed drag artifacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -91,6 +91,14 @@ git-tree-sha1 = "c2412372bdf40ba73f496dc0fe427d063e31533b"
     sha256 = "a0b8b682539d975c1cc331549d0222a0eda121f5b2977cc63486368a7dc07885"
     url = "https://caltech.box.com/shared/static/vdb6r7cv5tj6uhrphn5a4352smsxdqgs.gz"
 
+[ogw_computed_drag_h4]
+git-tree-sha1 = "4b29e533617216b6f01c27cbf070ccff9ca02361"
+lazy = true
+
+    [[ogw_computed_drag_h4.download]]
+    sha256 = "dbb74dbdacd8cc784cc636936b982cf166b646ef6c0368b987e57503387bfcda"
+    url = "https://caltech.box.com/shared/static/bxe0nbaherr0vebyke13alnrhsllg20k.gz"
+
 [ogw_computed_drag_h6]
 git-tree-sha1 = "eda18e3fb3c23e68d5baa1798c654d3b88181c9f"
 lazy = true

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-321
+322
 
 # **README**
 #
@@ -20,6 +20,9 @@
 
 
 #=
+
+322
+- Fixed bug in non-orographic gravity wave parameterization where the same scratch field is used for both u and v forcings.
 
 321
 - Implicit timestepping for microphysics tendencies, with diagonal Jacobian entries.

--- a/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
@@ -49,6 +49,8 @@ function non_orographic_gravity_wave_cache(Y, gw::NonOrographicGravityWave)
             ᶜlevel,
             u_waveforcing = similar(Y.c.ρ),
             v_waveforcing = similar(Y.c.ρ),
+            u_waveforcing_top = similar(Fields.level(Y.c.ρ, 1)),
+            v_waveforcing_top = similar(Fields.level(Y.c.ρ, 1)),
             uforcing = similar(Y.c.ρ),
             vforcing = similar(Y.c.ρ),
             gw_ncval = Val(nc),
@@ -122,6 +124,8 @@ function non_orographic_gravity_wave_cache(Y, gw::NonOrographicGravityWave)
             ᶜlevel,
             u_waveforcing = similar(Y.c.ρ),
             v_waveforcing = similar(Y.c.ρ),
+            u_waveforcing_top = similar(Fields.level(Y.c.ρ, 1)),
+            v_waveforcing_top = similar(Fields.level(Y.c.ρ, 1)),
             uforcing = similar(Y.c.ρ),
             vforcing = similar(Y.c.ρ),
             gw_ncval = Val(nc),
@@ -451,7 +455,7 @@ function non_orographic_gravity_wave_forcing(
         )
 
         #extract the momentum flux outside the model top.
-        u_waveforcing_top = p.scratch.temp_field_level
+        u_waveforcing_top = p.non_orographic_gravity_wave.u_waveforcing_top
         copyto!(
             Fields.field_values(u_waveforcing_top),
             Fields.field_values(
@@ -466,7 +470,7 @@ function non_orographic_gravity_wave_forcing(
             0,
         )
 
-        v_waveforcing_top = p.scratch.temp_field_level
+        v_waveforcing_top = p.non_orographic_gravity_wave.v_waveforcing_top
         copyto!(
             Fields.field_values(v_waveforcing_top),
             Fields.field_values(

--- a/test/parameterized_tendencies/gravity_wave/non_orographic_gravity_wave/test_nogw_mima.jl
+++ b/test/parameterized_tendencies/gravity_wave/non_orographic_gravity_wave/test_nogw_mima.jl
@@ -198,7 +198,11 @@ scratch = (;
 )
 
 for j in 1:length(lat)
-    local non_orographic_gravity_wave = non_orographic_gravity_wave_param(lat[j], FT)
+    local non_orographic_gravity_wave = (;
+        non_orographic_gravity_wave_param(lat[j], FT)...,
+        u_waveforcing_top = similar(Fields.level(ᶜz, 1), FT),
+        v_waveforcing_top = similar(Fields.level(ᶜz, 1), FT),
+    )
     # Create input parameters at each level
     local params_nogw = (; non_orographic_gravity_wave, scratch)
     for i in 1:length(lon)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
* `u_waveforcing` and `v_waveforcing` were using the same scratch field. Fixed this.
* Added support for `h_elem = 4` artifact in `ogw_computed_drag`. Needed for ClimaCoupler CI.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
