### PR TITLE
set updraft microphysics tracers to grid-mean in weathermodel initial condition

### DIFF
--- a/src/setups/WeatherModel.jl
+++ b/src/setups/WeatherModel.jl
@@ -130,9 +130,25 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
         Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs,
     )
 
+    # Microphysics fields from file (rain/snow water content)
+    has_microphysics_vars = NC.NCDataset(file_path) do ds
+        haskey(ds, "cswc") && haskey(ds, "crwc")
+    end
+    if has_microphysics_vars
+        ᶜq_rai = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "crwc", center_space; svi_kwargs...,
+        )
+        ᶜq_sno = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "cswc", center_space; svi_kwargs...,
+        )
+    else
+        ᶜq_rai = nothing
+        ᶜq_sno = nothing
+    end
+
     # Moisture and EDMF
     assign_moisture_edmf!(
-        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, file_path, svi_kwargs,
+        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
     )
 
     return nothing

--- a/src/setups/common/overwrite_from_file.jl
+++ b/src/setups/common/overwrite_from_file.jl
@@ -120,15 +120,16 @@ function assign_velocity_energy!(
 end
 
 """
-    assign_moisture_edmf!(Y, ᶜT, ᶜq_tot, e_pot, thermo_params, file_path, svi_kwargs)
+    assign_moisture_edmf!(Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno)
 
-Assign moisture variables, cloud water from file (if available), and
-EDMF subdomain initialization.
+Assign moisture variables and EDMF subdomain initialization.
+
+`ᶜq_rai` and `ᶜq_sno` are the rain and snow specific humidities regridded
+from file, or `nothing` when the file does not contain microphysics fields.
 """
 function assign_moisture_edmf!(
-    Y, ᶜT, ᶜq_tot, e_pot, thermo_params, file_path, svi_kwargs,
+    Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
 )
-    center_space = Fields.axes(Y.c)
 
     if hasproperty(Y.c, :ρq_tot)
         Y.c.ρq_tot .= ᶜq_tot .* Y.c.ρ
@@ -144,22 +145,13 @@ function assign_moisture_edmf!(
     if hasproperty(Y.c, :ρq_icl)
         fill!(Y.c.ρq_icl, 0)
     end
-    if hasproperty(Y.c, :ρq_sno) && hasproperty(Y.c, :ρq_rai)
-        has_microphysics_vars = NC.NCDataset(file_path) do ds
-            haskey(ds, "cswc") && haskey(ds, "crwc")
-        end
-        if has_microphysics_vars
-            Y.c.ρq_sno .=
-                SpaceVaryingInputs.SpaceVaryingInput(
-                    file_path, "cswc", center_space; svi_kwargs...,
-                ) .* Y.c.ρ
-            Y.c.ρq_rai .=
-                SpaceVaryingInputs.SpaceVaryingInput(
-                    file_path, "crwc", center_space; svi_kwargs...,
-                ) .* Y.c.ρ
+    if hasproperty(Y.c, :ρq_rai) && hasproperty(Y.c, :ρq_sno)
+        if !isnothing(ᶜq_rai)
+            Y.c.ρq_rai .= ᶜq_rai .* Y.c.ρ
+            Y.c.ρq_sno .= ᶜq_sno .* Y.c.ρ
         else
-            fill!(Y.c.ρq_sno, 0)
             fill!(Y.c.ρq_rai, 0)
+            fill!(Y.c.ρq_sno, 0)
         end
     end
 
@@ -174,8 +166,15 @@ function assign_moisture_edmf!(
             # SGS 1M microphysics tracers
             hasproperty(s, :q_lcl) && fill!(s.q_lcl, 0)
             hasproperty(s, :q_icl) && fill!(s.q_icl, 0)
-            hasproperty(s, :q_rai) && fill!(s.q_rai, 0)
-            hasproperty(s, :q_sno) && fill!(s.q_sno, 0)
+            if hasproperty(s, :q_rai) && hasproperty(s, :q_sno)
+                if !isnothing(ᶜq_rai)
+                    s.q_rai .= ᶜq_rai
+                    s.q_sno .= ᶜq_sno
+                else
+                    fill!(s.q_rai, 0)
+                    fill!(s.q_sno, 0)
+                end
+            end
         end
     end
 
@@ -264,9 +263,26 @@ function overwrite_from_file!(
         Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs,
     )
 
+    # Microphysics fields from file (rain/snow water content)
+    center_space = Fields.axes(Y.c)
+    has_microphysics_vars = NC.NCDataset(file_path) do ds
+        haskey(ds, "cswc") && haskey(ds, "crwc")
+    end
+    if has_microphysics_vars
+        ᶜq_rai = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "crwc", center_space; svi_kwargs...,
+        )
+        ᶜq_sno = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "cswc", center_space; svi_kwargs...,
+        )
+    else
+        ᶜq_rai = nothing
+        ᶜq_sno = nothing
+    end
+
     # Moisture and EDMF
     assign_moisture_edmf!(
-        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, file_path, svi_kwargs,
+        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
     )
 
     return nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Prognostic EDMF with 1M is not stable with WeatherModel initial condition. I'm not sure if the instability is from the initial condition, but it is more physical to set microphysics tracers in the updraft to be the same as grid-mean.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
