### PR TITLE
Update CI pipeline after MPI fix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -760,11 +760,9 @@ steps:
         soft_fail:
           - exit_status: -1
           - exit_status: 255
-        #soft_fail: true # remove this once MPI issues have been fixed
         agents:
           slurm_ntasks: 2
           slurm_mem: 24G
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
       # This job occasionally times out. We add a soft file when the agent is
       # lost because of timeout
@@ -778,12 +776,10 @@ steps:
         soft_fail:
           - exit_status: -1
           - exit_status: 255
-        #soft_fail: true # remove this once MPI issues have been fixed
         agents:
           slurm_gpus_per_task: 1
           slurm_ntasks: 2
           slurm_mem: 24G
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
       - label: ":computer: Restart: Using AtmosSimulation"
         command: >
@@ -831,7 +827,6 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
       - label: ":metro: MPI: Test restart for baroclinic wave"
         key: "restart_mpi_baro_wave"
@@ -848,7 +843,6 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
         timeout_in_minutes: 20
         #retry:
         #  automatic: true
@@ -864,7 +858,6 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16GB
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
       - label: ":metro: MPI: Prepare for calling remap pipeline"
         key: "prep_remap"
@@ -878,7 +871,6 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16G
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
       - label: ":metro: MPI: Test remap pipeline"
         depends_on: "prep_remap"
@@ -914,7 +906,6 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 2
           slurm_mem: 16GB
-          modules: mpiwrapper/2024_05_27 climacommon/2025_03_18
 
   - group: "Autodiff"
     steps:


### PR DESCRIPTION
This PR updates the CI buildkite pipeline now that MPI has been fixed and re-added to climacommon on central.