### PR TITLE
Try adding copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# Copilot instructions for ClimaAtmos.jl
+
+The authoritative agent brief for this repository is [`AGENTS.md`](../AGENTS.md)
+at the repository root. Read it in full before suggesting code, reviewing a PR,
+or answering a question about this codebase, and follow it as if its contents
+were inlined here.
+
+In particular:
+
+- For **code review**, follow the rubric in
+  [`docs/agents/review.md`](../docs/agents/review.md).
+- For **writing or modifying code**, follow the patterns in
+  [`docs/agents/software_design_patterns.md`](../docs/agents/software_design_patterns.md).
+- For **contributor workflow** (formatting, tests, NEWS.md, configs), defer to
+  [`docs/src/contributor_guide.md`](../docs/src/contributor_guide.md).
+
+If `AGENTS.md` and this file ever disagree, `AGENTS.md` wins — update this file
+to match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# ClimaAtmos Agent Guide
+
+## Repo exploration
+
+- Before broad repo search or codebase exploration, read [docs/agents/repo_structure.md](docs/agents/repo_structure.md).
+
+## Pull request reviews
+
+- When asked to review a pull request, follow [docs/agents/review.md](docs/agents/review.md).
+- Apply the full checklist and output schema in [docs/agents/review.md](docs/agents/review.md); keep reviews concise, evidence-based, and findings-first.
+- During review, also enforce [docs/agents/software_design_patterns.md](docs/agents/software_design_patterns.md) for changed code and adjacent affected code, as required by [docs/agents/review.md](docs/agents/review.md).
+
+## Local norms
+
+- Prefer Julia 1.11.x for local work. CI also runs 1.10 and 1.11.
+- For runtime validation, prefer `julia +1.11 --project=.buildkite .buildkite/ci_driver.jl ...`.
+- For package tests, prefer `Pkg.test()` over manually `include`ing `test/runtests.jl` because test-only deps are loaded through the package test path.
+- Keep edits inside the owning subtree when possible; use [src/ClimaAtmos.jl](src/ClimaAtmos.jl) to trace where a feature is wired.
+- Match existing style: explicit names, narrow imports, comments that explain why.
+- Follow the software design patterns in [docs/agents/software_design_patterns.md](docs/agents/software_design_patterns.md) for new code and refactor toward them when touching existing code.
+
+## Self-correction
+
+- If the code map in [docs/agents/repo_structure.md](docs/agents/repo_structure.md) is discovered to be stale, update it.
+- If the user gives a correction about how work should be done in this repo, add it to `Local norms` or another clearly labeled persistent section in this file so future sessions inherit it.

--- a/docs/agents/repo_structure.md
+++ b/docs/agents/repo_structure.md
@@ -1,0 +1,31 @@
+# Codebase map
+
+- `src/ClimaAtmos.jl`: package entry point. It `include`s the main subsystems; start here when you need the owning source area.
+- `src/solver/`: configuration and CLI wiring. `cli_options.jl` defines `--config_file` and `--job_id`; `yaml_helper.jl` loads `config/default_configs/default_config.yml` and merges overlay YAML; `types.jl`, `model_getters.jl`, `type_getters.jl`, and `solve.jl` turn config into a runnable model.
+- `src/simulation/AtmosSimulations.jl`: high-level `AtmosSimulation(config)` construction.
+- `src/prognostic_equations/`, `src/parameterized_tendencies/`, `src/callbacks/`, `src/diagnostics/`, `src/setups/`, `src/surface_conditions/`, `src/topography/`, `src/cache/`, `src/parameters/`, `src/utils/`: domain subtrees. Search by physics/runtime concept first.
+- `config/`: YAML/TOML config library. `default_configs/default_config.yml` is the schema baseline; `common_configs/` holds reusable numerics; `model_configs/`, `gpu_configs/`, `mpi_configs/`, `perf_configs/`, and `longrun_configs/` are scenario overlays.
+- `.buildkite/ci_driver.jl`: canonical run entry for CI-style simulations. It parses config, builds the simulation, runs `solve_atmos!`, and performs validation/output checks.
+- `.buildkite/pipeline.yml`: canonical config composition examples. Use it to see which config families are combined in automation.
+- `docs/make.jl` and `docs/src/`: Documenter entry point plus user/contributor docs. Good references for API usage and config recipes.
+- `perf/`, `post_processing/`, `calibration/`, `reproducibility_tests/`, `runscripts/`, `examples/`: performance tools, analysis scripts, calibration workflows, reproducibility helpers, launch scripts, and smaller usage examples.
+
+## Configuration
+
+- Config files use `.yml` and usually encode scenario/family in the filename, e.g. `single_column_*`, `diagnostic_edmfx_*`, `prognostic_edmfx_*`.
+- Config wiring is layered: default config loads first, then each repeated `--config_file` overlay is merged in order, with later files winning on conflicts.
+- Common pattern: one numerics file from `config/common_configs/` plus one scenario file from `config/model_configs/` or another config family.
+- YAML can point at parameter TOML via `toml: [toml/... ]`.
+- `job_id` must be unique across `config/`; this is enforced in `test/config.jl`.
+- If you add keys to `config/default_configs/default_config.yml`, keep the `help` and `value` wrapper.
+
+## Test locations
+
+- `test/runtests.jl`: top-level test driver. Tests are grouped by `TEST_GROUP`: `infrastructure`, `diagnostics`, `dynamics`, `parameterizations`, `restarts`, `era5`.
+- `test/solver/`, `test/diagnostics/`, `test/prognostic_equations/`, `test/parameterized_tendencies/`, `test/conservation/`: tests mostly mirror the source layout.
+- `test/test_helpers.jl`: shared testing utilities.
+- `test/config.jl`: config invariants and uniqueness checks; inspect this before changing config semantics.
+
+## Self-correction
+
+- If this code map is discovered to be stale, update it.

--- a/docs/agents/review.md
+++ b/docs/agents/review.md
@@ -1,0 +1,125 @@
+# ClimaAtmos PR Review Instructions
+
+You are reviewing PRs for ClimaAtmos.jl.
+
+Keep the review concise, evidence-based, and findings-first. Optimize for concrete bugs, regressions, and missing validation. Do not write broad architecture summaries.
+
+## Review workflow
+
+Work in this order:
+
+1. Review changed files first.
+2. Step to the nearest controlling compute paths only when needed to confirm behavior or risk.
+3. Use local evidence: changed code, nearby tests, call sites, docs, and config usage.
+4. Check [software_design_patterns.md](software_design_patterns.md) for changed code and any adjacent code whose behavior is directly affected.
+5. Report only evidence-backed findings or clearly labeled risks/open questions.
+
+## Review checklist
+
+### Correctness and science risk (in order)
+
+- [ ] Check behavior, numerics, stability, conservation, restart reproducibility, diagnostics, and config semantics.
+- [ ] Prioritize high-risk areas: implicit solver, Jacobian, prognostic equations, parameterized tendencies, restart logic, and output/reproducibility paths.
+- [ ] Label concerns as one of: definite bug, likely regression, or plausible risk.
+- [ ] Flag any user-visible config key, diagnostic name, default, release-facing behavior, or CLI flag change that is missing a `NEWS.md` entry.
+
+### Validation
+
+- [ ] Map validation to the test groups in `test/runtests.jl`: infrastructure, diagnostics, dynamics, parameterizations, restarts, era5.
+- [ ] For config or runtime workflow changes, name the affected `.buildkite/ci_driver.jl` jobs.
+- [ ] If validation is missing, name the exact missing test group, nearby test file, or Buildkite job.
+
+### Compatibility, performance, and style
+
+- [ ] Check API and config compatibility: keys, defaults, diagnostics/output names, initialization, restart/reproducibility behavior, and downstream public APIs.
+- [ ] Check concrete performance risks in hot paths: allocations, type instability, repeated work, and scaling regressions.
+- [ ] Check consistency with `docs/src/contributor_guide.md` and `.JuliaFormatter.toml`.
+- [ ] Avoid low-signal style commentary unless it hides or causes a real issue.
+
+## Severity rules
+
+Use exactly these labels for every finding: `high`, `medium`, `low`.
+
+Choose the severity based on the user-visible and scientific impact, not on how easy the fix is.
+
+### `high`
+
+Use `high` for correctness or science regressions, hot-path performance breakage, or compatibility breaks with clear impact.
+
+Examples that belong in `high`:
+
+- Wrong numerics.
+- Broken conservation.
+- Restart non-bit-reproducibility.
+- Silently changed defaults that alter a published config.
+- Public API breaking changes without deprecation.
+- GPU runs broken.
+- Allocations or regressions in a tendency hot path.
+- Allocations or regressions in a Jacobian hot path.
+- Type instability inside a hot path.
+- A new allocation introduced inside a hot path.
+
+### `medium`
+
+Use `medium` for likely regressions, plausible science risk without definitive proof, or missing safeguards around changed behavior.
+
+Examples that belong in `medium`:
+
+- Plausible numerical drift.
+- Missing test coverage for changed behavior.
+- Undocumented config change.
+- Undocumented diagnostic change.
+- A formatting or style violation that hides a real issue.
+
+### `low`
+
+Use `low` for issues with no expected behavior impact.
+
+Examples that belong in `low`:
+
+- Style nits.
+- Naming nits.
+- Documentation nits.
+- Refactor suggestions with no behavior impact.
+
+Low-severity items may be batched into a single bullet when that improves readability.
+
+## Output schema (must follow)
+
+### Review summary
+
+Start with a brief scope statement that includes:
+
+- Files changed.
+- Tests run.
+- Any specific areas of focus.
+- Any known review limitations.
+
+Then list findings in descending severity.
+
+For each finding, include all of the following:
+
+- Severity label: `high`, `medium`, or `low`.
+- Category.
+- Short title.
+- Affected files or functions.
+- Specific bug or risk.
+- Two to five sentences of reasoning grounded in local evidence.
+- Missing validation, if applicable.
+
+Then include:
+
+- Open questions/assumptions.
+- Residual testing gaps.
+
+If no findings are found, write exactly:
+
+`No concrete bugs found.`
+
+Then list residual risks briefly.
+
+## Repo facts to enforce
+
+- Some simulation validation is Buildkite-driven.
+- Restart/reproducibility, conservation, diagnostics, and implicit solver changes are especially sensitive.
+- If evidence is insufficient, report a risk or open question; do not invent failures.

--- a/docs/agents/software_design_patterns.md
+++ b/docs/agents/software_design_patterns.md
@@ -1,0 +1,137 @@
+# Software Design Patterns (SDPs)
+
+This file is an agent-facing checklist for writing robust, maintainable, and GPU-compatible Julia code.
+
+Unless explicitly instructed otherwise, treat all rules below as defaults.
+
+## How to use this file
+
+- Apply these patterns in new code.
+- Prefer refactoring toward these patterns when touching existing code.
+- If a rule must be broken, keep the exception narrow and document why.
+
+## 1. Use structs over strings in tendency functions
+
+Avoid string-based model dispatch in hot paths.
+
+Bad:
+
+```julia
+struct Foo{T}
+    model::T
+end
+function baz(f)
+    if f.model == "ModelA"
+        # do something ModelA-specific
+    elseif f.model == "ModelB"
+        # do something ModelB-specific
+    end
+end
+f = Foo("ModelA")
+baz(f)
+```
+
+Preferred:
+
+```julia
+struct ModelA end
+struct ModelB end
+struct Foo{T <: Union{ModelA, ModelB}}
+    model::T
+end
+function baz(f)
+    if f.model isa ModelA
+        # do something ModelA-specific
+    elseif f.model isa ModelB
+        # do something ModelB-specific
+    end
+end
+f = Foo(ModelA())
+baz(f)
+```
+
+Exception:
+
+- Strings are acceptable at initialization boundaries (for example, parsing user/config input), but convert to typed structs as early as possible.
+
+## 2. Avoid `using` / `import` inside `src/` submodules
+
+Inside `src/`, do not add local/module-internal `using` or `import` patterns like this:
+
+```julia
+module Foo
+
+baz() = 1
+
+module Bar
+  using Foo: baz
+  bing() = baz()
+end
+
+end
+```
+
+Prefer explicit qualification or project-established module patterns.
+
+## 3. Do not use `Symbol`s in broadcasted expressions
+
+Avoid symbol-based broadcast patterns. Use concrete, type-stable values/structures instead.
+
+## 4. Do not use abstract types in struct fields
+
+Struct fields should be concrete/parametric for type stability and performance.
+
+## 5. Avoid broadcast from within kernels
+
+GPU compilers can fail to infer through broadcast inside kernels. Prefer explicit, inference-friendly kernel code. (A kernel is the RHS of any @. / Operators.column_integral_* / Fields.bycolumn expression.)
+
+## 6. Do not use `Function` as a struct field type
+
+Bad:
+
+```julia
+struct A
+    f::Function
+end
+```
+
+Preferred:
+
+```julia
+struct A{F <: Function}
+    f::F
+end
+```
+
+## 7. Define `isbits` structs when possible
+
+If a new struct does not contain `ClimaCore` objects, verify a representative instance is `isbits`:
+
+```julia
+isbits(A(...))
+```
+
+## 8. Do not use `mutable struct`
+
+Prefer immutable structs. Only use mutability when required and explicitly justified.
+
+## 9. Prefer `SVector` or `Tuple` over `Vector` / `Array`
+
+For fixed-size data, use stack-friendly/static representations.
+
+## 10. Reduce allocations
+
+- Avoid explicit allocators like `collect` and `reshape` in performance-sensitive paths.
+- Prefer allocation-light transforms (for example, `map`) instead of manual accumulate patterns that create temporary arrays.
+
+## 11. Do not use `@assert` within kernels
+
+Use `error(...)` instead. Do not capture runtime variables in the error message within kernels.
+
+## 12. Do not use `@views`
+
+Follow project conventions that avoid `@views`.
+
+## 13. Do not use `Dict` in kernels
+
+`Dict` is not allowed in CPU/GPU kernels. Replace with custom structs or `NamedTuple`s.


### PR DESCRIPTION
Feel free to edit or commit to this branch if you have ideas or improvements.
## Purpose 
This is an attempt at refining copilot reviews on GitHub by adding instructions. The instructions are llm generated or pulled from the clima policies wiki.

## To-do
- I'm not sure how to check if this works without merging it, but it can be deleted easily if needed. The copilot review I requested here will not use these instructions.
- Is copilot the right tool for this, or is code rabbit better?


## Content
Add review instruction files.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
