### PR TITLE
Make AtmosSimulation match YAML config

### DIFF
--- a/.buildkite/ci_driver.jl
+++ b/.buildkite/ci_driver.jl
@@ -164,7 +164,7 @@ if config.parsed_args["check_steady_state"]
     @info "    Relative RMSE of u₃ on $n_levels levels closest to the surface:"
     @info "        $level_u₃_rel_errs"
 
-    if t_end > 24 * 60 * 60
+    if Float64(t_end) > 24 * 60 * 60
         # TODO: Float32 simulations currently show significant divergence of uₕ.
         @test ᶜuₕ_rel_err < (FT == Float32 ? 0.05 : 0.005)
         @test ᶠu₃_rel_err < 0.0005

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -341,9 +341,6 @@ netcdf_output_at_levels:
 netcdf_interpolation_num_points:
   help: "Override the number of interpolation point for the NetCDF output. This configuration has to be a list of integers, e.g. [180, 90, 10]."
   value: ~
-netcdf_horizontal_method:
-  help: "Horizontal interpolation method for NetCDF remapping to lat/lon (or other) grids. Options: `bilinear` (default) or `spectral`."
-  value: "bilinear"
 check_nan_every:
   help: "Check if the state contains NaNs every this number of iterations"
   value: 1024
@@ -438,11 +435,6 @@ radiation_reset_rng_seed:
   value: false
 log_to_file:
   help: "Log to stdout and file simultaneously. The log file is saved within the output directory"
-  value: false
-use_itime:
-  help: "If set to true, ITime (integer time) is used. This should be set to true when precision with time is necessary as floating point time may encounter floating point errors. When converting an ITime back to a float, the float will be Float64. See the examples below where there will be a difference in ITime and Float64:
-  1. Surface conditions that explicitly depend on time (e.g. TRMM_LBA),
-  2. Time dependent forcing/tendencies use time rounded to the nearest unit of time for dt"
   value: false
 prescribed_flow:
   help: "Prescribe a flow field [`nothing` (default), `ShipwayHill2012`]"

--- a/config/model_configs/baroclinic_wave_equil_conservation_ft64_sparse_autodiff.yml
+++ b/config/model_configs/baroclinic_wave_equil_conservation_ft64_sparse_autodiff.yml
@@ -12,4 +12,3 @@ diagnostics:
   - short_name: [massa, energya]
     period: 1days
     writer: dict
-use_itime: true

--- a/config/model_configs/box_density_current_test.yml
+++ b/config/model_configs/box_density_current_test.yml
@@ -18,4 +18,3 @@ netcdf_interpolation_num_points: [40, 40, 80]
 diagnostics:
   - short_name: [wa, ua, va, ta, thetaa, ha]
     period: 5secs
-use_itime: true

--- a/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/diagnostic_edmfx_aquaplanet_gpu.yml
@@ -16,4 +16,3 @@ non_orographic_gravity_wave: true
 orographic_gravity_wave: "raw_topo"
 t_end: 12hours
 toml: [toml/diagnostic_edmfx_0M.toml]
-use_itime: true

--- a/config/model_configs/edonly_edmfx_aquaplanet.yml
+++ b/config/model_configs/edonly_edmfx_aquaplanet.yml
@@ -6,4 +6,3 @@ turbconv: edonly_edmfx
 microphysics_model: "0M"
 t_end: 3hours
 dt_save_state_to_disk: 600secs
-use_itime: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -34,5 +34,4 @@ diagnostics:
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
     period: 1hours
-use_itime: true
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
@@ -38,4 +38,3 @@ diagnostics:
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
     period: 10mins
-use_itime: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -39,5 +39,4 @@ diagnostics:
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
     period: 1hours
-use_itime: true
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
@@ -38,4 +38,3 @@ diagnostics:
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
     reduction_time: average
     period: 10mins
-use_itime: true

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,6 +25,12 @@ ClimaAtmos.AutoDenseJacobian
 ClimaAtmos.AutoSparseJacobian
 ```
 
+## Diagnostics
+
+```@docs
+ClimaAtmos.DiagnosticsConfig
+```
+
 ## Topography
 
 ```@docs

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1483,7 +1483,7 @@ function make_plots(
 
     make_plots_generic(
         output_paths,
-        vcat((var_groups_zt...)...),
+        collect(Iterators.flatten(var_groups_zt)),
         plot_fn = plot_parsed_attribute_title!,
         summary_files = [tmp_file],
         MAX_NUM_COLS = 2,
@@ -1537,7 +1537,7 @@ function make_plots(::EDMFSpherePlots, output_paths::Vector{<:AbstractString})
     )
     make_plots_generic(
         output_paths,
-        vcat((var_groups_zt...)...),
+        collect(Iterators.flatten(var_groups_zt)),
         plot_fn = plot_parsed_attribute_title!,
         summary_files = [tmp_file],
         MAX_NUM_COLS = 2,

--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -145,8 +145,7 @@ simulation = CA.AtmosSimulation{FT}(; job_id,
     # Callbacks
     callback_kwargs = (; dt_rad = "1hours"),
     # Diagnostics
-    default_diagnostics = false,
-    diagnostics,
+    diagnostics = CA.DiagnosticsConfig(; default = false, additional = diagnostics),
     # Numerics
     jacobian = CA.ManualSparseJacobian(; approximate_solve_iters = 2),  # TODO: Fix implicit diffusion for LES
     # Misc

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -142,6 +142,7 @@ include(joinpath("callbacks", "callbacks.jl"))
 
 include(joinpath("diagnostics", "Diagnostics.jl"))
 import .Diagnostics as CAD
+import .Diagnostics: DiagnosticsConfig
 
 include(joinpath("callbacks", "get_callbacks.jl"))
 

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -1,107 +1,46 @@
-function get_diagnostics(
-    parsed_args,
-    atmos_model,
-    Y, p, dt,
-    t_start, start_date, output_dir,
+# Reduction-time keys allowed in diagnostic spec dicts.
+# Lowercased so callers can use "Max" or "max" interchangeably.
+const _DIAG_ALLOWED_REDUCTIONS = Dict(
+    "inst" => (nothing, nothing),       # just dump the variable
+    "nothing" => (nothing, nothing),    # also accepts the literal string "nothing"
+    "max" => (max, nothing),
+    "min" => (min, nothing),
+    "average" => ((+), CAD.average_pre_output_hook!),
 )
 
+"""
+    scheduled_diagnostics_from_specs(specs, Y, t_start, start_date, writers)
+
+Convert a list of YAML-style diagnostic spec dicts into a flat
+`Vector{ScheduledDiagnostic}`. Each spec must contain at least `short_name`
+and `period`; supports optional `reduction_time`, `writer`, `output_name`,
+`pressure_coordinates`, and `compute_every`.
+
+`writers` is a tuple `(dict, hdf5, netcdf [, pressure_netcdf])` whose
+instances are bound to the resulting diagnostics' `output_writer` fields.
+Errors if any spec requests pressure coordinates but the writers tuple does
+not include a pressure NetCDFWriter.
+"""
+function scheduled_diagnostics_from_specs(
+    specs,
+    Y,
+    t_start,
+    start_date,
+    writers,
+)
     FT = Spaces.undertype(axes(Y.c))
 
-    # We either get the diagnostics section in the YAML file, or we return an empty list
-    # (which will result in an empty list being created by the map below)
-    yaml_diagnostics = get(parsed_args, "diagnostics", [])
-
-    # ALLOWED_REDUCTIONS is the collection of reductions we support. The keys are the
-    # strings that have to be provided in the YAML file. The values are tuples with the
-    # function that has to be passed to reduction_time_func and the one that has to passed
-    # to pre_output_hook!
-
-    # We make "nothing" a string so that we can accept also the word "nothing", in addition
-    # to the absence of the value
-    #
-    # NOTE: Everything has to be lowercase in ALLOWED_REDUCTIONS (so that we can match
-    # "max" and "Max")
-    ALLOWED_REDUCTIONS = Dict(
-        "inst" => (nothing, nothing), # nothing is: just dump the variable
-        "nothing" => (nothing, nothing),
-        "max" => (max, nothing),
-        "min" => (min, nothing),
-        "average" => ((+), CAD.average_pre_output_hook!),
-    )
-
-    dict_writer = CAD.DictWriter()
-    hdf5_writer = CAD.HDF5Writer(output_dir)
-
-    if !isnothing(parsed_args["netcdf_interpolation_num_points"])
-        num_netcdf_points =
-            tuple(parsed_args["netcdf_interpolation_num_points"]...)
-    else
-        # From the given space, calculate the number of diagnostic grid points if not
-        # specified by the user
-        num_netcdf_points = default_netcdf_points(axes(Y.c), parsed_args)
-    end
-
-    z_sampling_method =
-        parsed_args["netcdf_output_at_levels"] ? CAD.LevelsMethod() :
-        CAD.FakePressureLevelsMethod()
-
-    # Map config string to ClimaCore.Remapping type (NetCDFWriter expects AbstractRemappingMethod)
-    netcdf_horizontal_str = get(parsed_args, "netcdf_horizontal_method", "spectral")
-    horizontal_method = if netcdf_horizontal_str == "bilinear"
-        CC.Remapping.BilinearRemapping()
-    elseif netcdf_horizontal_str == "spectral"
-        CC.Remapping.SpectralElementRemapping()
-    else
+    dict_writer, hdf5_writer, netcdf_writer = writers[1], writers[2], writers[3]
+    pressure_netcdf_writer = length(writers) >= 4 ? writers[4] : nothing
+    if any(d -> get(d, "pressure_coordinates", false), specs) &&
+       isnothing(pressure_netcdf_writer)
         error(
-            "netcdf_horizontal_method must be \"bilinear\" or \"spectral\", got \"$(netcdf_horizontal_str)\"",
+            "diagnostic specs request pressure coordinates, but the writers \
+            tuple does not include a pressure NetCDFWriter.",
         )
     end
 
-    # The start_date keyword was added in v0.2.9. For prior versions, the diagnostics will
-    # not contain the date
-    maybe_add_start_date =
-        pkgversion(CAD.ClimaDiagnostics) >= v"0.2.9" ? (; start_date) : (;)
-
-    netcdf_writer = CAD.NetCDFWriter(
-        axes(Y.c),
-        output_dir,
-        num_points = num_netcdf_points;
-        z_sampling_method,
-        horizontal_method,
-        sync_schedule = CAD.EveryStepSchedule(),
-        init_time = t_start,
-        maybe_add_start_date...,
-    )
-
-    # Create NetCDF writer for diagnostics in pressure coordinates if they
-    # exist
-    write_in_pressure_coords = any(yaml_diagnostics) do yaml_diag
-        get(yaml_diag, "pressure_coordinates", false)
-    end
-    pressure_netcdf_writer = nothing
-    if write_in_pressure_coords
-        z_sampling_method = ClimaDiagnostics.Writers.RealPressureLevelsMethod(
-            p.precomputed.ᶜp,
-            t_start,
-        )
-        pressure_space = ClimaDiagnostics.Writers.pressure_space(z_sampling_method)
-        pressure_netcdf_writer = CAD.NetCDFWriter(
-            pressure_space,
-            output_dir,
-            num_points = num_netcdf_points;
-            z_sampling_method,
-            horizontal_method,
-            sync_schedule = CAD.EveryStepSchedule(),
-            init_time = t_start,
-            maybe_add_start_date...,
-        )
-    end
-
-    writers = (dict_writer, hdf5_writer, netcdf_writer)
-    isnothing(pressure_netcdf_writer) || (writers = (writers..., pressure_netcdf_writer))
-
-    # The default writer is netcdf
-    ALLOWED_WRITERS = Dict(
+    allowed_writers = Dict(
         "nothing" => netcdf_writer,
         "dict" => dict_writer,
         "h5" => hdf5_writer,
@@ -110,10 +49,10 @@ function get_diagnostics(
         "netcdf" => netcdf_writer,
     )
 
-    diagnostics_ragged = map(yaml_diagnostics) do yaml_diag
-        short_names = yaml_diag["short_name"]
-        output_name = get(yaml_diag, "output_name", nothing)
-        in_pressure_coords = get(yaml_diag, "pressure_coordinates", false)
+    diagnostics_ragged = map(specs) do spec
+        short_names = spec["short_name"]
+        output_name = get(spec, "output_name", nothing)
+        in_pressure_coords = get(spec, "pressure_coordinates", false)
 
         if short_names isa Vector
             isnothing(output_name) || error(
@@ -124,61 +63,51 @@ function get_diagnostics(
         end
 
         map(short_names) do short_name
-            # Return "nothing" if "reduction_time" is not in the YAML block
-            #
-            # We also normalize everything to lowercase, so that can accept "max" but
-            # also "Max"
-            reduction_time_yaml =
-                lowercase(get(yaml_diag, "reduction_time", "nothing"))
+            reduction_key = lowercase(get(spec, "reduction_time", "nothing"))
+            haskey(_DIAG_ALLOWED_REDUCTIONS, reduction_key) ||
+                error("reduction $reduction_key not implemented")
+            reduction_time_func, pre_output_hook! =
+                _DIAG_ALLOWED_REDUCTIONS[reduction_key]
 
-            if !haskey(ALLOWED_REDUCTIONS, reduction_time_yaml)
-                error("reduction $reduction_time_yaml not implemented")
-            else
-                reduction_time_func, pre_output_hook! =
-                    ALLOWED_REDUCTIONS[reduction_time_yaml]
-            end
-
-            writer_ext = lowercase(get(yaml_diag, "writer", "nothing"))
-
-            if !haskey(ALLOWED_WRITERS, writer_ext)
+            writer_ext = lowercase(get(spec, "writer", "nothing"))
+            haskey(allowed_writers, writer_ext) ||
                 error("writer $writer_ext not implemented")
+            writer = if in_pressure_coords
+                writer_ext in ("netcdf", "nothing") ||
+                    error("Writing in pressure coordinates is only \
+                    compatible with the NetCDF writer")
+                pressure_netcdf_writer
             else
-                writer = if in_pressure_coords
-                    writer_ext in ("netcdf", "nothing") ||
-                        error("Writing in pressure coordinates is only \
-                        compatible with the NetCDF writer")
-                    pressure_netcdf_writer
-                else
-                    ALLOWED_WRITERS[writer_ext]
-                end
+                allowed_writers[writer_ext]
             end
 
-            haskey(yaml_diag, "period") ||
+            haskey(spec, "period") ||
                 error("period keyword required for diagnostics")
 
-            period_str = yaml_diag["period"]
             output_schedule =
-                parse_frequency_to_schedule(FT, period_str, start_date, t_start)
+                parse_frequency_to_schedule(FT, spec["period"], start_date, t_start)
             compute_schedule =
-                parse_frequency_to_schedule(FT, period_str, start_date, t_start)
+                parse_frequency_to_schedule(FT, spec["period"], start_date, t_start)
 
-            if isnothing(output_name)
-                output_short_name = CAD.descriptive_short_name(
+            output_short_name = if isnothing(output_name)
+                CAD.descriptive_short_name(
                     CAD.get_diagnostic_variable(short_name),
                     output_schedule,
                     reduction_time_func,
                     pre_output_hook!,
                 )
+            else
+                output_name
             end
 
-            if isnothing(reduction_time_func)
-                compute_every = compute_schedule
-            elseif !("compute_every" in keys(yaml_diag))
-                compute_every = CAD.EveryStepSchedule()
+            compute_every = if isnothing(reduction_time_func)
+                compute_schedule
+            elseif !haskey(spec, "compute_every")
+                CAD.EveryStepSchedule()
             else
-                compute_every_str = yaml_diag["compute_every"]
-                compute_every =
-                    parse_frequency_to_schedule(FT, compute_every_str, start_date, t_start)
+                parse_frequency_to_schedule(
+                    FT, spec["compute_every"], start_date, t_start,
+                )
             end
 
             CAD.ScheduledDiagnostic(
@@ -193,41 +122,7 @@ function get_diagnostics(
         end
     end
 
-    # Flatten the array of arrays of diagnostics
-    diagnostics = vcat(diagnostics_ragged...)
-
-    if parsed_args["output_default_diagnostics"]
-        diagnostics = [
-            CAD.default_diagnostics(
-                atmos_model,
-                dt isa ITime ?
-                ITime(time_to_seconds(parsed_args["t_end"])) - t_start :
-                FT(time_to_seconds(parsed_args["t_end"]) - t_start),
-                start_date,
-                t_start;
-                output_writer = netcdf_writer,
-                topography = has_topography(axes(Y.c)),
-            )...,
-            diagnostics...,
-        ]
-    end
-    diagnostics = collect(diagnostics)
-
-    periods_reductions = extract_diagnostic_periods(diagnostics)
-    periods_str = join(CA.promote_period.(periods_reductions), ", ")
-    @info "Saving accumulated diagnostics to disk with frequency: $(periods_str)"
-
-    for writer in writers
-        writer_str = nameof(typeof(writer))
-        diags_with_writer =
-            filter((x) -> getproperty(x, :output_writer) == writer, diagnostics)
-        diags_outputs = [
-            getproperty(diag, :output_short_name) for diag in diags_with_writer
-        ]
-        @info "$writer_str: $diags_outputs"
-    end
-
-    return diagnostics, writers, periods_reductions
+    return collect(Iterators.flatten(diagnostics_ragged))
 end
 
 """
@@ -512,99 +407,6 @@ function ogw_callback(
 end
 
 
-function get_callbacks(config, sim_info, atmos, params, Y, p)
-    (; parsed_args, comms_ctx) = config
-    (; dt, output_dir, start_date, t_start, t_end) = sim_info
-
-    callbacks = ()
-
-    # Progress logging
-    if parsed_args["log_progress"]
-        callbacks = (callbacks..., progress_logging_callback(dt, t_start, t_end)...)
-    end
-
-    # NaN checking
-    check_nan_every = parsed_args["check_nan_every"]
-    callbacks = (callbacks..., nan_checking_callback(check_nan_every)...)
-
-    # Graceful exit
-    callbacks = (callbacks..., graceful_exit_callback(output_dir)...)
-
-    # Checkpointing
-    checkpoint_frequency = parse_checkpoint_frequency(parsed_args["dt_save_state_to_disk"])
-    callbacks = (
-        callbacks...,
-        checkpoint_callback(
-            checkpoint_frequency,
-            output_dir,
-            start_date,
-            t_start,
-        )...,
-    )
-
-    # Garbage collection
-    callbacks = (callbacks..., gc_callback(comms_ctx)...)
-
-    # Conservation checking
-    if parsed_args["check_conservation"]
-        callbacks = (callbacks..., conservation_checking_callback()...)
-    end
-
-    # External forcing
-    if parsed_args["external_forcing"] in
-       ["ReanalysisTimeVarying", "ReanalysisMonthlyAveragedDiurnal"] &&
-       parsed_args["config"] == "column"
-        callbacks = (callbacks..., scm_external_forcing_callback()...)
-    end
-
-    # Radiation
-    callbacks = (
-        callbacks...,
-        radiation_callback(
-            atmos.radiation_mode,
-            parsed_args["dt_rad"],
-            dt,
-            t_start,
-            t_end,
-            checkpoint_frequency,
-        )...,
-    )
-
-    # Non-orographic gravity wave
-    callbacks = (
-        callbacks...,
-        nogw_callback(
-            atmos.non_orographic_gravity_wave,
-            parsed_args["dt_nogw"],
-            dt,
-            t_start,
-            t_end,
-            checkpoint_frequency,
-        )...,
-    )
-
-    # Orographic gravity wave
-    callbacks = (
-        callbacks...,
-        ogw_callback(
-            atmos.orographic_gravity_wave,
-            parsed_args["dt_ogw"],
-            dt,
-            t_start,
-            t_end,
-            checkpoint_frequency,
-        )...,
-    )
-
-    # Enforce physical constraints filter
-    callbacks = (
-        callbacks...,
-        enforce_physical_constraints_callback(dt),
-    )
-
-    return callbacks
-end
-
 """
     default_model_callbacks(model::AtmosModel; kwargs...)
 
@@ -648,9 +450,7 @@ needs_enforce_physical_constraints(model::AtmosModel) =
     model.turbconv_model isa AbstractEDMF
 
 
-function default_model_callbacks(component; kwargs...)
-    return ()
-end
+default_model_callbacks(component; kwargs...) = ()
 
 function default_model_callbacks(radiation::AtmosRadiation;
     dt_rad = "6hours",
@@ -666,50 +466,66 @@ function default_model_callbacks(radiation::AtmosRadiation;
         dt,
         t_start,
         t_end,
-        checkpoint_frequency;
+        checkpoint_frequency,
     )
 end
 
-# Gravity wave component callbacks
+# Gravity-wave component callbacks (both orographic and non-orographic)
 function default_model_callbacks(gravity_wave::AtmosGravityWave;
     dt_nogw = "3hours",
+    dt_ogw = "6hours",
     start_date,
     dt,
     t_start,
     t_end,
     checkpoint_frequency,
     kwargs...)
-    return nogw_callback(
-        gravity_wave.non_orographic_gravity_wave,
-        dt_nogw,
-        dt,
-        t_start,
-        t_end,
-        checkpoint_frequency;
+    return (
+        nogw_callback(
+            gravity_wave.non_orographic_gravity_wave,
+            dt_nogw, dt, t_start, t_end, checkpoint_frequency,
+        )...,
+        ogw_callback(
+            gravity_wave.orographic_gravity_wave,
+            dt_ogw, dt, t_start, t_end, checkpoint_frequency,
+        )...,
     )
 end
 
+default_model_callbacks(scm::SCMSetup; kwargs...) =
+    default_model_callbacks(scm.external_forcing; kwargs...)
+
+default_model_callbacks(::ExternalDrivenTVForcing; kwargs...) =
+    scm_external_forcing_callback()
+
 """
-    common_callbacks(model, dt, output_dir, start_date, t_start, t_end, comms_ctx; kwargs...)
+    common_callbacks(model, dt, output_dir, start_date, t_start, t_end, comms_ctx, checkpoint_frequency; kwargs...)
 
 Get commonly used callbacks like progress logging, NaN checking, conservation, etc.
 These are not model-specific but are frequently needed across simulations.
 
 # Keyword Arguments
-- `progress_logging = false`: Enable progress reporting
-- `checkpoint_frequency`: Frequency for saving state to disk
-- `external_forcing_column = false`: Enable external forcing for single column
+- `log_progress::Bool = true`: Emit periodic progress logging callback.
+- `check_nan_every::Int = 1024`: Step cadence for the NaN-detection callback.
+  Set to `0` to disable.
+- `check_conservation::Bool = false`: Enable the conservation-check callback.
 """
 function common_callbacks(
-    model, dt, output_dir, start_date, t_start, t_end, comms_ctx, checkpoint_frequency,
+    model, dt, output_dir, start_date, t_start, t_end, comms_ctx, checkpoint_frequency;
+    log_progress::Bool = true,
+    check_nan_every::Int = 1024,
+    check_conservation::Bool = false,
+    kwargs...,
 )
     callbacks = ()
 
     # Progress logging
-    callbacks = (callbacks..., progress_logging_callback(dt, t_start, t_end)...)
+    if log_progress
+        callbacks = (callbacks..., progress_logging_callback(dt, t_start, t_end)...)
+    end
 
     # NaN checking
-    callbacks = (callbacks..., nan_checking_callback(1024)...)
+    callbacks = (callbacks..., nan_checking_callback(check_nan_every)...)
 
     # Graceful exit
     callbacks = (callbacks..., graceful_exit_callback(output_dir)...)
@@ -722,6 +538,15 @@ function common_callbacks(
 
     # Garbage collection
     callbacks = (callbacks..., gc_callback(comms_ctx)...)
+
+    # Conservation checking
+    if check_conservation
+        callbacks = (callbacks..., conservation_checking_callback()...)
+    end
+
+    # Enforce physical constraints filter (no-op fallback for non-EDMF models;
+    # keep unconditional so EDMF runs always get it without extra wiring).
+    callbacks = (callbacks..., enforce_physical_constraints_callback(dt))
 
     return callbacks
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -97,33 +97,3 @@ else
     WallTimeInfo = ClimaUtilities.OnlineLogging.WallTimeInfo
     report_walltime = ClimaUtilities.OnlineLogging.report_walltime
 end
-
-if pkgversion(ClimaDiagnostics) < v"0.2.14"
-    function default_netcdf_points(space, parsed_args)
-        # Estimate the number of points we need to cover the entire domain
-        # ncolumns is the number of local columns
-        tot_num_columns =
-            ClimaComms.nprocs(ClimaComms.context(space)) *
-            Fields.ncolumns(space)
-        if parsed_args["config"] == "plane"
-            num1, num2 = tot_num_columns, 0
-        elseif parsed_args["config"] == "sphere"
-            num2 = round(Int, sqrt(tot_num_columns / 2))
-            num1 = 2num2
-        elseif parsed_args["config"] == "box"
-            num2 = round(Int, sqrt(tot_num_columns))
-            num1 = num2
-        elseif parsed_args["config"] == "column"
-            # We need at least two points horizontally because our column is
-            # actually a box
-            num1, num2 = 2, 2
-        else
-            error("Uncaught case")
-        end
-        return (num1, num2, Spaces.nlevels(space))
-    end
-else
-    function default_netcdf_points(space, _)
-        return ClimaDiagnostics.Writers.default_num_points(space)
-    end
-end

--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -103,3 +103,4 @@ include("negative_scalars_diagnostics.jl")
 
 # Default diagnostics and higher level interfaces
 include("default_diagnostics.jl")
+include("diagnostics_config.jl")

--- a/src/diagnostics/diagnostics_config.jl
+++ b/src/diagnostics/diagnostics_config.jl
@@ -1,0 +1,71 @@
+"""
+    DiagnosticsConfig(; default = true, additional = (), interpolation_num_points = nothing, output_at_levels = true)
+
+Specification of which diagnostics a simulation produces and how their NetCDF
+output is shaped. A single `DiagnosticsConfig` value is passed to
+[`AtmosSimulation`](@ref ClimaAtmos.AtmosSimulation) via the `diagnostics`
+keyword argument.
+
+# Fields
+
+- `default::Bool = true`: include the built-in ClimaAtmos diagnostic set for
+  the chosen `AtmosModel`.
+- `additional = ()`: extra user-supplied diagnostics. Each entry can be:
+    - a `ClimaDiagnostics.ScheduledDiagnostic` (full control);
+    - a `Pair` like `"ua" => (; period = "30mins", reduction = "average")`
+      (short_name => options as a NamedTuple);
+    - a NamedTuple with at least `short_name` and `period`,
+      e.g. `(; short_name = "ts", period = "1hours")`;
+    - a YAML-style `Dict{String,Any}` (the same shape produced by the
+      `diagnostics:` YAML key).
+
+  Mixed lists are allowed.
+- `interpolation_num_points = nothing`: override the NetCDF remap grid (e.g.
+  `(180, 90, 10)`). When `nothing`, falls back to the default chosen from the
+  underlying space.
+- `output_at_levels::Bool = true`: write at model levels (no vertical
+  interpolation). Set `false` to interpolate to pressure levels.
+
+A simulation produces no diagnostics when `default = false` and `additional`
+is empty.
+"""
+@kwdef struct DiagnosticsConfig{A}
+    default::Bool = true
+    additional::A = ()
+    interpolation_num_points::Union{Nothing, Tuple, AbstractVector} = nothing
+    output_at_levels::Bool = true
+end
+
+# `reduction` is a friendlier alias for the YAML schema's `reduction_time` key.
+_diag_key(k::Symbol) = k === :reduction ? "reduction_time" : String(k)
+
+"""
+    normalize_diag_entry(entry)
+
+Convert a user-supplied diagnostic spec into either a
+`ClimaDiagnostics.ScheduledDiagnostic` (passed through unchanged) or a
+`Dict{String,Any}` matching the YAML diagnostic schema. Used internally by
+`setup_diagnostics_and_writers` so callers can write diagnostics in several
+convenient forms — see [`DiagnosticsConfig`](@ref).
+"""
+normalize_diag_entry(sd::ClimaDiagnostics.ScheduledDiagnostic) = sd
+normalize_diag_entry(d::AbstractDict) = Dict{String, Any}(String(k) => v for (k, v) in d)
+normalize_diag_entry(nt::NamedTuple) =
+    Dict{String, Any}(_diag_key(k) => v for (k, v) in pairs(nt))
+normalize_diag_entry(p::Pair{<:AbstractString, <:AbstractString}) = error(
+    "Ambiguous diagnostic spec $(repr(p)): the reduction is unspecified. \
+    Use `\"$(p.first)\" => (; period = $(repr(p.second)), reduction = \"average\")` \
+    (or another reduction such as \"inst\", \"min\", \"max\") to be explicit.",
+)
+function normalize_diag_entry(p::Pair{<:AbstractString, <:NamedTuple})
+    d = Dict{String, Any}("short_name" => p.first)
+    for (k, v) in pairs(p.second)
+        d[_diag_key(k)] = v
+    end
+    return d
+end
+normalize_diag_entry(x) = error(
+    "Cannot interpret $(typeof(x)) as a diagnostic. Expected a \
+    ScheduledDiagnostic, a Pair (short_name => period or short_name => NamedTuple), \
+    a NamedTuple, or a Dict.",
+)

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -1,3 +1,4 @@
+import ClimaCore
 import ClimaCore: Grids
 import ClimaUtilities.TimeManager: ITime
 import ClimaAtmos.Diagnostics as CAD
@@ -18,8 +19,7 @@ ClimaComms.device(sim::AtmosSimulation) = ClimaComms.device(sim.integrator.u.c)
 
 
 function setup_diagnostics_and_writers(
-    use_default_diagnostics,
-    diagnostics,
+    diagnostics_config::CAD.DiagnosticsConfig,
     model,
     Y,
     p,
@@ -29,24 +29,36 @@ function setup_diagnostics_and_writers(
     start_date,
     output_dir,
 )
-    all_diagnostics = []
-    writers = ()
+    (; default, additional, interpolation_num_points, output_at_levels) =
+        diagnostics_config
 
-    # Helper function to create default NetCDF writer
-    default_nc_writer() = CAD.NetCDFWriter(
+    all_diagnostics = []
+
+    num_points = if isnothing(interpolation_num_points)
+        ClimaDiagnostics.Writers.default_num_points(axes(Y.c))
+    else
+        tuple(interpolation_num_points...)
+    end
+    z_sampling_method =
+        output_at_levels ? CAD.LevelsMethod() : CAD.FakePressureLevelsMethod()
+    horizontal_method = ClimaCore.Remapping.BilinearRemapping()
+
+    # Build writers once. All paths below bind diagnostics to these instances.
+    netcdf_writer = CAD.NetCDFWriter(
         axes(Y.c),
-        output_dir,
-        num_points = ClimaDiagnostics.Writers.default_num_points(axes(Y.c));
-        z_sampling_method = CAD.LevelsMethod(),  # TODO: Could make this configurable
+        output_dir;
+        num_points,
+        z_sampling_method,
+        horizontal_method,
         sync_schedule = CAD.EveryStepSchedule(),
         init_time = t_start,
         start_date,
     )
+    writers = (CAD.DictWriter(), CAD.HDF5Writer(output_dir), netcdf_writer)
 
     # Add default diagnostics if enabled
-    if use_default_diagnostics
+    if default
         sim_duration = t_end isa ITime ? t_end - dt : t_end
-        netcdf_writer = default_nc_writer()
         default_diag_list = CAD.default_diagnostics(
             model,
             sim_duration,
@@ -57,49 +69,46 @@ function setup_diagnostics_and_writers(
         )
         append!(all_diagnostics, default_diag_list)
         @info "Added $(length(default_diag_list)) default ClimaAtmos diagnostics"
-        # Create default writers tuple (matches get_diagnostics pattern)
-        writers = (
-            CAD.DictWriter(),
-            CAD.HDF5Writer(output_dir),
-            netcdf_writer,
-        )
     end
 
     # Add user-provided diagnostics
-    if !isempty(diagnostics)
-        if diagnostics isa AbstractVector &&
-           all(d -> d isa CAD.ScheduledDiagnostic, diagnostics)
-            # User provided ScheduledDiagnostic objects directly
-            append!(all_diagnostics, diagnostics)
-            @info "Added $(length(diagnostics)) user-provided ScheduledDiagnostic objects"
+    if !isempty(additional)
+        normalized = map(CAD.normalize_diag_entry, additional)
+        prebuilt = filter(d -> d isa CAD.ScheduledDiagnostic, normalized)
+        dict_specs = filter(d -> d isa AbstractDict, normalized)
 
-            # Create default writers if not already created (from default_diagnostics)
-            if isempty(writers)
-                writers = (
-                    CAD.DictWriter(),
-                    CAD.HDF5Writer(output_dir),
-                    default_nc_writer(),
+        if !isempty(prebuilt)
+            append!(all_diagnostics, prebuilt)
+            @info "Added $(length(prebuilt)) user-provided ScheduledDiagnostic objects"
+        end
+
+        if !isempty(dict_specs)
+            # If any dict spec requests pressure coordinates, build the pressure
+            # writer here and extend the shared writers tuple before delegating.
+            if any(d -> get(d, "pressure_coordinates", false), dict_specs) &&
+               length(writers) < 4
+                pressure_z_sampling = ClimaDiagnostics.Writers.RealPressureLevelsMethod(
+                    p.precomputed.ᶜp, t_start,
                 )
+                pressure_space =
+                    ClimaDiagnostics.Writers.pressure_space(pressure_z_sampling)
+                pressure_netcdf_writer = CAD.NetCDFWriter(
+                    pressure_space,
+                    output_dir;
+                    num_points,
+                    z_sampling_method = pressure_z_sampling,
+                    horizontal_method,
+                    sync_schedule = CAD.EveryStepSchedule(),
+                    init_time = t_start,
+                    start_date,
+                )
+                writers = (writers..., pressure_netcdf_writer)
             end
-        else
-            # YAML-style diagnostics: get_diagnostics will return its own writers
-            diag_config = Dict(
-                "diagnostics" => diagnostics,
-                "netcdf_interpolation_num_points" => nothing,
-                "netcdf_output_at_levels" => false,
-                "output_default_diagnostics" => false,
-                "netcdf_horizontal_method" => "bilinear",
-            )
-            user_scheduled_diagnostics, user_writers, _ = get_diagnostics(
-                diag_config,
-                model,
-                Y, p, dt,
-                t_start, start_date,
-                output_dir,
+
+            user_scheduled_diagnostics = scheduled_diagnostics_from_specs(
+                dict_specs, Y, t_start, start_date, writers,
             )
             append!(all_diagnostics, user_scheduled_diagnostics)
-            # Use writers from get_diagnostics (they match the user's config)
-            writers = user_writers
             @info "Added $(length(user_scheduled_diagnostics)) user-provided YAML-style diagnostics"
         end
     end
@@ -161,9 +170,9 @@ Construct an atmospheric simulation with floating-point type `FT` (default: Floa
 - `log_to_file::Bool = false`: Write log output to a file in `output_dir`.
 
 ### Diagnostics
-- `default_diagnostics::Bool = true`: Enable standard ClimaAtmos diagnostics.
-- `diagnostics = ()`: Additional diagnostics. Can be `ScheduledDiagnostic` objects or
-  YAML-style diagnostic specifications.
+- `diagnostics::DiagnosticsConfig = DiagnosticsConfig()`: Specification of which
+  diagnostics the simulation produces and how their NetCDF output is shaped.
+  See [`DiagnosticsConfig`](@ref).
 
 ### Callbacks
 - `default_callbacks::Bool = true`: Enable common simulation callbacks.
@@ -219,22 +228,23 @@ function AtmosSimulation{FT}(;
         ),
     ),
     surface_setup = SurfaceConditions.DefaultExchangeCoefficients(),
+    steady_state_velocity = nothing, # Predicted steady-state velocity for diagnostics
     job_id = "atmos_sim",
     output_dir = nothing,
     output_dir_style = "activelink",  # TODO: Should this be an actual type?
     restart_file = nothing,
     detect_restart_file = false,
-    tracers = [], # TODO: set these from the model
+    aerosol_names = [], # TODO: set from the model
+    time_varying_trace_gases = (),
     # Callbacks
     default_callbacks = true,   # Enable common simulation callbacks  
     callbacks = (),             # User-provided additional callbacks
     callback_kwargs = (),       # Kwargs for default_callbacks
     # Diagnostics
-    default_diagnostics = true, # Enable standard ClimaAtmos diagnostics
-    diagnostics = (),           # User-provided diagnostics (YAML string format or ScheduledDiagnostics )
+    diagnostics = CAD.DiagnosticsConfig(),
     # Numerics
     jacobian::JacobianAlgorithm = ManualSparseJacobian(approximate_solve_iters = 1),
-    debug_jacobian::Bool = false,
+    debug_jacobian = false,
     # Misc 
     checkpoint_frequency = Inf,
     log_to_file = false,
@@ -248,7 +258,7 @@ function AtmosSimulation{FT}(;
     if !isnothing(restart_file)
         # Handle restart: validates t_start, loads state, logs info, extracts spaces
         (Y, t_start, spaces) = handle_restart(
-            restart_file, t_start, start_date, model, context, true, FT,
+            restart_file, t_start, start_date, model, context,
         )
         # t_start is already converted from restart file, but we still need to convert dt and t_end
         to_seconds(t) = t isa AbstractString ? time_to_seconds(t) : Float64(t)
@@ -257,7 +267,7 @@ function AtmosSimulation{FT}(;
         # Promote with t_start to ensure all have compatible types
         (dt, t_start, t_end, _) = promote(dt, t_start, t_end, ITime(0))
     else
-        dt, t_start, t_end = convert_time_args(dt, t_start, t_end, true, start_date, FT)
+        dt, t_start, t_end = convert_time_args(dt, t_start, t_end, start_date)
         spaces = get_spaces(grid)
         Y = Setups.initial_state(
             setup, params, model,
@@ -269,12 +279,9 @@ function AtmosSimulation{FT}(;
         )
     end
 
-    # TODO: Add steady state velocity
-    steady_state_velocity = nothing
-    time_varying_trace_gas_names = ()
     p = build_cache(
-        Y, model, params, surface_setup, dt, start_date, tracers,
-        time_varying_trace_gas_names, steady_state_velocity,
+        Y, model, params, surface_setup, dt, start_date, aerosol_names,
+        time_varying_trace_gases, steady_state_velocity,
         nothing,  # vwb_species - not available in this context
     )
 
@@ -289,7 +296,8 @@ function AtmosSimulation{FT}(;
             )...,
             common_callbacks(
                 model, dt, output_dir, start_date, t_start, t_end, context,
-                checkpoint_frequency,
+                checkpoint_frequency;
+                callback_kwargs...,
             )...)
     else
         callbacks
@@ -308,7 +316,7 @@ function AtmosSimulation{FT}(;
     integrator = CTS.init(integrator_args...; integrator_kwargs...)
 
     all_diagnostics, writers, periods_reductions = setup_diagnostics_and_writers(
-        default_diagnostics, diagnostics, model,
+        diagnostics, model,
         Y, p, dt,
         t_start, t_end, start_date,
         output_dir,

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -15,30 +15,18 @@ import ClimaUtilities.TimeManager: ITime
 import ClimaDiagnostics
 
 """
-    convert_time_args(dt, t_start, t_end, use_itime, start_date, FT)
+    convert_time_args(dt, t_start, t_end, start_date)
 
-Convert dt, t_start, and t_end to either ITime or FloatType based on the use_itime flag.
+Convert dt, t_start, and t_end to ITime.
 """
-function convert_time_args(dt, t_start, t_end, use_itime, start_date, FT)
-    # Helper to convert time to seconds (handles both numbers and strings)
+function convert_time_args(dt, t_start, t_end, start_date)
     to_seconds(t) = t isa AbstractString ? time_to_seconds(t) : Float64(t)
-
-    if use_itime
-        dt_seconds = to_seconds(dt)
-        t_start_seconds = to_seconds(t_start)
-        t_end_seconds = to_seconds(t_end)
-        dt = ITime(dt_seconds)
-        t_start = ITime(t_start_seconds, epoch = start_date)
-        t_end = ITime(t_end_seconds, epoch = start_date)
-        # ITime(0) is added for backward compatibility (since t_start used to always be 0)
-        (dt, t_start, t_end, _) = promote(dt, t_start, t_end, ITime(0))
-        return (dt, t_start, t_end)
-    else
-        dt = dt isa AbstractString ? FT(time_to_seconds(dt)) : FT(dt)
-        t_start = t_start isa AbstractString ? FT(time_to_seconds(t_start)) : FT(t_start)
-        t_end = t_end isa AbstractString ? FT(time_to_seconds(t_end)) : FT(t_end)
-        return (dt, t_start, t_end)
-    end
+    dt = ITime(to_seconds(dt))
+    t_start = ITime(to_seconds(t_start), epoch = start_date)
+    t_end = ITime(to_seconds(t_end), epoch = start_date)
+    # ITime(0) is added for backward compatibility (since t_start used to always be 0)
+    (dt, t_start, t_end, _) = promote(dt, t_start, t_end, ITime(0))
+    return (dt, t_start, t_end)
 end
 
 function get_atmos(config::AtmosConfig, params; setup_type = nothing)
@@ -284,14 +272,11 @@ function get_spaces(grid)
 end
 
 function get_state_restart(config::AtmosConfig, restart_file, atmos_model_hash)
-    (; parsed_args, comms_ctx) = config
-    (; start_date) = get_sim_info(config)
     return get_state_restart(
         restart_file,
-        start_date,
+        parse_date(config.parsed_args["start_date"]),
         atmos_model_hash,
-        comms_ctx,
-        parsed_args["use_itime"],
+        config.comms_ctx,
     )
 end
 
@@ -300,14 +285,13 @@ function get_state_restart(
     start_date,
     atmos_model_hash,
     comms_ctx,
-    use_itime,
 )
     @assert !isnothing(restart_file)
     reader = InputOutput.HDF5Reader(restart_file, comms_ctx)
     Y = InputOutput.read_field(reader, "Y")
     # TODO: Do not use InputOutput.HDF5 directly
     t_start = InputOutput.HDF5.read_attribute(reader.file, "time")
-    t_start = use_itime ? ITime(t_start; epoch = start_date) : t_start
+    t_start = ITime(t_start; epoch = start_date)
     if "atmos_model_hash" in keys(InputOutput.HDF5.attrs(reader.file))
         atmos_model_hash_in_restart =
             InputOutput.HDF5.read_attribute(reader.file, "atmos_model_hash")
@@ -319,7 +303,7 @@ function get_state_restart(
 end
 
 """
-    handle_restart(restart_file, t_start_original, start_date, model, context, itime, FT)
+    handle_restart(restart_file, t_start_original, start_date, model, context)
 
 Handle restart file loading with validation and logging.
 
@@ -328,7 +312,7 @@ logs restart information, and returns the state, t_start, and spaces.
 
 Returns:
 - `Y`: State loaded from restart file
-- `t_start`: Time from restart file (already converted to ITime or FT)
+- `t_start`: Time from restart file (ITime)
 - `spaces`: Named tuple with center_space and face_space extracted from Y
 """
 function handle_restart(
@@ -337,8 +321,6 @@ function handle_restart(
     start_date,
     model,
     context,
-    itime,
-    FT,
 )
     # Validate t_start before restart (matches get_simulation behavior)
     t_start_seconds =
@@ -348,23 +330,11 @@ function handle_restart(
         @warn "Non zero `t_start` passed with a restarting simulation. The provided `t_start` will be ignored."
     end
 
-    (Y, t_start_from_restart) = get_state_restart(
-        restart_file, start_date, hash(model), context, itime,
+    (Y, t_start) = get_state_restart(
+        restart_file, start_date, hash(model), context,
     )
 
-    # Ensure t_start is properly typed (convert to FT if not using itime)
-    t_start = if itime
-        t_start_from_restart  # Already ITime from get_state_restart
-    else
-        # Ensure it's the correct FloatType
-        t_start_from_restart isa AbstractString ?
-        FT(time_to_seconds(t_start_from_restart)) : FT(t_start_from_restart)
-    end
-
-    restart_time = t_start isa ITime ?
-                   string(t_start) :
-                   "$(t_start) seconds"
-    @info "Restarting simulation from file" restart_file restart_time
+    @info "Restarting simulation from file" restart_file restart_time = string(t_start)
 
     spaces = (; center_space = axes(Y.c), face_space = axes(Y.f))
 
@@ -746,7 +716,6 @@ end
 
 function get_sim_info(config::AtmosConfig)
     (; comms_ctx, parsed_args) = config
-    FT = eltype(config)
 
     (; job_id) = config
 
@@ -777,9 +746,7 @@ function get_sim_info(config::AtmosConfig)
         parsed_args["dt"],
         parsed_args["t_start"],
         parsed_args["t_end"],
-        parsed_args["use_itime"],
         epoch,
-        FT,
     )
     sim = (;
         output_dir,
@@ -857,7 +824,7 @@ function args_integrator(Y, p, tspan, ode_algo, callback,
     end
     problem = CTS.ODEProblem(tendency_function, Y, tspan, p)
     # Promote to ensure t_begin, t_end, and dt_integrator all have the same type
-    # dt_integrator can be ITime when use_itime=true, while p.dt is always FT
+    # (dt_integrator is ITime, p.dt is FT)
     t_begin, t_end, dt = promote(tspan[1], tspan[2], dt_integrator)
     # Save solution to integrator.sol at the beginning and end
     saveat = [t_begin, t_end]
@@ -988,6 +955,32 @@ function get_grid(parsed_args, params, context)
     end
 end
 
+"""
+    callback_kwargs_from_parsed_args(parsed_args)
+
+Bundle the YAML callback knobs (per-component frequencies + universal
+toggles) into a NamedTuple suitable for splatting into
+`default_model_callbacks` and `common_callbacks`.
+"""
+callback_kwargs_from_parsed_args(parsed_args) = (;
+    dt_rad = parsed_args["dt_rad"],
+    dt_nogw = parsed_args["dt_nogw"],
+    dt_ogw = parsed_args["dt_ogw"],
+    log_progress = parsed_args["log_progress"],
+    check_nan_every = parsed_args["check_nan_every"],
+    check_conservation = parsed_args["check_conservation"],
+)
+
+function diagnostics_config_from_parsed_args(parsed_args)
+    enabled = parsed_args["enable_diagnostics"]
+    return DiagnosticsConfig(;
+        default = enabled && parsed_args["output_default_diagnostics"],
+        additional = enabled ? get(parsed_args, "diagnostics", ()) : (),
+        interpolation_num_points = parsed_args["netcdf_interpolation_num_points"],
+        output_at_levels = parsed_args["netcdf_output_at_levels"],
+    )
+end
+
 function get_simulation(config::AtmosConfig)
     sim_info = get_sim_info(config)
     params = ClimaAtmosParameters(config)
@@ -1019,8 +1012,6 @@ function get_simulation(config::AtmosConfig)
                 sim_info.start_date,
                 atmos,
                 comms_ctx,
-                config.parsed_args["use_itime"],
-                eltype(params),
             )
             # Fix the t_start in sim_info with the one from the restart
             sim_info = merge(sim_info, (; t_start))
@@ -1111,35 +1102,59 @@ function get_simulation(config::AtmosConfig)
     @info "ode_configuration: $s"
 
     s = @timed_str begin
-        callback = get_callbacks(config, sim_info, atmos, params, Y, p)
+        checkpoint_frequency = parse_checkpoint_frequency(
+            config.parsed_args["dt_save_state_to_disk"],
+        )
+        callback_kwargs = callback_kwargs_from_parsed_args(config.parsed_args)
+        callback = (
+            default_model_callbacks(
+                atmos;
+                start_date = sim_info.start_date,
+                dt = sim_info.dt,
+                t_start = sim_info.t_start,
+                t_end = sim_info.t_end,
+                output_dir = sim_info.output_dir,
+                checkpoint_frequency,
+                callback_kwargs...,
+            )...,
+            common_callbacks(
+                atmos,
+                sim_info.dt,
+                sim_info.output_dir,
+                sim_info.start_date,
+                sim_info.t_start,
+                sim_info.t_end,
+                config.comms_ctx,
+                checkpoint_frequency;
+                callback_kwargs...,
+            )...,
+        )
     end
-    @info "get_callbacks: $s"
+    @info "Built callbacks: $s"
 
     # Initialize diagnostics
-    if config.parsed_args["enable_diagnostics"]
-        s = @timed_str begin
-            scheduled_diagnostics, writers, periods_reductions =
-                get_diagnostics(
-                    config.parsed_args,
-                    atmos,
-                    Y,
-                    p,
-                    sim_info.dt,
-                    sim_info.t_start,
-                    sim_info.start_date,
-                    output_dir,
-                )
-        end
-        @info "initializing diagnostics: $s"
-
-        # Check for consistency between diagnostics and checkpoints
-        validate_checkpoint_diagnostics_consistency(
-            parse_checkpoint_frequency(config.parsed_args["dt_save_state_to_disk"]),
-            periods_reductions,
-        )
-    else
-        writers = nothing
+    s = @timed_str begin
+        diag_cfg = diagnostics_config_from_parsed_args(config.parsed_args)
+        scheduled_diagnostics, writers, periods_reductions =
+            setup_diagnostics_and_writers(
+                diag_cfg,
+                atmos,
+                Y,
+                p,
+                sim_info.dt,
+                sim_info.t_start,
+                sim_info.t_end,
+                sim_info.start_date,
+                output_dir,
+            )
     end
+    @info "initializing diagnostics: $s"
+
+    # Check for consistency between diagnostics and checkpoints
+    validate_checkpoint_diagnostics_consistency(
+        parse_checkpoint_frequency(config.parsed_args["dt_save_state_to_disk"]),
+        periods_reductions,
+    )
 
     continuous_callbacks = tuple()
     discrete_callbacks = callback
@@ -1172,7 +1187,7 @@ function get_simulation(config::AtmosConfig)
     end
     @info "init integrator: $s"
 
-    if config.parsed_args["enable_diagnostics"]
+    if !isempty(scheduled_diagnostics)
         s = @timed_str begin
             integrator = ClimaDiagnostics.IntegratorWithDiagnostics(
                 integrator,

--- a/test/diagnostics/diagnostics_config.jl
+++ b/test/diagnostics/diagnostics_config.jl
@@ -1,0 +1,76 @@
+using Test
+import ClimaAtmos as CA
+import ClimaAtmos.Diagnostics as CAD
+
+@testset "DiagnosticsConfig defaults" begin
+    cfg = CA.DiagnosticsConfig()
+    @test cfg.default == true
+    @test cfg.additional == ()
+    @test cfg.interpolation_num_points === nothing
+    @test cfg.output_at_levels == true
+end
+
+@testset "DiagnosticsConfig overrides" begin
+    spec = ["ts" => (; period = "1hours", reduction = "average")]
+    cfg = CA.DiagnosticsConfig(;
+        default = false,
+        additional = spec,
+        interpolation_num_points = (180, 90, 10),
+        output_at_levels = false,
+    )
+    @test cfg.default == false
+    @test cfg.additional == spec
+    @test cfg.interpolation_num_points == (180, 90, 10)
+    @test cfg.output_at_levels == false
+end
+
+@testset "normalize_diag_entry: bare Pair{String,String} is rejected" begin
+    # The bare short_name => period shorthand is ambiguous (no reduction);
+    # callers must specify the reduction via NamedTuple options.
+    @test_throws ErrorException CAD.normalize_diag_entry("ts" => "1hours")
+end
+
+@testset "normalize_diag_entry: Pair{String,NamedTuple}" begin
+    d = CAD.normalize_diag_entry("ua" => (; period = "30mins", reduction = "average"))
+    @test d isa Dict{String, Any}
+    @test d["short_name"] == "ua"
+    @test d["period"] == "30mins"
+    # `reduction` aliases to canonical YAML key `reduction_time`
+    @test d["reduction_time"] == "average"
+    @test !haskey(d, "reduction")
+end
+
+@testset "normalize_diag_entry: NamedTuple" begin
+    d = CAD.normalize_diag_entry((;
+        short_name = "va",
+        period = "1hours",
+        writer = "netcdf",
+    ))
+    @test d isa Dict{String, Any}
+    @test d["short_name"] == "va"
+    @test d["period"] == "1hours"
+    @test d["writer"] == "netcdf"
+end
+
+@testset "normalize_diag_entry: NamedTuple with reduction alias" begin
+    d = CAD.normalize_diag_entry((;
+        short_name = "ts",
+        period = "1hours",
+        reduction = "max",
+    ))
+    @test d["reduction_time"] == "max"
+    @test !haskey(d, "reduction")
+end
+
+@testset "normalize_diag_entry: AbstractDict passes through with stringified keys" begin
+    d = CAD.normalize_diag_entry(Dict("short_name" => "ts", "period" => "1hours"))
+    @test d isa Dict{String, Any}
+    @test d["short_name"] == "ts"
+    @test d["period"] == "1hours"
+end
+
+@testset "normalize_diag_entry: rejects unsupported types" begin
+    @test_throws ErrorException CAD.normalize_diag_entry(42)
+    @test_throws ErrorException CAD.normalize_diag_entry("just a string")
+    @test_throws ErrorException CAD.normalize_diag_entry(:symbol_only)
+end

--- a/test/parameterized_tendencies/gravity_wave/gw_remap_plot_utils.jl
+++ b/test/parameterized_tendencies/gravity_wave/gw_remap_plot_utils.jl
@@ -206,16 +206,11 @@ function remap_to_latlon(
     config::PlotConfig,
     FT = Float64,
 )
-    # Create directory if needed
-    if !isdir(remap_dir)
-        mkpath(remap_dir)
-    end
-
-    # Create timestamped filenames
-    timestamp = Dates.format(now(), "yyyymmdd_HHMMSS")
-    datafile_cg = joinpath(remap_dir, "data_cg_$(timestamp).nc")
-    weightfile = joinpath(remap_dir, "remap_weights_$(timestamp).nc")
-    datafile_rll = joinpath(remap_dir, "data_rll_$(timestamp).nc")
+    isdir(remap_dir) || mkpath(remap_dir)
+    call_dir = mktempdir(remap_dir; cleanup = false)
+    datafile_cg = joinpath(call_dir, "data_cg.nc")
+    weightfile = joinpath(call_dir, "remap_weights.nc")
+    datafile_rll = joinpath(call_dir, "data_rll.nc")
 
     # Write ClimaCore fields to NetCDF
     NCDataset(datafile_cg, "c") do nc

--- a/test/restart_AtmosSimulation.jl
+++ b/test/restart_AtmosSimulation.jl
@@ -38,7 +38,7 @@ function amip_target_diagedmf(context, output_dir)
     diff_mode = CA.Implicit()
     hyperdiff = CA.cam_se_hyperdiffusion(FT)
 
-    tracers = (
+    aerosol_names = (
         "CB1", "CB2",
         "DST01", "DST02", "DST03", "DST04", "DST05",
         "OC1", "OC2",
@@ -122,7 +122,7 @@ function amip_target_diagedmf(context, output_dir)
 
     args = (; model,
         grid,
-        tracers,
+        aerosol_names,
         dt = 1secs,
         t_end = 3secs,
         checkpoint_frequency = 1secs,
@@ -392,7 +392,7 @@ if MANYTESTS
                         grid,
                         job_id,
                         callback_kwargs,
-                        default_diagnostics = false,
+                        diagnostics = CA.DiagnosticsConfig(; default = false),
                         dt = 1secs,
                         t_end = 3secs,
                         checkpoint_frequency = 1secs,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,7 @@ end
 # ============================================================================
 if TEST_GROUP in ("diagnostics", "all")
     @safetestset "Diagnostics unit tests" begin @time include("diagnostics/unit_diagnostics.jl") end
+    @safetestset "DiagnosticsConfig" begin @time include("diagnostics/diagnostics_config.jl") end
 end
 
 # ============================================================================


### PR DESCRIPTION
This PR updates the YAML and programmatic interfaces to have the same functionality, and unifies the way they set up callbacks and diagnostics. This is the first step outlined in #4461 

Content
- Diagnostics are now specified via a `DiagnosticsConfig` struct. The new struct accepts many input shapes for diagnostics: `"ts" => "1hours"` (shortest form), `"ua" => (; period, reduction)` (pair with options), `(; short_name = "va", period = "1hours", writer = "netcdf")` (NamedTuple) raw Dicts, or pre-built ScheduledDiagnostic objects. Mixed lists allowed.
- Set one path to set up diagnostics via `setup_diagnostics_and_writers` -> `scheduled_diagnostics_from_specs`
- Changed the YAML config to use `common_callbacks/default_model_callbacks` functions that the programmatic interface uses
- Deleted YAML keys: `use_itime` (itime is now always used), `netcdf_horizontal_method` (hardcoded to default bilinear)

Todo: make the diagnostic specification clearer - reduction is not clear now.