### PR TITLE
Consolidate Jacobian interface in AtmosSimulation

### DIFF
--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -148,7 +148,7 @@ simulation = CA.AtmosSimulation{FT}(; job_id,
     default_diagnostics = false,
     diagnostics,
     # Numerics
-    approximate_linear_solve_iters = 2,  # TODO: Fix implicit diffusion for LES
+    jacobian = CA.ManualSparseJacobian(; approximate_solve_iters = 2),  # TODO: Fix implicit diffusion for LES
     # Misc
     checkpoint_frequency = "1days",
     log_to_file = true,

--- a/src/prognostic_equations/implicit/auto_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/auto_sparse_jacobian.jl
@@ -20,8 +20,29 @@ struct AutoSparseJacobian{A <: SparseJacobian, P} <: SparseJacobian
     sparse_jacobian_alg::A
     padding_bands_per_block::P
 end
+
+"""
+    AutoSparseJacobian(sparse_jacobian_alg, [padding_bands_per_block = nothing])
+
+Construct an [`AutoSparseJacobian`](@ref) that reuses the sparsity structure
+of the given `sparse_jacobian_alg`.
+"""
 AutoSparseJacobian(sparse_jacobian_alg) =
     AutoSparseJacobian(sparse_jacobian_alg, nothing)
+
+"""
+    AutoSparseJacobian(; approximate_solve_iters = 1, padding_bands_per_block = nothing)
+
+Construct an [`AutoSparseJacobian`](@ref) that reuses the sparsity structure
+of an inner [`ManualSparseJacobian`](@ref) built from `approximate_solve_iters`.
+"""
+AutoSparseJacobian(;
+    approximate_solve_iters::Int = 1,
+    padding_bands_per_block = nothing,
+) = AutoSparseJacobian(
+    ManualSparseJacobian(; approximate_solve_iters),
+    padding_bands_per_block,
+)
 
 function jacobian_cache(alg::AutoSparseJacobian, Y, atmos; verbose = true)
     (; sparse_jacobian_alg, padding_bands_per_block) = alg

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -15,61 +15,52 @@ use_derivative(::UseDerivative) = true
 use_derivative(::IgnoreDerivative) = false
 
 """
-    ManualSparseJacobian(
-        topography_flag,
-        diffusion_flag,
-        sgs_advection_flag,
-        sgs_entr_detr_flag,
-        sgs_mass_flux_flag,
-        sgs_nh_pressure_flag,
-        sgs_vertdiff_flag,
-        approximate_solve_iters,
-    )
+    ManualSparseJacobian(; approximate_solve_iters = 1)
 
 A [`JacobianAlgorithm`](@ref) that approximates the Jacobian using analytically
 derived tendency derivatives and inverts it using a specialized nested linear
-solver. Certain groups of derivatives can be toggled on or off by setting their
-`DerivativeFlag`s to either `UseDerivative` or `IgnoreDerivative`.
+solver.
+
+Which derivative blocks are computed is determined automatically from the
+`AtmosModel` (topography, diffusion mode, EDMF modes) when the cache is
+built — users do not configure them directly.
 
 # Arguments
 
-- `topography_flag::DerivativeFlag`: whether the derivative of vertical
-  contravariant velocity with respect to horizontal covariant velocity should be
-  computed
-- `diffusion_flag::DerivativeFlag`: whether the derivatives of the grid-scale
-  diffusion tendency should be computed
-- `sgs_advection_flag::DerivativeFlag`: whether the derivatives of the
-  subgrid-scale advection tendency should be computed
-- `sgs_entr_detr_flag::DerivativeFlag`: whether the derivatives of the
-  subgrid-scale entrainment and detrainment tendencies should be computed
-- `sgs_mass_flux_flag::DerivativeFlag`: whether the derivatives of the
-  subgrid-scale mass flux tendency should be computed
-- `sgs_nh_pressure_flag::DerivativeFlag`: whether the derivatives of the
-  subgrid-scale non-hydrostatic pressure drag tendency should be computed
-- `sgs_vertdiff_flag::DerivativeFlag`: whether the derivatives of the
-  subgrid-scale vertical diffusion tendency should be computed
-- `approximate_solve_iters::Int`: number of iterations to take for the
-  approximate linear solve required when the `diffusion_flag` is `UseDerivative`
+- `approximate_solve_iters::Int = 1`: number of iterations to take for the
+  approximate linear solve required when grid-scale diffusion is treated
+  implicitly.
 """
-struct ManualSparseJacobian{F1, F2, F3, F4, F5, F6, F7} <: SparseJacobian
-    topography_flag::F1
-    diffusion_flag::F2
-    sgs_advection_flag::F3
-    sgs_entr_detr_flag::F4
-    sgs_mass_flux_flag::F5
-    sgs_nh_pressure_flag::F6
-    sgs_vertdiff_flag::F7
+struct ManualSparseJacobian <: SparseJacobian
     approximate_solve_iters::Int
+end
+ManualSparseJacobian(; approximate_solve_iters::Int = 1) =
+    ManualSparseJacobian(approximate_solve_iters)
+
+# Compute the seven DerivativeFlags that specialize the manual-sparse cache.
+# Flags are dispatch-relevant at cache build time, so we return them as a
+# NamedTuple of concrete `UseDerivative`/`IgnoreDerivative` instances.
+function _derivative_flags(atmos, Y)
+    return (;
+        topography_flag = DerivativeFlag(has_topography(axes(Y.c))),
+        diffusion_flag = DerivativeFlag(atmos.diff_mode),
+        sgs_advection_flag = DerivativeFlag(atmos.sgs_adv_mode),
+        sgs_entr_detr_flag = DerivativeFlag(atmos.sgs_entr_detr_mode),
+        sgs_mass_flux_flag = DerivativeFlag(atmos.sgs_mf_mode),
+        sgs_nh_pressure_flag = DerivativeFlag(atmos.sgs_nh_pressure_mode),
+        sgs_vertdiff_flag = DerivativeFlag(atmos.sgs_vertdiff_mode),
+    )
 end
 
 function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
+    derivative_flags = _derivative_flags(atmos, Y)
     (;
         topography_flag,
         diffusion_flag,
         sgs_advection_flag,
         sgs_mass_flux_flag,
-        approximate_solve_iters,
-    ) = alg
+    ) = derivative_flags
+    approximate_solve_iters = alg.approximate_solve_iters
     FT = Spaces.undertype(axes(Y.c))
 
     DiagonalRow = DiagonalMatrixRow{FT}
@@ -382,7 +373,10 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
             )
         end
 
-    return (; matrix = MatrixFields.FieldMatrixWithSolver(matrix, Y, full_alg))
+    return (;
+        matrix = MatrixFields.FieldMatrixWithSolver(matrix, Y, full_alg),
+        derivative_flags,
+    )
 end
 
 # TODO: There are a few for loops in this function. This is because
@@ -395,7 +389,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
         sgs_entr_detr_flag,
         sgs_mass_flux_flag,
         sgs_vertdiff_flag,
-    ) = alg
+    ) = cache.derivative_flags
     (; matrix) = cache
     (; params) = p
     (; ᶜΦ) = p.core

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -177,10 +177,9 @@ Construct an atmospheric simulation with floating-point type `FT` (default: Floa
 
 ### Numerics
 - `ode_config`: ODE solver algorithm. Default: `IMEXAlgorithm(ARS343(), NewtonsMethod(...))`.
-- `use_dense_jacobian::Bool = false`: Use a dense Jacobian matrix.
-- `use_auto_jacobian::Bool = false`: Use automatic differentiation for the Jacobian.
-- `approximate_linear_solve_iters::Int = 1`: Number of approximate linear solve iterations.
-- `auto_jacobian_padding_bands::Int = 0`: Extra bandwidth for auto-differentiated Jacobian.
+- `jacobian::JacobianAlgorithm = ManualSparseJacobian(; approximate_solve_iters = 1)`:
+  Jacobian algorithm for the implicit solve. Use [`ManualSparseJacobian`](@ref),
+  [`AutoSparseJacobian`](@ref), or [`AutoDenseJacobian`](@ref).
 - `debug_jacobian::Bool = false`: Enable Jacobian debugging output.
 - `tracers = []`: Additional tracer species.
 
@@ -234,11 +233,8 @@ function AtmosSimulation{FT}(;
     default_diagnostics = true, # Enable standard ClimaAtmos diagnostics
     diagnostics = (),           # User-provided diagnostics (YAML string format or ScheduledDiagnostics )
     # Numerics
-    use_dense_jacobian = false,
-    use_auto_jacobian = false,
-    approximate_linear_solve_iters = 1,
-    auto_jacobian_padding_bands = 0,
-    debug_jacobian = false,
+    jacobian::JacobianAlgorithm = ManualSparseJacobian(approximate_solve_iters = 1),
+    debug_jacobian::Bool = false,
     # Misc 
     checkpoint_frequency = Inf,
     log_to_file = false,
@@ -304,8 +300,7 @@ function AtmosSimulation{FT}(;
     integrator_args, integrator_kwargs = args_integrator(
         Y, p, (t_start, t_end), ode_config,
         callback_set,
-        use_dense_jacobian, use_auto_jacobian, auto_jacobian_padding_bands,
-        approximate_linear_solve_iters, debug_jacobian,
+        jacobian, debug_jacobian,
         nothing,
         dt,
     )

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -524,46 +524,42 @@ function _config_surface_setup(parsed_args)
 end
 
 function get_jacobian(ode_algo, Y, atmos, parsed_args)
+    jacobian = jacobian_from_parsed_args(parsed_args)
     return get_jacobian(
-        ode_algo,
-        Y,
-        atmos,
-        parsed_args["use_dense_jacobian"],
-        parsed_args["use_auto_jacobian"],
-        parsed_args["auto_jacobian_padding_bands"],
-        parsed_args["approximate_linear_solve_iters"],
-        parsed_args["debug_jacobian"],
+        ode_algo, Y, atmos, jacobian, parsed_args["debug_jacobian"],
     )
 end
 
-function get_jacobian(ode_algo, Y, atmos, use_dense_jacobian, use_auto_jacobian,
-    auto_jacobian_padding_bands,
-    approximate_linear_solve_iters, debug_jacobian,
+# Translate YAML config keys into a user-facing JacobianAlgorithm stub.
+function jacobian_from_parsed_args(parsed_args)
+    approximate_solve_iters = parsed_args["approximate_linear_solve_iters"]
+    if parsed_args["use_dense_jacobian"]
+        return AutoDenseJacobian()
+    elseif parsed_args["use_auto_jacobian"]
+        return AutoSparseJacobian(;
+            approximate_solve_iters,
+            padding_bands_per_block = parsed_args["auto_jacobian_padding_bands"],
+        )
+    else
+        return ManualSparseJacobian(; approximate_solve_iters)
+    end
+end
+
+function get_jacobian(
+    ode_algo, Y, atmos, jacobian::JacobianAlgorithm, debug_jacobian,
 )
     ode_algo isa Union{CTS.IMEXAlgorithm, CTS.RosenbrockAlgorithm} ||
         return nothing
-    jacobian_algorithm = if use_dense_jacobian
-        AutoDenseJacobian()
-    else
-        manual_jacobian_algorithm = ManualSparseJacobian(
-            DerivativeFlag(has_topography(axes(Y.c))),
-            DerivativeFlag(atmos.diff_mode),
-            DerivativeFlag(atmos.sgs_adv_mode),
-            DerivativeFlag(atmos.sgs_entr_detr_mode),
-            DerivativeFlag(atmos.sgs_mf_mode),
-            DerivativeFlag(atmos.sgs_nh_pressure_mode),
-            DerivativeFlag(atmos.sgs_vertdiff_mode),
-            approximate_linear_solve_iters,
+    @info "Jacobian algorithm: $(summary_string(jacobian))"
+    jac = Jacobian(jacobian, Y, atmos; verbose = debug_jacobian)
+    if hasproperty(jac.cache, :derivative_flags)
+        flags_str = join(
+            ("$k = $(typeof(v).name.name)" for (k, v) in pairs(jac.cache.derivative_flags)),
+            ", ",
         )
-        use_auto_jacobian ?
-        AutoSparseJacobian(
-            manual_jacobian_algorithm,
-            auto_jacobian_padding_bands,
-        ) : manual_jacobian_algorithm
+        @info "Jacobian derivative flags: $flags_str"
     end
-    @info "Jacobian algorithm: $(summary_string(jacobian_algorithm))"
-    verbose = debug_jacobian
-    return Jacobian(jacobian_algorithm, Y, atmos; verbose)
+    return jac
 end
 
 function ode_configuration(::Type{FT}, args) where {FT}
@@ -821,10 +817,7 @@ end
 
 function args_integrator(args, Y, p, tspan, ode_algo, callback, dt_integrator)
     return args_integrator(Y, p, tspan, ode_algo, callback,
-        args["use_dense_jacobian"],
-        args["use_auto_jacobian"],
-        args["auto_jacobian_padding_bands"],
-        args["approximate_linear_solve_iters"],
+        jacobian_from_parsed_args(args),
         args["debug_jacobian"],
         args["prescribed_flow"],
         dt_integrator,
@@ -832,9 +825,7 @@ function args_integrator(args, Y, p, tspan, ode_algo, callback, dt_integrator)
 end
 
 function args_integrator(Y, p, tspan, ode_algo, callback,
-    use_dense_jacobian, use_auto_jacobian, auto_jacobian_padding_bands,
-    approximate_linear_solve_iters, debug_jacobian, prescribed_flow,
-    dt_integrator,
+    jacobian, debug_jacobian, prescribed_flow, dt_integrator,
 )
     (; atmos) = p
     s = @timed_str begin
@@ -844,10 +835,8 @@ function args_integrator(Y, p, tspan, ode_algo, callback,
             T_exp_T_lim! = remaining_tendency!
             T_imp! = CTS.ODEFunction(
                 implicit_tendency!;
-                jac_prototype = get_jacobian(ode_algo, Y, atmos,
-                    use_dense_jacobian, use_auto_jacobian,
-                    auto_jacobian_padding_bands,
-                    approximate_linear_solve_iters, debug_jacobian,
+                jac_prototype = get_jacobian(
+                    ode_algo, Y, atmos, jacobian, debug_jacobian,
                 ),
                 Wfact = update_jacobian!,
             )

--- a/test/restart_AtmosSimulation.jl
+++ b/test/restart_AtmosSimulation.jl
@@ -103,8 +103,7 @@ function amip_target_diagedmf(context, output_dir)
 
     grid = CA.SphereGrid(FT; topography, h_elem, z_elem, z_max, dz_bottom, context)
 
-    # TODO: Use jacobian flags
-    approximate_linear_solve_iters = 2
+    jacobian = CA.ManualSparseJacobian(; approximate_solve_iters = 2)
     max_newton_iters_ode = 1
 
     newtons_method = CTS.NewtonsMethod(;
@@ -127,7 +126,7 @@ function amip_target_diagedmf(context, output_dir)
         dt = 1secs,
         t_end = 3secs,
         checkpoint_frequency = 1secs,
-        approximate_linear_solve_iters,
+        jacobian,
         callback_kwargs,
         ode_config,
         surface_setup,


### PR DESCRIPTION
This PR slightly simplifies the Jacobian interface. 

Content:
- replace four Jacobian-related AtmosSimulation kwargs with a single JacobianAlgorithm
- move the seven DerivativeFlags off ManualSparseJacobian into the cache where they're derived from AtmosModel at build time. 
