### PR TITLE
remove type conversion from `0` comparison

### DIFF
--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -493,7 +493,7 @@ function calc_nonpropagating_forcing!(
     # Exclude cells with zero weights from the mask to avoid division by zero.
     # Zero weight means p == p_ref at that cell, so it contributes nothing
     # to the pressure-weighted average.
-    @. ᶜmask = ᶜmask && (ᶜweights != FT(0))
+    @. ᶜmask = ᶜmask && (ᶜweights != 0)
 
     parent(ᶜweights) .= parent(ᶜweights .* ᶜmask)
 

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -493,7 +493,7 @@ function calc_nonpropagating_forcing!(
     # Exclude cells with zero weights from the mask to avoid division by zero.
     # Zero weight means p == p_ref at that cell, so it contributes nothing
     # to the pressure-weighted average.
-    @. ᶜmask = ᶜmask && (ᶜweights != 0)
+    @. ᶜmask = ᶜmask && (!iszero(ᶜweights))
 
     parent(ᶜweights) .= parent(ᶜweights .* ᶜmask)
 
@@ -511,12 +511,12 @@ function calc_nonpropagating_forcing!(
     # When wtsum=0, the mask is empty (no cells between z_pbl and z_ref),
     # so we set forcing to 0 for those columns
     @. ᶜuforcing += ifelse(
-        ᶜwtsum == 0,
+        iszero(ᶜwtsum),
         FT(0),
         grav * τ_x * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )
     @. ᶜvforcing += ifelse(
-        ᶜwtsum == 0,
+        iszero(ᶜwtsum,
         FT(0),
         grav * τ_y * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -516,7 +516,7 @@ function calc_nonpropagating_forcing!(
         grav * τ_x * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )
     @. ᶜvforcing += ifelse(
-        iszero(ᶜwtsum,
+        iszero(ᶜwtsum),
         FT(0),
         grav * τ_y * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -511,12 +511,12 @@ function calc_nonpropagating_forcing!(
     # When wtsum=0, the mask is empty (no cells between z_pbl and z_ref),
     # so we set forcing to 0 for those columns
     @. ᶜuforcing += ifelse(
-        ᶜwtsum == FT(0),
+        ᶜwtsum == 0,
         FT(0),
         grav * τ_x * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )
     @. ᶜvforcing += ifelse(
-        ᶜwtsum == FT(0),
+        ᶜwtsum == 0,
         FT(0),
         grav * τ_y * τ_np / τ_l / ᶜwtsum * ᶜweights,
     )


### PR DESCRIPTION
## Purpose 

remove a type conversion from `0` equality in orographic wave parameterization. 
The comparison is equivalent even without converting to FT. The `FT` conversion is actually omitted in llvm:

```julia
julia> test(x) = x == 0
test (generic function with 1 method)

julia> test2(x) = x == eltype(x)(0)
test2 (generic function with 1 method)

julia> @code_llvm test(0.0)
; Function Signature: test(Float64)
;  @ REPL[1]:1 within `test`
define i8 @julia_test_1357(double %"x::Float64") #0 {
top:
; ┌ @ float.jl:661 within `==` @ float.jl:621
   %0 = fcmp oeq double %"x::Float64", 0.000000e+00
; │ @ float.jl:661 within `==`
; │┌ @ bool.jl:40 within `&`
    %1 = zext i1 %0 to i8
    ret i8 %1
; └└
}

julia> @code_llvm test2(0.0)
; Function Signature: test2(Float64)
;  @ REPL[2]:1 within `test2`
define i8 @julia_test2_1390(double %"x::Float64") #0 {
top:
; ┌ @ float.jl:621 within `==`
   %0 = fcmp oeq double %"x::Float64", 0.000000e+00
   %1 = zext i1 %0 to i8
   ret i8 %1
; └
}
```

I think the best way to do it should be to use `iszero` but I am not sure how it will play with the ClimaCore machinery.