### PR TITLE
avoid dividing by zero ustar in edmf boundary conditions

### DIFF
--- a/src/prognostic_equations/edmfx_boundary_condition.jl
+++ b/src/prognostic_equations/edmfx_boundary_condition.jl
@@ -122,7 +122,7 @@ function get_first_interior_variance(
     obukhov_length,
     local_geometry,
 ) where {FT}
-    c_star = -kinematic_scalar_flux / ustar
+    c_star = -kinematic_scalar_flux / max(ustar, eps(FT))
     # TODO: Do we need geometry here? Or is c_star always scalar? Otherwise, replace c_star_sq by c_star * c_star
     c_star_sq = Geometry._norm_sqr(c_star, local_geometry)
     if obukhov_length < 0 # Unstable conditions


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
We recently came across this problem here: https://github.com/CliMA/ClimaCoupler.jl/pull/1914. Even though ustar should be non zero, I think this is safer.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
