### PR TITLE
Refactor diagnostics: lazy compute API, radiation helpers, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - os: ''
         test_group:
           - infrastructure
+          - diagnostics
           - dynamics
           - parameterizations
           - restarts

--- a/src/cache/tracer_cache.jl
+++ b/src/cache/tracer_cache.jl
@@ -67,7 +67,7 @@ function tracer_cache(Y, prescribed_aerosol_names, time_varying_trace_gases, sta
         # The keys in the merra2_aerosols.nc file have to match the ones passed with the
         # configuration. The file also has to be defined on the globe and provide
         # time series of lon-lat-z data.
-        prescribed_aerosol_names_as_symbols = Symbol.(prescribed_aerosol_names)
+        prescribed_aerosol_names_as_symbols = Symbol.(Tuple(prescribed_aerosol_names))
         target_space = axes(Y.c)
         extrapolation_bc = (Intp.Periodic(), Intp.Flat(), Intp.Flat())
         timevaryinginputs = [

--- a/src/diagnostics/conservation_diagnostics.jl
+++ b/src/diagnostics/conservation_diagnostics.jl
@@ -8,32 +8,24 @@
 ###
 # Total mass of the air (scalar)
 ###
-add_diagnostic_variable!(
-    short_name = "massa",
+add_diagnostic_variable!(short_name = "massa", units = "kg",
     long_name = "Total Mass of the Air",
-    units = "kg",
     compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return [sum(state.c.ρ)]
-        else
-            out .= [sum(state.c.ρ)]
-        end
+        massa = sum(state.c.ρ)
+        isnothing(out) && return [massa]
+        out .= massa
     end,
 )
 
 ###
 # Total energy of air (scalar)
 ###
-add_diagnostic_variable!(
-    short_name = "energya",
+add_diagnostic_variable!(short_name = "energya", units = "J",
     long_name = "Total Energy of the Air",
-    units = "J",
     compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return [sum(state.c.ρe_tot)]
-        else
-            out .= [sum(state.c.ρe_tot)]
-        end
+        energya = sum(state.c.ρe_tot)
+        isnothing(out) && return [energya]
+        out .= energya
     end,
 )
 
@@ -42,21 +34,12 @@ add_diagnostic_variable!(
 ###
 compute_watera!(out, state, cache, time) =
     compute_watera!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_watera!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("watera", model)
+compute_watera!(_, _, _, _, model) = error_diagnostic_variable("watera", model)
 
-function compute_watera!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    if isnothing(out)
-        return [sum(state.c.ρq_tot)]
-    else
-        out .= [sum(state.c.ρq_tot)]
-    end
+function compute_watera!(out, state, _, _, ::MoistMicrophysics)
+    watera = sum(state.c.ρq_tot)
+    isnothing(out) && return [watera]
+    out .= watera
 end
 
 add_diagnostic_variable!(
@@ -71,31 +54,17 @@ add_diagnostic_variable!(
 ###
 compute_energyo!(out, state, cache, time) =
     compute_energyo!(out, state, cache, time, cache.atmos.surface_model)
-compute_energyo!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("energyo", model)
+compute_energyo!(_, _, _, _, model) = error_diagnostic_variable("energyo", model)
 
-function compute_energyo!(
-    out,
-    state,
-    cache,
-    time,
-    surface_model::T,
-) where {T <: SlabOceanSST}
-    sfc_cρh =
-        surface_model.ρ_ocean *
-        surface_model.cp_ocean *
-        surface_model.depth_ocean
-    if isnothing(out)
-        return [horizontal_integral_at_boundary(state.sfc.T .* sfc_cρh)]
-    else
-        out .= [horizontal_integral_at_boundary(state.sfc.T .* sfc_cρh)]
-    end
+function compute_energyo!(out, state, _, _, surface_model::SlabOceanSST)
+    sfc_cρh = surface_model.ρ_ocean * surface_model.cp_ocean * surface_model.depth_ocean
+    energyo = horizontal_integral_at_boundary(state.sfc.T .* sfc_cρh)
+    isnothing(out) && return [energyo]
+    out .= energyo
 end
 
-add_diagnostic_variable!(
-    short_name = "energyo",
+add_diagnostic_variable!(short_name = "energyo", units = "J",
     long_name = "Total Energy of the Ocean",
-    units = "J",
     compute! = compute_energyo!,
 )
 
@@ -103,42 +72,19 @@ add_diagnostic_variable!(
 # Total water of the slab ocean (scalar)
 ###
 compute_watero!(out, state, cache, time) = compute_watero!(
-    out,
-    state,
-    cache,
-    time,
-    cache.atmos.microphysics_model,
-    cache.atmos.surface_model,
+    out, state, cache, time, cache.atmos.microphysics_model, cache.atmos.surface_model,
 )
-compute_watero!(
-    _,
-    _,
-    _,
-    _,
-    microphysics_model::T1,
-    surface_model::T2,
-) where {T1, T2} = error_diagnostic_variable(
-    "Can only compute total water of the ocean with a moist model and with SlabOceanSST",
-)
+compute_watero!(_, _, _, _, microphysics_model, surface_model) =
+    error_diagnostic_variable("Can only compute total water of the ocean \
+                               with a moist model and with SlabOceanSST")
 
-function compute_watero!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::MoistMicrophysics,
-    surface_model::SlabOceanSST,
-)
-    if isnothing(out)
-        return [horizontal_integral_at_boundary(state.sfc.water)]
-    else
-        out .= [horizontal_integral_at_boundary(state.sfc.water)]
-    end
+function compute_watero!(out, state, _, _, ::MoistMicrophysics, ::SlabOceanSST)
+    watero = horizontal_integral_at_boundary(state.sfc.water)
+    isnothing(out) && return [watero]
+    out .= watero
 end
 
-add_diagnostic_variable!(
-    short_name = "watero",
+add_diagnostic_variable!(short_name = "watero", units = "kg",
     long_name = "Total Water of the Ocean",
-    units = "kg",
     compute! = compute_watero!,
 )

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -1,102 +1,67 @@
-# This file is included in Diagnostics.jl
-#
-# README: Adding a new core diagnostic:
-#
-# In addition to the metadata (names, comments, ...), the most important step in adding a
-# new DiagnosticVariable is defining its compute! function. `compute!` has to take four
-# arguments: (out, state, cache, time), and has to write the diagnostic in place into the
-# `out` variable.
-#
-# Often, it is possible to compute certain diagnostics only for specific models (e.g.,
-# humidity for moist models). For that, it is convenient to adopt the following pattern:
-#
-# 1. Define a catch base function that does the computation we want to do for the case we know
-# how to handle, for example
-#
-# function compute_hur!(
-#     out,
-#     state,
-#     cache,
-#     time,
-#     ::T,
-# ) where {T <: MoistMicrophysics}
-#     thermo_params = CAP.thermodynamics_params(cache.params)
-#     out .= TD.relative_humidity.(thermo_params, cache.precomputed.ᶜT, state.c.ρ, cache.precomputed.ᶜq_tot_nonneg, cache.precomputed.ᶜq_liq, cache.precomputed.ᶜq_ice))
-# end
-#
-# 2. Define a function that has the correct signature and calls this function
-#
-# compute_hur!(out, state, cache, time) =
-#     compute_hur!(out, state, cache, time, cache.atmos.microphysics_model)
-#
-# 3. Define a function that returns an error when the model is incorrect
-#
-# compute_hur!(_, _, _, _, model::T) where {T} =
-#     error_diagnostic_variable("relative_humidity", model)
-#
-# We can also output a specific error message
-#
-# compute_hur!(_, _, _, _, model::T) where {T} =
-#     error_diagnostic_variable("relative humidity makes sense only for moist models")
+#=
+This file is included in Diagnostics.jl
 
-# General helper functions for undefined diagnostics for a particular model
-error_diagnostic_variable(
-    message = "Cannot compute $variable with model = $T",
-) = error(message)
-error_diagnostic_variable(variable, model::T) where {T} =
+README: Adding a new core diagnostic:
+
+In addition to the metadata (names, comments, ...), the most important step
+in adding a new DiagnosticVariable is defining its compute function. 
+`compute` takes three arguments: (state, cache, time), 
+and returns the diagnostic value, preferring lazy fields when possible.
+
+Often, it is possible to compute certain diagnostics only for specific models
+(e.g., humidity for moist models). For that, it is convenient to adopt the following pattern:
+
+1. Define a function for the case we know how to handle:
+
+function compute_hur(state, cache, time, ::MoistMicrophysics)
+    tps = CAP.thermodynamics_params(cache.params)
+    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
+    @. lazy(TD.relative_humidity(tps, ᶜT, state.c.ρ, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
+end
+
+2. Define a dispatch function with the correct signature:
+
+compute_hur(state, cache, time) =
+    compute_hur(state, cache, time, cache.atmos.microphysics_model)
+
+3. Define an error fallback for unsupported models:
+
+compute_hur(state, cache, time, model) = error_diagnostic_variable("hur", model)
+
+=#
+
+# General helper functions for undefined diagnostics
+error_diagnostic_variable(message = "Cannot compute variable") = error(message)
+error_diagnostic_variable(variable, ::T) where {T} =
     error_diagnostic_variable("Cannot compute $variable with model = $T")
 
 ###
 # Density (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "rhoa",
-    long_name = "Air Density",
-    standard_name = "air_density",
-    units = "kg m^-3",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(state.c.ρ)
-        else
-            out .= state.c.ρ
-        end
-    end,
+add_diagnostic_variable!(short_name = "rhoa", units = "kg m^-3",
+    long_name = "Air Density", standard_name = "air_density",
+    compute = (state, _, _) -> state.c.ρ,
 )
 
 ###
 # U velocity (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "ua",
+add_diagnostic_variable!(short_name = "ua", units = "m s^-1",
     long_name = "Eastward Wind",
     standard_name = "eastward_wind",
-    units = "m s^-1",
     comments = "Eastward (zonal) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(u_component.(Geometry.UVector.(cache.precomputed.ᶜu)))
-        else
-            out .= u_component.(Geometry.UVector.(cache.precomputed.ᶜu))
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(u_component(UVec(cache.precomputed.ᶜu)))),
 )
 
 ###
 # V velocity (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "va",
+
+add_diagnostic_variable!(short_name = "va", units = "m s^-1",
     long_name = "Northward Wind",
     standard_name = "northward_wind",
-    units = "m s^-1",
     comments = "Northward (meridional) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(v_component.(Geometry.VVector.(cache.precomputed.ᶜu)))
-        else
-            out .= v_component.(Geometry.VVector.(cache.precomputed.ᶜu))
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(v_component(VVec(cache.precomputed.ᶜu)))),
 )
 
 ###
@@ -104,1035 +69,556 @@ add_diagnostic_variable!(
 ###
 # TODO: may want to convert to omega (Lagrangian pressure tendency) as standard output,
 # but this is probably more useful for now
-#
-add_diagnostic_variable!(
-    short_name = "wa",
+add_diagnostic_variable!(short_name = "wa", units = "m s^-1",
     long_name = "Upward Air Velocity",
     standard_name = "upward_air_velocity",
-    units = "m s^-1",
     comments = "Vertical wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(w_component.(Geometry.WVector.(cache.precomputed.ᶠu)))
-        else
-            out .= w_component.(Geometry.WVector.(cache.precomputed.ᶠu))
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(w_component(WVec(cache.precomputed.ᶠu)))),
 )
 
 ###
 # Temperature (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "ta",
+add_diagnostic_variable!(short_name = "ta", units = "K",
     long_name = "Air Temperature",
     standard_name = "air_temperature",
-    units = "K",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜT)
-        else
-            out .= cache.precomputed.ᶜT
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜT,
 )
 
 ###
 # Potential temperature (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "thetaa",
+function compute_thetaa(state, cache, _)
+    tps = CAP.thermodynamics_params(cache.params)
+    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
+    ᶜρ = state.c.ρ
+    return @. lazy(TD.potential_temperature(tps, ᶜT, ᶜρ, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
+end
+
+add_diagnostic_variable!(short_name = "thetaa", units = "K",
     long_name = "Air Potential Temperature",
     standard_name = "air_potential_temperature",
-    units = "K",
-    compute! = (out, state, cache, time) -> begin
-        thermo_params = CAP.thermodynamics_params(cache.params)
-        (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
-        if isnothing(out)
-            return TD.potential_temperature.(
-                thermo_params,
-                ᶜT,
-                state.c.ρ,
-                ᶜq_tot_nonneg,
-                ᶜq_liq,
-                ᶜq_ice,
-            )
-        else
-            out .=
-                TD.potential_temperature.(
-                    thermo_params,
-                    ᶜT,
-                    state.c.ρ,
-                    ᶜq_tot_nonneg,
-                    ᶜq_liq,
-                    ᶜq_ice,
-                )
-        end
-    end,
+    compute = compute_thetaa,
 )
 
 ###
 # Enthalpy (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "ha",
+function compute_ha(_, cache, _)
+    thermo_params = CAP.thermodynamics_params(cache.params)
+    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
+    return @. lazy(TD.enthalpy(thermo_params, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
+end
+
+add_diagnostic_variable!(short_name = "ha", units = "m^2 s^-2",
     long_name = "Air Specific Enthalpy",
-    units = "m^2 s^-2",
-    compute! = (out, state, cache, time) -> begin
-        thermo_params = CAP.thermodynamics_params(cache.params)
-        (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
-        if isnothing(out)
-            return TD.enthalpy.(thermo_params, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice)
-        else
-            out .= TD.enthalpy.(thermo_params, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice)
-        end
-    end,
+    compute = compute_ha,
 )
 
 ###
 # Air pressure (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "pfull",
+add_diagnostic_variable!(short_name = "pfull", units = "Pa",
     long_name = "Pressure at Model Full-Levels",
-    units = "Pa",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜp)
-        else
-            out .= cache.precomputed.ᶜp
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜp,
 )
 
 ###
 # Vorticity (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "rv",
+function compute_rv(_, cache, _)
+    vort = @. w_component(WVec(wcurlₕ(cache.precomputed.ᶜu)))  # TODO: Allocates
+    # We need to ensure smoothness, so we call DSS
+    Spaces.weighted_dss!(vort)
+    return vort
+end
+
+add_diagnostic_variable!(short_name = "rv", units = "s^-1",
     long_name = "Relative Vorticity",
     standard_name = "relative_vorticity",
-    units = "s^-1",
     comments = "Vertical component of relative vorticity",
-    compute! = (out, state, cache, time) -> begin
-        vort = @. w_component.(Geometry.WVector(wcurlₕ(cache.precomputed.ᶜu)))
-        # We need to ensure smoothness, so we call DSS
-        Spaces.weighted_dss!(vort)
-        if isnothing(out)
-            return copy(vort)
-        else
-            out .= vort
-        end
-    end,
+    compute = compute_rv,
 )
 
 ###
 # Geopotential height (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "zg",
+add_diagnostic_variable!(short_name = "zg", units = "m",
     long_name = "Geopotential Height",
     standard_name = "geopotential_height",
-    units = "m",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return cache.core.ᶜΦ ./ CAP.grav(cache.params)
-        else
-            out .= cache.core.ᶜΦ ./ CAP.grav(cache.params)
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(cache.core.ᶜΦ / CAP.grav(cache.params))),
 )
 
 ###
 # Cloud fraction (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "cl",
+add_diagnostic_variable!(short_name = "cl", units = "%",
     long_name = "Cloud fraction",
-    units = "%",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜcloud_fraction) .* 100
-        else
-            out .= cache.precomputed.ᶜcloud_fraction .* 100
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(cache.precomputed.ᶜcloud_fraction * 100)),
 )
 
 ###
 # Total kinetic energy
 ###
-add_diagnostic_variable!(
-    short_name = "ke",
+add_diagnostic_variable!(short_name = "ke", units = "m^2 s^-2",
     long_name = "Total Kinetic Energy",
     standard_name = "total_kinetic_energy",
-    units = "m^2 s^-2",
     comments = "The kinetic energy on cell centers",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜK)
-        else
-            out .= cache.precomputed.ᶜK
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜK,
 )
 
 ###
 # Mixing length (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "lmix",
+function compute_lmix(state, cache, _)
+    turbconv_model = cache.atmos.turbconv_model
+    # TODO: consolidate remaining mixing length types
+    # (smagorinsky_lilly, dz) into a single function
+    if isa(turbconv_model, PrognosticEDMFX) ||
+       isa(turbconv_model, DiagnosticEDMFX) ||
+       isa(turbconv_model, EDOnlyEDMFX)
+        return ᶜmixing_length(state, cache)
+    end
+    (; params) = cache
+    (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = cache.precomputed
+    ᶜdz = Fields.Δz_field(axes(state.c))
+    ᶜprandtl_nvec = @. lazy(turbulent_prandtl_number(
+        params, ᶜlinear_buoygrad, ᶜstrain_rate_norm,
+    ))
+    return @. lazy(
+        smagorinsky_lilly_length(
+            CAP.c_smag(params),
+            sqrt(max(ᶜlinear_buoygrad, 0)),   # N_eff
+            ᶜdz, ᶜprandtl_nvec, ᶜstrain_rate_norm,
+        ),
+    )
+end
+
+add_diagnostic_variable!(short_name = "lmix", units = "m",
     long_name = "Environment Mixing Length",
-    units = "m",
     comments = """
-    Calculated as smagorinsky length scale without EDMF SGS model,
-    or from mixing length closure with EDMF SGS model.
+    Calculated as smagorinsky length scale without EDMF
+    SGS model, or from mixing length closure with EDMF
+    SGS model.
     """,
-    compute! = (out, state, cache, time) -> begin
-        turbconv_model = cache.atmos.turbconv_model
-        # TODO: consolidate remaining mixing length types
-        # (smagorinsky_lilly, dz) into a single mixing length function
-        if isa(turbconv_model, PrognosticEDMFX) ||
-           isa(turbconv_model, DiagnosticEDMFX) ||
-           isa(turbconv_model, EDOnlyEDMFX)
-            ᶜmixing_length_field = ᶜmixing_length(state, cache)
-        else
-            (; params) = cache
-            (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = cache.precomputed
-            ᶜdz = Fields.Δz_field(axes(state.c))
-            ᶜprandtl_nvec = @. lazy(
-                turbulent_prandtl_number(
-                    params,
-                    ᶜlinear_buoygrad,
-                    ᶜstrain_rate_norm,
-                ),
-            )
-            ᶜmixing_length_field = @. lazy(
-                smagorinsky_lilly_length(
-                    CAP.c_smag(params),
-                    sqrt(max(ᶜlinear_buoygrad, 0)),   # N_eff
-                    ᶜdz,
-                    ᶜprandtl_nvec,
-                    ᶜstrain_rate_norm,
-                ),
-            )
-        end
-
-
-        if isnothing(out)
-            return Base.materialize(ᶜmixing_length_field)
-        else
-            out .= ᶜmixing_length_field
-        end
-    end,
+    compute = compute_lmix,
 )
 
 ###
 # Buoyancy gradient (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "bgrad",
+add_diagnostic_variable!(short_name = "bgrad", units = "s^-2",
     long_name = "Linearized Buoyancy Gradient",
-    units = "s^-2",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜlinear_buoygrad)
-        else
-            out .= cache.precomputed.ᶜlinear_buoygrad
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜlinear_buoygrad,
 )
 
 ###
 # Strain rate magnitude (3d)
 ###
-add_diagnostic_variable!(
-    short_name = "strain",
+add_diagnostic_variable!(short_name = "strain", units = "s^-2",
     long_name = "String Rate Magnitude",
-    units = "s^-2",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.ᶜstrain_rate_norm)
-        else
-            out .= cache.precomputed.ᶜstrain_rate_norm
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜstrain_rate_norm,
 )
 
 ###
 # Smagorinsky Lilly diffusivity
 ###
-add_diagnostic_variable!(
-    short_name = "Dh_smag",
+add_diagnostic_variable!(short_name = "Dh_smag", units = "m^2 s^-1",
     long_name = "Horizontal smagorinsky diffusivity",
-    units = "m^2 s^-1",
-    compute! = (out, _, cache, _) -> begin
-        (; ᶜD_h) = cache.precomputed
-        isnothing(out) ? copy(ᶜD_h) : (out .= ᶜD_h)
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜD_h,
 )
-add_diagnostic_variable!(
-    short_name = "Dv_smag",
+add_diagnostic_variable!(short_name = "Dv_smag", units = "m^2 s^-1",
     long_name = "Vertical smagorinsky diffusivity",
-    units = "m^2 s^-1",
-    compute! = (out, _, cache, _) -> begin
-        (; ᶜD_v) = cache.precomputed
-        isnothing(out) ? copy(ᶜD_v) : (out .= ᶜD_v)
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜD_v,
 )
-add_diagnostic_variable!(
-    short_name = "strainh_smag",
+add_diagnostic_variable!(short_name = "strainh_smag", units = "s",
     long_name = "Horizontal strain rate magnitude (for Smagorinsky)",
-    units = "s",
-    compute! = (out, state, cache, _) -> begin
-        (; ᶜS_norm_h) = cache.precomputed
-        isnothing(out) ? copy(ᶜS_norm_h) : (out .= ᶜS_norm_h)
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜS_norm_h,
 )
-add_diagnostic_variable!(
-    short_name = "strainv_smag",
+add_diagnostic_variable!(short_name = "strainv_smag", units = "s",
     long_name = "Vertical strain rate magnitude (for Smagorinsky)",
-    units = "s",
-    compute! = (out, state, cache, _) -> begin
-        (; ᶜS_norm_v) = cache.precomputed
-        isnothing(out) ? copy(ᶜS_norm_v) : (out .= ᶜS_norm_v)
-    end,
+    compute = (_, cache, _) -> cache.precomputed.ᶜS_norm_v,
 )
 
 ###
 # Relative humidity (3d)
 ###
-compute_hur!(out, state, cache, time) =
-    compute_hur!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hur!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hur", model)
+compute_hur(state, cache, time) =
+    compute_hur(state, cache, time, cache.atmos.microphysics_model)
+compute_hur(_, _, _, model) = error_diagnostic_variable("hur", model)
 
-function compute_hur!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    thermo_params = CAP.thermodynamics_params(cache.params)
+function compute_hur(_, cache, _, ::MoistMicrophysics)
+    tps = CAP.thermodynamics_params(cache.params)
     (; ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
-    if isnothing(out)
-        return TD.relative_humidity.(
-            thermo_params,
-            ᶜT,
-            ᶜp,
-            ᶜq_tot_nonneg,
-            ᶜq_liq,
-            ᶜq_ice,
-        )
-    else
-        out .=
-            TD.relative_humidity.(
-                thermo_params,
-                ᶜT,
-                ᶜp,
-                ᶜq_tot_nonneg,
-                ᶜq_liq,
-                ᶜq_ice,
-            )
-    end
+    return @. lazy(TD.relative_humidity(tps, ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
 end
 
-add_diagnostic_variable!(
-    short_name = "hur",
+add_diagnostic_variable!(short_name = "hur", units = "",
     long_name = "Relative Humidity",
     standard_name = "relative_humidity",
-    units = "",
-    comments = "Total amount of water vapor in the air relative to the amount achievable by saturation at the current temperature",
-    compute! = compute_hur!,
+    comments = "Total amount of water vapor in the air relative to the amount \
+                achievable by saturation at the current temperature",
+    compute = compute_hur,
 )
 
 ###
 # Total specific humidity (3d)
 ###
-compute_hus!(out, state, cache, time) =
-    compute_hus!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hus!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hus", model)
+compute_hus(state, cache, time) =
+    compute_hus(state, cache, time, cache.atmos.microphysics_model)
+compute_hus(_, _, _, model) = error_diagnostic_variable("hus", model)
 
-function compute_hus!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    if isnothing(out)
-        return state.c.ρq_tot ./ state.c.ρ
-    else
-        out .= state.c.ρq_tot ./ state.c.ρ
-    end
-end
+compute_hus(state, _, _, ::MoistMicrophysics) = @. lazy(specific(state.c.ρq_tot, state.c.ρ))
 
-add_diagnostic_variable!(
-    short_name = "hus",
+add_diagnostic_variable!(short_name = "hus", units = "kg kg^-1",
     long_name = "Specific Humidity",
     standard_name = "specific_humidity",
-    units = "kg kg^-1",
     comments = "Mass of all water phases per mass of air",
-    compute! = compute_hus!,
+    compute = compute_hus,
 )
 
 ###
 # Liquid water specific humidity (3d)
 ###
-compute_clw!(out, state, cache, time) =
-    compute_clw!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_clw!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("clw", model)
+compute_clw(state, cache, time) =
+    compute_clw(state, cache, time, cache.atmos.microphysics_model)
+compute_clw(_, _, _, model) = error_diagnostic_variable("clw", model)
 
-function compute_clw!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::EquilibriumMicrophysics0M,
-)
-    if isnothing(out)
-        return copy(cache.precomputed.ᶜq_liq)
-    else
-        out .= cache.precomputed.ᶜq_liq
-    end
-end
+compute_clw(_, cache, _, ::EquilibriumMicrophysics0M) = cache.precomputed.ᶜq_liq
 
-function compute_clw!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::NonEquilibriumMicrophysics,
-)
-    if isnothing(out)
-        return state.c.ρq_lcl ./ state.c.ρ
-    else
-        out .= state.c.ρq_lcl ./ state.c.ρ
-    end
-end
+compute_clw(state, _, _, ::NonEquilibriumMicrophysics) =
+    @. lazy(specific(state.c.ρq_lcl, state.c.ρ))
 
-add_diagnostic_variable!(
-    short_name = "clw",
+add_diagnostic_variable!(short_name = "clw", units = "kg kg^-1",
     long_name = "Mass Fraction of Cloud Liquid Water",
     standard_name = "mass_fraction_of_cloud_liquid_water_in_air",
-    units = "kg kg^-1",
     comments = """
     Includes both large-scale and convective cloud.
-    This is calculated as the mass of cloud liquid water in the grid cell divided by
-    the mass of air (including the water in all phases) in the grid cells.
+    This is calculated as the mass of cloud liquid water
+    in the grid cell divided by the mass of air
+    (including water in all phases) in the grid cells.
     """,
-    compute! = compute_clw!,
+    compute = compute_clw,
 )
 
 ###
 # Ice water specific humidity (3d)
 ###
-compute_cli!(out, state, cache, time) =
-    compute_cli!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_cli!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("cli", model)
+compute_cli(state, cache, time) =
+    compute_cli(state, cache, time, cache.atmos.microphysics_model)
+compute_cli(_, _, _, model) = error_diagnostic_variable("cli", model)
 
-function compute_cli!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::EquilibriumMicrophysics0M,
-)
-    if isnothing(out)
-        return copy(cache.precomputed.ᶜq_ice)
-    else
-        out .= cache.precomputed.ᶜq_ice
-    end
-end
+compute_cli(_, cache, _, ::EquilibriumMicrophysics0M) = cache.precomputed.ᶜq_ice
 
-function compute_cli!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::NonEquilibriumMicrophysics,
-)
-    if isnothing(out)
-        return state.c.ρq_icl ./ state.c.ρ
-    else
-        out .= state.c.ρq_icl ./ state.c.ρ
-    end
-end
+compute_cli(state, _, _, ::NonEquilibriumMicrophysics) =
+    @. lazy(specific(state.c.ρq_icl, state.c.ρ))
 
-add_diagnostic_variable!(
-    short_name = "cli",
+add_diagnostic_variable!(short_name = "cli", units = "kg kg^-1",
     long_name = "Mass Fraction of Cloud Ice",
     standard_name = "mass_fraction_of_cloud_ice_in_air",
-    units = "kg kg^-1",
     comments = """
     Includes both large-scale and convective cloud.
-    This is calculated as the mass of cloud ice in the grid cell divided by
-    the mass of air (including the water in all phases) in the grid cell.
+    This is calculated as the mass of cloud ice in the
+    grid cell divided by the mass of air (including water
+    in all phases) in the grid cell.
     """,
-    compute! = compute_cli!,
+    compute = compute_cli,
 )
 
 ###
 # Surface specific humidity (2d)
 ###
-compute_hussfc!(out, state, cache, time) =
-    compute_hussfc!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hussfc!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hussfc", model)
+compute_hussfc(state, cache, time) =
+    compute_hussfc(state, cache, time, cache.atmos.microphysics_model)
+compute_hussfc(_, _, _, model) = error_diagnostic_variable("hussfc", model)
 
-function compute_hussfc!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    # q_vap_sfc is the total specific humidity at the surface (no liquid/ice)
-    if isnothing(out)
-        return copy(cache.precomputed.sfc_conditions.q_vap_sfc)
-    else
-        out .= cache.precomputed.sfc_conditions.q_vap_sfc
-    end
-end
+# q_vap_sfc is the total specific humidity at the surface
+compute_hussfc(_, cache, _, ::MoistMicrophysics) =
+    cache.precomputed.sfc_conditions.q_vap_sfc
 
-add_diagnostic_variable!(
-    short_name = "hussfc",
+add_diagnostic_variable!(short_name = "hussfc", units = "kg kg^-1",
     long_name = "Surface Specific Humidity",
     standard_name = "specific_humidity",
-    units = "kg kg^-1",
-    comments = "Mass of all water phases per mass of air in the layer infinitely close to the surface",
-    compute! = compute_hussfc!,
+    comments = "Mass of all water phases per mass of air in the layer \
+                infinitely close to the surface",
+    compute = compute_hussfc,
 )
 
 ###
 # Surface temperature (2d)
 ###
-add_diagnostic_variable!(
-    short_name = "ts",
+add_diagnostic_variable!(short_name = "ts", units = "K",
     long_name = "Surface Temperature",
     standard_name = "surface_temperature",
-    units = "K",
     comments = "Temperature of the lower boundary of the atmosphere",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(cache.precomputed.sfc_conditions.T_sfc)
-        else
-            out .= cache.precomputed.sfc_conditions.T_sfc
-        end
-    end,
+    compute = (_, cache, _) -> cache.precomputed.sfc_conditions.T_sfc,
 )
 
 ###
 # Near-surface air temperature (2d)
 ###
-add_diagnostic_variable!(
-    short_name = "tas",
+add_diagnostic_variable!(short_name = "tas", units = "K",
     long_name = "Near-Surface Air Temperature",
     standard_name = "air_temperature",
-    units = "K",
     comments = "Temperature at the bottom cell center of the atmosphere",
-    compute! = (out, state, cache, time) -> begin
-        T_level = Fields.level(cache.precomputed.ᶜT, 1)
-        if isnothing(out)
-            return copy(T_level)
-        else
-            out .= T_level
-        end
-    end,
+    compute = (_, cache, _) -> Fields.level(cache.precomputed.ᶜT, 1),
 )
 
 ###
 # Near-surface U velocity (2d)
 ###
-add_diagnostic_variable!(
-    short_name = "uas",
+function compute_uas(_, cache, _)
+    ᶜu₁ = Fields.level(cache.precomputed.ᶜu, 1)
+    return @. lazy(u_component(UVec(ᶜu₁)))
+end
+
+add_diagnostic_variable!(short_name = "uas", units = "m s^-1",
     long_name = "Eastward Near-Surface Wind",
     standard_name = "eastward_wind",
-    units = "m s^-1",
     comments = "Eastward component of the wind at the bottom cell center of the atmosphere",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(
-                u_component.(
-                    Geometry.UVector.(Fields.level(cache.precomputed.ᶜu, 1)),
-                ),
-            )
-        else
-            out .=
-                u_component.(
-                    Geometry.UVector.(Fields.level(cache.precomputed.ᶜu, 1)),
-                )
-        end
-    end,
+    compute = compute_uas,
 )
 
 ###
 # Near-surface V velocity (2d)
 ###
-add_diagnostic_variable!(
-    short_name = "vas",
+function compute_vas(_, cache, _)
+    ᶜu₁ = Fields.level(cache.precomputed.ᶜu, 1)
+    return @. lazy(v_component(VVec(ᶜu₁)))
+end
+
+add_diagnostic_variable!(short_name = "vas", units = "m s^-1",
     long_name = "Northward Near-Surface Wind",
     standard_name = "northward_wind",
-    units = "m s^-1",
-    comments = "Northward (meridional) wind component at the bottom cell center of the atmosphere",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            return copy(
-                v_component.(
-                    Geometry.VVector.(Fields.level(cache.precomputed.ᶜu, 1)),
-                ),
-            )
-        else
-            out .=
-                v_component.(
-                    Geometry.VVector.(Fields.level(cache.precomputed.ᶜu, 1)),
-                )
-        end
-    end,
+    comments = "Northward (meridional) wind component \
+                at the bottom cell center of the atmosphere",
+    compute = compute_vas,
 )
 
 ###
 # Eastward and northward surface drag component (2d)
 ###
-function compute_tau!(out, state, cache, component)
+function compute_tau(cache, component)
     (; surface_ct3_unit) = cache.core
     (; ρ_flux_uₕ) = cache.precomputed.sfc_conditions
-
-    if isnothing(out)
-        return getproperty(
-            Geometry.UVVector.(
-                adjoint.(ρ_flux_uₕ) .* surface_ct3_unit,
-            ).components.data,
-            component,
-        )
-    else
-        out .= getproperty(
-            Geometry.UVVector.(
-                adjoint.(ρ_flux_uₕ) .* surface_ct3_unit,
-            ).components.data,
-            component,
-        )
-    end
-
-    return
+    ρ_flux = @. UV(adjoint(ρ_flux_uₕ) * surface_ct3_unit)  # TODO: this allocates
+    return getproperty(ρ_flux.components.data, component)
 end
 
-compute_tauu!(out, state, cache, time) = compute_tau!(out, state, cache, :1)
-compute_tauv!(out, state, cache, time) = compute_tau!(out, state, cache, :2)
+compute_tauu(_, cache, _) = compute_tau(cache, :1)
+compute_tauv(_, cache, _) = compute_tau(cache, :2)
 
-add_diagnostic_variable!(
-    short_name = "tauu",
+add_diagnostic_variable!(short_name = "tauu", units = "Pa",
     long_name = "Surface Downward Eastward Wind Stress",
     standard_name = "downward_eastward_stress",
-    units = "Pa",
     comments = "Eastward component of the surface drag",
-    compute! = compute_tauu!,
+    compute = compute_tauu,
 )
-
-add_diagnostic_variable!(
-    short_name = "tauv",
+add_diagnostic_variable!(short_name = "tauv", units = "Pa",
     long_name = "Surface Downward Northward Wind Stress",
     standard_name = "downward_northward_stress",
-    units = "Pa",
     comments = "Northward component of the surface drag",
-    compute! = compute_tauv!,
+    compute = compute_tauv,
 )
 
 ###
-# Surface energy flux (2d) - TODO: this may need to be split into sensible and latent heat fluxes
+# Surface energy flux (2d)
+# TODO: may need to split into sensible and latent heat
 ###
-function compute_hfes!(out, state, cache, time)
+function compute_hfes(_, cache, _)
     (; ρ_flux_h_tot) = cache.precomputed.sfc_conditions
     (; surface_ct3_unit) = cache.core
-    if isnothing(out)
-        return dot.(ρ_flux_h_tot, surface_ct3_unit)
-    else
-        out .= dot.(ρ_flux_h_tot, surface_ct3_unit)
-    end
+    return @. lazy(dot(ρ_flux_h_tot, surface_ct3_unit))
 end
 
-add_diagnostic_variable!(
-    short_name = "hfes",
+add_diagnostic_variable!(short_name = "hfes", units = "W m^-2",
     long_name = "Surface Upward Energy Flux",
-    units = "W m^-2",
     comments = "Energy flux at the surface",
-    compute! = compute_hfes!,
+    compute = compute_hfes,
 )
 
 ###
 # Surface evaporation (2d)
 ###
-compute_evspsbl!(out, state, cache, time) =
-    compute_evspsbl!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_evspsbl!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("evspsbl", model)
+compute_evspsbl(state, cache, time) =
+    compute_evspsbl(state, cache, time, cache.atmos.microphysics_model)
+compute_evspsbl(_, _, _, model) = error_diagnostic_variable("evspsbl", model)
 
-function compute_evspsbl!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
+function compute_evspsbl(_, cache, _, ::MoistMicrophysics)
     (; ρ_flux_q_tot) = cache.precomputed.sfc_conditions
     (; surface_ct3_unit) = cache.core
-
-    if isnothing(out)
-        return dot.(ρ_flux_q_tot, surface_ct3_unit)
-    else
-        out .= dot.(ρ_flux_q_tot, surface_ct3_unit)
-    end
+    return @. lazy(dot(ρ_flux_q_tot, surface_ct3_unit))
 end
 
-add_diagnostic_variable!(
-    short_name = "evspsbl",
+add_diagnostic_variable!(short_name = "evspsbl", units = "kg m^-2 s^-1",
     long_name = "Evaporation Including Sublimation and Transpiration",
-    units = "kg m^-2 s^-1",
-    comments = "evaporation at the surface",
-    compute! = compute_evspsbl!,
+    comments = "Evaporation at the surface",
+    compute = compute_evspsbl,
 )
 
 ###
 # Latent heat flux (2d)
 ###
-compute_hfls!(out, state, cache, time) =
-    compute_hfls!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hfls!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hfls", model)
+compute_hfls(state, cache, time) =
+    compute_hfls(state, cache, time, cache.atmos.microphysics_model)
+compute_hfls(_, _, _, model) = error_diagnostic_variable("hfls", model)
 
-function compute_hfls!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
+function compute_hfls(_, cache, _, ::MoistMicrophysics)
     (; ρ_flux_q_tot) = cache.precomputed.sfc_conditions
     (; surface_ct3_unit) = cache.core
     thermo_params = CAP.thermodynamics_params(cache.params)
     LH_v0 = TD.Parameters.LH_v0(thermo_params)
-
-    if isnothing(out)
-        return dot.(ρ_flux_q_tot, surface_ct3_unit) .* LH_v0
-    else
-        out .= dot.(ρ_flux_q_tot, surface_ct3_unit) .* LH_v0
-    end
+    return @. lazy(dot(ρ_flux_q_tot, surface_ct3_unit) * LH_v0)
 end
 
-add_diagnostic_variable!(
-    short_name = "hfls",
+add_diagnostic_variable!(short_name = "hfls", units = "W m^-2",
     long_name = "Surface Upward Latent Heat Flux",
     standard_name = "surface_upward_latent_heat_flux",
-    units = "W m^-2",
-    compute! = compute_hfls!,
+    compute = compute_hfls,
 )
 
 ###
 # Sensible heat flux (2d)
 ###
-compute_hfss!(out, state, cache, time) =
-    compute_hfss!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hfss!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hfss", model)
+compute_hfss(state, cache, time) =
+    compute_hfss(state, cache, time, cache.atmos.microphysics_model)
+compute_hfss(_, _, _, model) = error_diagnostic_variable("hfss", model)
 
-function compute_hfss!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: DryModel}
+function compute_hfss(_, cache, _, ::DryModel)
     (; ρ_flux_h_tot) = cache.precomputed.sfc_conditions
     (; surface_ct3_unit) = cache.core
-
-    if isnothing(out)
-        return dot.(ρ_flux_h_tot, surface_ct3_unit)
-    else
-        out .= dot.(ρ_flux_h_tot, surface_ct3_unit)
-    end
+    return @. lazy(dot(ρ_flux_h_tot, surface_ct3_unit))
 end
 
-function compute_hfss!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
+function compute_hfss(_, cache, _, ::MoistMicrophysics)
     (; ρ_flux_h_tot, ρ_flux_q_tot) = cache.precomputed.sfc_conditions
     (; surface_ct3_unit) = cache.core
     thermo_params = CAP.thermodynamics_params(cache.params)
     LH_v0 = TD.Parameters.LH_v0(thermo_params)
-
-    if isnothing(out)
-        return dot.(ρ_flux_h_tot, surface_ct3_unit) .-
-               dot.(ρ_flux_q_tot, surface_ct3_unit) .* LH_v0
-    else
-        out .=
-            dot.(ρ_flux_h_tot, surface_ct3_unit) .-
-            dot.(ρ_flux_q_tot, surface_ct3_unit) .* LH_v0
-    end
+    return @. lazy(
+        dot(ρ_flux_h_tot, surface_ct3_unit) -
+        dot(ρ_flux_q_tot, surface_ct3_unit) * LH_v0,
+    )
 end
 
-add_diagnostic_variable!(
-    short_name = "hfss",
+add_diagnostic_variable!(short_name = "hfss", units = "W m^-2",
     long_name = "Surface Upward Sensible Heat Flux",
     standard_name = "surface_upward_sensible_heat_flux",
-    units = "W m^-2",
-    compute! = compute_hfss!,
+    compute = compute_hfss,
 )
 
 ###
 # Precipitation (2d)
 ###
-compute_pr!(out, state, cache, time) =
-    compute_pr!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_pr!(_, _, _, _, microphysics_model::T) where {T} =
-    error_diagnostic_variable("pr", microphysics_model)
+compute_pr(state, cache, time) =
+    compute_pr(state, cache, time, cache.atmos.microphysics_model)
+compute_pr(_, _, _, model) = error_diagnostic_variable("pr", model)
 
-function compute_pr!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        DryModel,
-        EquilibriumMicrophysics0M,
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return cache.precomputed.surface_rain_flux .+
-               cache.precomputed.surface_snow_flux
-    else
-        out .=
-            cache.precomputed.surface_rain_flux .+
-            cache.precomputed.surface_snow_flux
-    end
-end
+compute_pr(_, cache, _, ::Union{DryModel, MoistMicrophysics}) =
+    @. lazy(cache.precomputed.surface_rain_flux + cache.precomputed.surface_snow_flux)
 
-add_diagnostic_variable!(
-    short_name = "pr",
+add_diagnostic_variable!(short_name = "pr", units = "kg m^-2 s^-1",
     long_name = "Precipitation",
     standard_name = "precipitation",
-    units = "kg m^-2 s^-1",
     comments = "Total precipitation including rain and snow",
-    compute! = compute_pr!,
+    compute = compute_pr,
 )
 
-compute_prra!(out, state, cache, time) =
-    compute_prra!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_prra!(_, _, _, _, microphysics_model::T) where {T} =
-    error_diagnostic_variable("prra", microphysics_model)
+compute_prra(state, cache, time) =
+    compute_prra(state, cache, time, cache.atmos.microphysics_model)
+compute_prra(_, _, _, model) = error_diagnostic_variable("prra", model)
 
-function compute_prra!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        DryModel,
-        EquilibriumMicrophysics0M,
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return cache.precomputed.surface_rain_flux
-    else
-        out .= cache.precomputed.surface_rain_flux
-    end
-end
+compute_prra(_, cache, _, ::Union{DryModel, MoistMicrophysics}) =
+    cache.precomputed.surface_rain_flux
 
-add_diagnostic_variable!(
-    short_name = "prra",
+add_diagnostic_variable!(short_name = "prra", units = "kg m^-2 s^-1",
     long_name = "Rainfall Flux",
     standard_name = "rainfall_flux",
-    units = "kg m^-2 s^-1",
     comments = "Precipitation including all forms of water in the liquid phase",
-    compute! = compute_prra!,
+    compute = compute_prra,
 )
 
-compute_prsn!(out, state, cache, time) =
-    compute_prsn!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_prsn!(_, _, _, _, microphysics_model::T) where {T} =
-    error_diagnostic_variable("prsn", microphysics_model)
+compute_prsn(state, cache, time) =
+    compute_prsn(state, cache, time, cache.atmos.microphysics_model)
+compute_prsn(_, _, _, model) = error_diagnostic_variable("prsn", model)
 
-function compute_prsn!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        DryModel,
-        EquilibriumMicrophysics0M,
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return cache.precomputed.surface_snow_flux
-    else
-        out .= cache.precomputed.surface_snow_flux
-    end
-end
+compute_prsn(_, cache, _, ::Union{DryModel, MoistMicrophysics}) =
+    cache.precomputed.surface_snow_flux
 
-add_diagnostic_variable!(
-    short_name = "prsn",
+add_diagnostic_variable!(short_name = "prsn", units = "kg m^-2 s^-1",
     long_name = "Snowfall Flux",
     standard_name = "snowfall_flux",
-    units = "kg m^-2 s^-1",
     comments = "Precipitation including all forms of water in the solid phase",
-    compute! = compute_prsn!,
+    compute = compute_prsn,
 )
 
 ###
 # Precipitation (3d)
 ###
-compute_husra!(out, state, cache, time) =
-    compute_husra!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_husra!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("husra", model)
+compute_husra(state, cache, time) =
+    compute_husra(state, cache, time, cache.atmos.microphysics_model)
+compute_husra(_, _, _, model) = error_diagnostic_variable("husra", model)
 
-function compute_husra!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return state.c.ρq_rai ./ state.c.ρ
-    else
-        out .= state.c.ρq_rai ./ state.c.ρ
-    end
-end
+compute_husra(state, _, _,
+    ::Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M},
+) = @. lazy(specific(state.c.ρq_rai, state.c.ρ))
 
-add_diagnostic_variable!(
-    short_name = "husra",
+add_diagnostic_variable!(short_name = "husra", units = "kg kg^-1",
     long_name = "Mass Fraction of Rain",
     standard_name = "mass_fraction_of_rain_in_air",
-    units = "kg kg^-1",
     comments = """
-    This is calculated as the mass of rain water in the grid cell divided by
+    This is calculated as the mass of rain water in the grid cell divided by 
     the mass of air (dry air + water vapor + cloud condensate) in the grid cells.
     """,
-    compute! = compute_husra!,
+    compute = compute_husra,
 )
 
-compute_hussn!(out, state, cache, time) =
-    compute_hussn!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hussn!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hussn", model)
+compute_hussn(state, cache, time) =
+    compute_hussn(state, cache, time, cache.atmos.microphysics_model)
+compute_hussn(_, _, _, model) = error_diagnostic_variable("hussn", model)
 
-function compute_hussn!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return state.c.ρq_sno ./ state.c.ρ
-    else
-        out .= state.c.ρq_sno ./ state.c.ρ
-    end
-end
+compute_hussn(state, _, _,
+    ::Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M},  # TODO: Remove 2M from dispatch
+) = @. lazy(specific(state.c.ρq_sno, state.c.ρ))
 
-add_diagnostic_variable!(
-    short_name = "hussn",
+add_diagnostic_variable!(short_name = "hussn", units = "kg kg^-1",
     long_name = "Mass Fraction of Snow",
     standard_name = "mass_fraction_of_snow_in_air",
-    units = "kg kg^-1",
     comments = """
-    This is calculated as the mass of snow in the grid cell divided by
+    This is calculated as the mass of snow in the grid cell divided by 
     the mass of air (dry air + water vapor + cloud condensate) in the grid cells.
     """,
-    compute! = compute_hussn!,
+    compute = compute_hussn,
 )
 
-compute_cdnc!(out, state, cache, time) =
-    compute_cdnc!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_cdnc!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("cdnc", model)
+compute_cdnc(state, cache, time) =
+    compute_cdnc(state, cache, time, cache.atmos.microphysics_model)
+compute_cdnc(_, _, _, model) = error_diagnostic_variable("cdnc", model)
 
-function compute_cdnc!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return state.c.ρn_lcl
-    else
-        out .= state.c.ρn_lcl
-    end
-end
+compute_cdnc(state, _, _, ::NonEquilibriumMicrophysics2M) = state.c.ρn_lcl
 
-add_diagnostic_variable!(
-    short_name = "cdnc",
+add_diagnostic_variable!(short_name = "cdnc", units = "m^-3",
     long_name = "Cloud Liquid Droplet Number Concentration",
     standard_name = "number_concentration_of_cloud_liquid_water_particles_in_air",
-    units = "m^-3",
     comments = """
-    This is calculated as the number of cloud liquid water droplets in the grid 
-    cell divided by the cell volume.
+    This is calculated as the number of cloud liquid water droplets in the grid cell
+    divided by the cell volume.
     """,
-    compute! = compute_cdnc!,
+    compute = compute_cdnc,
 )
 
-compute_ncra!(out, state, cache, time) =
-    compute_ncra!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_ncra!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("ncra", model)
+compute_ncra(state, cache, time) =
+    compute_ncra(state, cache, time, cache.atmos.microphysics_model)
+compute_ncra(_, _, _, model) = error_diagnostic_variable("ncra", model)
 
-function compute_ncra!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::Union{
-        NonEquilibriumMicrophysics2M,
-        NonEquilibriumMicrophysics2MP3,
-    },
-)
-    if isnothing(out)
-        return state.c.ρn_rai
-    else
-        out .= state.c.ρn_rai
-    end
-end
+compute_ncra(state, _, _, ::NonEquilibriumMicrophysics2M) = state.c.ρn_rai
 
-add_diagnostic_variable!(
-    short_name = "ncra",
+add_diagnostic_variable!(short_name = "ncra", units = "m^-3",
     long_name = "Raindrop Number Concentration",
     standard_name = "number_concentration_of_raindrops_in_air",
-    units = "m^-3",
-    comments = """
-    This is calculated as the number of raindrops in the grid cell divided
-    by the cell volume.
-    """,
-    compute! = compute_ncra!,
+    comments = "This is calculated as the number of raindrops in the grid cell \
+                divided by the cell volume.",
+    compute = compute_ncra,
 )
 
 ###
@@ -1141,30 +627,19 @@ add_diagnostic_variable!(
 compute_orog!(out, state, cache, time) =
     compute_orog!(out, state, cache, time, axes(state.c).grid.hypsography)
 
-function compute_orog!(out, state, cache, time, hypsography::Grids.Flat)
-    # When we have a Flat topography, we just have to return a field of zeros
-    if isnothing(out)
-        return zeros(Spaces.horizontal_space(axes(state.c.ρ)))
-    else
-        # There's shouldn't be much point in this branch, but let's leave it here for
-        # consistency
-        out .= zeros(Spaces.horizontal_space(axes(state.c.ρ)))
-    end
+function compute_orog!(out, state, _, _, ::Grids.Flat)
+    hspace = Spaces.horizontal_space(axes(state.c.ρ))
+    isnothing(out) ? zeros(hspace) : (out .= 0)
 end
 
-function compute_orog!(out, state, cache, time, hypsography)
-    if isnothing(out)
-        return Geometry.tofloat.(hypsography.surface)
-    else
-        out .= Geometry.tofloat.(hypsography.surface)
-    end
+function compute_orog!(out, _, _, _, hypsography)
+    sfc = @. lazy(Geometry.tofloat(hypsography.surface))
+    isnothing(out) ? Base.materialize(sfc) : (out .= sfc)
 end
 
-add_diagnostic_variable!(
-    short_name = "orog",
+add_diagnostic_variable!(short_name = "orog", units = "m",
     long_name = "Surface Altitude",
     standard_name = "surface_altitude",
-    units = "m",
     comments = "Elevation of the horizontal coordinates",
     compute! = compute_orog!,
 )
@@ -1172,373 +647,196 @@ add_diagnostic_variable!(
 ###
 # Condensed water path (2d)
 ###
-compute_clwvi!(out, state, cache, time) =
-    compute_clwvi!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_clwvi!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("clwvi", model)
+compute_clwvi(state, cache, time) =
+    compute_clwvi(state, cache, time, cache.atmos.microphysics_model)
+compute_clwvi(_, _, _, model) = error_diagnostic_variable("clwvi", model)
 
-function compute_clwvi!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::EquilibriumMicrophysics0M,
-)
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        clw = cache.scratch.ᶜtemp_scalar
-        @. clw =
-            state.c.ρ * (
-                cache.precomputed.ᶜq_liq +
-                cache.precomputed.ᶜq_ice
-            )
-        Operators.column_integral_definite!(out, clw)
-        return out
-    else
-        clw = cache.scratch.ᶜtemp_scalar
-        @. clw =
-            state.c.ρ * (
-                cache.precomputed.ᶜq_liq +
-                cache.precomputed.ᶜq_ice
-            )
-        Operators.column_integral_definite!(out, clw)
-    end
+function compute_clwvi(state, cache, _, ::EquilibriumMicrophysics0M)
+    out = cache.scratch.ᶠtemp_field_level
+    (; ᶜq_liq, ᶜq_ice) = cache.precomputed
+    clw = @. lazy(state.c.ρ * (ᶜq_liq + ᶜq_ice))
+    Operators.column_integral_definite!(out, clw)
+    return out
 end
 
-function compute_clwvi!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::NonEquilibriumMicrophysics,
-)
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        clw = cache.scratch.ᶜtemp_scalar
-        @. clw = state.c.ρq_lcl + state.c.ρq_icl
-        Operators.column_integral_definite!(out, clw)
-        return out
-    else
-        clw = cache.scratch.ᶜtemp_scalar
-        @. clw = state.c.ρq_lcl + state.c.ρq_icl
-        Operators.column_integral_definite!(out, clw)
-    end
+function compute_clwvi(state, cache, _, ::NonEquilibriumMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    clw = @. lazy(state.c.ρq_lcl + state.c.ρq_icl)
+    Operators.column_integral_definite!(out, clw)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "clwvi",
+add_diagnostic_variable!(short_name = "clwvi", units = "kg m^-2",
     long_name = "Condensed Water Path",
     standard_name = "atmosphere_mass_content_of_cloud_condensed_water",
-    units = "kg m^-2",
     comments = """
-    Mass of condensed (liquid + ice) water in the column divided by the area of the column
-    (not just the area of the cloudy portion of the column). It doesn't include precipitating hydrometeors.
+    Mass of condensed (liquid + ice) water in the column divided by
+    the area of the column (not just the cloudy portion).
+    Does not include precipitating hydrometeors.
     """,
-    compute! = compute_clwvi!,
+    compute = compute_clwvi,
 )
 
 ###
 # Liquid water path (2d)
 ###
-compute_lwp!(out, state, cache, time) =
-    compute_lwp!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_lwp!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("lwp", model)
+compute_lwp(state, cache, time) =
+    compute_lwp(state, cache, time, cache.atmos.microphysics_model)
+compute_lwp(_, _, _, model) = error_diagnostic_variable("lwp", model)
 
-function compute_lwp!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::EquilibriumMicrophysics0M,
-)
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        lw = cache.scratch.ᶜtemp_scalar
-        @. lw = state.c.ρ * cache.precomputed.ᶜq_liq
-        Operators.column_integral_definite!(out, lw)
-        return out
-    else
-        lw = cache.scratch.ᶜtemp_scalar
-        @. lw = state.c.ρ * cache.precomputed.ᶜq_liq
-        Operators.column_integral_definite!(out, lw)
-    end
+function compute_lwp(state, cache, _, ::EquilibriumMicrophysics0M)
+    out = cache.scratch.ᶠtemp_field_level
+    lw = @. lazy(state.c.ρ * cache.precomputed.ᶜq_liq)
+    Operators.column_integral_definite!(out, lw)
+    return out
 end
 
-function compute_lwp!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::NonEquilibriumMicrophysics,
-)
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        lw = cache.scratch.ᶜtemp_scalar
-        @. lw = state.c.ρq_lcl
-        Operators.column_integral_definite!(out, lw)
-        return out
-    else
-        lw = cache.scratch.ᶜtemp_scalar
-        @. lw = state.c.ρq_lcl
-        Operators.column_integral_definite!(out, lw)
-    end
+function compute_lwp(state, cache, _, ::NonEquilibriumMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    lw = state.c.ρq_lcl
+    Operators.column_integral_definite!(out, lw)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "lwp",
+add_diagnostic_variable!(short_name = "lwp", units = "kg m^-2",
     long_name = "Liquid Water Path",
     standard_name = "atmosphere_mass_content_of_cloud_liquid_water",
-    units = "kg m^-2",
-    comments = """
-    The total mass of liquid water in cloud per unit area.
-    (not just the area of the cloudy portion of the column). It doesn't include precipitating hydrometeors.
-    """,
-    compute! = compute_lwp!,
+    comments = "The total mass of liquid water in cloud per unit area. \
+                Does not include precipitating hydrometeors.",
+    compute = compute_lwp,
 )
 
 ###
 # Ice water path (2d)
 ###
-compute_clivi!(out, state, cache, time) =
-    compute_clivi!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_clivi!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("clivi", model)
+compute_clivi(state, cache, time) =
+    compute_clivi(state, cache, time, cache.atmos.microphysics_model)
+compute_clivi(_, _, _, model) = error_diagnostic_variable("clivi", model)
 
-function compute_clivi!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        cli = cache.scratch.ᶜtemp_scalar
-        @. cli = state.c.ρ * cache.precomputed.ᶜq_ice
-        Operators.column_integral_definite!(out, cli)
-        return out
-    else
-        cli = cache.scratch.ᶜtemp_scalar
-        @. cli = state.c.ρ * cache.precomputed.ᶜq_ice
-        Operators.column_integral_definite!(out, cli)
-    end
+function compute_clivi(state, cache, _, ::MoistMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    cli = @. lazy(state.c.ρ * cache.precomputed.ᶜq_ice)
+    Operators.column_integral_definite!(out, cli)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "clivi",
+add_diagnostic_variable!(short_name = "clivi", units = "kg m^-2",
     long_name = "Ice Water Path",
     standard_name = "atmosphere_mass_content_of_cloud_ice",
-    units = "kg m^-2",
-    comments = """
-    The total mass of ice in cloud per unit area.
-    (not just the area of the cloudy portion of the column). It doesn't include precipitating hydrometeors.
-    """,
-    compute! = compute_clivi!,
+    comments = "The total mass of ice in cloud per unit area. \
+                Does not include precipitating hydrometeors.",  # TODO: This comment is not correct for 2M
+    compute = compute_clivi,
 )
 
 
 ###
 # Vertical integrated dry static energy (2d)
 ###
-function compute_dsevi!(out, state, cache, time)
+function compute_dsevi(state, cache, _)
     thermo_params = CAP.thermodynamics_params(cache.params)
     ᶜT = cache.precomputed.ᶜT
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        cp = CAP.cp_d(cache.params)
-        dse = cache.scratch.ᶜtemp_scalar
-        @. dse = state.c.ρ * (TD.dry_static_energy(thermo_params, ᶜT, cache.core.ᶜΦ))
-        Operators.column_integral_definite!(out, dse)
-        return out
-    else
-        cp = CAP.cp_d(cache.params)
-        dse = cache.scratch.ᶜtemp_scalar
-        @. dse = state.c.ρ * (TD.dry_static_energy(thermo_params, ᶜT, cache.core.ᶜΦ))
-        Operators.column_integral_definite!(out, dse)
-    end
+    out = cache.scratch.ᶠtemp_field_level
+    dse = @. lazy(state.c.ρ * TD.dry_static_energy(thermo_params, ᶜT, cache.core.ᶜΦ))
+    Operators.column_integral_definite!(out, dse)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "dsevi",
+add_diagnostic_variable!(short_name = "dsevi", units = "",
     long_name = "Dry Static Energy Vertical Integral",
-    units = "",
-    comments = """
-    """,
-    compute! = compute_dsevi!,
+    compute = compute_dsevi,
 )
 
 ###
-# column integrated cloud fraction (2d)
+# Column integrated cloud fraction (2d)
 ###
-compute_clvi!(out, state, cache, time) =
-    compute_clvi!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_clvi!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("clvi", model)
+compute_clvi(state, cache, time) =
+    compute_clvi(state, cache, time, cache.atmos.microphysics_model)
+compute_clvi(_, _, _, model) = error_diagnostic_variable("clvi", model)
 
-function compute_clvi!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        cloud_cover = cache.scratch.ᶜtemp_scalar
-        FT = Spaces.undertype(axes(cloud_cover))
-        @. cloud_cover = ifelse(
-            cache.precomputed.ᶜcloud_fraction > zero(FT),
-            one(FT),
-            zero(FT),
-        )
-        Operators.column_integral_definite!(out, cloud_cover)
-        return out
-    else
-        cloud_cover = cache.scratch.ᶜtemp_scalar
-        FT = Spaces.undertype(axes(cloud_cover))
-        @. cloud_cover = ifelse(
-            cache.precomputed.ᶜcloud_fraction > zero(FT),
-            one(FT),
-            zero(FT),
-        )
-        Operators.column_integral_definite!(out, cloud_cover)
-    end
+function compute_clvi(_, cache, _, ::MoistMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    (; ᶜcloud_fraction) = cache.precomputed
+    FT = eltype(ᶜcloud_fraction)
+    cloud_cover = @. lazy(ifelse(ᶜcloud_fraction > zero(FT), one(FT), zero(FT)))
+    Operators.column_integral_definite!(out, cloud_cover)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "clvi",
+add_diagnostic_variable!(short_name = "clvi", units = "m",
     long_name = "Vertical Cloud Fraction Integral",
-    units = "m",
-    comments = """
-    The total height of the column occupied at least partially by cloud.
-    """,
-    compute! = compute_clvi!,
+    comments = "The total height of the column occupied at least partially by cloud.",
+    compute = compute_clvi,
 )
 
 
 ###
 # Column integrated total specific humidity (2d)
 ###
-compute_prw!(out, state, cache, time) =
-    compute_prw!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_prw!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("prw", model)
+compute_prw(state, cache, time) =
+    compute_prw(state, cache, time, cache.atmos.microphysics_model)
+compute_prw(_, _, _, model) = error_diagnostic_variable("prw", model)
 
-function compute_prw!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        Operators.column_integral_definite!(out, state.c.ρq_tot)
-        return out
-    else
-        Operators.column_integral_definite!(out, state.c.ρq_tot)
-    end
+function compute_prw(state, cache, _, ::MoistMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    Operators.column_integral_definite!(out, state.c.ρq_tot)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "prw",
+add_diagnostic_variable!(short_name = "prw", units = "kg m^-2",
     long_name = "Water Vapor Path",
     standard_name = "atmospheric_mass_content_of_water_vapor",
-    units = "kg m^-2",
     comments = "Vertically integrated specific humidity",
-    compute! = compute_prw!,
+    compute = compute_prw,
 )
 
 ###
 # Column integrated relative humidity (2d)
 ###
-compute_hurvi!(out, state, cache, time) =
-    compute_hurvi!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_hurvi!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("hurvi", model)
+compute_hurvi(state, cache, time) =
+    compute_hurvi(state, cache, time, cache.atmos.microphysics_model)
+compute_hurvi(_, _, _, model) = error_diagnostic_variable("hurvi", model)
 
-function compute_hurvi!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
+function compute_hurvi(state, cache, _, ::MoistMicrophysics)
     thermo_params = CAP.thermodynamics_params(cache.params)
     (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
     # Vapor specific humidity = q_tot - q_liq - q_ice
     ᶜq_vap = @. lazy(ᶜq_tot_nonneg - ᶜq_liq - ᶜq_ice)
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        # compute vertical integral of saturation specific humidity
-        # note next line currently allocates; currently no correct scratch space
-        sat_vi = zeros(axes(Fields.level(state.f, half)))
-        sat = cache.scratch.ᶜtemp_scalar
-        @. sat =
-            state.c.ρ *
-            TD.q_vap_saturation(thermo_params, ᶜT, state.c.ρ, ᶜq_liq, ᶜq_ice)
-        Operators.column_integral_definite!(sat_vi, sat)
-        # compute saturation-weighted vertical integral of specific humidity
-        hur_weighted = cache.scratch.ᶜtemp_scalar_2
-        @. hur_weighted = state.c.ρ * ᶜq_vap / sat_vi
-        Operators.column_integral_definite!(out, hur_weighted)
-        return out
-    else
-        # compute vertical integral of saturation specific humidity
-        # note next line currently allocates; currently no correct scratch space
-        sat_vi = zeros(axes(Fields.level(state.f, half)))
-        sat = cache.scratch.ᶜtemp_scalar
-        @. sat =
-            state.c.ρ *
-            TD.q_vap_saturation(thermo_params, ᶜT, state.c.ρ, ᶜq_liq, ᶜq_ice)
-        Operators.column_integral_definite!(sat_vi, sat)
-        # compute saturation-weighted vertical integral of specific humidity
-        hur_weighted = cache.scratch.ᶜtemp_scalar_2
-        @. hur_weighted = state.c.ρ * ᶜq_vap / sat_vi
-        Operators.column_integral_definite!(out, hur_weighted)
-    end
+    # vertical integral of saturation specific humidity
+    sat_vi = cache.scratch.ᶠtemp_field_level
+    sat = @. lazy(
+        state.c.ρ * TD.q_vap_saturation(thermo_params, ᶜT, state.c.ρ, ᶜq_liq, ᶜq_ice),
+    )
+    Operators.column_integral_definite!(sat_vi, sat)
+    # saturation-weighted vertical integral
+    hur_weighted = @. lazy(state.c.ρ * ᶜq_vap / sat_vi)
+    out = cache.scratch.ᶠtemp_field_level
+    Operators.column_integral_definite!(out, hur_weighted)
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "hurvi",
+add_diagnostic_variable!(short_name = "hurvi", units = "kg m^-2",
     long_name = "Relative Humidity Saturation-Weighted Vertical Integral",
-    units = "kg m^-2",
     comments = "Integrated relative humidity over the vertical column",
-    compute! = compute_hurvi!,
+    compute = compute_hurvi,
 )
 
 
 ###
 # Vapor specific humidity (3d)
 ###
-compute_husv!(out, state, cache, time) =
-    compute_husv!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_husv!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("husv", model)
+compute_husv(state, cache, time) =
+    compute_husv(state, cache, time, cache.atmos.microphysics_model)
+compute_husv(_, _, _, model) = error_diagnostic_variable("husv", model)
 
-function compute_husv!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {T <: MoistMicrophysics}
-    # Vapor specific humidity = q_tot - q_liq - q_ice
+function compute_husv(_, cache, _, ::MoistMicrophysics)
     (; ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
-    if isnothing(out)
-        return @. ᶜq_tot_nonneg - ᶜq_liq - ᶜq_ice
-    else
-        out .= @. ᶜq_tot_nonneg - ᶜq_liq - ᶜq_ice
-    end
+    return @. lazy(ᶜq_tot_nonneg - ᶜq_liq - ᶜq_ice)
 end
 
-add_diagnostic_variable!(
-    short_name = "husv",
+add_diagnostic_variable!(short_name = "husv", units = "kg kg^-1",
     long_name = "Vapor Specific Humidity",
-    units = "kg kg^-1",
     comments = "Mass of water vapor per mass of air",
-    compute! = compute_husv!,
+    compute = compute_husv,
 )
 
 ###
@@ -1547,211 +845,124 @@ add_diagnostic_variable!(
 
 # These are only available when `check_steady_state` is `true`.
 
-add_diagnostic_variable!(
-    short_name = "uapredicted",
+add_diagnostic_variable!(short_name = "uapredicted", units = "m s^-1",
     long_name = "Predicted Eastward Wind",
-    units = "m s^-1",
     comments = "Predicted steady-state eastward (zonal) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            u_component.(cache.steady_state_velocity.ᶜu)
-        else
-            out .= u_component.(cache.steady_state_velocity.ᶜu)
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(u_component(cache.steady_state_velocity.ᶜu))),
 )
 
-add_diagnostic_variable!(
-    short_name = "vapredicted",
+add_diagnostic_variable!(short_name = "vapredicted", units = "m s^-1",
     long_name = "Predicted Northward Wind",
-    units = "m s^-1",
     comments = "Predicted steady-state northward (meridional) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            v_component.(cache.steady_state_velocity.ᶜu)
-        else
-            out .= v_component.(cache.steady_state_velocity.ᶜu)
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(v_component(cache.steady_state_velocity.ᶜu))),
 )
 
-add_diagnostic_variable!(
-    short_name = "wapredicted",
+add_diagnostic_variable!(short_name = "wapredicted", units = "m s^-1",
     long_name = "Predicted Upward Air Velocity",
-    units = "m s^-1",
     comments = "Predicted steady-state vertical wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            w_component.(cache.steady_state_velocity.ᶠu)
-        else
-            out .= w_component.(cache.steady_state_velocity.ᶠu)
-        end
-    end,
+    compute = (_, cache, _) -> @.(lazy(w_component(cache.steady_state_velocity.ᶠu))),
 )
 
-add_diagnostic_variable!(
-    short_name = "uaerror",
+compute_uaerror(cache) = @. lazy(
+    u_component(UVW(cache.precomputed.ᶜu)) -
+    u_component(cache.steady_state_velocity.ᶜu),
+)
+
+add_diagnostic_variable!(short_name = "uaerror", units = "m s^-1",
     long_name = "Error of Eastward Wind",
-    units = "m s^-1",
     comments = "Error of steady-state eastward (zonal) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            u_component.(Geometry.UVWVector.(cache.precomputed.ᶜu)) .-
-            u_component.(cache.steady_state_velocity.ᶜu)
-        else
-            out .=
-                u_component.(Geometry.UVWVector.(cache.precomputed.ᶜu)) .-
-                u_component.(cache.steady_state_velocity.ᶜu)
-        end
-    end,
+    compute = (_, cache, _) -> compute_uaerror(cache),
 )
 
-add_diagnostic_variable!(
-    short_name = "vaerror",
+compute_vaerror(cache) = @. lazy(
+    v_component(UVW(cache.precomputed.ᶜu)) -
+    v_component(cache.steady_state_velocity.ᶜu),
+)
+
+add_diagnostic_variable!(short_name = "vaerror", units = "m s^-1",
     long_name = "Error of Northward Wind",
-    units = "m s^-1",
     comments = "Error of steady-state northward (meridional) wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            v_component.(Geometry.UVWVector.(cache.precomputed.ᶜu)) .-
-            v_component.(cache.steady_state_velocity.ᶜu)
-        else
-            out .=
-                v_component.(Geometry.UVWVector.(cache.precomputed.ᶜu)) .-
-                v_component.(cache.steady_state_velocity.ᶜu)
-        end
-    end,
+    compute = (_, cache, _) -> compute_vaerror(cache),
 )
 
-add_diagnostic_variable!(
-    short_name = "waerror",
+compute_waerror(cache) = @. lazy(
+    w_component(UVW(cache.precomputed.ᶠu)) -
+    w_component(cache.steady_state_velocity.ᶠu),
+)
+
+add_diagnostic_variable!(short_name = "waerror", units = "m s^-1",
     long_name = "Error of Upward Air Velocity",
-    units = "m s^-1",
     comments = "Error of steady-state vertical wind component",
-    compute! = (out, state, cache, time) -> begin
-        if isnothing(out)
-            w_component.(Geometry.UVWVector.(cache.precomputed.ᶠu)) .-
-            w_component.(cache.steady_state_velocity.ᶠu)
-        else
-            out .=
-                w_component.(Geometry.UVWVector.(cache.precomputed.ᶠu)) .-
-                w_component.(cache.steady_state_velocity.ᶠu)
-        end
-    end,
+    compute = (_, cache, _) -> compute_waerror(cache),
 )
 
 ###
 # Convective Available Potential Energy (2d)
 ###
-function compute_cape!(out, state, cache, time)
-    thermo_params = lazy.(CAP.thermodynamics_params(cache.params))
-    FT = eltype(thermo_params)
-    g = lazy.(TD.Parameters.grav(thermo_params))
+function compute_cape(state, cache, _)
+    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice, ᶜp, sfc_conditions) = cache.precomputed
+    tps = CAP.thermodynamics_params(cache.params)
+    FT = eltype(tps)
+    g = TD.Parameters.grav(tps)
 
     # Get surface parcel properties from sfc_conditions
     # At the surface, q_tot ≈ q_vap (no condensate)
-    surface_q = lazy.(cache.precomputed.sfc_conditions.q_vap_sfc)
-    surface_T = lazy.(cache.precomputed.sfc_conditions.T_sfc)
+    surface_q = sfc_conditions.q_vap_sfc
+    surface_T = sfc_conditions.T_sfc
     # Use lowest level pressure as approximate surface pressure
-    surface_p = lazy.(Fields.level(ᶠinterp.(cache.precomputed.ᶜp), half))
+    surface_p = lazy.(Fields.level(ᶠinterp.(ᶜp), half))
     # Compute liquid-ice potential temperature at surface (no condensate, so q_liq=q_ice=0)
     surface_θ_liq_ice =
-        lazy.(
-            TD.liquid_ice_pottemp_given_pressure.(
-                thermo_params,
-                surface_T,
-                surface_p,
-                surface_q,
-            ),
-        )
+        lazy.(TD.liquid_ice_pottemp_given_pressure.(tps, surface_T, surface_p, surface_q))
 
     # Helper function to extract just T from saturation_adjustment result
     # (avoids broadcasting issues with NamedTuple containing bool)
-    _parcel_T_from_sa(thermo_params, p, θ_liq_ice, q_tot, maxiter) =
-        TD.saturation_adjustment(
-            thermo_params,
-            TD.pθ_li(),
-            p,
-            θ_liq_ice,
-            q_tot;
-            maxiter,
-        ).T
+    _parcel_T_from_sa(tps, p, θ_liq_ice, q_tot, maxiter) =
+        TD.saturation_adjustment(tps, TD.pθ_li(), p, θ_liq_ice, q_tot; maxiter).T
 
     # Create parcel thermodynamic states at each level based on energy & moisture at surface
-    parcel_T =
-        lazy.(
-            _parcel_T_from_sa.(
-                thermo_params,
-                cache.precomputed.ᶜp,
-                surface_θ_liq_ice,
-                surface_q,
-                4,
-            ),
-        )
+    parcel_T = lazy.(_parcel_T_from_sa.(tps, ᶜp, surface_θ_liq_ice, surface_q, 4))
 
     # Calculate virtual temperatures for parcel & environment
-    parcel_Tv = lazy.(TD.virtual_temperature.(thermo_params, parcel_T, surface_q))
-    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = cache.precomputed
-    env_Tv =
-        lazy.(
-            TD.virtual_temperature.(
-                thermo_params,
-                ᶜT,
-                ᶜq_tot_nonneg,
-                ᶜq_liq,
-                ᶜq_ice,
-            ),
-        )
+    parcel_Tv = lazy.(TD.virtual_temperature.(tps, parcel_T, surface_q))
+    env_Tv = lazy.(TD.virtual_temperature.(tps, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
 
     # Calculate buoyancy from the difference in virtual temperatures
     ᶜbuoyancy = cache.scratch.ᶜtemp_scalar
-    ᶜbuoyancy .= g .* (parcel_Tv .- env_Tv) ./ env_Tv
+    @. ᶜbuoyancy = g * (parcel_Tv - env_Tv) / env_Tv
 
-    # restrict to tropospheric buoyancy (generously below 20km) TODO: integrate from LFC to LNB 
-    FT = Spaces.undertype(axes(ᶜbuoyancy))
-    ᶜbuoyancy .=
-        ᶜbuoyancy .*
-        ifelse.(
-            Fields.coordinate_field(state.c.ρ).z .< FT(20000.0),
-            FT(1.0),
-            FT(0.0),
-        )
+    # restrict to tropospheric buoyancy (generously below 20km) TODO: integrate from LFC to LNB
+    z = Fields.coordinate_field(state.c.ρ).z
+    @. ᶜbuoyancy = ᶜbuoyancy * ifelse(z < FT(20000), FT(1), FT(0))
 
     # Integrate positive buoyancy to get CAPE
-    out′ = isnothing(out) ? zeros(axes(Fields.level(state.f, half))) : out
-    Operators.column_integral_definite!(out′, lazy.(max.(ᶜbuoyancy, 0)))
-    return out′
+    out = cache.scratch.ᶠtemp_field_level
+    Operators.column_integral_definite!(out, lazy.(max.(ᶜbuoyancy, 0)))
+    return out
 end
 
-add_diagnostic_variable!(
-    short_name = "cape",
+add_diagnostic_variable!(short_name = "cape", units = "J kg^-1",
     long_name = "Convective Available Potential Energy",
     standard_name = "convective_available_potential_energy",
-    units = "J kg^-1",
-    comments = "Energy available to a parcel lifted moist adiabatically from the surface. We assume fully reversible phase changes and no precipitation.",
-    compute! = compute_cape!,
+    comments = "Energy available to a parcel lifted moist adiabatically from the surface. \
+                Assumes fully reversible phase changes and no precipitation.",
+    compute = compute_cape,
 )
 
 ###
 # Mean sea level pressure (2d)
 ###
-function compute_mslp!(out, state, cache, time)
-    thermo_params = CAP.thermodynamics_params(cache.params)
-    g = TD.Parameters.grav(thermo_params)
-    q_tot_nonneg_level = Fields.level(cache.precomputed.ᶜq_tot_nonneg, 1)
-    q_liq_level = Fields.level(cache.precomputed.ᶜq_liq, 1)
-    q_ice_level = Fields.level(cache.precomputed.ᶜq_ice, 1)
-    R_m_surf = @. lazy(
-        TD.gas_constant_air(
-            thermo_params,
-            q_tot_nonneg_level,
-            q_liq_level,
-            q_ice_level,
-        ),
-    )
+function compute_mslp(state, cache, _)
+    (; ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice, ᶜp, ᶜT) = cache.precomputed
+    tps = CAP.thermodynamics_params(cache.params)
+    g = TD.Parameters.grav(tps)
+    q_tot_safe_level = Fields.level(ᶜq_tot_nonneg, 1)
+    q_liq_level = Fields.level(ᶜq_liq, 1)
+    q_ice_level = Fields.level(ᶜq_ice, 1)
+    R_m_surf = lazy.(TD.gas_constant_air.(tps, q_tot_safe_level, q_liq_level, q_ice_level))
 
-    p_level = Fields.level(cache.precomputed.ᶜp, 1)
-    t_level = Fields.level(cache.precomputed.ᶜT, 1)
+    p_level = Fields.level(ᶜp, 1)
+    t_level = Fields.level(ᶜT, 1)
     z_level = Fields.level(Fields.coordinate_field(state.c.ρ).z, 1)
 
     # Reduce to mean sea level using hypsometric formulation with lapse rate adjustment
@@ -1769,135 +980,97 @@ function compute_mslp!(out, state, cache, time)
     #     accounts for virtual-temperature effects in the exponent
     #   - Γ constant lapse rate (6.5 K/km here)
 
-    if isnothing(out)
-        return p_level .* (1 .+ Γ .* z_level ./ t_level) .^ (g / Γ ./ R_m_surf)
-    else
-        out .= p_level .* (1 .+ Γ .* z_level ./ t_level) .^ (g / Γ ./ R_m_surf)
-    end
+    return @. lazy(p_level * (1 + Γ * z_level / t_level)^(g / Γ / R_m_surf))
 end
 
-add_diagnostic_variable!(
-    short_name = "mslp",
+add_diagnostic_variable!(short_name = "mslp", units = "Pa",
     long_name = "Mean Sea Level Pressure",
     standard_name = "mean_sea_level_pressure",
-    units = "Pa",
-    comments = "Mean sea level pressure computed using a lapse-rate-dependent hypsometric reduction (ERA-style; Γ=6.5 K/km with virtual temperature via moist gas constant).",
-    compute! = compute_mslp!,
+    comments = """
+    Mean sea level pressure computed using a lapse-rate-dependent hypsometric reduction 
+    (ERA-style; Γ=6.5 K/km with virtual temperature via moist gas constant).""",
+    compute = compute_mslp,
 )
 
 ###
 # Rainwater path (2d)
 ###
-compute_rwp!(out, state, cache, time) =
-    compute_rwp!(out, state, cache, time, cache.atmos.microphysics_model)
-compute_rwp!(_, _, _, _, model::T) where {T} =
-    error_diagnostic_variable("rwp", model)
+compute_rwp(state, cache, time) =
+    compute_rwp(state, cache, time, cache.atmos.microphysics_model)
+compute_rwp(_, _, _, model) = error_diagnostic_variable("rwp", model)
 
-function compute_rwp!(
-    out,
-    state,
-    cache,
-    time,
-    microphysics_model::T,
-) where {
-    T <: Union{
-        NonEquilibriumMicrophysics1M,
-        NonEquilibriumMicrophysics2M,
+function compute_rwp(state, cache, _,
+    ::Union{
+        NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M,
         NonEquilibriumMicrophysics2MP3,
     },
-}
-    if isnothing(out)
-        out = zeros(axes(Fields.level(state.f, half)))
-        rw = cache.scratch.ᶜtemp_scalar
-        @. rw = state.c.ρq_rai
-        Operators.column_integral_definite!(out, rw)
-        return out
-    else
-        rw = cache.scratch.ᶜtemp_scalar
-        @. rw = state.c.ρq_rai
-        Operators.column_integral_definite!(out, rw)
-    end
+)
+    rwp = cache.scratch.ᶠtemp_field_level
+    Operators.column_integral_definite!(rwp, state.c.ρq_rai)
+    return rwp
 end
 
-add_diagnostic_variable!(
-    short_name = "rwp",
+add_diagnostic_variable!(short_name = "rwp", units = "kg m^-2",
     long_name = "Rainwater Path",
     standard_name = "atmosphere_mass_content_of_rainwater",
-    units = "kg m^-2",
     comments = """
     The total mass of rainwater per unit area.
     (not just the area of the cloudy portion of the column).
     """,
-    compute! = compute_rwp!,
+    compute = compute_rwp,
 )
 
 ###
 # Covariances (3d)
 ###
-function compute_covariance_diagnostics!(out, state, cache, time, type)
-    thermo_params = CAP.thermodynamics_params(cache.params)
-
-    # Read T-based variances from cache
+function compute_covariance_diagnostics(_, cache, _, type)
     (; ᶜT′T′, ᶜq′q′) = cache.precomputed
-
-    result = if type == :qt_qt
-        ᶜq′q′
+    if type == :qt_qt
+        return ᶜq′q′
     elseif type == :T_T
-        ᶜT′T′
+        return ᶜT′T′
     elseif type == :T_qt
         corr = correlation_Tq(cache.params)
-        @. corr * sqrt(max(0, ᶜT′T′)) * sqrt(max(0, ᶜq′q′))
+        return @. lazy(corr * sqrt(max(0, ᶜT′T′)) * sqrt(max(0, ᶜq′q′)))
     else
         error("Unknown variance type")
     end
-
-    if isnothing(out)
-        return copy(result)
-    else
-        out .= result
-    end
 end
 
-compute_env_q_tot_variance!(out, state, cache, time) =
-    compute_covariance_diagnostics!(out, state, cache, time, :qt_qt)
-compute_env_temperature_variance!(out, state, cache, time) =
-    compute_covariance_diagnostics!(out, state, cache, time, :T_T)
-compute_env_q_tot_temperature_covariance!(out, state, cache, time) =
-    compute_covariance_diagnostics!(out, state, cache, time, :T_qt)
+compute_env_q_tot_variance(state, cache, time) =
+    compute_covariance_diagnostics(state, cache, time, :qt_qt)
+compute_env_temperature_variance(state, cache, time) =
+    compute_covariance_diagnostics(state, cache, time, :T_T)
+compute_env_q_tot_temperature_covariance(state, cache, time) =
+    compute_covariance_diagnostics(state, cache, time, :T_qt)
 
-function compute_env_q_tot_temperature_correlation!(out, state, cache, time)
+function compute_env_q_tot_temperature_correlation(_, cache, _)
     corr = correlation_Tq(cache.params)
-    if isnothing(out)
-        return fill(corr, axes(state.c))
-    else
-        out .= corr
-    end
+    (; ᶜtemp_scalar) = cache.scratch
+    return @. lazy(one(ᶜtemp_scalar) * corr)
 end
 
-add_diagnostic_variable!(
-    short_name = "env_q_tot_variance",
+add_diagnostic_variable!(short_name = "env_q_tot_variance", units = "kg^2 kg^-2",
     long_name = "Environment Variance of Total Specific Humidity",
-    units = "kg^2 kg^-2",
-    compute! = compute_env_q_tot_variance!,
+    compute = compute_env_q_tot_variance,
 )
 
 add_diagnostic_variable!(
-    short_name = "env_temperature_variance",
+    short_name = "env_temperature_variance", units = "K^2",
     long_name = "Environment Variance of Temperature",
-    units = "K^2",
-    compute! = compute_env_temperature_variance!,
+    compute = compute_env_temperature_variance,
 )
 
 add_diagnostic_variable!(
     short_name = "env_q_tot_temperature_covariance",
     long_name = "Environment Covariance of Total Specific Humidity and Temperature",
     units = "kg K kg^-1",
-    compute! = compute_env_q_tot_temperature_covariance!,
+    compute = compute_env_q_tot_temperature_covariance,
 )
 
 add_diagnostic_variable!(
     short_name = "env_q_tot_temperature_correlation",
     long_name = "Environment Correlation of Total Specific Humidity and Temperature",
     units = "1",
-    compute! = compute_env_q_tot_temperature_correlation!,
+    compute = compute_env_q_tot_temperature_correlation,
 )

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -52,7 +52,7 @@ compute_waup(state, cache, time) =
 compute_waup(_, _, _, turbconv_model) = error_diagnostic_variable("waup", turbconv_model)
 
 compute_waup(_, cache, _, ::Union{PrognosticEDMFX, DiagnosticEDMFX}) =
-    @. lazy(w_component(Geometry.WVector(cache.precomputed.ᶜuʲs.:1)))
+    @. lazy(w_component(WVec(cache.precomputed.ᶜuʲs.:1)))
 
 add_diagnostic_variable!(short_name = "waup", units = "m s^-1",
     long_name = "Updraft Upward Air Velocity",
@@ -434,7 +434,7 @@ compute_waen(state, cache, time) =
 compute_waen(_, _, _, turbconv_model) = error_diagnostic_variable("waen", turbconv_model)
 
 compute_waen(_, cache, _, ::Union{PrognosticEDMFX, DiagnosticEDMFX}) =
-    @. lazy(w_component(Geometry.WVector(cache.precomputed.ᶜu⁰)))
+    @. lazy(w_component(WVec(cache.precomputed.ᶜu⁰)))
 
 add_diagnostic_variable!(short_name = "waen", units = "m s^-1",
     long_name = "Environment Upward Air Velocity",

--- a/src/diagnostics/gravitywave_diagnostics.jl
+++ b/src/diagnostics/gravitywave_diagnostics.jl
@@ -4,67 +4,37 @@
 ###
 # Eastward Non-Orographic Gravity-Wave Tendency 
 ###
-compute_utendnogw!(out, state, cache, time) = compute_utendnogw!(
-    out,
-    state,
-    cache,
-    time,
-    cache.atmos.non_orographic_gravity_wave,
+compute_utendnogw(state, cache, time) = compute_utendnogw(
+    state, cache, time, cache.atmos.non_orographic_gravity_wave,
 )
-compute_utendnogw!(_, _, _, _, non_orographic_gravity_wave) =
+compute_utendnogw(_, _, _, non_orographic_gravity_wave) =
     error_diagnostic_variable("utendnogw", non_orographic_gravity_wave)
 
-function compute_utendnogw!(out, state, cache, time, ::NonOrographicGravityWave)
-    if pkgversion(ClimaDiagnostics) >= v"0.2.13"
-        return cache.non_orographic_gravity_wave.uforcing
-    else
-        if isnothing(out)
-            return copy(cache.non_orographic_gravity_wave.uforcing)
-        else
-            out .= cache.non_orographic_gravity_wave.uforcing
-        end
-    end
-end
+compute_utendnogw(_, cache, _, ::NonOrographicGravityWave) =
+    cache.non_orographic_gravity_wave.uforcing
 
-add_diagnostic_variable!(
-    short_name = "utendnogw",
+add_diagnostic_variable!(short_name = "utendnogw", units = "m s^-2",
     long_name = "Eastward Acceleration Due to Non-Orographic Gravity Wave Drag",
     standard_name = "tendency_of_eastward_wind_due_to_nonorographic_gravity_wave_drag",
-    units = "m s-2",
     comments = "Eastward Acceleration Due to Non-Orographic Gravity Wave Drag",
-    compute! = compute_utendnogw!,
+    compute = compute_utendnogw,
 )
 
 ###
 # Northward Non-Orographic Gravity-Wave Tendency 
 ###
-compute_vtendnogw!(out, state, cache, time) = compute_vtendnogw!(
-    out,
-    state,
-    cache,
-    time,
-    cache.atmos.non_orographic_gravity_wave,
+compute_vtendnogw(state, cache, time) = compute_vtendnogw(
+    state, cache, time, cache.atmos.non_orographic_gravity_wave,
 )
-compute_vtendnogw!(_, _, _, _, non_orographic_gravity_wave) =
+compute_vtendnogw(_, _, _, non_orographic_gravity_wave) =
     error_diagnostic_variable("vtendnogw", non_orographic_gravity_wave)
 
-function compute_vtendnogw!(out, state, cache, time, ::NonOrographicGravityWave)
-    if pkgversion(ClimaDiagnostics) >= v"0.2.13"
-        return cache.non_orographic_gravity_wave.vforcing
-    else
-        if isnothing(out)
-            return copy(cache.non_orographic_gravity_wave.vforcing)
-        else
-            out .= cache.non_orographic_gravity_wave.vforcing
-        end
-    end
-end
+compute_vtendnogw(_, cache, _, ::NonOrographicGravityWave) =
+    cache.non_orographic_gravity_wave.vforcing
 
-add_diagnostic_variable!(
-    short_name = "vtendnogw",
+add_diagnostic_variable!(short_name = "vtendnogw", units = "m s^-2",
     long_name = "Northward Acceleration Due to Non-Orographic Gravity Wave Drag",
     standard_name = "tendency_of_northward_wind_due_to_nonorographic_gravity_wave_drag",
-    units = "m s-2",
     comments = "Northward Acceleration Due to Non-Orographic Gravity Wave Drag",
-    compute! = compute_vtendnogw!,
+    compute = compute_vtendnogw,
 )

--- a/src/diagnostics/radiation_diagnostics.jl
+++ b/src/diagnostics/radiation_diagnostics.jl
@@ -1,1145 +1,505 @@
 # This file is included in Diagnostics.jl
 
 """
-    apply_geometric_scaling!(out, z, planet_radius, FT)
+    geometric_scaling(z, planet_radius)
 
-Apply spherical shell geometric correction to radiative fluxes at radial height `z`.
+Compute geometric scaling factor for radiative fluxes at radial height `z`.
 
 Helper function for scaling radiation diagnostics.
 """
-function apply_geometric_scaling!(out, z, planet_radius, FT)
-    @. out *= ((z + planet_radius) / planet_radius)^(FT(2))
+geometric_scaling(z, planet_radius) = ((z + planet_radius) / planet_radius)^2
+
+"""
+    ᶠradiation_field_3d(state, cache, radiation_mode, field_name::Symbol)
+    ᶠradiation_field_toa(state, cache, radiation_mode, field_name::Symbol)
+    ᶠradiation_field_sfc(state, cache, field_name::Symbol)
+
+Compute radiative fluxes as a diagnostic field in 3d, at TOA, or at the surface.
+
+# Arguments
+- `state, cache`: The model state and cache
+- `radiation_mode`: The RRTMGP radiation mode
+- `field_name`: Symbol naming the flux field on `cache.radiation.rrtmgp_model`,
+  e.g. `:face_sw_flux_dn`
+
+"""
+function ᶠradiation_field_3d(state, cache, radiation_mode, field_name::Symbol)
+    (; deep_atmosphere) = radiation_mode
+    planet_radius = CAP.planet_radius(cache.params)
+    z = Fields.coordinate_field(axes(state.f)).z
+    field = getproperty(cache.radiation.rrtmgp_model, field_name)
+    flux = Fields.array2field(field, axes(state.f))
+    deep_atmosphere ? lazy.(flux .* geometric_scaling.(z, planet_radius)) : flux
 end
+
+function ᶠradiation_field_sfc(state, cache, field_name::Symbol)
+    field = getproperty(cache.radiation.rrtmgp_model, field_name)
+    Fields.level(Fields.array2field(field, axes(state.f)), half)
+end
+
+function ᶠradiation_field_toa(state, cache, radiation_mode, field_name::Symbol)
+    (; deep_atmosphere) = radiation_mode
+    nlevels = Spaces.nlevels(axes(state.c))
+    z_max = Spaces.z_max(axes(state.f))
+    planet_radius = CAP.planet_radius(cache.params)
+    field = getproperty(cache.radiation.rrtmgp_model, field_name)
+    flux = Fields.level(Fields.array2field(field, axes(state.f)), nlevels + half)
+    deep_atmosphere ? lazy.(flux .* geometric_scaling.(z_max, planet_radius)) : flux
+end
+
 # Radiative fluxes
 
 ###
 # Downwelling shortwave radiation (3d)
 ###
-compute_rsd!(out, state, cache, time) =
-    compute_rsd!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsd!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rsd", radiation_mode)
+compute_rsd(state, cache, time) =
+    compute_rsd(state, cache, time, cache.atmos.radiation_mode)
+compute_rsd(_, _, _, radiation_mode) = error_diagnostic_variable("rsd", radiation_mode)
 
-function compute_rsd!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_dn,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_sw_flux_dn,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+compute_rsd(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_3d(state, cache, radiation_mode, :face_sw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rsd",
+add_diagnostic_variable!(short_name = "rsd", units = "W m^-2",
     long_name = "Downwelling Shortwave Radiation",
     standard_name = "surface_downwelling_shortwave_flux_in_air",
-    units = "W m^-2",
-    comments = "Downwelling shortwave radiation",
-    compute! = compute_rsd!,
+    comments = "Downwelling shortwave radiation (3d)",
+    compute = compute_rsd,
 )
 
 ###
 # TOA downwelling shortwave radiation (2d)
 ###
-compute_rsdt!(out, state, cache, time) =
-    compute_rsdt!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsdt!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rsdt", radiation_mode)
+compute_rsdt(state, cache, time) =
+    compute_rsdt(state, cache, time, cache.atmos.radiation_mode)
+compute_rsdt(_, _, _, radiation_mode) = error_diagnostic_variable("rsdt", radiation_mode)
 
-function compute_rsdt!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    nlevels = Spaces.nlevels(axes(state.c))
-    z_max = Spaces.z_max(axes(state.f))
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_sw_flux_dn,
-                    axes(state.f),
-                ),
-                nlevels + half,
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-        return out
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_dn,
-                axes(state.f),
-            ),
-            nlevels + half,
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-    end
-end
+compute_rsdt(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_toa(state, cache, radiation_mode, :face_sw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rsdt",
+add_diagnostic_variable!(short_name = "rsdt", units = "W m^-2",
     long_name = "TOA Incident Shortwave Radiation",
     standard_name = "toa_incoming_shortwave_flux",
-    units = "W m^-2",
     comments = "Downward shortwave radiation at the top of the atmosphere",
-    compute! = compute_rsdt!,
+    compute = compute_rsdt,
 )
 
 ###
 # Surface downwelling shortwave radiation (2d)
 ###
-compute_rsds!(out, state, cache, time) =
-    compute_rsds!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsds!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rsds", radiation_mode)
+compute_rsds(state, cache, time) =
+    compute_rsds(state, cache, time, cache.atmos.radiation_mode)
+compute_rsds(_, _, _, radiation_mode) = error_diagnostic_variable("rsds", radiation_mode)
 
-function compute_rsds!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_sw_flux_dn,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_dn,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rsds(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_sw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rsds",
+add_diagnostic_variable!(short_name = "rsds", units = "W m^-2",
     long_name = "Surface Downwelling Shortwave Radiation",
     standard_name = "surface_downwelling_shortwave_flux_in_air",
-    units = "W m^-2",
     comments = "Downwelling shortwave radiation at the surface",
-    compute! = compute_rsds!,
+    compute = compute_rsds,
 )
 
 ###
-# Upwelling shortwave radiation (2d)
+# Upwelling shortwave radiation (3d)
 ###
-compute_rsu!(out, state, cache, time) =
-    compute_rsu!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsu!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rsu", radiation_mode)
+compute_rsu(state, cache, time) =
+    compute_rsu(state, cache, time, cache.atmos.radiation_mode)
+compute_rsu(_, _, _, radiation_mode) = error_diagnostic_variable("rsu", radiation_mode)
 
-function compute_rsu!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_up,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_sw_flux_up,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+compute_rsu(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_3d(state, cache, radiation_mode, :face_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsu",
+add_diagnostic_variable!(short_name = "rsu", units = "W m^-2",
     long_name = "Upwelling Shortwave Radiation",
     standard_name = "surface_upwelling_shortwave_flux_in_air",
-    units = "W m^-2",
-    comments = "Upwelling shortwave radiation",
-    compute! = compute_rsu!,
+    comments = "Upwelling shortwave radiation (3d)",
+    compute = compute_rsu,
 )
 
 ###
 # TOA upwelling shortwave radiation (2d)
 ###
-compute_rsut!(out, state, cache, time) =
-    compute_rsut!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsut!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsut(state, cache, time) =
+    compute_rsut(state, cache, time, cache.atmos.radiation_mode)
+compute_rsut(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsut", radiation_mode)
 
-function compute_rsut!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    nlevels = Spaces.nlevels(axes(state.c))
-    z_max = Spaces.z_max(axes(state.f))
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_sw_flux_up,
-                    axes(state.f),
-                ),
-                nlevels + half,
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-        return out
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_up,
-                axes(state.f),
-            ),
-            nlevels + half,
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-    end
-end
+compute_rsut(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_toa(state, cache, radiation_mode, :face_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsut",
+add_diagnostic_variable!(short_name = "rsut", units = "W m^-2",
     long_name = "TOA Outgoing Shortwave Radiation",
     standard_name = "toa_outgoing_shortwave_flux",
-    units = "W m^-2",
     comments = "Upwelling shortwave radiation at the top of the atmosphere",
-    compute! = compute_rsut!,
+    compute = compute_rsut,
 )
 
 ###
 # Surface upwelling shortwave radiation (2d)
 ###
-compute_rsus!(out, state, cache, time) =
-    compute_rsus!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsus!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rsus", radiation_mode)
+compute_rsus(state, cache, time) =
+    compute_rsus(state, cache, time, cache.atmos.radiation_mode)
+compute_rsus(_, _, _, radiation_mode) = error_diagnostic_variable("rsus", radiation_mode)
 
-function compute_rsus!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_sw_flux_up,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_sw_flux_up,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rsus(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsus",
+add_diagnostic_variable!(short_name = "rsus", units = "W m^-2",
     long_name = "Surface Upwelling Shortwave Radiation",
     standard_name = "surface_upwelling_shortwave_flux_in_air",
-    units = "W m^-2",
     comments = "Upwelling shortwave radiation at the surface",
-    compute! = compute_rsus!,
+    compute = compute_rsus,
 )
 
 ###
 # Downwelling longwave radiation (3d)
 ###
-compute_rld!(out, state, cache, time) =
-    compute_rld!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rld!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rld", radiation_mode)
+compute_rld(state, cache, time) =
+    compute_rld(state, cache, time, cache.atmos.radiation_mode)
+compute_rld(_, _, _, radiation_mode) = error_diagnostic_variable("rld", radiation_mode)
 
-function compute_rld!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_lw_flux_dn,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_lw_flux_dn,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+compute_rld(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_3d(state, cache, radiation_mode, :face_lw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rld",
+add_diagnostic_variable!(short_name = "rld", units = "W m^-2",
     long_name = "Downwelling Longwave Radiation",
     standard_name = "surface_downwelling_longwave_flux_in_air",
-    units = "W m^-2",
     comments = "Downwelling longwave radiation",
-    compute! = compute_rld!,
+    compute = compute_rld,
 )
 
 ###
 # Surface downwelling longwave radiation (2d)
 ###
-compute_rlds!(out, state, cache, time) =
-    compute_rlds!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlds!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rlds(state, cache, time) =
+    compute_rlds(state, cache, time, cache.atmos.radiation_mode)
+compute_rlds(_, _, _, radiation_mode) =
     error_diagnostic_variable("rlds", radiation_mode)
 
-function compute_rlds!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_lw_flux_dn,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_lw_flux_dn,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rlds(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_lw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rlds",
+add_diagnostic_variable!(short_name = "rlds", units = "W m^-2",
     long_name = "Surface Downwelling Longwave Radiation",
     standard_name = "surface_downwelling_longwave_flux_in_air",
-    units = "W m^-2",
     comments = "Downwelling longwave radiation at the surface",
-    compute! = compute_rlds!,
+    compute = compute_rlds,
 )
 
 ###
 # Upwelling longwave radiation (3d)
 ###
-compute_rlu!(out, state, cache, time) =
-    compute_rlu!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlu!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rlu", radiation_mode)
+compute_rlu(state, cache, time) =
+    compute_rlu(state, cache, time, cache.atmos.radiation_mode)
+compute_rlu(_, _, _, radiation_mode) = error_diagnostic_variable("rlu", radiation_mode)
 
-function compute_rlu!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_lw_flux_up,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_lw_flux_up,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+compute_rlu(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_3d(state, cache, radiation_mode, :face_lw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rlu",
+add_diagnostic_variable!(short_name = "rlu", units = "W m^-2",
     long_name = "Upwelling Longwave Radiation",
     standard_name = "surface_upwelling_longwave_flux_in_air",
-    units = "W m^-2",
     comments = "Upwelling longwave radiation",
-    compute! = compute_rlu!,
+    compute = compute_rlu,
 )
 
 ###
 # TOA upwelling longwave radiation (2d)
 ###
-compute_rlut!(out, state, cache, time) =
-    compute_rlut!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlut!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rlut(state, cache, time) =
+    compute_rlut(state, cache, time, cache.atmos.radiation_mode)
+compute_rlut(_, _, _, radiation_mode) =
     error_diagnostic_variable("rlut", radiation_mode)
 
-function compute_rlut!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    nlevels = Spaces.nlevels(axes(state.c))
-    z_max = Spaces.z_max(axes(state.f))
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_lw_flux_up,
-                    axes(state.f),
-                ),
-                nlevels + half,
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-        return out
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_lw_flux_up,
-                axes(state.f),
-            ),
-            nlevels + half,
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-    end
-end
+compute_rlut(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_toa(state, cache, radiation_mode, :face_lw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rlut",
+add_diagnostic_variable!(short_name = "rlut", units = "W m^-2",
     long_name = "TOA Outgoing Longwave Radiation",
     standard_name = "toa_outgoing_longwave_flux",
-    units = "W m^-2",
     comments = "Upwelling longwave radiation at the top of the atmosphere",
-    compute! = compute_rlut!,
+    compute = compute_rlut,
 )
 
 ###
 # Surface upwelling longwave radiation (2d)
 ###
-compute_rlus!(out, state, cache, time) =
-    compute_rlus!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlus!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rlus(state, cache, time) =
+    compute_rlus(state, cache, time, cache.atmos.radiation_mode)
+compute_rlus(_, _, _, radiation_mode) =
     error_diagnostic_variable("rlus", radiation_mode)
 
-function compute_rlus!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_lw_flux_up,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_lw_flux_up,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rlus(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_lw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rlus",
+add_diagnostic_variable!(short_name = "rlus", units = "W m^-2",
     long_name = "Surface Upwelling Longwave Radiation",
     standard_name = "surface_upwelling_longwave_flux_in_air",
-    units = "W m^-2",
     comments = "Upwelling longwave radiation at the surface",
-    compute! = compute_rlus!,
+    compute = compute_rlus,
 )
 
 ###
 # Downelling clear sky shortwave radiation (3d)
 ###
-compute_rsdcs!(out, state, cache, time) =
-    compute_rsdcs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsdcs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsdcs(state, cache, time) =
+    compute_rsdcs(state, cache, time, cache.atmos.radiation_mode)
+compute_rsdcs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsdcs", radiation_mode)
 
-function compute_rsdcs!(
-    out,
-    state,
-    cache,
-    time,
+compute_rsdcs(state, cache, _,
     radiation_mode::RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-)
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+) = ᶠradiation_field_3d(state, cache, radiation_mode, :face_clear_sw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rsdcs",
+add_diagnostic_variable!(short_name = "rsdcs", units = "W m^-2",
     long_name = "Downwelling Clear-Sky Shortwave Radiation",
     standard_name = "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
-    comments = "Downwelling clear sky shortwave radiation",
-    compute! = compute_rsdcs!,
+    comments = "Downwelling clear sky shortwave radiation (3d)",
+    compute = compute_rsdcs,
 )
 
 ###
 # Surface downwelling clear sky shortwave radiation (2d)
 ###
-compute_rsdscs!(out, state, cache, time) =
-    compute_rsdscs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsdscs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsdscs(state, cache, time) =
+    compute_rsdscs(state, cache, time, cache.atmos.radiation_mode)
+compute_rsdscs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsdscs", radiation_mode)
 
-function compute_rsdscs!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_sw_flux_dn,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rsdscs(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_clear_sw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rsdscs",
+add_diagnostic_variable!(short_name = "rsdscs", units = "W m^-2",
     long_name = "Surface Downwelling Clear-Sky Shortwave Radiation",
     standard_name = "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Downwelling clear-sky shortwave radiation at the surface",
-    compute! = compute_rsdscs!,
+    compute = compute_rsdscs,
 )
 
 ###
 # Upwelling clear sky shortwave radiation (3d)
 ###
-compute_rsucs!(out, state, cache, time) =
-    compute_rsucs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsucs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsucs(state, cache, time) =
+    compute_rsucs(state, cache, time, cache.atmos.radiation_mode)
+compute_rsucs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsucs", radiation_mode)
 
-function compute_rsucs!(
-    out,
-    state,
-    cache,
-    time,
+compute_rsucs(state, cache, _,
     radiation_mode::RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-)
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+) = ᶠradiation_field_3d(state, cache, radiation_mode, :face_clear_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsucs",
+add_diagnostic_variable!(short_name = "rsucs", units = "W m^-2",
     long_name = "Upwelling Clear-Sky Shortwave Radiation",
     standard_name = "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
-    comments = "Upwelling clear sky shortwave radiation",
-    compute! = compute_rsucs!,
+    comments = "Upwelling clear sky shortwave radiation (3d)",
+    compute = compute_rsucs,
 )
 
 ###
 # TOA upwelling clear sky shortwave radiation (2d)
 ###
-compute_rsutcs!(out, state, cache, time) =
-    compute_rsutcs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsutcs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsutcs(state, cache, time) =
+    compute_rsutcs(state, cache, time, cache.atmos.radiation_mode)
+compute_rsutcs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsutcs", radiation_mode)
 
-function compute_rsutcs!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    nlevels = Spaces.nlevels(axes(state.c))
-    z_max = Spaces.z_max(axes(state.f))
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-                    axes(state.f),
-                ),
-                nlevels + half,
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-        return out
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-                axes(state.f),
-            ),
-            nlevels + half,
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-    end
-end
+compute_rsutcs(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_toa(state, cache, radiation_mode, :face_clear_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsutcs",
+add_diagnostic_variable!(short_name = "rsutcs", units = "W m^-2",
     long_name = "TOA Outgoing Clear-Sky Shortwave Radiation",
     standard_name = "toa_outgoing_shortwave_flux_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Upwelling clear-sky shortwave radiation at the top of the atmosphere",
-    compute! = compute_rsutcs!,
+    compute = compute_rsutcs,
 )
 
 ###
 # Surface clear sky upwelling shortwave radiation (2d)
 ###
-compute_rsuscs!(out, state, cache, time) =
-    compute_rsuscs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rsuscs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rsuscs(state, cache, time) =
+    compute_rsuscs(state, cache, time, cache.atmos.radiation_mode)
+compute_rsuscs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rsuscs", radiation_mode)
 
-function compute_rsuscs!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_sw_flux_up,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rsuscs(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_clear_sw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rsuscs",
+add_diagnostic_variable!(short_name = "rsuscs", units = "W m^-2",
     long_name = "Surface Upwelling Clear-Sky Shortwave Radiation",
     standard_name = "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Upwelling clear-sky shortwave radiation at the surface",
-    compute! = compute_rsuscs!,
+    compute = compute_rsuscs,
 )
 
 
 ###
 # Downwelling clear sky longwave radiation (3d)
 ###
-compute_rldcs!(out, state, cache, time) =
-    compute_rldcs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rldcs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rldcs(state, cache, time) =
+    compute_rldcs(state, cache, time, cache.atmos.radiation_mode)
+compute_rldcs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rldcs", radiation_mode)
 
-function compute_rldcs!(
-    out,
-    state,
-    cache,
-    time,
+compute_rldcs(state, cache, _,
     radiation_mode::RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-)
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+) = ᶠradiation_field_3d(state, cache, radiation_mode, :face_clear_lw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rldcs",
+add_diagnostic_variable!(short_name = "rldcs", units = "W m^-2",
     long_name = "Downwelling Clear-Sky Longwave Radiation",
     standard_name = "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
-    comments = "Downwelling clear sky longwave radiation",
-    compute! = compute_rldcs!,
+    comments = "Downwelling clear sky longwave radiation (3d)",
+    compute = compute_rldcs,
 )
 
 ###
 # Surface clear sky downwelling longwave radiation (2d)
 ###
-compute_rldscs!(out, state, cache, time) =
-    compute_rldscs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rldscs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rldscs(state, cache, time) =
+    compute_rldscs(state, cache, time, cache.atmos.radiation_mode)
+compute_rldscs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rldscs", radiation_mode)
 
-function compute_rldscs!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    if isnothing(out)
-        return copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
-                    axes(state.f),
-                ),
-                half,
-            ),
-        )
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_lw_flux_dn,
-                axes(state.f),
-            ),
-            half,
-        )
-    end
-end
+compute_rldscs(state, cache, _, ::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_sfc(state, cache, :face_clear_lw_flux_dn)
 
-add_diagnostic_variable!(
-    short_name = "rldscs",
+add_diagnostic_variable!(short_name = "rldscs", units = "W m^-2",
     long_name = "Surface Downwelling Clear-Sky Longwave Radiation",
     standard_name = "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Downwelling clear-sky longwave radiation at the surface",
-    compute! = compute_rldscs!,
+    compute = compute_rldscs,
 )
 
 ###
 # Upwelling clear sky longwave radiation (3d)
 ###
-compute_rlucs!(out, state, cache, time) =
-    compute_rlucs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlucs!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("rlucs", radiation_mode)
+compute_rlucs(state, cache, time) =
+    compute_rlucs(state, cache, time, cache.atmos.radiation_mode)
+compute_rlucs(_, _, _, radiation_mode) = error_diagnostic_variable("rlucs", radiation_mode)
 
-function compute_rlucs!(
-    out,
-    state,
-    cache,
-    time,
+compute_rlucs(state, cache, _,
     radiation_mode::RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-)
-    z_lev = Fields.coordinate_field(axes(state.f)).z
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
-                axes(state.f),
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-        return out
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
-            axes(state.f),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_lev, planet_radius, FT)
-    end
-end
+) = ᶠradiation_field_3d(state, cache, radiation_mode, :face_clear_lw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rlucs",
+add_diagnostic_variable!(short_name = "rlucs", units = "W m^-2",
     long_name = "Upwelling Clear-Sky Longwave Radiation",
     standard_name = "surface_upwelling_longwave_flux_in_air_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Upwelling clear sky longwave radiation",
-    compute! = compute_rlucs!,
+    compute = compute_rlucs,
 )
 
 ###
 # TOA clear sky upwelling longwave radiation (2d)
 ###
-compute_rlutcs!(out, state, cache, time) =
-    compute_rlutcs!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_rlutcs!(_, _, _, _, radiation_mode::T) where {T} =
+compute_rlutcs(state, cache, time) =
+    compute_rlutcs(state, cache, time, cache.atmos.radiation_mode)
+compute_rlutcs(_, _, _, radiation_mode) =
     error_diagnostic_variable("rlutcs", radiation_mode)
 
-function compute_rlutcs!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::T,
-) where {T <: RRTMGPI.AbstractRRTMGPMode}
-    nlevels = Spaces.nlevels(axes(state.c))
-    z_max = Spaces.z_max(axes(state.f))
-    planet_radius = CAP.planet_radius(cache.params)
-    FT = eltype(cache.params)
-    if isnothing(out)
-        out = copy(
-            Fields.level(
-                Fields.array2field(
-                    cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
-                    axes(state.f),
-                ),
-                nlevels + half,
-            ),
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-        return out
-    else
-        out .= Fields.level(
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.face_clear_lw_flux_up,
-                axes(state.f),
-            ),
-            nlevels + half,
-        )
-        radiation_mode.deep_atmosphere &&
-            apply_geometric_scaling!(out, z_max, planet_radius, FT)
-    end
-end
+compute_rlutcs(state, cache, _, radiation_mode::RRTMGPI.AbstractRRTMGPMode) =
+    ᶠradiation_field_toa(state, cache, radiation_mode, :face_clear_lw_flux_up)
 
-add_diagnostic_variable!(
-    short_name = "rlutcs",
+add_diagnostic_variable!(short_name = "rlutcs", units = "W m^-2",
     long_name = "TOA Outgoing Clear-Sky Longwave Radiation",
     standard_name = "toa_outgoing_longwave_flux_assuming_clear_sky",
-    units = "W m^-2",
     comments = "Upwelling clear-sky longwave radiation at the top of the atmosphere",
-    compute! = compute_rlutcs!,
+    compute = compute_rlutcs,
 )
 
 
 ###
-# Effective radius for liquid clouds (3d)
+# Effective radius for liquid/ice clouds (3d)
 ###
-compute_reffclw!(out, state, cache, time) =
-    compute_reffclw!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_reffclw!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("reffclw", radiation_mode)
 
-function compute_reffclw!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::Union{
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-        RRTMGPI.AllSkyRadiation,
-    },
-)
-    FT = eltype(state)
-    if isnothing(out)
-        return Fields.array2field(
-            cache.radiation.rrtmgp_model.center_cloud_liquid_effective_radius,
-            axes(state.c),
-        ) .* FT(1e-6) # RRTMGP stores r_eff in microns
-    else
-        out .=
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.center_cloud_liquid_effective_radius,
-                axes(state.c),
-            ) .* FT(1e-6)
-    end
+# RRTMGP stores effective radii in microns; convert to SI metres.
+function ᶜreff_field(state, cache, field_name::Symbol)
+    field = getproperty(cache.radiation.rrtmgp_model, field_name)
+    reff = Fields.array2field(field, axes(state.c))
+    return @. lazy(reff / 1_000_000)  # μm -> m
 end
 
-add_diagnostic_variable!(
-    short_name = "reffclw",
+compute_reffclw(state, cache, time) =
+    compute_reffclw(state, cache, time, cache.atmos.radiation_mode)
+compute_reffclw(_, _, _, radiation_mode) =
+    error_diagnostic_variable("reffclw", radiation_mode)
+
+compute_reffclw(state, cache, _,
+    ::Union{RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics, RRTMGPI.AllSkyRadiation},
+) = ᶜreff_field(state, cache, :center_cloud_liquid_effective_radius)
+
+add_diagnostic_variable!(short_name = "reffclw", units = "m",
     long_name = "Effective radius for liquid clouds",
     standard_name = "effective_radius_of_cloud_liquid_particles",
-    units = "m",
-    comments = "In-cloud ratio of the third moment over the second moment of the particle size distribution. Set to zero outside of clouds.",
-    compute! = compute_reffclw!,
+    comments = "In-cloud ratio of the third moment over the second moment \
+                of the particle size distribution. Set to zero outside of clouds.",
+    compute = compute_reffclw,
 )
 
 ###
 # Effective radius for ice clouds (3d)
 ###
-compute_reffcli!(out, state, cache, time) =
-    compute_reffcli!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_reffcli!(_, _, _, _, radiation_mode::T) where {T} =
+compute_reffcli(state, cache, time) =
+    compute_reffcli(state, cache, time, cache.atmos.radiation_mode)
+compute_reffcli(_, _, _, radiation_mode) =
     error_diagnostic_variable("reffcli", radiation_mode)
 
-function compute_reffcli!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::Union{
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-        RRTMGPI.AllSkyRadiation,
-    },
-)
-    FT = eltype(state)
-    if isnothing(out)
-        return Fields.array2field(
-            cache.radiation.rrtmgp_model.center_cloud_ice_effective_radius,
-            axes(state.c),
-        ) .* FT(1e-6) # RRTMGP stores r_eff in microns
-    else
-        out .=
-            Fields.array2field(
-                cache.radiation.rrtmgp_model.center_cloud_ice_effective_radius,
-                axes(state.c),
-            ) .* FT(1e-6)
-    end
-end
+compute_reffcli(state, cache, _,
+    ::Union{RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics, RRTMGPI.AllSkyRadiation},
+) = ᶜreff_field(state, cache, :center_cloud_ice_effective_radius)
 
-add_diagnostic_variable!(
-    short_name = "reffcli",
+add_diagnostic_variable!(short_name = "reffcli", units = "m",
     long_name = "Effective radius for ice clouds",
     standard_name = "effective_radius_of_cloud_ice_particles",
-    units = "m",
-    comments = "In-cloud ratio of the third moment over the second moment of the particle size distribution. Set to zero outside of clouds.",
-    compute! = compute_reffcli!,
+    comments = "In-cloud ratio of the third moment over the second moment \
+                of the particle size distribution. Set to zero outside of clouds.",
+    compute = compute_reffcli,
 )
 
 ###
-# Aerosol extinction optical depth (2d)
+# Aerosol optical depth diagnostics (2d)
 ###
-compute_od550aer!(out, state, cache, time) =
-    compute_od550aer!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_od550aer!(_, _, _, _, radiation_mode::T) where {T} =
-    error_diagnostic_variable("od550aer", radiation_mode)
 
-function compute_od550aer!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::Union{
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-        RRTMGPI.AllSkyRadiation,
-        RRTMGPI.ClearSkyRadiation,
-    },
-)
+# Requires aerosol_radiation = true; field is defined on the surface face level.
+function ᶠaod_field(state, cache, field_name::Symbol)
     @assert cache.atmos.radiation_mode.aerosol_radiation "aerosol_radiation must be true to enable aerosol optical depth diagnostics"
-    FT = eltype(state)
-    if isnothing(out)
-        return Fields.array2field(
-            cache.radiation.rrtmgp_model.aod_sw_extinction,
-            axes(Fields.level(state.f, half)),
-        )
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.aod_sw_extinction,
-            axes(Fields.level(state.f, half)),
-        )
-    end
+    field = getproperty(cache.radiation.rrtmgp_model, field_name)
+    return Fields.array2field(field, axes(Fields.level(state.f, half)))
 end
 
-add_diagnostic_variable!(
-    short_name = "od550aer",
+const _AerosolRadiationModes = Union{
+    RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
+    RRTMGPI.AllSkyRadiation,
+    RRTMGPI.ClearSkyRadiation,
+}
+
+compute_od550aer(state, cache, time) =
+    compute_od550aer(state, cache, time, cache.atmos.radiation_mode)
+compute_od550aer(_, _, _, radiation_mode) =
+    error_diagnostic_variable("od550aer", radiation_mode)
+
+compute_od550aer(state, cache, _, ::_AerosolRadiationModes) =
+    ᶠaod_field(state, cache, :aod_sw_extinction)
+
+add_diagnostic_variable!(short_name = "od550aer", units = "",
     long_name = "Ambient Aerosol Optical Thickness at 550nm",
     standard_name = "atmosphere_optical_thickness_due_to_ambient_aerosol_particles",
-    units = "",
     comments = "Aerosol optical depth from the ambient aerosols at wavelength 550 nm",
-    compute! = compute_od550aer!,
+    compute = compute_od550aer,
 )
 
 ###
 # Aerosol scattering optical depth (2d)
 ###
-compute_odsc550aer!(out, state, cache, time) =
-    compute_odsc550aer!(out, state, cache, time, cache.atmos.radiation_mode)
-compute_odsc550aer!(_, _, _, _, radiation_mode::T) where {T} =
+compute_odsc550aer(state, cache, time) =
+    compute_odsc550aer(state, cache, time, cache.atmos.radiation_mode)
+compute_odsc550aer(_, _, _, radiation_mode) =
     error_diagnostic_variable("odsc550aer", radiation_mode)
 
-function compute_odsc550aer!(
-    out,
-    state,
-    cache,
-    time,
-    radiation_mode::Union{
-        RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics,
-        RRTMGPI.AllSkyRadiation,
-        RRTMGPI.ClearSkyRadiation,
-    },
-)
-    @assert cache.atmos.radiation_mode.aerosol_radiation "aerosol_radiation must be true to enable aerosol optical depth diagnostics"
-    FT = eltype(state)
-    if isnothing(out)
-        return Fields.array2field(
-            cache.radiation.rrtmgp_model.aod_sw_scattering,
-            axes(Fields.level(state.f, half)),
-        )
-    else
-        out .= Fields.array2field(
-            cache.radiation.rrtmgp_model.aod_sw_scattering,
-            axes(Fields.level(state.f, half)),
-        )
-    end
-end
+compute_odsc550aer(state, cache, _, ::_AerosolRadiationModes) =
+    ᶠaod_field(state, cache, :aod_sw_scattering)
 
-add_diagnostic_variable!(
-    short_name = "odsc550aer",
+add_diagnostic_variable!(short_name = "odsc550aer", units = "",
     long_name = "Ambient Scattering Aerosol Optical Thickness at 550nm",
-    units = "",
     comments = "Aerosol scattering optical depth from the ambient aerosols at wavelength 550 nm",
-    compute! = compute_odsc550aer!,
+    compute = compute_odsc550aer,
 )

--- a/src/setups/common/prognostic_variables.jl
+++ b/src/setups/common/prognostic_variables.jl
@@ -151,7 +151,10 @@ function turbconv_center_variables(
         )
     else  # NonEquilibriumMicrophysics2M
         sgsʲs = uniform_subdomains(
-            (; ρa, mse, q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno, n_liq, n_rai),
+            (; ρa, mse, q_tot,
+                q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno,
+                n_lcl = n_liq, n_rai,
+            ),
             turbconv_model,
         )
     end

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -12,6 +12,10 @@ const CT2 = Geometry.Contravariant2Vector
 const CT12 = Geometry.Contravariant12Vector
 const CT3 = Geometry.Contravariant3Vector
 const CT123 = Geometry.Contravariant123Vector
+const UVec = Geometry.UVector
+const VVec = Geometry.VVector
+const WVec = Geometry.WVector
+const UV = Geometry.UVVector
 const UVW = Geometry.UVWVector
 
 const divₕ = Operators.Divergence()

--- a/test/diagnostics/unit_diagnostics.jl
+++ b/test/diagnostics/unit_diagnostics.jl
@@ -1,0 +1,458 @@
+#=
+Unit tests for diagnostic compute functions defined in:
+  - conservation_diagnostics.jl
+  - core_diagnostics.jl
+  - edmfx_diagnostics.jl
+  - gravitywave_diagnostics.jl
+  - radiation_diagnostics.jl
+
+Design
+======
+Tests are driven by two tables:
+
+  VALID_CASES  — each entry is case(name, key) or case(name, (key1, key2, ...))
+                 where each key identifies a fixture in the `states` dict.
+                 The test loop runs the diagnostic against every listed fixture
+                 and asserts the result is all-finite. Multi-key entries exercise
+                 different model-dispatch paths for the same diagnostic.
+
+  SKIP_CASES   — Set of names from out-of-scope files (tracer_diagnostics.jl,
+                 negative_scalars_diagnostics.jl). These are excluded from the
+                 exhaustiveness check; their own test files should cover them.
+
+An exhaustiveness @testset verifies every registered diagnostic name appears in
+exactly one of the two tables. The check fails if a new diagnostic is added to a
+source file without a corresponding entry here.
+
+Additional spot-checks for model-dispatch error paths (variables that must throw
+on unsupported models) are in the "Model dispatch error paths" @testset below.
+These are not subject to exhaustiveness.
+
+Adding a new diagnostic
+=======================
+1. Identify which existing fixture key(s) cover the compute path(s). Prefer
+   reusing an existing key from `states` over adding a new fixture — most
+   model combinations are already present.
+
+2. Add case(name, key) or case(name, (key1, key2, ...)) to VALID_CASES, grouped
+   with related variables and annotated with the dispatch rationale.
+
+3. If no existing fixture covers the required model combination, add a new
+   fixture at the end of the fixture section and register it in `states` with a
+   descriptive key. Keep fixtures minimal: use the smallest grid (column unless
+   a sphere is required) and only enable the model components the diagnostic
+   actually needs.
+
+4. If the diagnostic must error on unsupported models, add a @test_throws case
+   to the "Model dispatch error paths" @testset.
+
+Fixtures
+========
+All fixtures are built once at module load time and shared across all cases.
+The `states` dict maps symbol keys to (Y, p) tuples. Available keys:
+
+  :dry            — DryModel + SlabOceanSST, column
+  :sphere         — DryModel + SlabOceanSST, sphere (also used for rv, orog, energyo)
+  :ssv            — DryModel + steady-state velocity, plane grid
+  :m0             — EquilibriumMicrophysics0M, column
+  :m1             — NonEquilibriumMicrophysics1M, column
+  :m2             — NonEquilibriumMicrophysics2M, column
+  :nogw           — 0M + NonOrographicGravityWave, column
+  :m0_slab_sphere — 0M + SlabOceanSST, sphere (watero)
+  :smag           — SmagorinskyLilly, sphere
+  :m0_pedmfx      — 0M + PrognosticEDMFX, column
+  :m1_pedmfx      — 1M + PrognosticEDMFX, column
+  :m1_dedmfx      — 1M + DiagnosticEDMFX, column
+  :m2_pedmfx      — 2M + PrognosticEDMFX, column
+  :vd             — VerticalDiffusion, column
+  :dwh            — DecayWithHeightDiffusion, column
+  :allsky         — AllSkyRadiationWithClearSkyDiagnostics + aerosol_radiation=true, column
+
+Pattern: Arrange – Act – Assert.
+=#
+
+using Test
+using Dates
+
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaAtmos.Parameters as CAP
+import ClimaCore: Fields, Spaces
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+"""
+    build_state_cache(FT, model; grid, kwargs...) -> (Y, p)
+
+Construct a minimal state vector `Y` and cache `p` for `model` on `grid`.
+All keyword arguments have sensible defaults; override only what the diagnostic
+under test actually requires (e.g. `aerosol_names` for aerosol diagnostics,
+`set_steady_state_velocity = true` for steady-state error diagnostics).
+"""
+function build_state_cache(FT, model; grid,
+    params = CA.ClimaAtmosParameters(FT),
+    ic = CA.Setups.DecayingProfile(; params),
+    surface_setup = CA.SurfaceConditions.DefaultExchangeCoefficients(),
+    dt = FT(1.0), start_date = DateTime(2010, 1, 1),
+    aerosol_names = [], time_varying_trace_gas_names = (),
+    set_steady_state_velocity = false,
+    vwb_species = nothing,
+)
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(ic, params, model, spaces.center_space, spaces.face_space)
+    # steady state velocity is only needed for some diagnostics
+    steady_state_velocity =
+        set_steady_state_velocity ?
+        CA.get_steady_state_velocity(
+            params, Y, CA.NoTopography(), "ConstantBuoyancyFrequencyProfile", "Linear",
+        ) : nothing
+    p = CA.build_cache(
+        Y, model, params, surface_setup, dt, start_date,
+        aerosol_names, time_varying_trace_gas_names, steady_state_velocity, vwb_species,
+    )
+    return Y, p
+end
+
+"""
+    compute_diag(diag, Y, p, t = 0)
+
+Invoke the compute function of a `DiagnosticVariable`, dispatching to either
+`diag.compute(Y, p, t)` or `diag.compute!(nothing, Y, p, t)` as appropriate.
+Also tests that exactly one of `compute` / `compute!` is defined.
+"""
+function compute_diag(diag, Y, p, t = 0)
+    has_compute = !isnothing(diag.compute)
+    has_compute! = !isnothing(diag.compute!)
+    # Exactly one of compute / compute! must be defined
+    @test has_compute != has_compute!
+    return has_compute ? diag.compute(Y, p, t) : diag.compute!(nothing, Y, p, t)
+end
+
+"""
+    field_data(result) -> AbstractArray
+
+Materialise a (possibly lazy) diagnostic result and return a flat numeric array
+suitable for `all(isfinite, ...)` checks.
+"""
+field_data(r) = parent(Base.materialize(r))
+
+# Look up a registered DiagnosticVariable by short name.
+getdiag(name) = CA.Diagnostics.get_diagnostic_variable(name)
+
+# ---------------------------------------------------------------------------
+# Fixtures — built once, shared across all test cases
+# ---------------------------------------------------------------------------
+
+FT = Float32
+params = CA.ClimaAtmosParameters(FT)
+
+sphere = CA.SphereGrid(FT; h_elem = 2)
+column = CA.ColumnGrid(FT)
+
+# Model configurations, state, cache
+
+## Dry model, also tests slab ocean
+model_dry =
+    CA.AtmosModel(; microphysics_model = CA.DryModel(), surface_model = CA.SlabOceanSST())
+(Y_dry, p_dry) = build_state_cache(FT, model_dry; grid = column);
+
+## Sphere with dry model
+(Y_sphere, p_sphere) = build_state_cache(FT, model_dry; grid = sphere);
+
+## Model with steady-state velocity
+# Mirrors the plane_no_topography_float64_test.yml config:
+#   PlaneGrid + LinearWarp (the default for PlaneGrid) + NoTopography
+#   + ConstantBuoyancyFrequencyProfile initial condition.
+plane = CA.PlaneGrid(FT; x_elem = 4, z_elem = 5, z_stretch = false)
+(Y_ssv, p_ssv) = build_state_cache(FT, model_dry; grid = plane,
+    ic = CA.Setups.ConstantBuoyancyFrequencyProfile(),
+    set_steady_state_velocity = true,
+);
+
+## Microphysics-specific models
+model_0m = CA.AtmosModel(; microphysics_model = CA.EquilibriumMicrophysics0M())
+model_1m = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophysics1M())
+model_2m = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophysics2M())
+(Y_0m, p_0m) = build_state_cache(FT, model_0m; grid = column);
+(Y_1m, p_1m) = build_state_cache(FT, model_1m; grid = column);
+(Y_2m, p_2m) = build_state_cache(FT, model_2m; grid = column);
+
+## Non-orographic gravity wave
+nogw_params = CA.NonOrographicGravityWaveParameters(FT)
+non_orographic_gravity_wave = CA.NonOrographicGravityWave(;
+    (f => getfield(nogw_params, f) for f in fieldnames(typeof(nogw_params)))...,
+)
+microphysics_model = CA.EquilibriumMicrophysics0M()
+model_nogw = CA.AtmosModel(; microphysics_model, non_orographic_gravity_wave)
+(Y_nogw, p_nogw) = build_state_cache(FT, model_nogw; grid = column);
+
+## Sphere with moist model + slab ocean (watero needs MoistMicrophysics + SpectralElementSpace2D)
+model_0m_slab = CA.AtmosModel(;
+    microphysics_model = CA.EquilibriumMicrophysics0M(),
+    surface_model = CA.SlabOceanSST(),
+)
+(Y_0m_slab_sphere, p_0m_slab_sphere) = build_state_cache(FT, model_0m_slab; grid = sphere);
+
+## Smagorinsky-Lilly LES model
+model_smag = CA.AtmosModel(smagorinsky_lilly = CA.SmagorinskyLilly(; axes = :UV_W))
+(Y_smag, p_smag) = build_state_cache(FT, model_smag; grid = sphere);
+
+## Radiation models
+radiation_mode = CA.RRTMGPI.AllSkyRadiationWithClearSkyDiagnostics(;
+    aerosol_radiation = true,
+)
+model_allsky = CA.AtmosModel(; radiation_mode)
+(Y_allsky, p_allsky) = build_state_cache(FT, model_allsky; grid = column,
+    aerosol_names = ("DST01",),
+);
+# Radiation flux arrays are initialized to NaN by set_and_save! (filled only after solver runs).
+# Zero them so diagnostics return finite values when tested outside a time-stepping loop.
+let rrtm = p_allsky.radiation.rrtmgp_model
+    for f in propertynames(rrtm)
+        a = getproperty(rrtm, f)
+        if a isa AbstractArray && any(isnan, a)
+            @. a = ifelse(isnan(a), 0, a)
+        end
+    end
+end
+
+## EDMFX models
+# Shared EDMF configuration — minimal (no entr/detr, no SGS fluxes)
+tcp = CAP.turbconv_params(params)
+edmfx_model = CA.EDMFXModel(;
+    entr_model = CA.NoEntrainment(), detr_model = CA.NoDetrainment(),
+    scale_blending_method = CA.SmoothMinimumBlending(),
+)
+pedmfx = CA.PrognosticEDMFX(; area_fraction = tcp.min_area)
+dedmfx = CA.DiagnosticEDMFX(; area_fraction = tcp.min_area)
+
+model_0m_pedmfx = CA.AtmosModel(; microphysics_model = CA.EquilibriumMicrophysics0M(),
+    turbconv_model = pedmfx, edmfx_model)
+model_1m_pedmfx = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophysics1M(),
+    turbconv_model = pedmfx, edmfx_model)
+model_1m_dedmfx = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophysics1M(),
+    turbconv_model = dedmfx, edmfx_model)
+model_2m_pedmfx = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophysics2M(),
+    turbconv_model = pedmfx, edmfx_model)
+(Y_0m_pedmfx, p_0m_pedmfx) = build_state_cache(FT, model_0m_pedmfx; grid = column);
+(Y_1m_pedmfx, p_1m_pedmfx) = build_state_cache(FT, model_1m_pedmfx; grid = column);
+(Y_1m_dedmfx, p_1m_dedmfx) = build_state_cache(FT, model_1m_dedmfx; grid = column);
+(Y_2m_pedmfx, p_2m_pedmfx) = build_state_cache(FT, model_2m_pedmfx; grid = column);
+
+## VerticalDiffusion and DecayWithHeightDiffusion (no EDMF)
+vdp = CAP.vert_diff_params(params)
+model_vd = CA.AtmosModel(;
+    vertical_diffusion = CA.VerticalDiffusion{FT}(;
+        disable_momentum_vertical_diffusion = false, C_E = vdp.C_E))
+model_dwh = CA.AtmosModel(;
+    vertical_diffusion = CA.DecayWithHeightDiffusion{FT}(;
+        disable_momentum_vertical_diffusion = false, H = vdp.H, D₀ = vdp.D₀))
+(Y_vd, p_vd) = build_state_cache(FT, model_vd; grid = column)
+(Y_dwh, p_dwh) = build_state_cache(FT, model_dwh; grid = column)
+
+# ---------------------------------------------------------------------------
+# Case tables
+# ---------------------------------------------------------------------------
+
+# All fixtures indexed by symbol — used by the `case` constructor below.
+#! format: off
+states = Dict(
+    :dry            => (Y_dry,            p_dry),
+    :sphere         => (Y_sphere,         p_sphere),
+    :ssv            => (Y_ssv,            p_ssv),
+    :m0             => (Y_0m,             p_0m),
+    :m1             => (Y_1m,             p_1m),
+    :m2             => (Y_2m,             p_2m),
+    :nogw           => (Y_nogw,           p_nogw),
+    :m0_slab_sphere => (Y_0m_slab_sphere, p_0m_slab_sphere),
+    :smag           => (Y_smag,           p_smag),
+    :m0_pedmfx      => (Y_0m_pedmfx,      p_0m_pedmfx),
+    :m1_pedmfx      => (Y_1m_pedmfx,      p_1m_pedmfx),
+    :m1_dedmfx      => (Y_1m_dedmfx,      p_1m_dedmfx),
+    :m2_pedmfx      => (Y_2m_pedmfx,      p_2m_pedmfx),
+    :vd             => (Y_vd,             p_vd),
+    :dwh            => (Y_dwh,            p_dwh),
+    :allsky         => (Y_allsky,         p_allsky),
+)
+
+# case(name, key)  or  case(name, (key1, key2, ...))
+# Each key refers to an entry in `states`; the test loop runs the diagnostic
+# against every listed fixture, producing one test per (name, key) pair.
+case(name, key::Symbol) = (; name, keys = (key,))
+case(name, keys::Tuple) = (; name, keys)
+# Helper function to create multiple cases with the same name but different keys
+cases(names, keys) = map(n -> case(n, keys), names)
+
+#
+# VALID_CASES — diagnostic must compute without error; result must be all-finite
+# Each entry lists all fixture keys for which the diagnostic should be tested.
+# Multi-key entries exercise different model-dispatch paths.
+#
+VALID_CASES = [
+    # ---------------------------------------------------------------------------
+    # conservation_diagnostics.jl
+    # ---------------------------------------------------------------------------
+    case("massa",   :dry),
+    case("energya", :dry),
+    case("watera",  :m0),             # MoistMicrophysics only
+    case("energyo", :sphere),         # SlabOceanSST + SpectralElementSpace2D
+    case("watero",  :m0_slab_sphere), # MoistMicrophysics + SlabOceanSST + sphere
+
+    # ---------------------------------------------------------------------------
+    # core_diagnostics.jl
+    # ---------------------------------------------------------------------------
+    # no dispatch (universal)
+    cases((
+        "rhoa", "ua", "va", "wa", "ta", "thetaa", "ha", "pfull", "zg",
+        "bgrad", "strain", "cl", "ke", "ts", "tas", "uas", "vas", "tauu", "tauv",
+        "hfes", "dsevi", "env_q_tot_variance", "env_temperature_variance",
+        "env_q_tot_temperature_covariance", "env_q_tot_temperature_correlation",
+    ), :dry)...,
+    # sphere-only (DSS / hypsography)
+    cases(("rv", "orog"), :sphere)...,
+    # MoistMicrophysics, single path
+    cases((
+        "hus", "hur", "husv", "hussfc", "evspsbl", "hfls",
+        "clivi", "clvi", "prw", "hurvi", "cape", "mslp"
+    ), :m0)...,
+    # Union{DryModel, MoistMicrophysics}: single method
+    cases(("pr", "prra", "prsn"), :dry)...,
+    # EquilibriumMicrophysics0M (precomputed cache), NonEquilibriumMicrophysics (state)
+    cases(("clw", "cli", "clwvi", "lwp"), (:m0, :m1))...,
+    # DryModel, MoistMicrophysics (different flux computation)
+    case("hfss",  (:dry, :m0)),
+    # Non-EDMF (Smagorinsky formula), EDMF (mixing-length closure)
+    case("lmix",  (:dry, :m0_pedmfx)),
+    # 1M / 2M microphysics
+    cases(("husra", "hussn", "rwp"), :m1)...,  # Union{1M, 2M}, single method
+    cases(("cdnc", "ncra"), :m2)...,  # 2M only
+    # Smagorinsky-Lilly
+    cases(("Dh_smag", "Dv_smag", "strainh_smag", "strainv_smag"), :smag)...,
+    # steady-state velocity
+    cases(("uapredicted", "vapredicted", "wapredicted", "uaerror", "vaerror", "waerror"), :ssv)...,
+
+    # ---------------------------------------------------------------------------
+    # gravitywave_diagnostics.jl
+    # ---------------------------------------------------------------------------
+    cases(("utendnogw", "vtendnogw"), :nogw)...,
+
+    # ---------------------------------------------------------------------------
+    # radiation_diagnostics.jl
+    # All paths covered by :allsky (AllSkyRadiationWithClearSkyDiagnostics +
+    # aerosol_radiation = true), the most featureful radiation mode.
+    # ---------------------------------------------------------------------------
+    cases(("rsd", "rsdt", "rsds", "rsu", "rsut", "rsus"), :allsky)...,
+    cases(("rld", "rlds", "rlu", "rlut", "rlus"), :allsky)...,
+    cases(("rsdcs", "rsdscs", "rsucs", "rsutcs"), :allsky)...,
+    cases(("rsuscs", "rldcs", "rldscs", "rlucs", "rlutcs"), :allsky)...,
+    cases(("reffclw", "reffcli", "od550aer", "odsc550aer"), :allsky)...,
+
+    # ---------------------
+    # edmfx_diagnostics.jl
+    # ---------------------
+    # Union{PrognosticEDMFX, DiagnosticEDMFX}: single method
+    cases(("rhoaup", "waup", "taup", "thetaaup", "haup", "husup"), :m0_pedmfx)...,
+    cases(("hurup", "entr", "turbentr", "detr", "waen", "tke", "lmixw", "lmixtke", "lmixb"), :m0_pedmfx)...,
+    # PrognosticEDMFX only
+    cases(("rhoaen", "taen", "thetaaen", "haen", "husen", "huren"), :m0_pedmfx)...,
+    # PrognosticEDMFX, DiagnosticEDMFX
+    cases(("arup", "aren"), (:m0_pedmfx, :m1_dedmfx))...,
+    # 0M+Union{P,D}, NonEq+PrognosticEDMFX, NonEq+DiagnosticEDMFX
+    cases(("clwup", "cliup"), (:m0_pedmfx, :m1_dedmfx, :m1_pedmfx))...,
+    # Union{1M,2M}+PrognosticEDMFX, 1M+DiagnosticEDMFX
+    cases(("husraup", "hussnup"), (:m1_pedmfx, :m1_dedmfx))...,
+    # 0M+PrognosticEDMFX, NonEq+PrognosticEDMFX
+    cases(("clwen", "clien"), (:m0_pedmfx, :m1_pedmfx))...,
+    # 1M+PrognosticEDMFX
+    cases(("husraen", "hussnen"), :m1_pedmfx)...,
+    # 2M + PrognosticEDMFX
+    cases(("cdncup", "cdncen", "ncraup", "ncraen"), :m2_pedmfx)...,
+    # VerticalDiffusion, DecayWithHeightDiffusion, EDMF
+    cases(("edt", "evu"), (:vd, :dwh, :m0_pedmfx))...,
+]
+#! format: on
+#
+# SKIP_CASES — out-of-scope diagnostic files:
+#   - tracer_diagnostics.jl  : require tracer model (o3, mmr*, loadss)
+#   - negative_scalars_diagnostics.jl : budget monitoring (hus_neg_sum, etc.)
+# These are skipped here; their own test files should cover them.
+#
+SKIP_CASES = Set([
+    # tracer_diagnostics.jl
+    "loadss", "mmrbcpi", "mmrbcpo", "mmrdust", "mmrocpi", "mmrocpo",
+    "mmrso4", "mmrss", "o3",
+    # negative_scalars_diagnostics.jl
+    "cli_max", "cli_min", "cli_neg_frac", "cli_neg_mean", "cli_neg_sum",
+    "cli_pos_frac", "cli_pos_mean", "cli_pos_sum",
+    "clw_max", "clw_min", "clw_neg_frac", "clw_neg_mean", "clw_neg_sum",
+    "clw_pos_frac", "clw_pos_mean", "clw_pos_sum",
+    "hus_max", "hus_min", "hus_neg_frac", "hus_neg_mean", "hus_neg_sum",
+    "hus_pos_frac", "hus_pos_mean", "hus_pos_sum",
+    "husra_max", "husra_min", "husra_neg_frac", "husra_neg_mean", "husra_neg_sum",
+    "husra_pos_frac", "husra_pos_mean", "husra_pos_sum",
+    "hussn_max", "hussn_min", "hussn_neg_frac", "hussn_neg_mean", "hussn_neg_sum",
+    "hussn_pos_frac", "hussn_pos_mean", "hussn_pos_sum",
+])
+
+# ---------------------------------------------------------------------------
+# Exhaustiveness check
+# — every name in ALL_DIAGNOSTICS must appear in exactly one table
+# ---------------------------------------------------------------------------
+
+@testset "All diagnostic variables are accounted for" begin
+    all_names = Set(keys(CA.Diagnostics.ALL_DIAGNOSTICS))
+    covered = Set(c.name for c in VALID_CASES) ∪ SKIP_CASES
+    missing_ = setdiff(all_names, covered)
+    unexpected_ = setdiff(covered, all_names)
+    @test isempty(missing_)    # new diagnostic added without a test entry
+    @test isempty(unexpected_) # stale entry (diagnostic was removed)
+end
+
+# ---------------------------------------------------------------------------
+# Main test loop
+# Each (name, key) pair becomes one @testset — key identifies the fixture.
+# ---------------------------------------------------------------------------
+
+@testset "$(c.name) [$(key)]" for c in VALID_CASES, key in c.keys
+    (Y, p) = states[key]
+    diag = getdiag(c.name)
+    result = compute_diag(diag, Y, p)
+    @test all(isfinite, field_data(result))
+end
+
+# ---------------------------------------------------------------------------
+# Spot-checks for model-dispatch error paths
+# (not subject to exhaustiveness — these are additional regression guards)
+# ---------------------------------------------------------------------------
+
+@testset "Model dispatch error paths" begin
+    for name in ("hus", "hur", "husv", "clw", "cli", "hussfc",
+        "evspsbl", "hfls", "clwvi", "lwp", "clivi", "clvi",
+        "prw", "hurvi", "husra", "hussn", "rwp",
+        "cdnc", "ncra", "utendnogw", "vtendnogw")
+        @testset "$name errors on dry model" begin
+            @test_throws Exception compute_diag(getdiag(name), Y_dry, p_dry)
+        end
+    end
+
+    @testset "orog errors on column grid (no hypsography field)" begin
+        @test_throws Exception compute_diag(getdiag("orog"), Y_dry, p_dry)
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Pure-Julia helper: geometric_scaling (radiation_diagnostics.jl)
+# Not a DiagnosticVariable, so not in ALL_DIAGNOSTICS.
+# ---------------------------------------------------------------------------
+
+@testset "geometric_scaling" begin
+    gs = CA.Diagnostics.geometric_scaling
+    R = FT(CAP.planet_radius(params))
+    @test gs(FT(0), R) ≈ FT(1)   # scaling = 1 at surface
+    @test gs(R, R) ≈ FT(4)   # (2R/R)² = 4
+    @test gs(FT(10_000), R) > FT(1)
+    @test isfinite(gs(FT(30_000), R))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,14 @@ if TEST_GROUP in ("infrastructure", "all")
     @safetestset "Model getters" begin @time include("solver/model_getters.jl") end
     @safetestset "AtmosModel Constructor" begin @time include("solver/atmos_model_constructor.jl") end
     @safetestset "Topography tests" begin @time include("topography.jl") end
+
+end
+
+# ============================================================================
+# Diagnostics: Unit tests for diagnostic variables
+# ============================================================================
+if TEST_GROUP in ("diagnostics", "all")
+    @safetestset "Diagnostics unit tests" begin @time include("diagnostics/unit_diagnostics.jl") end
 end
 
 # ============================================================================


### PR DESCRIPTION
This PR refactors diagnostic variable computation functions to use the lazy `compute` API and adds a unit test suite covering all registered diagnostics.

## Compute API migration

Most diagnostics previously used `compute!`, which required every function to handle two cases — returning a copy when `out` is `nothing`, and writing in-place otherwise. These are replaced with `compute`, which returns a field or lazy broadcast directly; ClimaDiagnostics materialises the result as needed. The handful of diagnostics that write scalar outputs into a pre-allocated buffer (conservation integrals) retain `compute!`, but are simplified to the short-circuit form `isnothing(out) && return [val]; out .= val`.

## Radiation refactor

Repeated geometric-scaling and array-to-field logic is factored into three shared helpers (`ᶠradiation_field_3d`, `ᶠradiation_field_toa`, `ᶠradiation_field_sfc`), reducing each radiation compute function from ~20 lines to 2–3. The mutating `apply_geometric_scaling!` helper is replaced by a pure scalar `geometric_scaling(z, r)`. Also fixes a field name bug in `rldscs` (`cache.radiation_mode` → `cache.radiation`).

## Unit tests

`test/diagnostics/unit_diagnostics.jl` is a unit test suite for all registered diagnostics. Fixtures are collected in a `states` dict keyed by symbol; `case(name, keys)` entries cover multiple dispatch paths per diagnostic in a single declaration. An exhaustiveness check ensures every registered diagnostic is either tested or explicitly listed in `SKIP_CASES`.

## Changed files

- `src/diagnostics/conservation_diagnostics.jl`
- `src/diagnostics/core_diagnostics.jl`
- `src/diagnostics/gravitywave_diagnostics.jl`
- `src/diagnostics/radiation_diagnostics.jl`
- `src/utils/abbreviations.jl` — adds `[U/V/W]Vec` and `UV` abbreviations for
  `Geometry.[U/V/W]Vector` and `Geometry.UVVector`
- `test/diagnostics/unit_diagnostics.jl` — new file
