### PR TITLE
wip: fast horizontal substepping

### DIFF
--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -82,7 +82,7 @@ model = CA.AtmosModel(;
     surface_albedo = CA.ConstantAlbedo{FT}(; α = 0.07),
 
     # numerics
-    numerics = CA.AtmosNumerics(; hyperdiff = nothing),
+    numerics = CA.AtmosNumerics(; hyperdiff = nothing, n_horizontal_substeps = 5),
 )
 # @info "AtmosModel: \n$(summary(atmos))"
 

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -133,6 +133,7 @@ include(
     ),
 )
 include(joinpath("prognostic_equations", "advection.jl"))
+include(joinpath("prognostic_equations", "multirate_substepping.jl"))
 
 include(joinpath("cache", "temporary_quantities.jl"))
 include(joinpath("cache", "tracer_cache.jl"))

--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -161,5 +161,6 @@ function temporary_quantities(Y, atmos)
         ᶜtridiagonal_matrix_scalar = similar(Y.c, TridiagonalMatrixRow{FT}),
         ᶠtridiagonal_matrix_c3 = similar(Y.f, TridiagonalMatrixRow{C3{FT}}),
         (!isnothing(atmos.prescribed_flow) ? (; temp_Yₜ_imp = similar(Y)) : (;))...,
+        (!isnothing(atmos.numerics.dt_fast) ? (; Y_fast = similar(Y)) : (;))...,
     )
 end

--- a/src/prognostic_equations/multirate_substepping.jl
+++ b/src/prognostic_equations/multirate_substepping.jl
@@ -1,0 +1,147 @@
+#####
+##### Multirate horizontal substepping for sound/gravity waves
+#####
+
+import ClimaCore: Fields, Geometry, Spaces
+
+"""
+    set_fast_precomputed_quantities!(Y_fast, p, t)
+
+Minimal thermodynamic update for fast horizontal substeps. Stripped-down
+version of `set_implicit_precomputed_quantities!` that only updates the
+quantities needed by `horizontal_dynamics_tendency!`.
+
+The fast substeps only modify `Y_fast.c.ρ`, `Y_fast.c.ρe_tot`, and
+`Y_fast.c.uₕ`. Vertical velocity (`Y_fast.f.u₃`) and moisture quantities
+are unchanged during fast substeps.
+"""
+function set_fast_precomputed_quantities!(Y_fast, p, t)
+    (; ᶜΦ) = p.core
+    (; ᶜu, ᶠu³, ᶜK, ᶜT, ᶜq_tot_safe, ᶜq_liq_rai, ᶜq_ice_sno, ᶜh_tot, ᶜp) =
+        p.precomputed
+    ᶠuₕ³ = p.scratch.ᶠtemp_CT3
+    thermo_params = CAP.thermodynamics_params(p.params)
+    microphysics_model = p.atmos.microphysics_model
+
+    # 1. Velocity: uₕ changed, u₃ unchanged
+    @. ᶠuₕ³ = $compute_ᶠuₕ³(Y_fast.c.uₕ, Y_fast.c.ρ)
+    set_velocity_quantities!(ᶜu, ᶠu³, ᶜK, Y_fast.f.u₃, Y_fast.c.uₕ, ᶠuₕ³)
+
+    # 2. Internal energy (ρ and ρe_tot changed, Φ static)
+    ᶜe_int = @. lazy(specific(Y_fast.c.ρe_tot, Y_fast.c.ρ) - ᶜK - ᶜΦ)
+
+    # 3. Temperature from internal energy
+    if microphysics_model isa EquilibriumMicrophysics0M
+        # Saturation adjustment: condensate partition depends on T
+        @. ᶜq_tot_safe = max(0, specific(Y_fast.c.ρq_tot, Y_fast.c.ρ))
+        (; ᶜsa_result) = p.precomputed
+        @. ᶜsa_result = saturation_adjustment_tuple(
+            thermo_params,
+            TD.ρe(),
+            Y_fast.c.ρ,
+            ᶜe_int,
+            ᶜq_tot_safe,
+        )
+        @. ᶜT = ᶜsa_result.T
+        @. ᶜq_liq_rai = ᶜsa_result.q_liq
+        @. ᶜq_ice_sno = ᶜsa_result.q_ice
+    else  # DryModel or NonEquilibriumMicrophysics
+        # q values don't change during fast substeps, just recompute T
+        @. ᶜT = max(
+            CAP.T_min_sgs(p.params),
+            TD.air_temperature(
+                thermo_params,
+                ᶜe_int,
+                ᶜq_tot_safe,
+                ᶜq_liq_rai,
+                ᶜq_ice_sno,
+            ),
+        )
+    end
+
+    # 4. Pressure and enthalpy
+    ᶜe_tot = @. lazy(specific(Y_fast.c.ρe_tot, Y_fast.c.ρ))
+    @. ᶜh_tot = TD.total_enthalpy(
+        thermo_params,
+        ᶜe_tot,
+        ᶜT,
+        ᶜq_tot_safe,
+        ᶜq_liq_rai,
+        ᶜq_ice_sno,
+    )
+    @. ᶜp = TD.air_pressure(
+        thermo_params,
+        ᶜT,
+        Y_fast.c.ρ,
+        ᶜq_tot_safe,
+        ᶜq_liq_rai,
+        ᶜq_ice_sno,
+    )
+
+    # Exner (Π) and virtual potential temperature (θ_v) are computed lazily
+    # inside horizontal_dynamics_tendency! — no need to store them here.
+    return nothing
+end
+
+"""
+    slow_remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+
+Same as `remaining_tendency!` but skips `horizontal_dynamics_tendency!`,
+which is handled separately by fast substeps.
+"""
+NVTX.@annotate function slow_remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+    Yₜ_lim .= zero(eltype(Yₜ_lim))
+    Yₜ .= zero(eltype(Yₜ))
+    horizontal_tracer_advection_tendency!(Yₜ_lim, Y, p, t)
+    fill_with_nans!(p)
+    # horizontal_dynamics_tendency! is handled by fast substeps
+    hyperdiffusion_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+    explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
+    additional_tendency!(Yₜ, Y, p, t)
+    return Yₜ
+end
+
+"""
+    substepped_remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+
+Multirate explicit tendency that substeps the fast horizontal terms
+(sound/gravity waves) while evaluating slow terms once per slow step.
+
+Algorithm:
+1. Copy Y → Y_fast, then do N fast substeps of `horizontal_dynamics_tendency!`
+   (each substep updates thermodynamic quantities from the evolving state).
+2. Compute slow tendency into Yₜ (everything except horizontal dynamics).
+3. Add linearized fast contribution: `Yₜ += (Y_fast - Y) / dt_slow`.
+"""
+NVTX.@annotate function substepped_remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+    dt_fast = p.atmos.numerics.dt_fast::Float64
+    dt_slow = p.dt
+    n_substeps = floor(Int, dt_slow / dt_fast)
+    @assert n_substeps >= 2 "dt_fast=$dt_fast with dt_slow=$dt_slow gives $n_substeps substeps (need ≥ 2)"
+
+    # 1. Fast substeps (reuse Yₜ as fast tendency buffer)
+    (; Y_fast) = p.scratch
+    Y_fast .= Y
+
+    for i in 1:n_substeps
+        set_fast_precomputed_quantities!(Y_fast, p, t)
+        Yₜ .= zero(eltype(Yₜ))
+        horizontal_dynamics_tendency!(Yₜ, Y_fast, p, t)
+        @. Y_fast += dt_fast * Yₜ
+        # DSS: project shared element-boundary nodes for horizontal continuity
+        if do_dss(axes(Y_fast.c))
+            Spaces.weighted_dss!(
+                Y_fast.c => p.ghost_buffer.c,
+                Y_fast.f => p.ghost_buffer.f,
+            )
+        end
+    end
+
+    # 2. Slow tendency (overwrites Yₜ)
+    slow_remaining_tendency!(Yₜ, Yₜ_lim, Y, p, t)
+
+    # 3. Add linearized fast contribution
+    @. Yₜ += (Y_fast - Y) / dt_slow
+
+    return Yₜ
+end

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -843,11 +843,25 @@ function args_integrator(Y, p, tspan, ode_algo, callback,
     dt_integrator,
 )
     (; atmos) = p
+    dt_fast = atmos.numerics.dt_fast
+    use_multirate = if !isnothing(dt_fast)
+        n_substeps = floor(Int, dt_integrator / dt_fast)
+        if n_substeps < 2
+            @warn "dt_fast=$dt_fast with dt=$dt_integrator gives $n_substeps substeps; disabling multirate substepping (need ≥ 2)"
+            false
+        else
+            @info "Multirate substepping enabled: $n_substeps fast substeps of dt_fast=$dt_fast per slow step dt=$dt_integrator"
+            true
+        end
+    else
+        false
+    end
     s = @timed_str begin
         if isnothing(prescribed_flow)
 
             # This is the default case
-            T_exp_T_lim! = remaining_tendency!
+            T_exp_T_lim! = use_multirate ?
+                substepped_remaining_tendency! : remaining_tendency!
             T_imp_subproblem! =
                 p.atmos.turbconv_model isa PrognosticEDMFX ?
                 CTS.ODEFunction(

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -722,7 +722,7 @@ struct SmoothMinimumBlending <: AbstractScaleBlendingMethod end
 struct HardMinimumBlending <: AbstractScaleBlendingMethod end
 Base.broadcastable(x::AbstractScaleBlendingMethod) = tuple(x)
 
-struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, ED_TR_UP, TDC, RR, LIM, DM, HD}
+struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, ED_TR_UP, TDC, RR, LIM, DM, HD, DTF}
     """Enable specific upwinding schemes for specific equations"""
     energy_q_tot_upwinding::EN_UP
     tracer_upwinding::TR_UP
@@ -738,6 +738,8 @@ struct AtmosNumerics{EN_UP, TR_UP, ED_UP, SG_UP, ED_TR_UP, TDC, RR, LIM, DM, HD}
     diff_mode::DM
     """Hyperdiffusion model: nothing or Hyperdiffusion()"""
     hyperdiff::HD
+    """Fast timestep for horizontal substepping of sound/gravity waves (nothing = disabled)"""
+    dt_fast::DTF
 end
 Base.broadcastable(x::AtmosNumerics) = tuple(x)
 
@@ -762,6 +764,7 @@ function AtmosNumerics(;
         divergence_damping_factor = 5,
         prandtl_number = 1.0,
     ),
+    dt_fast = nothing,
     kwargs...,
 )
     # Helper to convert symbols/strings to Val types, or keep Val types as-is
@@ -779,6 +782,7 @@ function AtmosNumerics(;
         limiter,
         diff_mode,
         hyperdiff,
+        dt_fast,
     )
 end
 


### PR DESCRIPTION
This pull request introduces multirate horizontal substepping to the atmospheric model, allowing fast explicit integration of sound and gravity waves using a smaller timestep within each slow timestep. The implementation includes new logic for managing fast and slow tendencies, updates to the numerics configuration, and changes to model setup and cache handling. The most important changes are grouped below:

**Multirate Substepping Implementation:**

* Added a new module `multirate_substepping.jl` implementing functions for fast horizontal substeps (`set_fast_precomputed_quantities!`, `substepped_remaining_tendency!`, and `slow_remaining_tendency!`). These functions manage the explicit integration of horizontal dynamics at a finer timestep and combine their effect with the slow processes.

* Updated the main solver logic in `args_integrator` to select between standard and multirate tendency functions based on the presence and value of `dt_fast`, including runtime checks and logging for substepping configuration.

**Numerics and Configuration Updates:**

* Extended the `AtmosNumerics` struct to include a new field `dt_fast`, which controls the fast timestep for horizontal substepping. Updated its constructor to accept this new parameter. [[1]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66L725-R725) [[2]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66R741-R742) [[3]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66R767) [[4]](diffhunk://#diff-2f94c7adf07b3cbc2396d99087f28bfb189a773943c7e1994754d81ef01e1d66R785)

* In the example runscript `rcemipii_box_CRM_1M.jl`, set `n_horizontal_substeps = 5` in the numerics configuration, activating the new substepping logic for that case.

**Cache and Precomputed Quantity Handling:**

* Modified the cache allocation in `temporary_quantities.jl` to allocate a `Y_fast` buffer when `dt_fast` is enabled, supporting storage for the fast substep state.

**Module Inclusion:**

* Included the new `multirate_substepping.jl` file in the main `ClimaAtmos.jl` module, ensuring the new logic is available in the codebase.