### PR TITLE
Stabilize snow-induced fluctuations

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-340
+341
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+- Use two substeps for computing grid-mean microphysics tendencies to avoid fluctuations
+  which can lead to grid-mean instabilities;
+- Pass zero w_0 to entrainment and detrainment computations for prognostic EDMF to avoid
+  artificial area fraction growth when wʲ ≈ 0.
+
 340
 - Update to ClimaTimeSteppers v 0.9
 - Remove sgs u3 implicit subproblem tendency and Jacobian

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -267,7 +267,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
                 ᶜq_iceʲs.:($$j),
             ),
             vertical_buoyancy_acceleration(Y.c.ρ, ᶜρʲs.:($$j), ᶜgradᵥ_ᶠΦ, ᶜlg),
-            get_physical_w(ᶜu, ᶜlg),
+            FT(0),
             TD.relative_humidity(
                 thermo_params,
                 ᶜT⁰,
@@ -319,7 +319,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
                 ᶜq_iceʲs.:($$j),
             ),
             vertical_buoyancy_acceleration(Y.c.ρ, ᶜρʲs.:($$j), ᶜgradᵥ_ᶠΦ, ᶜlg),
-            get_physical_w(ᶜu, ᶜlg),
+            FT(0),
             TD.relative_humidity(
                 thermo_params,
                 ᶜT⁰,

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -203,7 +203,7 @@ end
     # tendencies are smoother and one substep for time-averaging suffices
     return BMT.average_bulk_microphysics_tendencies(
         eval.scheme, eval.mp, eval.tps, eval.ρ, T_hat, q_tot_hat,
-        eval.q_lcl, eval.q_icl, eval.q_rai, eval.q_sno, eval.dt, 1, eval.args...,
+        eval.q_lcl, eval.q_icl, eval.q_rai, eval.q_sno, eval.dt, 2, eval.args...,
     )
 end
 

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -115,15 +115,15 @@ function edmfx_nh_pressure_drag_tendency!(
        p.atmos.sgs_nh_pressure_mode == Explicit()
         (; params) = p
         n = n_mass_flux_subdomains(turbconv_model)
-        (; ᶠu₃⁰) = p.precomputed
         ᶠlg = Fields.local_geometry_field(Y.f)
         scale_height = CAP.R_d(params) * CAP.T_surf_ref(params) / CAP.grav(params)
+        # assume zero environmental velocity
         for j in 1:n
             @. Yₜ.f.sgsʲs.:($$j).u₃ -= ᶠupdraft_nh_pressure_drag(
                 params,
                 ᶠlg,
                 Y.f.sgsʲs.:($$j).u₃,
-                ᶠu₃⁰,
+                C3(0),
                 scale_height,
             )
         end

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -253,7 +253,7 @@ import ClimaAtmos: limit_sink
 
                     res_expected = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
-                        q_tot_hat, FT(0), FT(0), FT(0), FT(0), FT(60),
+                        q_tot_hat, FT(0), FT(0), FT(0), FT(0), FT(60), 2,
                     )
                     @test result.dq_lcl_dt ≈ res_expected.dq_lcl_dt rtol = FT(1e-4)
                     @test result.dq_icl_dt ≈ res_expected.dq_icl_dt rtol = FT(1e-4)
@@ -277,7 +277,7 @@ import ClimaAtmos: limit_sink
                     res_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
                         q_tot_sat, λ * excess_sat,
-                        (1 - λ) * excess_sat, FT(0), FT(0), FT(60),
+                        (1 - λ) * excess_sat, FT(0), FT(0), FT(60), 2,
                     )
                     @test result_mean.dq_lcl_dt ≈ res_direct.dq_lcl_dt rtol = FT(1e-4)
                     @test result_mean.dq_icl_dt ≈ res_direct.dq_icl_dt rtol = FT(1e-4)

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -357,7 +357,7 @@ using ClimaAtmos
                     result_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(),
                         mp, tps, ρ, T_mean,
-                        q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno, dt,
+                        q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno, dt, 2,
                     )
 
                     # Compare all fields
@@ -383,7 +383,7 @@ using ClimaAtmos
                     result_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(),
                         mp, tps, ρ, T_mean,
-                        q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno, dt,
+                        q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno, dt, 2,
                     )
 
                     @test result_quad.dq_lcl_dt ≈ result_direct.dq_lcl_dt rtol = FT(1e-5)
@@ -669,7 +669,7 @@ using ClimaAtmos
                 result_direct = BMT.average_bulk_microphysics_tendencies(
                     BMT.Microphysics1Moment(),
                     mp, tps, ρ, T_mean,
-                    q_tot, q_liq, q_ice, q_rai, q_sno, dt,
+                    q_tot, q_liq, q_ice, q_rai, q_sno, dt, 2,
                 )
 
                 # They must match exactly (both evaluate at grid mean)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Use two substeps for computing grid-mean microphysics tendencies to avoid fluctuations. These fluctuations can lead to instabilities in AMIP simulations.
- Pass `w^0 = 0` to entrainment and detrainment to avoid artificial area fraction growth when `w^j = 0`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
