### PR TITLE
unify prognostic edmf parameters in 0M and 1M

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-338
+339
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+339
+- Unify prognostic EDMF parameters in 0M and 1M
+
 338
 - Add fixed terminal velocity option;
 - Enforce physical constraints in a callback.

--- a/toml/longrun_aquaplanet_progedmf.toml
+++ b/toml/longrun_aquaplanet_progedmf.toml
@@ -4,11 +4,8 @@ value = 40000.0
 [zd_viscous]
 value = 40000.0
 
-[alpha_rayleigh_sgs_tracer]
-value = 1e-3
-
-[precipitation_timescale]
-value = 600
+[EDMF_surface_area]
+value = 0.1
 
 [EDMF_min_area]
 value = 1.0e-5
@@ -17,25 +14,25 @@ value = 1.0e-5
 value = 0.7
 
 [entr_inv_tau]
-value = 0.0002
+value = 0.0001
 
 [entr_coeff]
-value = 0.2
+value = 0.1
 
 [min_area_limiter_scale]
-value = 0
+value = 0.0001
 
 [min_area_limiter_power]
-value = 100
+value = 1
 
 [detr_inv_tau]
-value = 0
+value = 0.0001
 
 [detr_coeff]
 value = 0
 
 [detr_buoy_coeff]
-value = 0
+value = 1
 
 [detr_vertdiv_coeff]
 value = 0
@@ -43,5 +40,17 @@ value = 0
 [detr_massflux_vertdiv_coeff]
 value = 1
 
+[max_area_limiter_scale]
+value = 0.001
+
+[max_area_limiter_power]
+value = 1
+
 [pressure_normalmode_drag_coeff]
 value = 40.0
+
+[mixing_length_eddy_viscosity_coefficient]
+value = 0.56
+
+[precipitation_timescale]
+value = 1200

--- a/toml/prognostic_edmfx.toml
+++ b/toml/prognostic_edmfx.toml
@@ -26,7 +26,7 @@ value = 0.0001
 value = 1
 
 [detr_inv_tau]
-value = 0
+value = 0.0001
 
 [detr_coeff]
 value = 0
@@ -48,6 +48,9 @@ value = 1
 
 [pressure_normalmode_drag_coeff]
 value = 40.0
+
+[mixing_length_eddy_viscosity_coefficient]
+value = 0.56
 
 [precipitation_timescale]
 value = 3600

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -49,6 +49,9 @@ value = 1
 [pressure_normalmode_drag_coeff]
 value = 40.0
 
+[mixing_length_eddy_viscosity_coefficient]
+value = 0.56
+
 [tracer_vertical_diffusion_factor]
 value = 0
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
There are some case specific edmf tomls, which are used for testing pigroup etc. I didn't change them. I will clean them up together with the tests in the future.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
