### PR TITLE
Cleanup in 0M and 1M non-quadrature and quadrature paths

### DIFF
--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -800,52 +800,38 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
             nh_pressure³_dragʲ_data_prev_halflevel =
                 nh_pressure³_dragʲ_prev_halflevel.components.data.:1
 
-            # Microphysics sources and sinks. To be applied in updraft continuity,
+            # Microphysics sources and sinks. To be applied in continuity,
             # moisture and energy equations for updrafts and grid mean.
-
-            # 0-moment microphysics: sink of q_tot from precipitation removal
             if microphysics_model isa EquilibriumMicrophysics0M
-                @. ᶜmp_tendencyʲ_prev_level.dq_tot_dt =
-                    BMT.bulk_microphysics_tendencies(
-                        BMT.Microphysics0Moment(),
-                        microphys_0m_params,
-                        thermo_params,
-                        Tʲ_prev_level,
-                        q_liqʲ_prev_level,
-                        q_iceʲ_prev_level,
-                        TD.q_vap_saturation(
-                            thermo_params, Tʲ_prev_level, ρʲ_prev_level,
-                        ),
-                    )
-                @. ᶜmp_tendencyʲ_prev_level.dq_tot_dt = limit_sink(
-                    ᶜmp_tendencyʲ_prev_level.dq_tot_dt,
-                    q_totʲ_prev_level, dt,
-                )
-                @. ᶜmp_tendencyʲ_prev_level.e_tot_hlpr =
-                    e_tot_0M_precipitation_sources_helper(
-                        thermo_params,
-                        Tʲ_prev_level,
-                        q_liq_prev_level,
-                        q_ice_prev_level,
-                        Φ_prev_level,
-                    )
-                # 1-moment microphysics: cloud water (liquid and ice) and
-                # precipitation (rain and snow) tendencies. q_tot is constant, because
-                # all the species are considered a part of the working fluid.
-            elseif microphysics_model isa NonEquilibriumMicrophysics1M
-                # Microphysics tendencies from the updrafts (using fused BMT API)
-                compute_1m_precipitation_tendencies!(
-                    ᶜmp_tendencyʲ_prev_level,
+                # Sink of total water and energy from precipitation removal.
+                @. ᶜmp_tendencyʲ_prev_level = microphysics_tendencies_0m(
+                    microphys_0m_params,
+                    thermo_params,
                     ρʲ_prev_level,
-                    q_totʲ_prev_level,
+                    Tʲ_prev_level,
+                    q_tot_nonnegʲ_prev_level,
+                    q_liqʲ_prev_level,
+                    q_iceʲ_prev_level,
+                    Φ_prev_level,
+                    $(p.atmos.microphysics_tendency_timestepping),
+                    dt,
+                )
+            elseif microphysics_model isa NonEquilibriumMicrophysics1M
+                # Cloud water (liquid and ice) and precipitation
+                # (rain and snow) tendencies. Total water is constant, because
+                # all water species are considered part of the working fluid.
+                @. ᶜmp_tendencyʲ_prev_level = microphysics_tendencies_1m(
+                    ρʲ_prev_level,
+                    q_tot_nonnegʲ_prev_level,
                     q_lclʲ_prev_level,
                     q_iclʲ_prev_level,
                     q_raiʲ_prev_level,
                     q_snoʲ_prev_level,
                     Tʲ_prev_level,
-                    dt,
                     microphys_1m_params,
                     thermo_params,
+                    $(p.atmos.microphysics_tendency_timestepping),
+                    dt,
                 )
             end
 

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -876,46 +876,31 @@ set_microphysics_tendency_cache!(Y, p, _, _) = nothing
 function set_microphysics_tendency_cache!(Y, p, ::EquilibriumMicrophysics0M, _)
     (; dt) = p
     (; ᶜΦ) = p.core
-    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
-    (; ᶜmp_tendency) = p.precomputed
+    (; ᶜT, ᶜq_tot_nonneg, ᶜmp_tendency) = p.precomputed
 
     cm0 = CAP.microphysics_0m_params(p.params)
     thp = CAP.thermodynamics_params(p.params)
 
-    # TODO - The logic in 1m all configs and 0m EDMF is:
-    # SG_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    # and then always call the quadrature path anyway.
-    # We should do the same here. Concern is that ᶜT′T′/ᶜq′q′
-    # are currenly only allocated when sgs_quadrature is configured.
-
-    ### Grid-mean microphysics tendency (with/without quadrature sampling)
+    ### Grid-mean microphysics tendency with/without quadrature sampling.
     sgs_quad = p.atmos.sgs_quadrature
-    if !isnothing(sgs_quad)
-        # Evaluate over quadrature points; both dq_tot_dt and e_tot_hlpr
+    tst = p.atmos.microphysics_tendency_timestepping
+    if not_quadrature(sgs_quad)
+        # Evaluate on the grid-mean.
+        (; ᶜq_liq, ᶜq_ice) = p.precomputed
+        @. ᶜmp_tendency = microphysics_tendencies_0m(
+            cm0, thp, Y.c.ρ, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice, ᶜΦ, $(tst), dt,
+        )
+    else
+        # Evaluate over quadrature points. Both dq_tot_dt and e_tot_hlpr
         # are SGS-averaged so that the energy helper is consistent with
         # the nonlinear dependence on condensate at each quadrature point.
         (; ᶜT′T′, ᶜq′q′) = p.precomputed
         corr_Tq = correlation_Tq(p.params)
-        @. ᶜmp_tendency = microphysics_tendencies_quadrature_0m(
+        @. ᶜmp_tendency = microphysics_tendencies_0m(
             $(sgs_quad), cm0, thp, Y.c.ρ, ᶜT, ᶜq_tot_nonneg,
-            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ,
-        )
-    else
-        # ... or evaluate on the grid-mean.
-        @. ᶜmp_tendency.dq_tot_dt = BMT.bulk_microphysics_tendencies(
-            BMT.Microphysics0Moment(), cm0, thp, ᶜT, ᶜq_liq, ᶜq_ice,
-            TD.q_vap_saturation(thp, ᶜT, Y.c.ρ),
-        )
-        # For the grid-mean path (no SGS averaging), compute e_tot_hlpr
-        # from grid-mean values (exact for a single evaluation point).
-        @. ᶜmp_tendency.e_tot_hlpr = e_tot_0M_precipitation_sources_helper(
-            thp, ᶜT, ᶜq_liq, ᶜq_ice, ᶜΦ,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ, $(tst), dt,
         )
     end
-    # Apply the limiter
-    apply_0m_tendency_limits!(
-        ᶜmp_tendency, p.atmos.microphysics_tendency_timestepping, ᶜq_tot_nonneg, dt,
-    )
 
     # TODO - duplicated with tendency and implicit cache update
     (; ᶜρ_dq_tot_dt, ᶜρ_de_tot_dt) = p.precomputed
@@ -937,26 +922,28 @@ function set_microphysics_tendency_cache!(
     (; ᶜmp_tendency) = p.precomputed
     (; ᶜ∂tendency_∂q_tot) = p.precomputed
     (; ᶜT, ᶜq_tot_nonneg) = p.precomputed
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed # temperature-based variances
 
     thp = CAP.thermodynamics_params(p.params)
     cm0 = CAP.microphysics_0m_params(p.params)
 
     ### Updraft contribution is computed in diagnostic EDMF integral loop
 
-    ### Environment contribution
-    # Both dq_tot_dt and e_tot_hlpr are SGS-averaged.
-    sgs_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    corr_Tq = correlation_Tq(p.params)
-    @. ᶜmp_tendency = microphysics_tendencies_quadrature_0m(
-        $(sgs_quad), cm0, thp, Y.c.ρ, ᶜT, ᶜq_tot_nonneg,
-        ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ,
-    )
-    # Apply the limiter
-    apply_0m_tendency_limits!(
-        ᶜmp_tendency, p.atmos.microphysics_tendency_timestepping,
-        ᶜq_tot_nonneg, dt,
-    )
+    ### Environment contribution on the grid mean or quadrature points
+    sgs_quad = p.atmos.sgs_quadrature
+    tst = p.atmos.microphysics_tendency_timestepping
+    if not_quadrature(sgs_quad)
+        (; ᶜq_liq, ᶜq_ice) = p.precomputed
+        @. ᶜmp_tendency = microphysics_tendencies_0m(
+            cm0, thp, Y.c.ρ, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice, ᶜΦ, $(tst), dt,
+        )
+    else
+        (; ᶜT′T′, ᶜq′q′) = p.precomputed
+        corr_Tq = correlation_Tq(p.params)
+        @. ᶜmp_tendency = microphysics_tendencies_0m(
+            $(sgs_quad), cm0, thp, Y.c.ρ, ᶜT, ᶜq_tot_nonneg,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ, $(tst), dt,
+        )
+    end
     # Compute derivative
     q_min = CAP.q_min(p.params)
     @. ᶜ∂tendency_∂q_tot =
@@ -992,44 +979,43 @@ function set_microphysics_tendency_cache!(
     (; ᶜ∂tendency_∂q_totʲs) = p.precomputed
     (; ᶜρʲs, ᶜTʲs, ᶜq_tot_nonnegʲs, ᶜq_liqʲs, ᶜq_iceʲs) = p.precomputed
     (; ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed # temperature-based variances
 
     thp = CAP.thermodynamics_params(p.params)
     cm0 = CAP.microphysics_0m_params(p.params)
 
     n = n_mass_flux_subdomains(tm)
     q_min = CAP.q_min(p.params)
+    tst = p.atmos.microphysics_tendency_timestepping
 
     for j in 1:n
-        # Use GridMeanSGS dispatch for consistent threshold with environment
-        @. ᶜmp_tendencyʲs.:($$j) = microphysics_tendencies_quadrature_0m(
-            GridMeanSGS(), cm0, thp, ᶜρʲs.:($$j), ᶜTʲs.:($$j), ᶜq_tot_nonnegʲs.:($$j),
-            ᶜq_liqʲs.:($$j), ᶜq_iceʲs.:($$j), ᶜΦ,
+        # Point-wise evaluation of microphysics tendencies in the updraft
+        @. ᶜmp_tendencyʲs.:($$j) = microphysics_tendencies_0m(
+            cm0, thp, ᶜρʲs.:($$j), ᶜTʲs.:($$j), ᶜq_tot_nonnegʲs.:($$j),
+            ᶜq_liqʲs.:($$j), ᶜq_iceʲs.:($$j), ᶜΦ, $(tst), dt,
         )
-        # Apply the limiter
-        apply_0m_tendency_limits!(
-            ᶜmp_tendencyʲs.:($j), p.atmos.microphysics_tendency_timestepping,
-            ᶜq_tot_nonnegʲs.:($j), dt,
-        )
-
         @. ᶜ∂tendency_∂q_totʲs.:($$j) =
             _jac_coeff(ᶜmp_tendencyʲs.:($$j).dq_tot_dt, Y.c.sgsʲs.:($$j).q_tot, q_min)
     end
 
-    ### Environment contribution
+    ### Environment contribution with/without quadrature sampling.
     ᶜρ⁰ = @. lazy(
         TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰),
     )
-    SG_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    corr_Tq = correlation_Tq(p.params)
-    @. ᶜmp_tendency⁰ = microphysics_tendencies_quadrature_0m(
-        SG_quad, cm0, thp, ᶜρ⁰, ᶜT⁰, ᶜq_tot_nonneg⁰,
-        ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ,
-    )
-    # Apply the limiter
-    apply_0m_tendency_limits!(
-        ᶜmp_tendency⁰, p.atmos.microphysics_tendency_timestepping, ᶜq_tot_nonneg⁰, dt,
-    )
+    sgs_quad = p.atmos.sgs_quadrature
+    if not_quadrature(sgs_quad)
+        # Evaluate on the grid-mean.
+        @. ᶜmp_tendency⁰ = microphysics_tendencies_0m(
+            cm0, thp, ᶜρ⁰, ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰, ᶜΦ, $(tst), dt,
+        )
+    else
+        # Evaluate over quadrature points.
+        (; ᶜT′T′, ᶜq′q′) = p.precomputed
+        corr_Tq = correlation_Tq(p.params)
+        @. ᶜmp_tendency⁰ = microphysics_tendencies_0m(
+            $(sgs_quad), cm0, thp, ᶜρ⁰, ᶜT⁰, ᶜq_tot_nonneg⁰,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜΦ, $(tst), dt,
+        )
+    end
 
     # TODO - duplicated with tendency and implicit cache update
     (; ᶜρ_dq_tot_dt, ᶜρ_de_tot_dt) = p.precomputed
@@ -1061,7 +1047,6 @@ function set_microphysics_tendency_cache!(
 )
     (; dt) = p
     (; ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜmp_tendency, ᶜmp_derivative) = p.precomputed
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
 
     thp = CAP.thermodynamics_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
@@ -1074,18 +1059,22 @@ function set_microphysics_tendency_cache!(
 
     # Grid mean or quadrature sum over the SGS fluctuations
     # (writes into pre-allocated ᶜmp_tendency to avoid NamedTuple allocation)
-    sgs_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    corr_Tq = correlation_Tq(p.params)
-    @. ᶜmp_tendency = microphysics_tendencies_quadrature_1m(
-        BMT.Microphysics1Moment(), sgs_quad, cmp, thp, Y.c.ρ, ᶜT,
-        ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-        ᶜT′T′, ᶜq′q′, corr_Tq,
-    )
-    # Apply the limiter
-    apply_1m_tendency_limits!(
-        ᶜmp_tendency, p.atmos.microphysics_tendency_timestepping,
-        thp, ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, dt,
-    )
+    sgs_quad = p.atmos.sgs_quadrature
+    tst = p.atmos.microphysics_tendency_timestepping
+    if not_quadrature(sgs_quad)
+        @. ᶜmp_tendency = microphysics_tendencies_1m(
+            Y.c.ρ, ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
+            ᶜT, cmp, thp, $(tst), dt,
+        )
+    else
+        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        corr_Tq = correlation_Tq(p.params)
+        @. ᶜmp_tendency = microphysics_tendencies_1m(
+            BMT.Microphysics1Moment(), sgs_quad, cmp, thp, Y.c.ρ, ᶜT,
+            ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
+            ᶜT′T′, ᶜq′q′, corr_Tq, $(tst), dt,
+        )
+    end
     # Compute microphysics derivatives ∂(dqₓ/dt)/∂qₓ at the
     # grid-mean state for the implicit Jacobian diagonal.
     q_min = CAP.q_min(p.params)
@@ -1099,7 +1088,6 @@ function set_microphysics_tendency_cache!(
 )
     (; dt) = p
     (; ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜmp_tendency, ᶜmp_derivative) = p.precomputed
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
 
     thp = CAP.thermodynamics_params(p.params)
     cm1 = CAP.microphysics_1m_params(p.params)
@@ -1112,21 +1100,24 @@ function set_microphysics_tendency_cache!(
     ᶜq_rai = @. lazy(specific(Y.c.ρq_rai, Y.c.ρ))
     ᶜq_sno = @. lazy(specific(Y.c.ρq_sno, Y.c.ρ))
 
-    sgs_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    corr_Tq = correlation_Tq(p.params)
     # Grid mean or quadrature sum over the SGS fluctuations
     # (writes into pre-allocated ᶜmp_tendency to avoid NamedTuple allocation)
-    @. ᶜmp_tendency = microphysics_tendencies_quadrature_1m(
-        BMT.Microphysics1Moment(), sgs_quad, cm1, thp, Y.c.ρ, ᶜT,
-        ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-        ᶜT′T′, ᶜq′q′, corr_Tq,
-    )
-    # Apply the limiter
-    apply_1m_tendency_limits!(
-        ᶜmp_tendency, p.atmos.microphysics_tendency_timestepping,
-        thp, ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, dt,
-    )
-
+    sgs_quad = p.atmos.sgs_quadrature
+    tst = p.atmos.microphysics_tendency_timestepping
+    if not_quadrature(sgs_quad)
+        @. ᶜmp_tendency = microphysics_tendencies_1m(
+            Y.c.ρ, ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, ᶜT, cm1, thp,
+            $(tst), dt,
+        )
+    else
+        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        corr_Tq = correlation_Tq(p.params)
+        @. ᶜmp_tendency = microphysics_tendencies_1m(
+            BMT.Microphysics1Moment(), sgs_quad, cm1, thp, Y.c.ρ, ᶜT,
+            ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
+            ᶜT′T′, ᶜq′q′, corr_Tq, $(tst), dt,
+        )
+    end
     # Compute microphysics derivatives ∂(dqₓ/dt)/∂qₓ at the
     # grid-mean state for the implicit Jacobian diagonal.
     q_min = CAP.q_min(p.params)
@@ -1143,21 +1134,21 @@ function set_microphysics_tendency_cache!(
     (; ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
     (; ᶜmp_tendency⁰, ᶜmp_derivative) = p.precomputed
     (; ᶜmp_tendencyʲs, ᶜmp_derivativeʲs) = p.precomputed
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
 
     thp = CAP.thermodynamics_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
 
     n = n_mass_flux_subdomains(tm)
     q_min = CAP.q_min(p.params)
+    tst = p.atmos.microphysics_tendency_timestepping
 
     ### Updraft contribution
     for j in 1:n
-        compute_1m_precipitation_tendencies!(
-            ᶜmp_tendencyʲs.:($j), ᶜρʲs.:($j), ᶜq_tot_nonnegʲs.:($j),
-            Y.c.sgsʲs.:($j).q_lcl, Y.c.sgsʲs.:($j).q_icl,
-            Y.c.sgsʲs.:($j).q_rai, Y.c.sgsʲs.:($j).q_sno,
-            ᶜTʲs.:($j), dt, cmp, thp,
+        @. ᶜmp_tendencyʲs.:($$j) = microphysics_tendencies_1m(
+            ᶜρʲs.:($$j), ᶜq_tot_nonnegʲs.:($$j),
+            Y.c.sgsʲs.:($$j).q_lcl, Y.c.sgsʲs.:($$j).q_icl,
+            Y.c.sgsʲs.:($$j).q_rai, Y.c.sgsʲs.:($$j).q_sno,
+            ᶜTʲs.:($$j), cmp, thp, $(tst), dt,
         )
         # BMT cloud derivatives at updraft j state (same pattern as grid-mean).
         @. ᶜmp_derivativeʲs.:($$j) = _jac_coeffs_1m(
@@ -1178,21 +1169,21 @@ function set_microphysics_tendency_cache!(
     ᶜρ⁰ = @. lazy(
         TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰),
     )
-    SG_quad = something(p.atmos.sgs_quadrature, GridMeanSGS())
-    corr_Tq = correlation_Tq(p.params)
-    # Grid mean or quadrature sum over the SGS fluctuations
-    # (writes into pre-allocated ᶜmp_tendency to avoid NamedTuple allocation)
-    @. ᶜmp_tendency⁰ = microphysics_tendencies_quadrature_1m(
-        BMT.Microphysics1Moment(), SG_quad, cmp, thp, ᶜρ⁰, ᶜT⁰,
-        ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
-        ᶜT′T′, ᶜq′q′, corr_Tq,
-    )
-    # Apply the limiter
-    apply_1m_tendency_limits!(
-        ᶜmp_tendency⁰, p.atmos.microphysics_tendency_timestepping,
-        thp, ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰, dt,
-    )
-
+    sgs_quad = p.atmos.sgs_quadrature
+    if not_quadrature(sgs_quad)
+        @. ᶜmp_tendency⁰ = microphysics_tendencies_1m(
+            ᶜρ⁰, ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
+            ᶜT⁰, cmp, thp, $(tst), dt,
+        )
+    else
+        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        corr_Tq = correlation_Tq(p.params)
+        @. ᶜmp_tendency⁰ = microphysics_tendencies_1m(
+            BMT.Microphysics1Moment(), sgs_quad, cmp, thp, ᶜρ⁰, ᶜT⁰,
+            ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
+            ᶜT′T′, ᶜq′q′, corr_Tq, $(tst), dt,
+        )
+    end
     # Compute microphysics derivatives ∂(dqₓ/dt)/∂qₓ at the
     # grid-mean state for the implicit Jacobian diagonal.
     # Assuming S = α q: ∂(dρq_dt)/∂(ρq) = ∂(dq⁰_dt)/∂q⁰, so the grid-mean derivative

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -61,12 +61,10 @@ struct Microphysics0MEvaluator{CMP, SAE, FT}
     sat_eval::SAE
     Φ::FT
 end
-
 function Microphysics0MEvaluator(cm_params, thermo_params, ρ, Φ)
     sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ)
     return Microphysics0MEvaluator(cm_params, sat_eval, Φ)
 end
-
 @inline function (eval::Microphysics0MEvaluator)(T_hat, q_hat)
     # Diagnose condensate via saturation adjustment
     sa = eval.sat_eval(T_hat, q_hat)
@@ -90,59 +88,72 @@ end
 end
 
 """
-    microphysics_tendencies_quadrature_0m(
-        SG_quad, cm_params, thermo_params,
-        ρ, T_mean, q_tot_mean, T′T′, q′q′, corr_Tq, Φ,
-    )
+    microphysics_tendencies_0m(SG_quad, cmp, thp, ρ, T, q_tot, T′T′, q′q′, corr_Tq, Φ, tst, dt)
+    microphysics_tendencies_0m(cmp, thp, ρ, T, q_tot, q_liq, q_ice, Φ, tst, dt)
 
-Compute SGS-averaged 0-moment microphysics tendencies by integrating over
-the joint PDF of (T, q_tot). At each quadrature point, condensate is diagnosed
-from saturation excess, then 0M precipitation removal tendencies are computed.
+Computes 0-moment microphysics tendencies.
 
-# Returns
-NamedTuple with SGS-averaged `dq_tot_dt` and `e_tot_hlpr`.
-"""
-@inline function microphysics_tendencies_quadrature_0m(
-    SG_quad, cm_params, thermo_params, ρ, T_mean, q_tot_mean,
-    T′T′, q′q′, corr_Tq, Φ,
-)
-    # Create GPU-safe functor (Φ is constant within a grid cell)
-    evaluator = Microphysics0MEvaluator(cm_params, thermo_params, ρ, Φ)
-    # Integrate over quadrature points; both dq_tot_dt and e_tot_hlpr
-    # are averaged over the SGS distribution.
-    return integrate_over_sgs(
-        evaluator, SG_quad, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
-    )
-end
+When using SGS-quadratures, the tendencies are integrated over the joint PDF of (T, q_tot).
+At each quadrature point, condensate is diagnosed from saturation excess,
+then 0M precipitation removal tendencies are computed.
 
-"""
-    microphysics_tendencies_quadrature_0m(
-        ::GridMeanSGS, cm_params, thermo_params, ρ, T, q_tot,
-        q_liq, q_ice, Φ,
-    )
+The option without SGS-quadratures can be used in the EDMF updrafts, or to compute
+grid-mean tendency without taking account of fluctuations. It computes the
+0M precipitation removal tendencies based on the provided point-values of temperature
+and specific humidities.
 
-Fast path for grid-mean 0-moment microphysics evaluation (no SGS quadrature).
-Computes BMT tendencies directly at grid-mean state with supersaturation
-threshold (`q_vap_sat`), plus the energy helper.
+When running with explicit microphysics timestepping, the total water sink
+is limited by the available water.
 
-This dispatch allows updraft code to use the same interface as the environment,
-ensuring consistent threshold definitions.
+# Inputs
+- `SG_quad`: SGSQuadrature configuration
+- `cmp`, `thp` - cloud microphysics and thermodynamics parameters
+- `ρ`, `T` - density [kg/m3] and temperature [K]
+- `q_tot`, `q_liq`, `q_ice` - total water, liquid water and ice specific humidities [kg/kg]
+- `ϕ` - geopotential
+- `T′T′`: Variance of temperature ``\\langle T'^2 \\rangle``
+- `q′q′`: Variance of q_tot ``\\langle q'^2 \\rangle``
+- `corr_Tq`: Correlation coefficient ρ(T', q')
+- `tst`: microphysics timestepping configuration
+- `dt`: model timestep length [s]
 
 # Returns
 NamedTuple with `dq_tot_dt` and `e_tot_hlpr`.
 """
-@inline function microphysics_tendencies_quadrature_0m(
-    ::GridMeanSGS, cm_params, thermo_params, ρ, T, q_tot,
-    q_liq, q_ice, Φ,
+@inline function microphysics_tendencies_0m(
+    SG_quad, cmp, thp, ρ, T, q_tot_nonneg, T′T′, q′q′, corr_Tq, Φ, tst, dt,
 )
-    q_vap_sat = TD.q_vap_saturation(thermo_params, T, ρ)
+    # Create GPU-safe functor (Φ is constant within a grid cell)
+    # The evaluator does saturation adjustment, computes saturation vapor pressure
+    # and computes the total water sink and energy helper from 0M microphysics
+    evaluator = Microphysics0MEvaluator(cmp, thp, ρ, Φ)
+    # Integrate over quadrature points; both dq_tot_dt and e_tot_hlpr
+    # are averaged over the SGS distribution.
+    (; dq_tot_dt, e_tot_hlpr) = integrate_over_sgs(
+        evaluator, SG_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
+    )
+    # Apply limiter if using explicit microphysics timestepping
+    if tst isa Explicit
+        dq_tot_dt = explicit_0m_tendency_limit(dq_tot_dt, q_tot_nonneg, dt)
+    end
+    return (; dq_tot_dt, e_tot_hlpr)
+end
+@inline function microphysics_tendencies_0m(
+    cmp, thp, ρ, T, q_tot_nonneg, q_liq, q_ice, Φ, tst, dt,
+)
+    # Computes saturation vapor pressure, total water sink and energy helper
+    # based on provided mean temperature, total water, liquid and ice specific humidities.
+    # Does not take into account SGS fluctuations.
+    q_vap_sat = TD.q_vap_saturation(thp, T, ρ)
     dq_tot_dt = BMT.bulk_microphysics_tendencies(
-        BMT.Microphysics0Moment(), cm_params, thermo_params,
-        T, q_liq, q_ice, q_vap_sat,
+        BMT.Microphysics0Moment(), cmp, thp, T, q_liq, q_ice, q_vap_sat,
     )
-    e_tot_hlpr = e_tot_0M_precipitation_sources_helper(
-        thermo_params, T, q_liq, q_ice, Φ,
-    )
+    e_tot_hlpr = e_tot_0M_precipitation_sources_helper(thp, T, q_liq, q_ice, Φ)
+
+    # Apply limiter if using explicit microphysics timestepping
+    if tst isa Explicit
+        dq_tot_dt = explicit_0m_tendency_limit(dq_tot_dt, q_tot_nonneg, dt)
+    end
     return (; dq_tot_dt, e_tot_hlpr)
 end
 
@@ -151,46 +162,10 @@ end
 ###
 
 """
-    compute_1m_precipitation_tendencies!(mp_tendency, ρ, qₜ, qₗ, qᵢ, qᵣ, qₛ, T, dt, mp, thp)
-
-This function computes all microphysics tendencies (cloud condensation/evaporation,
-autoconversion, accretion, and precipitation) in a single call.
-
-# Arguments
-- `mp_tendency`: Output NamedTuple for liquid, ice, rain, snow tendencies [1/s]
-- `ρ`: Air density [kg/m³]
-- `qₜ`: Total water specific humidity [kg/kg]
-- `qₗ`: Cloud liquid specific humidity [kg/kg]
-- `qᵢ`: Cloud ice specific humidity [kg/kg]
-- `qᵣ`: Rain specific humidity [kg/kg]
-- `qₛ`: Snow specific humidity [kg/kg]
-- `T`: Air temperature [K]
-- `dt`: Model timestep [s] (for tendency limiting)
-- `mp`: Microphysics parameters (`CMP.Microphysics1MParams`)
-- `thp`: Thermodynamics parameters
-
-# Output
-Modifies `mp_tendency` in-place with limited tendencies.
-"""
-function compute_1m_precipitation_tendencies!(
-    mp_tendency, ρ, qₜ, qₗ, qᵢ, qᵣ, qₛ, T, dt, mp, thp,
-    microphysics_tendency_timestepping = Explicit(),
-)
-    @. mp_tendency = BMT.bulk_microphysics_tendencies(
-        BMT.Microphysics1Moment(), mp, thp, ρ, T, qₜ, qₗ, qᵢ, qᵣ, qₛ,
-    )
-    apply_1m_tendency_limits!(
-        mp_tendency, microphysics_tendency_timestepping,
-        thp, qₜ, qₗ, qᵢ, qᵣ, qₛ, dt,
-    )
-end
-
-"""
     (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
 
-Evaluate 1-moment microphysics tendencies at a quadrature point.
-
-This functor computes bulk microphysics tendencies at a perturbed thermodynamic
+GPU-safe functor for computing 1-moment microphysics tendencies at quadrature
+points. Computes bulk microphysics tendencies at a perturbed thermodynamic
 state `(T_hat, q_tot_hat)` for use in SGS quadrature integration. The condensate
 at each quadrature point is assumed to equal its mean value.
 
@@ -218,7 +193,6 @@ struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     q_sno::FT
     args::Args
 end
-
 @inline function (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
     FT = typeof(eval.ρ)
 
@@ -233,57 +207,62 @@ end
 end
 
 """
-    microphysics_tendencies_quadrature_1m(
-        scheme, SG_quad, mp, tps, ρ, T_mean, q_tot_mean,
-        q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, args...
+    microphysics_tendencies_1m(ρ, q_tot, q_lcl, q_icl, q_rai, q_sno, T, cmp, thp, tst, dt,)
+    microphysics_tendencies_1m(
+        scheme, sgs_quad, cmp, thp, ρ, T, q_tot,
+        q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, tst, dt,
     )
 
-Compute subgrid-scale (SGS) averaged microphysics tendencies by integrating
-point-wise microphysics over the joint PDF of (T, q_tot):
-
+Computes 1-moment microphysics tendencies. When using SGS-quadratures,
+the tendencies are integrated over the joint PDF of (T, q_tot).
 ```math
 \\bar{S} = \\int\\int S(T, q, \\dots) P(T, q) \\, dT \\, dq
 ```
+The option without SGS-quadratures can be used in the EDMF updrafts, or to compute
+grid-mean tendency without taking account of fluctuations.
 
-This enables microphysics tendencies to account for subgrid-scale fluctuations
-in temperature and moisture, capturing threshold effects at cloud edges and
-improving representation of phase changes.
+When running with explicit microphysics timestepping,
+the total water sink is limited by the available water.
 
 # Arguments
 - `scheme`: Microphysics scheme type (from CloudMicrophysics.BulkMicrophysicsTendencies)
-- `SG_quad`: SGSQuadrature configuration
-- `mp`: Microphysics parameters (scheme-specific)
-- `tps`: Thermodynamics parameters
-- `ρ`: Air density [kg/m³]
-- `T_mean`: Mean temperature [K]
-- `q_tot_mean`: Mean total water [kg/kg]
-- `q_lcl`: Cloud liquid [kg/kg] (not perturbed)
-- `q_icl`: Cloud ice [kg/kg] (not perturbed)
-- `q_rai`: Rain [kg/kg] (not perturbed)
-- `q_sno`: Snow [kg/kg] (not perturbed)
+- `sgs_quad`: SGSQuadrature configuration
+- `cmp`, `thp`: Microphysics and thermodynamics parameters
+- `ρ`, `T`: Air density [kg/m³] and temperature [K]
+- `q_tot`: Total water [kg/kg]
+- `q_lcl`, `q_icl`: Cloud liquid water and cloud ice [kg/kg]
+- `q_rai`, `q_sno`: Rain and snow [kg/kg]
 - `T′T′`: Variance of temperature ``\\langle T'^2 \\rangle``
 - `q′q′`: Variance of q_tot ``\\langle q'^2 \\rangle``
-- `corr_Tq`: Correlation coefficient ρ(T', q')
+- `corr_Tq`: Correlation coefficient ρ(T', q') obtained from `correlation_Tq(params)`.
 - `args...`: Additional arguments (e.g., N_lcl for 2M)
+- `tst`: microphysics timestepping configuration
+- `dt`: Model timestep [s] (for tendency limiting)
 
 # Returns
-NamedTuple with averaged source terms:
+NamedTuple with microphysics source terms:
 - `dq_lcl_dt`: Cloud liquid tendency [kg/kg/s]
 - `dq_icl_dt`: Cloud ice tendency [kg/kg/s]
 - `dq_rai_dt`: Rain tendency [kg/kg/s]
 - `dq_sno_dt`: Snow tendency [kg/kg/s]
-
-# Note on Variances
-Call sites must convert θ-based variances to T-based variances using the chain rule:
-```julia
-∂T_∂θ = ... # (∂T/∂θ_liq_ice) computed at grid mean state
-T′T′ = (∂T_∂θ)² × θ′θ′
-```
-The T-q correlation coefficient is obtained from `correlation_Tq(params)`.
 """
-@inline function microphysics_tendencies_quadrature_1m(
-    scheme, SG_quad, mp, tps, ρ, T_mean, q_tot_mean,
-    q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, args...,
+@inline function microphysics_tendencies_1m( #compute_1m_precipitation_tendencies!(
+    ρ, q_tot_nonneg, q_lcl, q_icl, q_rai, q_sno, T, cmp, thp, tst, dt,
+)
+    local_tendency = BMT.bulk_microphysics_tendencies(
+        BMT.Microphysics1Moment(), cmp, thp, ρ, T,
+        q_tot_nonneg, q_lcl, q_icl, q_rai, q_sno,
+    )
+    if tst isa Explicit
+        local_tendency = explicit_1m_tendency_limit(
+            local_tendency..., thp, q_tot_nonneg, q_lcl, q_icl, q_rai, q_sno, dt,
+        )
+    end
+    return local_tendency
+end
+@inline function microphysics_tendencies_1m( #microphysics_tendencies_quadrature_1m
+    scheme, sgs_quad, cmp, thp, ρ, T, q_tot_nonneg,
+    q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, tst, dt, args...,
 )
     # Clamp species humidities to prevent negativity in quadratures
     q_lcl_nonneg = max(0, q_lcl)
@@ -291,26 +270,22 @@ The T-q correlation coefficient is obtained from `correlation_Tq(params)`.
     q_rai_nonneg = max(0, q_rai)
     q_sno_nonneg = max(0, q_sno)
 
-    # Fast path for GridMeanSGS: skip quadrature, call BMT directly at grid mean
-    # This avoids the overhead of the quadrature loop for grid-mean-only evaluation
-    if SG_quad isa GridMeanSGS ||
-       (SG_quad isa SGSQuadrature && SG_quad.dist isa GridMeanSGS)
-        return BMT.bulk_microphysics_tendencies(
-            scheme, mp, tps, ρ, T_mean, q_tot_mean,
-            q_lcl_nonneg, q_icl_nonneg, q_rai_nonneg, q_sno_nonneg, args...,
-        )
-    end
-
-    # Create functor (no closure, GPU-safe)
+    # Create functor
     evaluator = Microphysics1MEvaluator(
-        scheme, mp, tps, ρ, T_mean, q_lcl_nonneg, q_icl_nonneg,
+        scheme, cmp, thp, ρ, T, q_lcl_nonneg, q_icl_nonneg,
         q_rai_nonneg, q_sno_nonneg, args,
     )
-
     # Integrate over quadrature points using functor (GPU-safe, no closure)
-    return integrate_over_sgs(
-        evaluator, SG_quad, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
+    local_tendency = integrate_over_sgs(
+        evaluator, sgs_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
     )
+    if tst isa Explicit
+        local_tendency = explicit_1m_tendency_limit(
+            local_tendency..., thp, q_tot_nonneg, q_lcl_nonneg, q_icl_nonneg,
+            q_rai_nonneg, q_sno_nonneg, dt,
+        )
+    end
+    return local_tendency
 end
 
 ###

--- a/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -677,3 +677,11 @@ avoiding the need to extract FT from the space. Variances and correlation are ig
 @inline function integrate_over_sgs(f, ::GridMeanSGS, μ_q, μ_T, q′q′, T′T′, corr_Tq)
     return f(μ_T, μ_q)
 end
+
+"""
+    Return true if no quadrature sampling is chosen.
+"""
+@inline function not_quadrature(sgs_quad)
+    return isnothing(sgs_quad) || sgs_quad isa GridMeanSGS ||
+           (sgs_quad isa SGSQuadrature && sgs_quad.dist isa GridMeanSGS)
+end

--- a/src/parameterized_tendencies/microphysics/tendency_limiters.jl
+++ b/src/parameterized_tendencies/microphysics/tendency_limiters.jl
@@ -32,6 +32,33 @@ max_rate = limit(q_rai, dt, 3)
 end
 
 """
+    limit_sink(S, q, dt, n=3)
+
+Limit a sink tendency to prevent species depletion.
+Only applies limiting when `S < 0` (sink), sources (`S ≥ 0`) pass unchanged.
+
+# Arguments
+- `S`: Raw tendency (source or sink) [kg/kg/s]
+- `q`: Available quantity [kg/kg]
+- `dt`: Timestep [s]
+- `n`: Number of competing sinks (default: 3)
+
+# Returns
+Limited tendency:
+- If `S < 0`: `-min(-S, limit(q, dt, n))`
+- If `S ≥ 0`: `S` (unchanged)
+
+# Example
+```julia
+# Limit rain evaporation to available rain
+S_evap_limited = limit_sink(S_evap, q_rain, dt, 3)
+```
+"""
+@inline function limit_sink(S, q, dt, n = 3)
+    return ifelse(S < zero(S), -min(-S, limit(q, dt, n)), S)
+end
+
+"""
     tendency_limiter(tendency, tend_bound_pos, tend_bound_neg)
 
 Limits a `tendency` to be within `[tend_bound_neg, tend_bound_pos]`.
@@ -108,96 +135,49 @@ dn_liq_auto *= f
     return min(f1, f2)
 end
 
+# ============================================================================
+# 0M Tendency Limiting
+# ============================================================================
 """
-    limit_sink(S, q, dt, n=3)
+    explicit_0m_tendency_limit(dq_tot_dt, q_tot, dt)
 
-Limit a sink tendency to prevent species depletion using smooth limiting.
-
-Only applies limiting when `S < 0` (sink). Source tendencies (`S ≥ 0`) pass through unchanged.
-
-# Arguments
-- `S`: Raw tendency (source or sink) [kg/kg/s]
-- `q`: Available quantity [kg/kg]
-- `dt`: Timestep [s]
-- `n`: Number of competing sinks (default: 3)
-
-# Returns
-Limited tendency:
-- If `S < 0`: `-min(-S, limit(q, dt, n))`
-- If `S ≥ 0`: `S` (unchanged)
-
-# Example
-```julia
-# Limit rain evaporation to available rain
-S_evap_limited = limit_sink(S_evap, q_rain, dt, 3)
-```
+Apply a limiter to 0M microphysics total water sink.
+To be used with explicit microphysics timesteppiong.
 """
-@inline function limit_sink(S, q, dt, n = 3)
-    return ifelse(
-        S < zero(S),
-        -min(-S, limit(q, dt, n)),
-        S,
-    )
+@inline function explicit_0m_tendency_limit(dq_tot_dt, q_tot, dt)
+    return limit_sink(dq_tot_dt, q_tot, dt)
 end
-
 
 # ============================================================================
 # 1M Tendency Limiting
 # ============================================================================
 
 """
-    apply_1m_tendency_limits!(ᶜmp_tendency, timestepping, tps, ᶜq_tot, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, dt)
-
-Apply physical limiting to 1M microphysics tendencies in-place.
-
-Dispatches on `timestepping::AbstractTimesteppingMode`:
-- **Explicit**: mass-conservation + temperature-rate limiting (see `_explicit_1m_tendency_limits`)
-- **Implicit**: no-op
-- **Nothing**: no-op
-
-Also acts as a function barrier: the timestepping mode is dispatched *outside*
-the broadcast, avoiding heap allocation.
-"""
-@inline function apply_1m_tendency_limits!(
-    ᶜmp_tendency, ::Explicit, tps, ᶜq_tot, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, dt,
-)
-    @. ᶜmp_tendency = _explicit_1m_tendency_limits(
-        ᶜmp_tendency, tps, ᶜq_tot, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno, dt,
+    explicit_1m_tendency_limit(
+        dq_lcl_dt, dq_icl_dt, dq_rai_dt, dq_sno_dt, tps, q_tot, q_liq, q_ice, q_rai, q_sno, dt
     )
-end
-@inline apply_1m_tendency_limits!(ᶜmp_tendency, ::Implicit, args...) = nothing
-@inline apply_1m_tendency_limits!(ᶜmp_tendency, ::Nothing, args...) = nothing
 
-"""
-    _explicit_1m_tendency_limits(mp_tendency, tps, q_tot, q_liq, q_ice, q_rai, q_sno, dt)
-
-Pointwise explicit-mode 1M tendency limiting (called inside broadcast).
+Explicit 1-moment microphysics tendency limiting (called inside broadcast).
 
 Two layers of limiting are applied:
 1. **Mass conservation**: prevents unphysical depletion of each species beyond
    available sources (via `tendency_limiter`). Each species is limited
    bidirectionally against its maximal cross-species source pool:
-   - `dq_lcl_dt`: source = `q_vap + q_ice`, sink = `q_liq`
-   - `dq_icl_dt`: source = `q_vap + q_liq`, sink = `q_ice`
-   - `dq_rai_dt`: source = `q_liq + q_sno`, sink = `q_rai`
-   - `dq_sno_dt`: source = `q_ice`, sink = `q_sno`
+   - `dq_lcl_dt`: source = `q_vap + q_icl`, sink = `q_lcl`
+   - `dq_icl_dt`: source = `q_vap + q_lcl`, sink = `q_icl`
+   - `dq_rai_dt`: source = `q_lcl + q_sno`, sink = `q_rai`
+   - `dq_sno_dt`: source = `q_icl`, sink = `q_sno`
 2. **Combined temperature rate**: caps the combined tendency to a maximum equivalent
    temperature change `dT/dt = (L_v/c_p)·dq_lcl + (L_s/c_p)·dq_icl`
    and rescales `dq_lcl_dt` and `dq_icl_dt` uniformly.
 """
-@inline function _explicit_1m_tendency_limits(
-    mp_tendency,
-    tps,
-    q_tot,
-    q_liq,
-    q_ice,
-    q_rai,
-    q_sno,
-    dt,
+@inline function explicit_1m_tendency_limit(
+    dq_lcl_dt, dq_icl_dt, dq_rai_dt, dq_sno_dt, tps,
+    q_tot, q_lcl, q_icl, q_rai, q_sno, dt,
 )
     FT = typeof(q_tot)
     # Guard against negative q_vap from numerical errors (AD-safe via max)
-    q_vap = max(zero(q_tot), q_tot - q_liq - q_ice - q_rai - q_sno)
+    q_vap = max(zero(q_tot), q_tot - q_lcl - q_icl - q_rai - q_sno)
 
     # Mass-conservation limits using cross-species source pools
     # n_sink: number of timesteps over which species would be depleted
@@ -206,24 +186,16 @@ Two layers of limiting are applied:
     n_source = 30
 
     dq_lcl_dt = tendency_limiter(
-        mp_tendency.dq_lcl_dt,
-        limit(q_vap + q_ice, dt, n_source),
-        limit(q_liq, dt, n_sink),
+        dq_lcl_dt, limit(q_vap + q_icl, dt, n_source), limit(q_lcl, dt, n_sink),
     )
     dq_icl_dt = tendency_limiter(
-        mp_tendency.dq_icl_dt,
-        limit(q_vap + q_liq, dt, n_source),
-        limit(q_ice, dt, n_sink),
+        dq_icl_dt, limit(q_vap + q_lcl, dt, n_source), limit(q_icl, dt, n_sink),
     )
     dq_rai_dt = tendency_limiter(
-        mp_tendency.dq_rai_dt,
-        limit(q_liq + q_sno, dt, n_source),
-        limit(q_rai, dt, n_sink),
+        dq_rai_dt, limit(q_lcl + q_sno, dt, n_source), limit(q_rai, dt, n_sink),
     )
     dq_sno_dt = tendency_limiter(
-        mp_tendency.dq_sno_dt,
-        limit(q_ice, dt, n_source),
-        limit(q_sno, dt, n_sink),
+        dq_sno_dt, limit(q_icl, dt, n_source), limit(q_sno, dt, n_sink),
     )
 
     # Combined temperature-rate limiter:
@@ -248,34 +220,6 @@ Two layers of limiting are applied:
         dq_sno_dt = dq_sno_dt,
     )
 end
-
-# ============================================================================
-# 0M Tendency Limiting
-# ============================================================================
-
-"""
-    apply_0m_tendency_limits!(ᶜmp_tendency, timestepping, ᶜq_tot, dt)
-
-Apply physical limiting to 0M microphysics tendencies in-place.
-
-No-op for implicit timestepping as the Jacobian handles stability.
-"""
-@inline apply_0m_tendency_limits!(ᶜmp_tendency, ::Implicit, args...) = nothing
-@inline function apply_0m_tendency_limits!(
-    ᶜmp_tendency, ::Explicit, ᶜq_tot, dt,
-)
-    @. ᶜmp_tendency = _explicit_0m_tendency_limits(ᶜmp_tendency, ᶜq_tot, dt)
-end
-@inline apply_0m_tendency_limits!(ᶜmp_tendency, ::Nothing, args...) = nothing
-
-@inline function _explicit_0m_tendency_limits(mp_tendency, q_tot, dt)
-    dq_tot_dt = limit_sink(mp_tendency.dq_tot_dt, q_tot, dt)
-    return (
-        dq_tot_dt = dq_tot_dt,
-        e_tot_hlpr = mp_tendency.e_tot_hlpr,
-    )
-end
-
 
 # ============================================================================
 # 2M Tendency Limiting

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -714,6 +714,7 @@ struct ReproducibleRestart end
 abstract type AbstractTimesteppingMode end
 struct Explicit <: AbstractTimesteppingMode end
 struct Implicit <: AbstractTimesteppingMode end
+Base.broadcastable(x::AbstractTimesteppingMode) = tuple(x)
 
 struct QuasiMonotoneLimiter end # For dispatching to use the ClimaCore QuasiMonotoneLimiter.
 

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -304,14 +304,12 @@ using ClimaAtmos
         end
     end
 
-    @testset "Microphysics Tendencies Quadrature" begin
+    @testset "Microphysics Tendencies 1M" begin
         import Thermodynamics as TD
         import ClimaParams as CP
         import CloudMicrophysics.Parameters as CMP
         import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
-
-        # Import from ClimaAtmos - function is in microphysics_wrappers.jl
-        using ClimaAtmos: microphysics_tendencies_quadrature_1m
+        using ClimaAtmos: microphysics_tendencies_1m
 
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
@@ -322,7 +320,6 @@ using ClimaAtmos
 
                 # Grid-mean state
                 ρ = FT(1.2)
-                p_c = FT(1e5)
                 T_mean = FT(280.0)
                 q_tot_mean = FT(0.01)
                 q_lcl_mean = FT(0.0001)
@@ -335,6 +332,10 @@ using ClimaAtmos
                 q′q′ = FT(1e-6)
                 corr_Tq = FT(0.6)
 
+                # No-op timestepping (no limiting)
+                tst = nothing
+                dt = FT(1.0)
+
                 # Test 1: Single quadrature point should match grid-mean evaluation
                 @testset "Single Point = Grid Mean" begin
                     # Use GaussianSGS: only Gaussian has χ=0 → (μ_T, μ_q)
@@ -344,12 +345,12 @@ using ClimaAtmos
                         distribution = ClimaAtmos.GaussianSGS(),
                     )
 
-                    # Quadrature result
-                    result_quad = microphysics_tendencies_quadrature_1m(
+                    # Quadrature result (no limiting)
+                    result_quad = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad_1pt, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq,
+                        T′T′, q′q′, corr_Tq, tst, dt,
                     )
 
                     # Direct evaluation at grid mean
@@ -371,11 +372,11 @@ using ClimaAtmos
                     quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
 
                     # Zero variances
-                    result_quad = microphysics_tendencies_quadrature_1m(
+                    result_quad = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0),  # Zero variances, zero correlation
+                        FT(0), FT(0), FT(0), tst, dt,
                     )
 
                     # Direct evaluation
@@ -393,11 +394,11 @@ using ClimaAtmos
                 @testset "NamedTuple Structure" begin
                     quad = ClimaAtmos.SGSQuadrature(FT)
 
-                    result = microphysics_tendencies_quadrature_1m(
+                    result = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq,
+                        T′T′, q′q′, corr_Tq, tst, dt,
                     )
 
                     @test haskey(result, :dq_lcl_dt)
@@ -412,25 +413,48 @@ using ClimaAtmos
                     quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
 
                     # With variance
-                    result_var = microphysics_tendencies_quadrature_1m(
+                    result_var = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.8),  # Non-zero variances
+                        FT(4.0), FT(1e-5), FT(0.8), tst, dt,
                     )
 
                     # Without variance
-                    result_no_var = microphysics_tendencies_quadrature_1m(
+                    result_no_var = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0),
+                        FT(0), FT(0), FT(0), tst, dt,
                     )
 
                     # Results should differ (unless microphysics is perfectly linear)
                     # At minimum, they should both be finite
                     @test isfinite(result_var.dq_lcl_dt)
                     @test isfinite(result_no_var.dq_lcl_dt)
+                end
+
+                # Test 5: Non-quadrature (direct) evaluation
+                @testset "Direct (non-quadrature) evaluation" begin
+                    result_direct_wrapper = microphysics_tendencies_1m(
+                        ρ, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
+                        T_mean, mp, tps, tst, dt,
+                    )
+
+                    result_bmt = BMT.bulk_microphysics_tendencies(
+                        BMT.Microphysics1Moment(),
+                        mp, tps, ρ, T_mean,
+                        q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
+                    )
+
+                    @test result_direct_wrapper.dq_lcl_dt ≈ result_bmt.dq_lcl_dt rtol =
+                        FT(1e-10)
+                    @test result_direct_wrapper.dq_icl_dt ≈ result_bmt.dq_icl_dt rtol =
+                        FT(1e-10)
+                    @test result_direct_wrapper.dq_rai_dt ≈ result_bmt.dq_rai_dt rtol =
+                        FT(1e-10)
+                    @test result_direct_wrapper.dq_sno_dt ≈ result_bmt.dq_sno_dt rtol =
+                        FT(1e-10)
                 end
             end
         end
@@ -442,7 +466,7 @@ using ClimaAtmos
         import ClimaParams as CP
         import CloudMicrophysics.Parameters as CMP
         import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
-        using ClimaAtmos: microphysics_tendencies_quadrature_1m
+        using ClimaAtmos: microphysics_tendencies_1m
 
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
@@ -453,7 +477,6 @@ using ClimaAtmos
 
                 # Realistic atmospheric state
                 ρ = FT(1.0)
-                p_c = FT(1e5)
                 T = FT(280.0)
                 q_tot = FT(0.015)
                 q_liq = FT(0.002)
@@ -466,10 +489,13 @@ using ClimaAtmos
                 q′q′ = FT(1e-5)
                 corr_Tq = FT(0.6)
 
-                result = microphysics_tendencies_quadrature_1m(
+                tst = nothing
+                dt = FT(1.0)
+
+                result = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq,
+                    T′T′, q′q′, corr_Tq, tst, dt,
                 )
 
                 # Total condensed water tendency
@@ -504,7 +530,7 @@ using ClimaAtmos
         import ClimaParams as CP
         import CloudMicrophysics.Parameters as CMP
         import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
-        using ClimaAtmos: microphysics_tendencies_quadrature_1m
+        using ClimaAtmos: microphysics_tendencies_1m
         using Test: @inferred
 
         # Test both Float32 and Float64 for type stability
@@ -516,7 +542,6 @@ using ClimaAtmos
                 quad = ClimaAtmos.SGSQuadrature(FT)
 
                 ρ = FT(1.0)
-                p_c = FT(1e5)
                 T = FT(280.0)
                 q_tot = FT(0.01)
                 q_liq = FT(0.001)
@@ -526,12 +551,14 @@ using ClimaAtmos
                 T′T′ = FT(1.0)
                 q′q′ = FT(1e-6)
                 corr_Tq = FT(0.6)
+                tst = nothing
+                dt = FT(1.0)
 
                 # Test type stability
-                result = @inferred microphysics_tendencies_quadrature_1m(
+                result = @inferred microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq,
+                    T′T′, q′q′, corr_Tq, tst, dt,
                 )
 
                 # Verify return type
@@ -561,14 +588,10 @@ using ClimaAtmos
                 # Grid-mean state
                 ρ = FT(1.0)
                 T_mean = FT(280.0)
-                q_tot_mean = FT(0.01)
                 q_lcl_mean = FT(0.001)
                 q_icl_mean = FT(0.0005)
                 q_rai = FT(0.0002)
                 q_sno = FT(0.0001)
-                q_cond_mean = q_lcl_mean + q_icl_mean
-                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
-                excess_mean = q_tot_mean - q_sat_mean
 
                 # Create evaluator
                 evaluator = Microphysics1MEvaluator(
@@ -606,7 +629,7 @@ using ClimaAtmos
         import ClimaParams as CP
         import CloudMicrophysics.Parameters as CMP
         import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
-        using ClimaAtmos: microphysics_tendencies_quadrature_1m
+        using ClimaAtmos: microphysics_tendencies_1m
 
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
@@ -616,7 +639,6 @@ using ClimaAtmos
 
                 # Grid-mean state
                 ρ = FT(1.2)
-                p_c = FT(1e5)
                 T_mean = FT(280.0)
                 q_tot = FT(0.01)
                 q_liq = FT(0.001)
@@ -634,13 +656,15 @@ using ClimaAtmos
                 T′T′ = FT(4.0)
                 q′q′ = FT(1e-5)
                 corr_Tq = FT(0.6)
+                tst = nothing
+                dt = FT(1.0)
 
                 # Quadrature path
-                result_quad = microphysics_tendencies_quadrature_1m(
+                result_quad = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad_gm, mp, tps, ρ,
                     T_mean, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq,
+                    T′T′, q′q′, corr_Tq, tst, dt,
                 )
 
                 # Direct BMT call
@@ -673,7 +697,7 @@ using ClimaAtmos
             @testset "FT = $FT" begin
                 toml_dict = CP.create_toml_dict(FT)
 
-                @testset "0M quadrature: dq_tot_dt ≤ 0" begin
+                @testset "0M: dq_tot_dt ≤ 0" begin
                     quad = ClimaAtmos.SGSQuadrature(FT)
                     mp_0m = CMP.Microphysics0MParams(toml_dict)
                     thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
@@ -682,46 +706,59 @@ using ClimaAtmos
                     T_mean = FT(280.0)
                     q_tot_mean = FT(0.015)
                     Φ = FT(5000.0)  # geopotential [J/kg]
+                    tst = nothing
+                    dt = FT(1.0)
 
-                    # Zero variances (grid-mean evaluation)
-                    result_zero = ClimaAtmos.microphysics_tendencies_quadrature_0m(
+                    # Zero variances (grid-mean evaluation via quadrature)
+                    result_zero = ClimaAtmos.microphysics_tendencies_0m(
                         quad, mp_0m, thp, ρ, T_mean, q_tot_mean,
-                        FT(0), FT(0), FT(0), Φ,
+                        FT(0), FT(0), FT(0), Φ, tst, dt,
                     )
                     @test result_zero.dq_tot_dt <= FT(0)
                     @test isfinite(result_zero.dq_tot_dt)
                     @test isfinite(result_zero.e_tot_hlpr)
 
                     # With variances (SGS fluctuations)
-                    result_var = ClimaAtmos.microphysics_tendencies_quadrature_0m(
+                    result_var = ClimaAtmos.microphysics_tendencies_0m(
                         quad, mp_0m, thp, ρ, T_mean, q_tot_mean,
-                        FT(4.0), FT(1e-5), FT(0.6), Φ,
+                        FT(4.0), FT(1e-5), FT(0.6), Φ, tst, dt,
                     )
                     @test result_var.dq_tot_dt <= FT(0)
                     @test isfinite(result_var.dq_tot_dt)
                     @test isfinite(result_var.e_tot_hlpr)
+
+                    # Direct (non-quadrature) evaluation with reasonable condensate
+                    q_liq = FT(0.001)
+                    q_ice = FT(0.0005)
+                    result_direct = ClimaAtmos.microphysics_tendencies_0m(
+                        mp_0m, thp, ρ, T_mean, q_tot_mean,
+                        q_liq, q_ice, Φ, tst, dt,
+                    )
+                    @test result_direct.dq_tot_dt <= FT(0)
+                    @test isfinite(result_direct.e_tot_hlpr)
                 end
 
-                @testset "1M quadrature: sign consistency" begin
+                @testset "1M: sign consistency" begin
                     quad = ClimaAtmos.SGSQuadrature(FT)
                     mp_1m = CMP.Microphysics1MParams(toml_dict; with_2M_autoconv = true)
                     thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
 
                     ρ = FT(1.0)
-                    p_c = FT(85000.0)
                     T = FT(280.0)
                     q_tot = FT(0.015)
                     q_liq = FT(0.001)
                     q_ice = FT(0.0005)
                     q_rai = FT(0.0001)
                     q_sno = FT(0.00005)
+                    tst = nothing
+                    dt = FT(1.0)
 
                     # With zero variances, quadrature should match direct BMT
-                    result_quad = ClimaAtmos.microphysics_tendencies_quadrature_1m(
+                    result_quad = ClimaAtmos.microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(0), FT(0), FT(0),
+                        FT(0), FT(0), FT(0), tst, dt,
                     )
 
                     result_direct = BMT.bulk_microphysics_tendencies(
@@ -740,17 +777,184 @@ using ClimaAtmos
                     end
 
                     # With non-zero variances, should still be finite
-                    result_var = ClimaAtmos.microphysics_tendencies_quadrature_1m(
+                    result_var = ClimaAtmos.microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.6),
+                        FT(4.0), FT(1e-5), FT(0.6), tst, dt,
                     )
                     for field in (:dq_lcl_dt, :dq_icl_dt, :dq_rai_dt, :dq_sno_dt)
                         @test isfinite(getfield(result_var, field))
                     end
+
+                    # Non-quadrature (direct) wrapper should also match
+                    result_direct_wrapper = ClimaAtmos.microphysics_tendencies_1m(
+                        ρ, q_tot, q_liq, q_ice, q_rai, q_sno,
+                        T, mp_1m, thp, tst, dt,
+                    )
+                    for field in (:dq_lcl_dt, :dq_icl_dt, :dq_rai_dt, :dq_sno_dt)
+                        @test getfield(result_direct_wrapper, field) ≈
+                              getfield(result_direct, field) rtol = FT(1e-10)
+                    end
                 end
             end
+        end
+    end
+
+    @testset "Performance Scaling" begin
+        # Verify that the computational cost scales as expected with quadrature order
+        # and that the direct (non-quadrature) path has negligible overhead vs raw BMT.
+        import Thermodynamics as TD
+        import ClimaParams as CP
+        import CloudMicrophysics.Parameters as CMP
+        import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
+        using ClimaAtmos: microphysics_tendencies_0m, microphysics_tendencies_1m
+
+        FT = Float64
+        toml_dict = CP.create_toml_dict(FT)
+        thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+        mp_0m = CMP.Microphysics0MParams(toml_dict)
+        mp_1m = CMP.Microphysics1MParams(toml_dict)
+
+        # Shared state
+        ρ = FT(1.0)
+        T = FT(280.0)
+        q_tot = FT(0.015)
+        q_lcl = FT(0.001)
+        q_icl = FT(0.0005)
+        q_rai = FT(0.0001)
+        q_sno = FT(0.00005)
+        q_liq = q_lcl + q_rai
+        q_ice = q_icl + q_sno
+        Φ = FT(5000.0)
+        T′T′ = FT(1.0)
+        q′q′ = FT(1e-6)
+        corr_Tq = FT(0.6)
+        tst = nothing
+        dt = FT(1.0)
+
+        N_warmup = 100
+        N_bench = 10_000
+
+        # --- 0M Performance ---
+        # We would be getting better measurements with BenchmarkTools, but I did not
+        # want to add them to the dependencies.
+        @testset "0M Performance" begin
+            # Direct BMT 0M
+            q_vap_sat = TD.q_vap_saturation(thp, T, ρ)
+            for _ in 1:N_warmup
+                BMT.bulk_microphysics_tendencies(
+                    BMT.Microphysics0Moment(), mp_0m, thp, T, q_liq, q_ice, q_vap_sat,
+                )
+            end
+            t_direct_0m = @elapsed for _ in 1:N_bench
+                BMT.bulk_microphysics_tendencies(
+                    BMT.Microphysics0Moment(), mp_0m, thp, T, q_liq, q_ice, q_vap_sat,
+                )
+            end
+
+            # Non-quadrature wrapper 0M
+            for _ in 1:N_warmup
+                microphysics_tendencies_0m(
+                    mp_0m, thp, ρ, T, q_tot, q_liq, q_ice, Φ, tst, dt,
+                )
+            end
+            t_wrapper_0m = @elapsed for _ in 1:N_bench
+                microphysics_tendencies_0m(
+                    mp_0m, thp, ρ, T, q_tot, q_liq, q_ice, Φ, tst, dt,
+                )
+            end
+
+            # 1st-order, 3rd-order, 5th-order quadrature 0M
+            timings_0m = Dict{Int, Float64}()
+            for order in (1, 3, 5)
+                quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = order)
+                for _ in 1:N_warmup
+                    microphysics_tendencies_0m(
+                        quad, mp_0m, thp, ρ, T, q_tot,
+                        T′T′, q′q′, corr_Tq, Φ, tst, dt,
+                    )
+                end
+                t = @elapsed for _ in 1:N_bench
+                    microphysics_tendencies_0m(
+                        quad, mp_0m, thp, ρ, T, q_tot,
+                        T′T′, q′q′, corr_Tq, Φ, tst, dt,
+                    )
+                end
+                timings_0m[order] = t
+            end
+
+            @info "0M Performance ($(N_bench) calls)" t_direct_0m t_wrapper_0m timings_0m
+
+            # Non-quadrature wrapper cost should be within direct BMT cost
+            @test t_wrapper_0m < 1.1 * t_direct_0m
+
+            # 3-point should not be more expensive than 3*3 * 1-point
+            @test timings_0m[3] < 9 * timings_0m[1]
+            # 5-point should not be more expensive than 5*5 * 1-point
+            @test timings_0m[5] < 25 * timings_0m[1]
+        end
+
+        # --- 1M Performance ---
+        @testset "1M Performance" begin
+            # Direct BMT 1M
+            for _ in 1:N_warmup
+                BMT.bulk_microphysics_tendencies(
+                    BMT.Microphysics1Moment(), mp_1m, thp, ρ, T,
+                    q_tot, q_lcl, q_icl, q_rai, q_sno,
+                )
+            end
+            t_direct_1m = @elapsed for _ in 1:N_bench
+                BMT.bulk_microphysics_tendencies(
+                    BMT.Microphysics1Moment(), mp_1m, thp, ρ, T,
+                    q_tot, q_lcl, q_icl, q_rai, q_sno,
+                )
+            end
+
+            # Non-quadrature wrapper 1M
+            for _ in 1:N_warmup
+                microphysics_tendencies_1m(
+                    ρ, q_tot, q_lcl, q_icl, q_rai, q_sno,
+                    T, mp_1m, thp, tst, dt,
+                )
+            end
+            t_wrapper_1m = @elapsed for _ in 1:N_bench
+                microphysics_tendencies_1m(
+                    ρ, q_tot, q_lcl, q_icl, q_rai, q_sno,
+                    T, mp_1m, thp, tst, dt,
+                )
+            end
+
+            # 1st-order, 3rd-order, 5th-order quadrature 1M
+            timings_1m = Dict{Int, Float64}()
+            for order in (1, 3, 5)
+                quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = order)
+                for _ in 1:N_warmup
+                    microphysics_tendencies_1m(
+                        BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
+                        q_tot, q_lcl, q_icl, q_rai, q_sno,
+                        T′T′, q′q′, corr_Tq, tst, dt,
+                    )
+                end
+                t = @elapsed for _ in 1:N_bench
+                    microphysics_tendencies_1m(
+                        BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
+                        q_tot, q_lcl, q_icl, q_rai, q_sno,
+                        T′T′, q′q′, corr_Tq, tst, dt,
+                    )
+                end
+                timings_1m[order] = t
+            end
+
+            @info "1M Performance ($(N_bench) calls)" t_direct_1m t_wrapper_1m timings_1m
+
+            # Non-quadrature wrapper should be within the cost of direct BMT
+            @test t_wrapper_1m < 1.1 * t_direct_1m
+
+            # 3-point quadrature should not be more expensive than 3*3 * 1-point
+            @test timings_1m[3] < 9 * timings_1m[1]
+            # 5-point quadrature should not be more expensive than 5*5 * 1-point
+            @test timings_1m[5] < 25 * timings_1m[1]
         end
     end
 

--- a/test/parameterized_tendencies/microphysics/tendency_limiters.jl
+++ b/test/parameterized_tendencies/microphysics/tendency_limiters.jl
@@ -6,7 +6,7 @@ Tests cover:
 2. `tendency_limiter()` - bidirectional tendency limiting
 3. `coupled_sink_limit_factor()` - uniform scaling for coupled sinks
 4. `limit_sink()` - sink-only tendency limiting
-5. `_explicit_1m_tendency_limits()` - end-to-end 1M explicit limiter
+5. `explicit_1m_tendency_limit()` - end-to-end 1M explicit limiter
 =#
 
 using Test
@@ -226,8 +226,8 @@ import ClimaAtmos:
         end
     end
 
-    @testset "_explicit_1m_tendency_limits() cross-species limiting" begin
-        import ClimaAtmos: _explicit_1m_tendency_limits
+    @testset "explicit_1m_tendency_limit() cross-species limiting" begin
+        import ClimaAtmos: explicit_1m_tendency_limit
         import Thermodynamics as TD
         import ClimaParams as CP
 
@@ -244,68 +244,52 @@ import ClimaAtmos:
             # n_sink=5 budget for q=0.01 is 0.01/(600*5) = 3.33e-6
             # n_source=30 budget for source pool is even larger.
             # Tendencies ~1e-7 are well below both budgets.
-            mp_tendency = (
-                dq_lcl_dt = FT(1e-7),
-                dq_icl_dt = FT(-5e-8),
-                dq_rai_dt = FT(-3e-8),
-                dq_sno_dt = FT(-2e-8),
-            )
+            dq_lcl_dt = FT(1e-7)
+            dq_icl_dt = FT(-5e-8)
+            dq_rai_dt = FT(-3e-8)
+            dq_sno_dt = FT(-2e-8)
             q_liq = FT(0.01)
             q_ice = FT(0.01)
             q_rai = FT(0.01)
             q_sno = FT(0.01)
             q_tot = FT(0.05)  # q_vap = 0.01 > 0
 
-            limited = _explicit_1m_tendency_limits(
-                mp_tendency,
-                thermo_params,
-                q_tot,
-                q_liq,
-                q_ice,
-                q_rai,
-                q_sno,
-                dt,
+            limited = explicit_1m_tendency_limit(
+                dq_lcl_dt, dq_icl_dt, dq_rai_dt, dq_sno_dt,
+                thermo_params, q_tot, q_liq, q_ice, q_rai, q_sno, dt,
             )
 
             # Should pass through nearly unchanged.
-            @test limited.dq_lcl_dt ≈ mp_tendency.dq_lcl_dt rtol = 0.05
-            @test limited.dq_icl_dt ≈ mp_tendency.dq_icl_dt rtol = 0.05
-            @test limited.dq_rai_dt ≈ mp_tendency.dq_rai_dt rtol = 0.05
-            @test limited.dq_sno_dt ≈ mp_tendency.dq_sno_dt rtol = 0.05
+            @test limited.dq_lcl_dt ≈ dq_lcl_dt rtol = 0.05
+            @test limited.dq_icl_dt ≈ dq_icl_dt rtol = 0.05
+            @test limited.dq_rai_dt ≈ dq_rai_dt rtol = 0.05
+            @test limited.dq_sno_dt ≈ dq_sno_dt rtol = 0.05
         end
 
         @testset "per-species sink limiting prevents depletion" begin
             # Rain has a large sink tendency relative to its small amount
-            mp_tendency = (
-                dq_lcl_dt = FT(0.001),
-                dq_icl_dt = FT(-0.0005),
-                dq_rai_dt = FT(-0.01),  # Would deplete rain in < dt
-                dq_sno_dt = FT(-0.0002),
-            )
+            dq_lcl_dt = FT(0.001)
+            dq_icl_dt = FT(-0.0005)
+            dq_rai_dt = FT(-0.01)  # Would deplete rain in < dt
+            dq_sno_dt = FT(-0.0002)
             q_liq = FT(0.001)
             q_ice = FT(0.0005)
             q_rai = FT(0.0001)  # Small amount
             q_sno = FT(0.0002)
             q_tot = FT(0.01)  # q_vap = 0.0082
 
-            limited = _explicit_1m_tendency_limits(
-                mp_tendency,
-                thermo_params,
-                q_tot,
-                q_liq,
-                q_ice,
-                q_rai,
-                q_sno,
-                dt,
+            limited = explicit_1m_tendency_limit(
+                dq_lcl_dt, dq_icl_dt, dq_rai_dt, dq_sno_dt,
+                thermo_params, q_tot, q_liq, q_ice, q_rai, q_sno, dt,
             )
 
             # Rain sink tendency should be limited (prevented from depleting)
             @test limited.dq_rai_dt * dt >= -q_rai
-            @test abs(limited.dq_rai_dt) < abs(mp_tendency.dq_rai_dt)
+            @test abs(limited.dq_rai_dt) < abs(dq_rai_dt)
 
             # With per-species limiting, other species are limited independently.
             # Snow should be limited but less aggressively than rain.
-            @test abs(limited.dq_sno_dt) <= abs(mp_tendency.dq_sno_dt)
+            @test abs(limited.dq_sno_dt) <= abs(dq_sno_dt)
         end
     end
 end


### PR DESCRIPTION
This PR unifies the microphysics tendency evaluation logic for 0-moment and 1-moment schemes. Previously, grid-mean and SGS-quadrature evaluations used separate functions with inconsistent signatures and duplicate external limiting logic. 

- Both 0M and 1M schemes now have two pathways - using the evaluator on quadrature points or directly calling BMT (when in updrafts or running without SGS fluctuations). We can't just have one pathway, because the arguments passed (variances) and the logic (saturation adjustment vs passing in cloud condensate) is inherently different.
- I added one definition of what it means without SGS fluctuations.
- All the if/else statements that I added are known at compile time and should not result in any run-time slow-downs.
- I put the explicit limiters inside the microphysics_tendencies to avoid code duplication.
- I changed the tendencies and limiters from mutating things in place to returning the result (in line with what we discussed in microphysics refactor issue https://github.com/CliMA/ClimaAtmos.jl/issues/4285)

Out of curiosity, I also added some simple timing test for the direct BMT vs non-quadrature vs quadrature runs. The test accuracy is not super high, because I did not want to add `BenchmarkTools` to the dependencies. But here is a quick glance at the quadrature penalty we have for 0M and 1M:

```
┌ Info: 0M Performance (10000 calls)
│   t_direct_0m = 0.0036955
│   t_wrapper_0m = 0.000869083
│   timings_0m =
│    Dict{Int64, Float64} with 3 entries:
│      5 => 0.0130378
│      3 => 0.00598933
└      1 => 0.00185075
┌ Info: 1M Performance (10000 calls)
│   t_direct_1m = 0.022510667
│   t_wrapper_1m = 0.014284125
│   timings_1m =
│    Dict{Int64, Float64} with 3 entries:
│      5 => 0.397994
│      3 => 0.168257
└      1 => 0.039695
```