### PR TITLE
Updates to controls on cloudiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ Artifacts.toml
 AGENTS.md
 MEMORY.md
 .agents
+# Claude Code worktrees
+.claude/worktrees/

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -905,7 +905,7 @@ function set_microphysics_tendency_cache!(
     Y, p, mp1m::NonEquilibriumMicrophysics1M, _,
 )
     (; dt) = p
-    (; ᶜT, ᶜq_tot_nonneg, ᶜmp_tendency) = p.precomputed
+    (; ᶜT, ᶜq_tot_nonneg, ᶜmp_tendency, ᶜcloud_fraction) = p.precomputed
 
     thp = CAP.thermodynamics_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
@@ -932,7 +932,7 @@ function set_microphysics_tendency_cache!(
         @. ᶜmp_tendency = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, Y.c.ρ, ᶜT,
             ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜcloud_fraction, dt, nsubs_quad,
         )
     end
 
@@ -943,7 +943,7 @@ function set_microphysics_tendency_cache!(
     Y, p, mp1m::NonEquilibriumMicrophysics1M, ::DiagnosticEDMFX,
 )
     (; dt) = p
-    (; ᶜT, ᶜq_tot_nonneg, ᶜmp_tendency) = p.precomputed
+    (; ᶜT, ᶜq_tot_nonneg, ᶜmp_tendency, ᶜcloud_fraction) = p.precomputed
 
     thp = CAP.thermodynamics_params(p.params)
     cm1 = CAP.microphysics_1m_params(p.params)
@@ -972,7 +972,7 @@ function set_microphysics_tendency_cache!(
         @. ᶜmp_tendency = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cm1, thp, Y.c.ρ, ᶜT,
             ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜcloud_fraction, dt, nsubs_quad,
         )
     end
 
@@ -985,7 +985,7 @@ function set_microphysics_tendency_cache!(
     (; dt) = p
     (; ᶜρʲs, ᶜTʲs, ᶜq_tot_nonnegʲs) = p.precomputed
     (; ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
-    (; ᶜmp_tendency⁰, ᶜmp_tendencyʲs) = p.precomputed
+    (; ᶜmp_tendency⁰, ᶜmp_tendencyʲs, ᶜcloud_fraction) = p.precomputed
 
     thp = CAP.thermodynamics_params(p.params)
     cmp = CAP.microphysics_1m_params(p.params)
@@ -1024,7 +1024,7 @@ function set_microphysics_tendency_cache!(
         @. ᶜmp_tendency⁰ = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, ᶜρ⁰, ᶜT⁰,
             ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜcloud_fraction, dt, nsubs_quad,
         )
     end
 

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -264,16 +264,24 @@ Given grid-mean condensate (`q_liq`, `q_ice`) and the subgrid variances and
 correlation of `(T, q_tot)`, the cloud fraction is determined by approximately
 matching the predicted condensate to the width of the subgrid saturation deficit PDF.
 
-# Algorithm
-1. Compute phase-specific saturation specific humidities and
-   Clausius-Clapeyron slopes `b = ∂q_sat/∂T = L·q_sat / (R_v·T²)`.
-2. Compute the SGS variance of the saturation deficit:
-   `σ_s² = σ_q² + b²·σ_T² − 2b·corr(T,q)·σ_T·σ_q`
-3. Normalize grid-mean condensate by the PDF width: `Q̂ = q_cond / σ_s`.
-4. Approximate the Gaussian CDF with `tanh(π/√6 · Q̂)` and match implied condensate 
-   from supersaturation to obtain cloud fraction.
-5. Merge liquid and ice via maximum overlap: `cf = max(cf_l, cf_i)`.
-6. Enforce zero cloud fraction when no condensate exists.
+# Algorithm 
+1. Diagnose the prognostic phase partition `λ = q_l / (q_l + q_i)` from
+   cloud condensate only. 
+2. When no condensate is present, fall back to a smooth temperature-based ramp.
+3. Form the phase-partitioned saturation specific humidity
+   `q_v_sat = λ q_sat,l + (1−λ) q_sat,i` and Clausius-Clapeyron slope
+   `b = λ b_l + (1−λ) b_i`.
+4. Compute the SGS variance of the saturation deficit:
+   `σ_s² = σ_q² + b²·σ_T² − 2b·corr(T,q)·σ_T·σ_q`.
+4. Compute the activation factor (combined-phases form):
+   `α = clamp(q_c / sqrt((q_t − q_v_sat)_+² + q_min²), 0, 1)`,
+   then `σ_qc = α σ_s`.
+5. Compute the saturation-deficit-corrected effective condensate
+   `q_c_eff = q_c + min(0, q_t − q_v_sat)`.
+6. Form the cloud fraction:
+   `f_c = ½[1 + erf(c_f q_c_eff / (√2 σ_qc))]`, approximated by a
+   variance-matched logistic CDF (`tanh`).
+7. Gate to zero when no prognostic condensate exists.
 
 With zero variance the function returns 0 when no condensate exists and
 1 when condensate is present, recovering the grid-scale behaviour.
@@ -311,111 +319,125 @@ Cloud fraction ∈ [0, 1]
 )
     FT = eltype(thermo_params)
 
-    # --- 1. Thermodynamic sensitivities (Clausius-Clapeyron) ---
+    # --- 1. Prognostic phase partition ---
+    # Use cloud condensate only; rain and snow are excluded.
+    q_c = q_liq + q_ice
+    λ = TD.liquid_fraction(thermo_params, T, q_liq, q_ice)
+
+    # --- 2. Phase-partitioned saturation specific humidity and CC slope ---
     qsat_l = TD.q_vap_saturation(thermo_params, T, ρ, TD.Liquid())
     qsat_i = TD.q_vap_saturation(thermo_params, T, ρ, TD.Ice())
-
     R_v = TD.Parameters.R_v(thermo_params)
     L_v = TD.latent_heat_vapor(thermo_params, T)
     L_s = TD.latent_heat_sublim(thermo_params, T)
 
-    # b = ∂q_sat/∂T  (Clausius-Clapeyron slope, assuming constant pressure)
-    b_l = L_v * qsat_l / (R_v * T^2)
-    b_i = L_s * qsat_i / (R_v * T^2)
+    # Phase-weighted q_v_sat and Clausius-Clapeyron slope b = ∂q_sat/∂T
+    qsat = λ * qsat_l + (FT(1) - λ) * qsat_i
+    b = (
+        λ * (L_v * qsat_l / (R_v * T * T)) +
+        (FT(1) - λ) * (L_s * qsat_i / (R_v * T * T))
+    )
 
-    # Standard deviations
+    # --- 3. SGS variance of saturation deficit (Sommeria-Deardorff) ---
+    # σ_s² = σ_q² + b²·σ_T² − 2b·corr(T', q')·σ_T·σ_q
     σ_q = sqrt(max(q′q′, zero(FT)))
     σ_T = sqrt(max(T′T′, zero(FT)))
+    sig2_s = q′q′ + b * b * T′T′ - FT(2) * b * corr_Tq * σ_T * σ_q
+    sig_s = sqrt(max(sig2_s, ϵ_numerics(FT)))
 
-    # --- 2. SGS variance of saturation deficit ---
-    # σ_s² = σ_q² + b²·σ_T² − 2b·corr(T', q')·σ_T·σ_q
-    sig2_l = q′q′ + b_l * b_l * T′T′ - FT(2) * b_l * corr_Tq * σ_T * σ_q
-    sig2_i = q′q′ + b_i * b_i * T′T′ - FT(2) * b_i * corr_Tq * σ_T * σ_q
+    # --- 4. Activation factor (combined-phase form) ---
+    # Bounds the SGS spread used in the cloud fraction by what the prognostic
+    # condensate can support relative to the equilibrium excess at the mean.
+    # As q_c → 0 in a clear sub-saturated subdomain, α → 0 and σ_qc → 0 so
+    # the cloud fraction goes smoothly to zero.
+    excess_eq = max(zero(FT), q_tot - qsat)
+    α = min(FT(1), q_c / sqrt(excess_eq * excess_eq + q_min * q_min))
+    σ_qc = α * sig_s
 
-    # Safety floor
-    sig_l = sqrt(max(sig2_l, ϵ_numerics(FT)))
-    sig_i = sqrt(max(sig2_i, ϵ_numerics(FT)))
+    # --- 5. Effective saturation-deficit-corrected condensate ---
+    # q_c_eff = q_c + min(0, q_t - q_v_sat)
+    # Recovers q_c when the grid mean is supersaturated; reduces to (q_t - qsat)
+    # when subsaturated, forcing f_c → 0 in deeply subsaturated states even
+    # if a numerical trace of prognostic condensate remains.
+    q_c_eff = q_c + min(zero(FT), q_tot - qsat)
 
-    # --- 3. Normalize condensate by PDF width ---
-    Q_hat_l = q_liq / sig_l
-    Q_hat_i = q_ice / sig_i
+    # --- 6. Distribution-specific cloud fraction ---
+    cf = _cloud_fraction_helper(
+        q_c_eff, σ_qc, q_tot, cf_steepness_scale, q_min, sgs_dist,
+    )
 
-    # --- 4. Formulation-Specific Cloud Fraction Helpers ---
-    cf_l =
-        _cloud_fraction_helper(Q_hat_l, sig_l, q_tot, cf_steepness_scale, q_min, sgs_dist)
-    cf_i =
-        _cloud_fraction_helper(Q_hat_i, sig_i, q_tot, cf_steepness_scale, q_min, sgs_dist)
-
-    # --- 5. Maximum overlap ---
-    cf = max(cf_l, cf_i)
-
-    # --- 6. No condensate → no cloud (branchless) ---
-    has_cond = TD.has_condensate(thermo_params, q_liq + q_ice)
+    # --- 7. Branchless gate: no prognostic condensate → no cloud ---
+    has_cond = TD.has_condensate(thermo_params, q_c)
     return ifelse(has_cond, cf, zero(FT))
 end
 
 """
-    _cloud_fraction_helper(Q_hat, sig_s, q_tot, cf_steepness_scale, q_min, sgs_dist)
+    _cloud_fraction_helper(q_c_eff, σ_qc, q_tot, cf_steepness_scale, q_min, sgs_dist)
 
-Compute the phase-specific cloud fraction from normalized condensate.
+Compute the cloud fraction from the saturation-deficit-corrected effective
+condensate `q_c_eff` and the activation-scaled standard
+deviation `σ_qc` (combined-phase form).
+
+The Gaussian CDF is approximated by a variance-matched logistic CDF
+(`erf(x/√2) ≈ tanh((π/(2√3)) x)`), giving
+
+    f_c ≈ (1/2) [1 + tanh((π/(2√3)) c_f q_c_eff / σ_qc)]
 
 # Arguments
-- `Q_hat`: Condensate normalized by the standard deviation of saturation deficit
-- `sig_s`: Standard deviation of saturation deficit [kg/kg]
+- `q_c_eff`: Saturation-deficit-corrected condensate [kg/kg]
+- `σ_qc`: Activation-scaled standard deviation of cloud condensate [kg/kg]
 - `q_tot`: Grid-mean total specific humidity [kg/kg]
-- `cf_steepness_scale`: Scaling factor for the steepness of the cloud fraction transition versus condensate
+- `cf_steepness_scale`: Tunable steepness factor `c_f` 
 - `q_min`: Minimum specific humidity threshold [kg/kg]
-- `sgs_dist`: Assumed sub-grid scale distribution type (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`)
+- `sgs_dist`: SGS distribution (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`)
 
 # Returns
-- Phase-specific cloud fraction ∈ [0, 1]
+- Cloud fraction ∈ [0, 1]
 """
 @inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
+    q_c_eff,
+    σ_qc,
     q_tot,
     cf_steepness_scale,
     q_min,
     ::GaussianSGS,
 )
-    FT = typeof(Q_hat)
-    # Analytical CDF approximation: π/√6 matches the variance of the logistic distribution to the normal distribution
-    coeff = (FT(π) / sqrt(FT(6))) * cf_steepness_scale
-    return tanh(coeff * Q_hat)
+    FT = typeof(q_c_eff)
+    # Variance-matched logistic-CDF approximation to the Gaussian CDF.
+    coeff = (FT(π) / (FT(2) * sqrt(FT(3)))) * cf_steepness_scale
+    σ_safe = max(σ_qc, ϵ_numerics(FT))
+    return FT(0.5) * (FT(1) + tanh(coeff * q_c_eff / σ_safe))
 end
 
 @inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
+    q_c_eff,
+    σ_qc,
     q_tot,
     cf_steepness_scale,
     q_min,
     ::LogNormalSGS,
 )
-    FT = typeof(Q_hat)
-    # Coefficient of variation (protect against division by zero)
-    C_v = sig_s / max(q_tot, q_min)
-
-    # Base coefficient corresponds to Gaussian limit (Cv -> 0)
-    coeff = (FT(π) / sqrt(FT(6))) * cf_steepness_scale
-
-    # Modulate coefficient with Cv based on offline optimal fits to lognormal 
-    # distribution for q_tot (RMSE < 5% for C_v in [0, 1])
-    c = coeff * (FT(1) + FT(0.3) * C_v)
-
-    return tanh(c * Q_hat)
+    FT = typeof(q_c_eff)
+    # Coefficient of variation, used to modulate the steepness for non-Gaussian
+    # q_tot tails. The Gaussian limit is recovered as C_v → 0.
+    C_v = σ_qc / max(q_tot, q_min)
+    base = (FT(π) / (FT(2) * sqrt(FT(3)))) * cf_steepness_scale
+    coeff = base * (FT(1) + FT(0.3) * C_v)
+    σ_safe = max(σ_qc, ϵ_numerics(FT))
+    return FT(0.5) * (FT(1) + tanh(coeff * q_c_eff / σ_safe))
 end
 
 @inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
+    q_c_eff,
+    σ_qc,
     q_tot,
     cf_steepness_scale,
     q_min,
     ::GridMeanSGS,
 )
-    FT = typeof(Q_hat)
-    return Q_hat > zero(FT) ? FT(1) : zero(FT)
+    FT = typeof(q_c_eff)
+    # No SGS spread: cloud is either there (q_c_eff > 0) or not.
+    return q_c_eff > zero(FT) ? FT(1) : zero(FT)
 end
 
 # ============================================================================

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -61,8 +61,12 @@ struct Microphysics0MEvaluator{CMP, SAE, FT}
     sat_eval::SAE
     Φ::FT
 end
-function Microphysics0MEvaluator(cm_params, thermo_params, ρ, Φ)
-    sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ)
+function Microphysics0MEvaluator(cm_params, thermo_params, ρ, T_mean, Φ)
+    # Grid-mean liquid fraction, held fixed across quadrature points
+    # (paper Eq. 3.31, equilibrium fallback). The 0M scheme has no prognostic
+    # phase memory, so we use a temperature-based ramp at the grid mean.
+    λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
+    sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)
     return Microphysics0MEvaluator(cm_params, sat_eval, Φ)
 end
 @inline function (eval::Microphysics0MEvaluator)(T_hat, q_hat)
@@ -125,7 +129,7 @@ NamedTuple with `dq_tot_dt` and `e_tot_hlpr`.
     # Create GPU-safe functor (Φ is constant within a grid cell)
     # The evaluator does saturation adjustment, computes saturation vapor pressure
     # and computes the total water sink and energy helper from 0M microphysics
-    evaluator = Microphysics0MEvaluator(cmp, thp, ρ, Φ)
+    evaluator = Microphysics0MEvaluator(cmp, thp, ρ, T, Φ)
     # Integrate over quadrature points; both dq_tot_dt and e_tot_hlpr
     # are averaged over the SGS distribution.
     (; dq_tot_dt, e_tot_hlpr) = integrate_over_sgs(
@@ -159,115 +163,80 @@ end
 ###
 
 """
-    equilibrium_cloud_condensates_1m(
-        tps,
-        T,
-        ρ,
-        q_tot,
-        q_lcl_mean,
-        q_icl_mean,
-        q_rai,
-        q_sno,
-    )
+    equilibrium_cloud_condensates_1m(tps, T, ρ, q_tot, λ, q_rai, q_sno)
 
 Compute the equilibrium cloud liquid and cloud ice specific humidities
-(`q_lcl_eq`, `q_icl_eq`) for a thermodynamic state `(T, ρ, q_tot)`
-in the one-moment microphysics scheme.
-
-The supersaturation excess is partitioned into liquid and ice using the
-liquid fraction diagnosed from the total liquid and ice condensates,
-including rain (`q_rai`) and snow (`q_sno`) contributions. Rain and snow
-condensates are then removed from the equilibrium partition to obtain the
-equilibrium cloud condensates.
+(`q_lcl_eq`, `q_icl_eq`) for a thermodynamic state `(T, ρ, q_tot)` using
+a prescribed (grid-mean) liquid fraction `λ`. Rain and snow condensates
+are removed from the equilibrium partition.
 
 Returns `(q_lcl_eq, q_icl_eq)`.
 """
-@inline function equilibrium_cloud_condensates_1m(
-    tps,
-    T,
-    ρ,
-    q_tot,
-    q_lcl_mean,
-    q_icl_mean,
-    q_rai,
-    q_sno,
-)
+@inline function equilibrium_cloud_condensates_1m(tps, T, ρ, q_tot, λ, q_rai, q_sno)
     FT = typeof(ρ)
-
-    # Saturation excess
     q_sat = TD.q_vap_saturation(tps, T, ρ)
     excess = max(FT(0), q_tot - q_sat)
-
-    # Partition excess condensate
-    λ = TD.liquid_fraction(tps, T, q_lcl_mean + q_rai, q_icl_mean + q_sno)
-
     q_lcl_eq = max(FT(0), λ * excess - q_rai)
     q_icl_eq = max(FT(0), (FT(1) - λ) * excess - q_sno)
-
     return q_lcl_eq, q_icl_eq
 end
 
 """
     (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
 
-GPU-safe functor for computing 1-moment microphysics tendencies at quadrature
-points. Computes bulk microphysics tendencies at a perturbed thermodynamic
-state `(T_hat, q_tot_hat)` for use in SGS quadrature integration. The condensate
-at each quadrature point is diagnosed using a perturbation-based model.
+GPU-safe functor for computing 1-moment microphysics tendencies at SGS
+quadrature points. The local thermodynamic state `(T_hat, q_tot_hat)` is
+sampled from the SGS distribution; the local condensate is diagnosed from
+the local saturation excess and capped at the *in-cloud* condensate
+`q_lcl_in_cloud = q_lcl_mean / max(CF, CF_min)` (and analogously for ice).
 
 # Arguments
 - `T_hat`: Temperature at quadrature point [K]
 - `q_tot_hat`: Total specific humidity at quadrature point [kg/kg]
 
 # Returns
-`NamedTuple` from `BMT.bulk_microphysics_tendencies` with fields:
+`NamedTuple` from `BMT.average_bulk_microphysics_tendencies` with fields:
 - `dq_lcl_dt`: Cloud liquid tendency [kg/kg/s]
 - `dq_icl_dt`: Cloud ice tendency [kg/kg/s]
 - `dq_rai_dt`: Rain tendency [kg/kg/s]
 - `dq_sno_dt`: Snow tendency [kg/kg/s]
-- `dt`: Model timestep [s] (for tendency averaging)
-- `nsubs`: Number of microphysics substeps
 
 # Condensate Diagnosis
 
-At each quadrature point, condensate is diagnosed as
+At each quadrature point, the local cloud condensate is
 
-    q_lcl_hat = q_lcl_mean + α_lcl * (q_lcl_eq_hat - q_lcl_mean_eq)
+    q_lcl_hat = min(q_lcl_in_cloud,
+                    max(0, λ (q_tot_hat - q_sat(T_hat, ρ)) - q_rai))
 
-where
+with `λ` the prognostic-state liquid fraction (held fixed across all
+quadrature points of the subdomain). At clear quadrature points
+(`q_tot_hat ≤ q_sat(T_hat, ρ)`), `q_lcl_hat = 0`. At strongly supersaturated
+points, `q_lcl_hat` saturates at the in-cloud value. This bounds the
+Jensen's-inequality amplification of nonlinear sinks (autoconversion,
+accretion) by the standard GCM in-cloud / clear partition while letting the
+quadrature respond to local thermodynamic variability through the
+saturation curve.
 
-    q_lcl_eq_hat = λ (q_tot_hat - q_sat(T_hat, ρ)) - q_rai
-
-with λ being the liquid fraction. The prefactor α_lcl scales the equilibrium
-fluctuation according to the ratio between the mean prognostic and equilibrium
-values of q_lcl (and similarly for `q_icl`).
-
-When the grid mean is close to equilibrium
-(`q_cond_mean ≈ max(0, excess_mean)`), the scaling approaches one, and the
-quadrature-point condensate reduces to the standard equilibrium form
-`max(0, excess_hat)`.
-
-When the grid mean is subsaturated (`excess_mean < 0`) and contains no
-condensate (`q_cond_mean = 0`), the scaling approaches zero, preventing
-condensate formation even if an individual quadrature point becomes locally
-supersaturated.
+When the subdomain is clear (`q_lcl_mean = 0`), `q_lcl_in_cloud = 0` and the
+local condensate is identically zero at every quadrature point;
+phase-change rates remain responsive to local SGS supersaturation through
+`q_v_hat - q_sat(T_hat, ρ)` inside `BMT`.
 """
 struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     scheme::S
     mp::MP
     tps::TPS
     ρ::FT
-    # Grid-mean state
+    # Grid-mean temperature (passed through; quadrature varies T_hat)
     T_mean::FT
-    q_lcl_mean::FT
-    q_icl_mean::FT
+    # In-cloud cloud condensates: q_mean / max(CF, CF_min)
+    q_lcl_in_cloud::FT
+    q_icl_in_cloud::FT
+    # Grid-mean precipitation (in-cloud / clear partition not applied)
     q_rai::FT
     q_sno::FT
-    # Precomputed grid-mean values (avoid redundant computation in quadrature loop)
-    q_lcl_mean_eq::FT
-    q_icl_mean_eq::FT
-    α_lcl::FT
-    α_icl::FT
+    # Prognostic-state liquid fraction, fixed across quadrature points
+    λ::FT
     # Numerical parameters
     dt::FT
     nsubs::Int
@@ -276,23 +245,14 @@ end
 @inline function (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
 
     q_lcl_eq_hat, q_icl_eq_hat = equilibrium_cloud_condensates_1m(
-        eval.tps,
-        T_hat,
-        eval.ρ,
-        q_tot_hat,
-        eval.q_lcl_mean,
-        eval.q_icl_mean,
-        eval.q_rai,
-        eval.q_sno,
+        eval.tps, T_hat, eval.ρ, q_tot_hat, eval.λ, eval.q_rai, eval.q_sno,
     )
 
-    # q_mean ≥ α * q_mean_eq and q_eq_hat ≥ 0, so q_hat must be positive,
-    # and we don't need to clip
-    q_lcl_hat = eval.q_lcl_mean + eval.α_lcl * (q_lcl_eq_hat - eval.q_lcl_mean_eq)
-    q_icl_hat = eval.q_icl_mean + eval.α_icl * (q_icl_eq_hat - eval.q_icl_mean_eq)
+    # Cap the local equilibrium fluctuation at the in-cloud condensate so that
+    # nonlinear sinks see at most the in-cloud value within the cloudy fraction.
+    q_lcl_hat = min(eval.q_lcl_in_cloud, q_lcl_eq_hat)
+    q_icl_hat = min(eval.q_icl_in_cloud, q_icl_eq_hat)
 
-    # Call CloudMicrophysics point-wise tendencies
-    # Average tendencies over dt with nsubs substeps
     return BMT.average_bulk_microphysics_tendencies(
         eval.scheme, eval.mp, eval.tps, eval.ρ, T_hat, q_tot_hat,
         q_lcl_hat, q_icl_hat, eval.q_rai, eval.q_sno, eval.dt, eval.nsubs, eval.args...,
@@ -303,13 +263,17 @@ end
     microphysics_tendencies_1m(ρ, q_tot, q_lcl, q_icl, q_rai, q_sno, T, cmp, thp, dt, nsubs,)
     microphysics_tendencies_1m(
         scheme, sgs_quad, cmp, thp, ρ, T, q_tot,
-        q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq, dt,
+        q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+        cloud_fraction, dt, nsubs,
     )
 
 Computes time-averaged 1-moment microphysics tendencies. When using SGS-quadratures,
-the tendencies are integrated over the joint PDF of (T, q_tot).
+the tendencies are integrated over the joint PDF of (T, q_tot), with the
+condensate at each quadrature point taken from the local equilibrium excess
+capped at the in-cloud condensate `q_lcl_mean / max(CF, CF_min)` (similarly
+for ice). The grid-mean (no-quadrature) path takes condensate inputs as-is.
 ```math
-\\bar{S} = \\int\\int S(T, q, \\dots) P(T, q) \\, dT \\, dq
+\\bar{S} = \\int\\int S(T, q, q_l(T, q; q_l^{ic}), \\dots) P(T, q) \\, dT \\, dq
 ```
 The option without SGS-quadratures can be used in the EDMF updrafts, or to compute
 grid-mean tendency without taking account of fluctuations.
@@ -320,11 +284,13 @@ grid-mean tendency without taking account of fluctuations.
 - `cmp`, `thp`: Microphysics and thermodynamics parameters
 - `ρ`, `T`: Air density [kg/m³] and temperature [K]
 - `q_tot`: Total water [kg/kg]
-- `q_lcl`, `q_icl`: Mean cloud liquid water and cloud ice [kg/kg]
+- `q_lcl_mean`, `q_icl_mean`: Mean cloud liquid water and cloud ice [kg/kg]
 - `q_rai`, `q_sno`: Rain and snow [kg/kg]
 - `T′T′`: Variance of temperature ``\\langle T'^2 \\rangle``
 - `q′q′`: Variance of q_tot ``\\langle q'^2 \\rangle``
 - `corr_Tq`: Correlation coefficient ρ(T', q') obtained from `correlation_Tq(params)`.
+- `cloud_fraction`: Subdomain cloud fraction CF ∈ [0, 1], used to convert grid-mean
+  condensates to in-cloud values via `q_lcl_in_cloud = q_lcl_mean / max(CF, CF_min)`.
 - `args...`: Additional arguments (e.g., N_lcl for 2M)
 - `dt`: Model timestep [s] (for tendency averaging)
 - `nsubs`: Number of substeps for computing average tendencies over time
@@ -347,34 +313,35 @@ NamedTuple with microphysics source terms:
 end
 @inline function microphysics_tendencies_1m( #microphysics_tendencies_quadrature_1m
     scheme, sgs_quad, cmp, thp, ρ, T, q_tot_nonneg,
-    q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq, dt, nsubs, args...,
+    q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+    cloud_fraction, dt, nsubs, args...,
 )
-    # Clamp species humidities to prevent negativity in quadratures
-    q_lcl_nonneg = max(0, q_lcl_mean)
-    q_icl_nonneg = max(0, q_icl_mean)
-    q_rai_nonneg = max(0, q_rai)
-    q_sno_nonneg = max(0, q_sno)
+    FT = typeof(ρ)
 
-    q_lcl_mean_eq, q_icl_mean_eq = equilibrium_cloud_condensates_1m(
-        thp,
-        T,
-        ρ,
-        q_tot_nonneg,
-        q_lcl_nonneg,
-        q_icl_nonneg,
-        q_rai_nonneg,
-        q_sno_nonneg,
-    )
+    # Clamp specific humidities to prevent negativity in quadratures
+    q_lcl_nonneg = max(FT(0), q_lcl_mean)
+    q_icl_nonneg = max(FT(0), q_icl_mean)
+    q_rai_nonneg = max(FT(0), q_rai)
+    q_sno_nonneg = max(FT(0), q_sno)
 
-    q_min = TD.Parameters.q_min(thp)
-    α_lcl = min(1, q_lcl_nonneg / sqrt(q_lcl_mean_eq^2 + q_min^2))
-    α_icl = min(1, q_icl_nonneg / sqrt(q_icl_mean_eq^2 + q_min^2))
+    # Convert grid-mean cloud condensates to in-cloud values, q_in_cloud = q_mean / CF.
+    # Floor CF to keep q_in_cloud finite at small cloud fractions.
+    CF_min = FT(0.01)
+    cf_eff = max(cloud_fraction, CF_min)
+    q_lcl_in_cloud = q_lcl_nonneg / cf_eff
+    q_icl_in_cloud = q_icl_nonneg / cf_eff
+
+    # Liquid fraction from prognostic cloud-condensate composition
+    # (paper Eq. 3.31): q_c = q_l + q_i (cloud condensate only; rain and snow
+    # are excluded). Held fixed across quadrature points. TD.liquid_fraction
+    # returns q_l/(q_l+q_i) when condensate exists and a smooth temperature
+    # ramp around T_freeze otherwise.
+    λ = TD.liquid_fraction(thp, T, q_lcl_nonneg, q_icl_nonneg)
 
     # Create functor
     evaluator = Microphysics1MEvaluator(
-        scheme, cmp, thp, ρ, T, q_lcl_nonneg, q_icl_nonneg,
-        q_rai_nonneg, q_sno_nonneg, q_lcl_mean_eq, q_icl_mean_eq,
-        α_lcl, α_icl, dt, nsubs, args,
+        scheme, cmp, thp, ρ, T, q_lcl_in_cloud, q_icl_in_cloud,
+        q_rai_nonneg, q_sno_nonneg, λ, dt, nsubs, args,
     )
     # Integrate over quadrature points using functor (GPU-safe, no closure)
     local_tendency = integrate_over_sgs(

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -62,9 +62,9 @@ struct Microphysics0MEvaluator{CMP, SAE, FT}
     Φ::FT
 end
 function Microphysics0MEvaluator(cm_params, thermo_params, ρ, T_mean, Φ)
-    # Grid-mean liquid fraction, held fixed across quadrature points
-    # (paper Eq. 3.31, equilibrium fallback). The 0M scheme has no prognostic
-    # phase memory, so we use a temperature-based ramp at the grid mean.
+    # Grid-mean liquid fraction, held fixed across quadrature points.
+    # The 0M scheme has no prognostic phase memory, so we use a
+    # temperature-based ramp at the grid mean.
     λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
     sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)
     return Microphysics0MEvaluator(cm_params, sat_eval, Φ)
@@ -163,32 +163,16 @@ end
 ###
 
 """
-    equilibrium_cloud_condensates_1m(tps, T, ρ, q_tot, λ, q_rai, q_sno)
-
-Compute the equilibrium cloud liquid and cloud ice specific humidities
-(`q_lcl_eq`, `q_icl_eq`) for a thermodynamic state `(T, ρ, q_tot)` using
-a prescribed (grid-mean) liquid fraction `λ`. Rain and snow condensates
-are removed from the equilibrium partition.
-
-Returns `(q_lcl_eq, q_icl_eq)`.
-"""
-@inline function equilibrium_cloud_condensates_1m(tps, T, ρ, q_tot, λ, q_rai, q_sno)
-    FT = typeof(ρ)
-    q_sat = TD.q_vap_saturation(tps, T, ρ)
-    excess = max(FT(0), q_tot - q_sat)
-    q_lcl_eq = max(FT(0), λ * excess - q_rai)
-    q_icl_eq = max(FT(0), (FT(1) - λ) * excess - q_sno)
-    return q_lcl_eq, q_icl_eq
-end
-
-"""
     (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
 
 GPU-safe functor for computing 1-moment microphysics tendencies at SGS
 quadrature points. The local thermodynamic state `(T_hat, q_tot_hat)` is
-sampled from the SGS distribution; the local condensate is diagnosed from
-the local saturation excess and capped at the *in-cloud* condensate
-`q_lcl_in_cloud = q_lcl_mean / max(CF, CF_min)` (and analogously for ice).
+sampled from the SGS distribution; condensate species are held fixed at
+their grid-mean values across all quadrature points. The quadrature thus
+captures thermodynamic variability in phase-change rates (cloud-water
+condensation/evaporation, rain evaporation, snow sublimation, snow melt)
+while preserving exact ⟨q_lcl_hat⟩ = q_lcl_mean and ⟨q_tot⟩ = q_t_mean,
+i.e. the prognostic condensate budget.
 
 # Arguments
 - `T_hat`: Temperature at quadrature point [K]
@@ -200,84 +184,30 @@ the local saturation excess and capped at the *in-cloud* condensate
 - `dq_icl_dt`: Cloud ice tendency [kg/kg/s]
 - `dq_rai_dt`: Rain tendency [kg/kg/s]
 - `dq_sno_dt`: Snow tendency [kg/kg/s]
-
-# Condensate Diagnosis
-
-At each quadrature point, the local cloud condensate is
-
-    q_lcl_hat = min(q_lcl_in_cloud,
-                    max(0, λ (q_tot_hat - q_sat(T_hat, ρ)) - q_rai))
-
-with `λ` the prognostic-state liquid fraction (held fixed across all
-quadrature points of the subdomain). At clear quadrature points
-(`q_tot_hat ≤ q_sat(T_hat, ρ)`), `q_lcl_hat = 0`. At strongly supersaturated
-points, `q_lcl_hat` saturates at the in-cloud value. This bounds the
-Jensen's-inequality amplification of nonlinear sinks (autoconversion,
-accretion) by the standard GCM in-cloud / clear partition while letting the
-quadrature respond to local thermodynamic variability through the
-saturation curve.
-
-When the subdomain is clear (`q_lcl_mean = 0`), `q_lcl_in_cloud = 0` and the
-local condensate is identically zero at every quadrature point;
-phase-change rates remain responsive to local SGS supersaturation through
-`q_v_hat - q_sat(T_hat, ρ)` inside `BMT`.
 """
 struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     scheme::S
     mp::MP
     tps::TPS
     ρ::FT
-    # Grid-mean temperature (passed through; quadrature varies T_hat)
+    # Grid-mean state (held fixed across quadrature points)
     T_mean::FT
-    # In-cloud cloud condensates: q_mean / max(CF, CF_min)
-    q_lcl_in_cloud::FT
-    q_icl_in_cloud::FT
-    # Precipitation specific humidities. In a cell with cloud, these are the
-    # in-cloud values q_mean/CF, gated on local saturation in the call below
-    # (precip co-located with cloud, max-overlap). In a clear cell (rain or
-    # snow falling through clear air from above), `has_cloud = false` disables
-    # the gating and these are the grid-mean values.
+    q_lcl::FT
+    q_icl::FT
     q_rai::FT
     q_sno::FT
-    # Whether the cell has prognostic cloud condensate above the q_min
-    # threshold. Controls precipitation gating in the evaluator.
-    has_cloud::Bool
-    # Prognostic-state liquid fraction, fixed across quadrature points
-    λ::FT
     # Numerical parameters
     dt::FT
     nsubs::Int
     args::Args
 end
 @inline function (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
-
-    q_lcl_eq_hat, q_icl_eq_hat = equilibrium_cloud_condensates_1m(
-        eval.tps, T_hat, eval.ρ, q_tot_hat, eval.λ, eval.q_rai, eval.q_sno,
-    )
-
-    # Cap the local equilibrium fluctuation at the in-cloud condensate so that
-    # nonlinear sinks see at most the in-cloud value within the cloudy fraction.
-    q_lcl_hat = min(eval.q_lcl_in_cloud, q_lcl_eq_hat)
-    q_icl_hat = min(eval.q_icl_in_cloud, q_icl_eq_hat)
-
-    # Gate precipitation by local saturation under max-overlap with cloud.
-    # In a cell with cloud, rain/snow co-locate with cloud: at cloudy
-    # quadrature points (q_lcl_hat > 0 or q_icl_hat > 0) the BMT receives the
-    # in-cloud precip; at clear quadrature points it receives 0, which zeros
-    # out the clear-sky precip terms (rain evap, snow sub, snow melt) so
-    # those processes are not double-counted with the implicit clear/cloudy
-    # partitioning supplied by the quadrature. In a cell without cloud
-    # (`has_cloud = false`), the gate is disabled — quadrature points all see
-    # the grid-mean precip, so clear-air rain evap of precip falling from
-    # above is computed correctly.
-    is_local_cloudy = (q_lcl_hat > zero(q_lcl_hat)) | (q_icl_hat > zero(q_icl_hat))
-    gate_off = eval.has_cloud & !is_local_cloudy
-    q_rai_hat = ifelse(gate_off, zero(eval.q_rai), eval.q_rai)
-    q_sno_hat = ifelse(gate_off, zero(eval.q_sno), eval.q_sno)
-
+    FT = typeof(eval.ρ)
+    q_tot_hat = max(FT(0), q_tot_hat)
     return BMT.average_bulk_microphysics_tendencies(
         eval.scheme, eval.mp, eval.tps, eval.ρ, T_hat, q_tot_hat,
-        q_lcl_hat, q_icl_hat, q_rai_hat, q_sno_hat, eval.dt, eval.nsubs, eval.args...,
+        eval.q_lcl, eval.q_icl, eval.q_rai, eval.q_sno,
+        eval.dt, eval.nsubs, eval.args...,
     )
 end
 
@@ -285,34 +215,62 @@ end
     microphysics_tendencies_1m(ρ, q_tot, q_lcl, q_icl, q_rai, q_sno, T, cmp, thp, dt, nsubs,)
     microphysics_tendencies_1m(
         scheme, sgs_quad, cmp, thp, ρ, T, q_tot,
-        q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+        q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
         cloud_fraction, dt, nsubs,
     )
 
-Computes time-averaged 1-moment microphysics tendencies. When using SGS-quadratures,
-the tendencies are integrated over the joint PDF of (T, q_tot), with the
-condensate at each quadrature point taken from the local equilibrium excess
-capped at the in-cloud condensate `q_lcl_mean / max(CF, CF_min)` (similarly
-for ice). The grid-mean (no-quadrature) path takes condensate inputs as-is.
+Computes time-averaged 1-moment microphysics tendencies.
+
+The 4-argument (no `sgs_quad`) form takes condensate inputs as-is and is used
+in EDMF updrafts or wherever the grid-mean state is to be evaluated directly.
+
+The quadrature form uses a top-hat decomposition into a cloudy fraction
+(weight CF) and a clear fraction (weight 1−CF), with max-overlap of cloud
+condensate with itself and **random overlap of precipitation**
+(`q_rai`, `q_sno` are the same in both fractions):
+
+- **Fully-clear cell** (`q_lcl + q_icl ≤ q_min`): quadrature over the joint
+  `(T, q_tot)` SGS PDF with `q_lcl = q_icl = 0` and grid-mean precipitation.
+  Below-cloud rain evaporation and snow sublimation are captured through
+  subsaturated quadrature points. Unit weight.
+
+- **Cell with cloud**:
+  - *Cloudy fraction (CF)*: single BMT call at `T_mean` with in-cloud cloud
+    condensate `q_lcl/cf_eff` (likewise for ice) and grid-mean precipitation,
+    where `cf_eff = sqrt(CF² + CF_min²)` is a smooth floor on the cloud
+    fraction. The in-cloud water vapor is set to
+    `q_v_in_cloud = max(q_v_grid_mean, q_sat(T_mean, ρ))`:
+    when the grid mean is supersaturated, the cloudy BMT condenses the
+    excess via MM2015; when the grid mean is at or below saturation, the
+    in-cloud vapor is clamped to `q_sat` so MM2015 does not spuriously
+    evaporate cloud water at a subsaturated grid-mean state. The quadrature
+    is dropped in the cloudy fraction because the local `(T, q_tot)`
+    variability has small effect on the rates once `q_v` is at or near
+    `q_sat`.
+  - *Clear fraction (1−CF)*: quadrature over the joint `(T, q_tot)` PDF
+    with no cloud condensate (`q_lcl = q_icl = 0`) and grid-mean
+    precipitation; captures below-cloud rain evaporation and snow
+    sublimation at partly-cloudy levels.
+
 ```math
-\\bar{S} = \\int\\int S(T, q, q_l(T, q; q_l^{ic}), \\dots) P(T, q) \\, dT \\, dq
+\\bar{S}_{\\rm grid} = CF \\cdot \\bar{S}_{\\rm cloudy} +
+                      (1-CF) \\cdot \\bar{S}_{\\rm clear}
 ```
-The option without SGS-quadratures can be used in the EDMF updrafts, or to compute
-grid-mean tendency without taking account of fluctuations.
 
 # Arguments
 - `scheme`: Microphysics scheme type (from CloudMicrophysics.BulkMicrophysicsTendencies)
 - `sgs_quad`: SGSQuadrature configuration
 - `cmp`, `thp`: Microphysics and thermodynamics parameters
-- `ρ`, `T`: Air density [kg/m³] and temperature [K]
-- `q_tot`: Total water [kg/kg]
-- `q_lcl_mean`, `q_icl_mean`: Mean cloud liquid water and cloud ice [kg/kg]
-- `q_rai`, `q_sno`: Rain and snow [kg/kg]
+- `ρ`, `T`: Air density [kg/m³] and temperature [K] (grid-mean)
+- `q_tot`: Grid-mean total water [kg/kg]
+- `q_lcl`, `q_icl`: Grid-mean cloud liquid water and cloud ice [kg/kg]
+- `q_rai`, `q_sno`: Grid-mean rain and snow [kg/kg]
 - `T′T′`: Variance of temperature ``\\langle T'^2 \\rangle``
 - `q′q′`: Variance of q_tot ``\\langle q'^2 \\rangle``
 - `corr_Tq`: Correlation coefficient ρ(T', q') obtained from `correlation_Tq(params)`.
-- `cloud_fraction`: Subdomain cloud fraction CF ∈ [0, 1], used to convert grid-mean
-  condensates to in-cloud values via `q_lcl_in_cloud = q_lcl_mean / max(CF, CF_min)`.
+- `cloud_fraction`: Subdomain cloud fraction CF ∈ [0, 1]; used in cloudy
+  cells to convert grid-mean species to in-cloud values
+  `q_in_cloud = q / max(CF, CF_min)` and to weight the cloudy contribution.
 - `args...`: Additional arguments (e.g., N_lcl for 2M)
 - `dt`: Model timestep [s] (for tendency averaging)
 - `nsubs`: Number of substeps for computing average tendencies over time
@@ -335,52 +293,96 @@ NamedTuple with microphysics source terms:
 end
 @inline function microphysics_tendencies_1m( #microphysics_tendencies_quadrature_1m
     scheme, sgs_quad, cmp, thp, ρ, T, q_tot_nonneg,
-    q_lcl_mean, q_icl_mean, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+    q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
     cloud_fraction, dt, nsubs, args...,
 )
     FT = typeof(ρ)
-
-    # Clamp specific humidities to prevent negativity in quadratures
-    q_lcl_nonneg = max(FT(0), q_lcl_mean)
-    q_icl_nonneg = max(FT(0), q_icl_mean)
+    # Clamp specific humidities to non-negative.
+    q_lcl_nonneg = max(FT(0), q_lcl)
+    q_icl_nonneg = max(FT(0), q_icl)
     q_rai_nonneg = max(FT(0), q_rai)
     q_sno_nonneg = max(FT(0), q_sno)
 
-    # Convert grid-mean cloud condensates to in-cloud values, q_in_cloud = q_mean / CF.
-    # Floor CF to keep q_in_cloud finite at small cloud fractions.
-    CF_min = FT(0.01)
-    cf_eff = max(cloud_fraction, CF_min)
-    q_lcl_in_cloud = q_lcl_nonneg / cf_eff
-    q_icl_in_cloud = q_icl_nonneg / cf_eff
-
-    # Apply max-overlap in-cloud scaling to precipitation only when cloud
-    # condensate is present in the cell. When the cell has no cloud (rain/snow
-    # falling through clear air from above), the max-overlap assumption is
-    # meaningless — keep grid-mean values so clear-sky evaporation rates are
-    # not artificially inflated.
     q_min = TD.Parameters.q_min(thp)
     has_cloud = (q_lcl_nonneg + q_icl_nonneg) > q_min
-    precip_scaling = ifelse(has_cloud, FT(1) / cf_eff, FT(1))
-    q_rai_in_cloud = q_rai_nonneg * precip_scaling
-    q_sno_in_cloud = q_sno_nonneg * precip_scaling
 
-    # Liquid fraction from prognostic cloud-condensate composition
-    # (paper Eq. 3.31): q_c = q_l + q_i (cloud condensate only; rain and snow
-    # are excluded). Held fixed across quadrature points. TD.liquid_fraction
-    # returns q_l/(q_l+q_i) when condensate exists and a smooth temperature
-    # ramp around T_freeze otherwise.
-    λ = TD.liquid_fraction(thp, T, q_lcl_nonneg, q_icl_nonneg)
+    if !has_cloud
+        # Fully-clear cell: quadrature over (T, q_tot) with grid-mean
+        # precipitation. q_lcl = q_icl = 0, so autoconversion / accretion
+        # vanish; the quadrature captures below-cloud rain evaporation and
+        # snow sublimation through subsaturated (T_hat, q_tot_hat) points.
+        evaluator = Microphysics1MEvaluator(
+            scheme, cmp, thp, ρ, T,
+            zero(FT), zero(FT), q_rai_nonneg, q_sno_nonneg,
+            dt, nsubs, args,
+        )
+        return integrate_over_sgs(
+            evaluator, sgs_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
+        )
+    end
 
-    # Create functor
-    evaluator = Microphysics1MEvaluator(
-        scheme, cmp, thp, ρ, T, q_lcl_in_cloud, q_icl_in_cloud,
-        q_rai_in_cloud, q_sno_in_cloud, has_cloud, λ, dt, nsubs, args,
+    # Cell with cloud: top-hat decomposition into cloudy (CF) and clear (1-CF)
+    # fractions. Cloud condensate uses max-overlap (q_lcl_in_cloud = q_lcl/CF,
+    # zero in the clear fraction). Precipitation uses random overlap
+    # (q_rai = q_sno = grid-mean in both fractions); this satisfies mass
+    # conservation and allows the clear-fraction BMT call to evaporate rain
+    # and sublimate snow with q_v < q_sat.
+    #
+    # CF floor uses a smooth quadrature `cf_eff = min(1, sqrt(CF² + CF_min²))`
+    # to avoid the discontinuity in q_in_cloud = q_mean / cf_eff as CF crosses
+    # the floor. For CF >> CF_min, cf_eff ≈ CF; for CF << CF_min,
+    # cf_eff ≈ CF_min; the upper cap preserves cf_eff = 1 at CF = 1 so the
+    # cloudy/clear partition has unit weight sum.
+    CF_min = FT(0.01)
+    cf_eff = min(FT(1), sqrt(cloud_fraction * cloud_fraction + CF_min * CF_min))
+    inv_cf = FT(1) / cf_eff
+    one_minus_cf = FT(1) - cf_eff
+    q_lcl_in_cloud = q_lcl_nonneg * inv_cf
+    q_icl_in_cloud = q_icl_nonneg * inv_cf
+
+    # Cloudy fraction: single BMT call at T_mean. The in-cloud water vapor is
+    # set to `max(q_v_grid_mean, q_sat)`:
+    #   - If the grid mean is supersaturated (q_v_grid > q_sat), the cloudy
+    #     BMT receives the actual supersaturation and the MM2015 relaxation
+    #     condenses the excess into cloud water — the in-cloud condensation
+    #     source.
+    #   - If the grid mean is at or below saturation, q_v_in_cloud is clamped
+    #     to q_sat so MM2015 does not spuriously evaporate cloud water at a
+    #     subsaturated grid-mean state where in-cloud air is in fact
+    #     saturated.
+    # q_tot_in_cloud = q_v_in_cloud + Σ in-cloud species. Quadrature is
+    # dropped in the cloudy fraction because the local (T, q_tot) variability
+    # has small effect once q_v is pinned (or close to) q_sat.
+    q_sat_mean = TD.q_vap_saturation(thp, T, ρ)
+    q_vap_grid =
+        q_tot_nonneg - q_lcl_nonneg - q_icl_nonneg - q_rai_nonneg - q_sno_nonneg
+    q_vap_in_cloud = max(q_vap_grid, q_sat_mean)
+    q_tot_in_cloud =
+        q_vap_in_cloud + q_lcl_in_cloud + q_icl_in_cloud + q_rai_nonneg + q_sno_nonneg
+    cloudy_tend = BMT.average_bulk_microphysics_tendencies(
+        scheme, cmp, thp, ρ, T, q_tot_in_cloud,
+        q_lcl_in_cloud, q_icl_in_cloud, q_rai_nonneg, q_sno_nonneg,
+        dt, nsubs, args...,
     )
-    # Integrate over quadrature points using functor (GPU-safe, no closure)
-    local_tendency = integrate_over_sgs(
-        evaluator, sgs_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
+
+    # Clear fraction: quadrature over (T, q_tot) with no cloud condensate
+    # and grid-mean precipitation. Captures below-cloud rain evaporation,
+    # snow sublimation, and snow melt where q_v_hat < q_sat(T_hat).
+    clear_evaluator = Microphysics1MEvaluator(
+        scheme, cmp, thp, ρ, T,
+        zero(FT), zero(FT), q_rai_nonneg, q_sno_nonneg,
+        dt, nsubs, args,
     )
-    return local_tendency
+    clear_tend = integrate_over_sgs(
+        clear_evaluator, sgs_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
+    )
+
+    return (
+        dq_lcl_dt = cf_eff * cloudy_tend.dq_lcl_dt + one_minus_cf * clear_tend.dq_lcl_dt,
+        dq_icl_dt = cf_eff * cloudy_tend.dq_icl_dt + one_minus_cf * clear_tend.dq_icl_dt,
+        dq_rai_dt = cf_eff * cloudy_tend.dq_rai_dt + one_minus_cf * clear_tend.dq_rai_dt,
+        dq_sno_dt = cf_eff * cloudy_tend.dq_sno_dt + one_minus_cf * clear_tend.dq_sno_dt,
+    )
 end
 
 ###

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -232,9 +232,16 @@ struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     # In-cloud cloud condensates: q_mean / max(CF, CF_min)
     q_lcl_in_cloud::FT
     q_icl_in_cloud::FT
-    # Grid-mean precipitation (in-cloud / clear partition not applied)
+    # Precipitation specific humidities. In a cell with cloud, these are the
+    # in-cloud values q_mean/CF, gated on local saturation in the call below
+    # (precip co-located with cloud, max-overlap). In a clear cell (rain or
+    # snow falling through clear air from above), `has_cloud = false` disables
+    # the gating and these are the grid-mean values.
     q_rai::FT
     q_sno::FT
+    # Whether the cell has prognostic cloud condensate above the q_min
+    # threshold. Controls precipitation gating in the evaluator.
+    has_cloud::Bool
     # Prognostic-state liquid fraction, fixed across quadrature points
     λ::FT
     # Numerical parameters
@@ -253,9 +260,24 @@ end
     q_lcl_hat = min(eval.q_lcl_in_cloud, q_lcl_eq_hat)
     q_icl_hat = min(eval.q_icl_in_cloud, q_icl_eq_hat)
 
+    # Gate precipitation by local saturation under max-overlap with cloud.
+    # In a cell with cloud, rain/snow co-locate with cloud: at cloudy
+    # quadrature points (q_lcl_hat > 0 or q_icl_hat > 0) the BMT receives the
+    # in-cloud precip; at clear quadrature points it receives 0, which zeros
+    # out the clear-sky precip terms (rain evap, snow sub, snow melt) so
+    # those processes are not double-counted with the implicit clear/cloudy
+    # partitioning supplied by the quadrature. In a cell without cloud
+    # (`has_cloud = false`), the gate is disabled — quadrature points all see
+    # the grid-mean precip, so clear-air rain evap of precip falling from
+    # above is computed correctly.
+    is_local_cloudy = (q_lcl_hat > zero(q_lcl_hat)) | (q_icl_hat > zero(q_icl_hat))
+    gate_off = eval.has_cloud & !is_local_cloudy
+    q_rai_hat = ifelse(gate_off, zero(eval.q_rai), eval.q_rai)
+    q_sno_hat = ifelse(gate_off, zero(eval.q_sno), eval.q_sno)
+
     return BMT.average_bulk_microphysics_tendencies(
         eval.scheme, eval.mp, eval.tps, eval.ρ, T_hat, q_tot_hat,
-        q_lcl_hat, q_icl_hat, eval.q_rai, eval.q_sno, eval.dt, eval.nsubs, eval.args...,
+        q_lcl_hat, q_icl_hat, q_rai_hat, q_sno_hat, eval.dt, eval.nsubs, eval.args...,
     )
 end
 
@@ -331,6 +353,17 @@ end
     q_lcl_in_cloud = q_lcl_nonneg / cf_eff
     q_icl_in_cloud = q_icl_nonneg / cf_eff
 
+    # Apply max-overlap in-cloud scaling to precipitation only when cloud
+    # condensate is present in the cell. When the cell has no cloud (rain/snow
+    # falling through clear air from above), the max-overlap assumption is
+    # meaningless — keep grid-mean values so clear-sky evaporation rates are
+    # not artificially inflated.
+    q_min = TD.Parameters.q_min(thp)
+    has_cloud = (q_lcl_nonneg + q_icl_nonneg) > q_min
+    precip_scaling = ifelse(has_cloud, FT(1) / cf_eff, FT(1))
+    q_rai_in_cloud = q_rai_nonneg * precip_scaling
+    q_sno_in_cloud = q_sno_nonneg * precip_scaling
+
     # Liquid fraction from prognostic cloud-condensate composition
     # (paper Eq. 3.31): q_c = q_l + q_i (cloud condensate only; rain and snow
     # are excluded). Held fixed across quadrature points. TD.liquid_fraction
@@ -341,7 +374,7 @@ end
     # Create functor
     evaluator = Microphysics1MEvaluator(
         scheme, cmp, thp, ρ, T, q_lcl_in_cloud, q_icl_in_cloud,
-        q_rai_nonneg, q_sno_nonneg, λ, dt, nsubs, args,
+        q_rai_in_cloud, q_sno_in_cloud, has_cloud, λ, dt, nsubs, args,
     )
     # Integrate over quadrature points using functor (GPU-safe, no closure)
     local_tendency = integrate_over_sgs(

--- a/src/parameterized_tendencies/microphysics/sgs_saturation.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_saturation.jl
@@ -22,15 +22,18 @@ saturation adjustment and 0-moment microphysics.
 Given (T_hat, q_hat) at a quadrature point, computes:
 1. Saturation specific humidity q_sat from Clausius-Clapeyron
 2. Condensate as saturation excess: q_cond = max(0, q_hat - q_sat)
-3. Liquid/ice partition using temperature-based ramp function
+3. Liquid/ice partition using a grid-mean liquid fraction `λ_mean`,
+   held fixed across all quadrature points (paper Eq. 3.31)
 
 # Fields
 - `thermo_params`: Thermodynamics parameters
 - `ρ`: Air density [kg/m³]
+- `λ_mean`: Grid-mean liquid fraction, fixed across quadrature points
 """
 struct SaturationAdjustmentEvaluator{TPS, T1}
     thermo_params::TPS
     ρ::T1
+    λ_mean::T1
 end
 
 """
@@ -61,11 +64,12 @@ NamedTuple with:
     # Condensate is the saturation excess (positive only)
     q_cond = max(FT(0), q_hat - q_sat)
 
-    # Partition condensate using liquid fraction based on temperature ramp
-    # liquid_fraction_ramp is appropriate for equilibrium thermodynamics
-    λ = TD.liquid_fraction_ramp(thp, T_hat)
-    q_liq = λ * q_cond
-    q_ice = (FT(1) - λ) * q_cond
+    # Partition condensate using a grid-mean liquid fraction held fixed across
+    # quadrature points (paper Eq. 3.31). The 0M / saturation-adjustment scheme
+    # has no prognostic phase memory, so `λ_mean` is supplied by the caller
+    # using a temperature-based ramp evaluated at the grid-mean temperature.
+    q_liq = eval.λ_mean * q_cond
+    q_ice = (FT(1) - eval.λ_mean) * q_cond
 
     # Return q_tot_quad = q_hat so the caller can compute the effective
     # integrated mean of the (possibly truncated) q_tot distribution.
@@ -126,8 +130,11 @@ NamedTuple with SGS-averaged:
 )
     FT = typeof(T_mean)
     q_min = TD.Parameters.q_min(thermo_params)
+    # Grid-mean liquid fraction, held fixed across all quadrature points
+    # (paper Eq. 3.31, equilibrium fallback)
+    λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
     # Create GPU-safe functor (not a closure)
-    evaluator = SaturationAdjustmentEvaluator(thermo_params, ρ)
+    evaluator = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)
 
     # Integrate over quadrature points
     result =

--- a/src/parameterized_tendencies/microphysics/sgs_saturation.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_saturation.jl
@@ -23,7 +23,7 @@ Given (T_hat, q_hat) at a quadrature point, computes:
 1. Saturation specific humidity q_sat from Clausius-Clapeyron
 2. Condensate as saturation excess: q_cond = max(0, q_hat - q_sat)
 3. Liquid/ice partition using a grid-mean liquid fraction `λ_mean`,
-   held fixed across all quadrature points (paper Eq. 3.31)
+   held fixed across all quadrature points
 
 # Fields
 - `thermo_params`: Thermodynamics parameters
@@ -65,9 +65,9 @@ NamedTuple with:
     q_cond = max(FT(0), q_hat - q_sat)
 
     # Partition condensate using a grid-mean liquid fraction held fixed across
-    # quadrature points (paper Eq. 3.31). The 0M / saturation-adjustment scheme
-    # has no prognostic phase memory, so `λ_mean` is supplied by the caller
-    # using a temperature-based ramp evaluated at the grid-mean temperature.
+    # quadrature points. The 0M / saturation-adjustment scheme has no
+    # prognostic phase memory, so `λ_mean` is supplied by the caller using a
+    # temperature-based ramp evaluated at the grid-mean temperature.
     q_liq = eval.λ_mean * q_cond
     q_ice = (FT(1) - eval.λ_mean) * q_cond
 
@@ -130,8 +130,7 @@ NamedTuple with SGS-averaged:
 )
     FT = typeof(T_mean)
     q_min = TD.Parameters.q_min(thermo_params)
-    # Grid-mean liquid fraction, held fixed across all quadrature points
-    # (paper Eq. 3.31, equilibrium fallback)
+    # Grid-mean liquid fraction, held fixed across all quadrature points.
     λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
     # Create GPU-safe functor (not a closure)
     evaluator = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -112,7 +112,10 @@ import ClimaParams as CP
                         # perturbations partially cancel in the saturation deficit
                         # s = q − q_sat(T).  The PDF width σ_s² = σ_q² + b²σ_T²
                         # − 2b·corr·σ_T·σ_q shrinks when corr increases (b > 0),
-                        # so Q̂ = q_cond / σ_s grows ⇒ cf grows.
+                        # so q_c_eff / σ_qc grows ⇒ cf grows.
+                        # Use larger σ_q (q'q' = 1e-4) here to keep CF away from
+                        # its saturation tail at q_c_eff ≫ σ_qc, where Float32
+                        # precision would round all values to 1.0.
                         corr_vals = FT[-0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9]
 
                         # Liquid-only case
@@ -120,7 +123,7 @@ import ClimaParams as CP
                             CA.compute_cloud_fraction_sd(
                                 thp, T, ρ, q_tot_base + FT(1e-3),
                                 FT(1e-3), FT(0),
-                                FT(1.0), FT(1e-6), c,
+                                FT(1.0), FT(1e-4), c,
                                 FT(1), q_min, sgs_dist,
                             ) for c in corr_vals
                         ]
@@ -134,7 +137,7 @@ import ClimaParams as CP
                             CA.compute_cloud_fraction_sd(
                                 thp, T_cold, ρ, q_tot_base + FT(1e-3),
                                 FT(0), FT(1e-3),
-                                FT(1.0), FT(1e-6), c,
+                                FT(1.0), FT(1e-4), c,
                                 FT(1), q_min, sgs_dist,
                             ) for c in corr_vals
                         ]

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -236,27 +236,22 @@ import ClimaAtmos: limit_sink
                 q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
                 nsubs_quad = 1
 
-                @testset "Subsaturated mean" begin
-                    # q_cond_mean = 0 → q_in_cloud = 0, so cap forces q_lcl_hat = 0
-                    # at every quadrature point regardless of local saturation.
+                @testset "Subsaturated mean (no condensate)" begin
+                    # Evaluator with zero condensates and a slightly supersaturated
+                    # quadrature point: BMT receives the same (T, q_tot, 0, 0, 0, 0)
+                    # state because the evaluator holds condensate fixed.
                     eval_sub = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
                         mp, thp, ρ, T_mean,
-                        FT(0), FT(0),       # q_lcl_in_cloud, q_icl_in_cloud
-                        FT(0), FT(0),       # q_rai, q_sno
-                        false,              # has_cloud
-                        FT(1),              # λ
-                        FT(60),             # dt
+                        FT(0), FT(0), FT(0), FT(0),  # q_lcl, q_icl, q_rai, q_sno
+                        FT(60),                       # dt
                         nsubs_quad,
                         (),
                     )
 
-                    # Quadrature point slightly supersaturated
                     q_tot_hat = q_sat_mean + FT(0.001)
                     result = eval_sub(T_mean, q_tot_hat)
 
-                    # Cap at q_in_cloud=0 forces q_lcl_hat = q_icl_hat = 0,
-                    # so phase-change tendencies match the all-vapor BMT call.
                     res_expected = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
                         q_tot_hat, FT(0), FT(0), FT(0), FT(0), FT(60), nsubs_quad,
@@ -265,34 +260,26 @@ import ClimaAtmos: limit_sink
                     @test result.dq_icl_dt ≈ res_expected.dq_icl_dt rtol = FT(1e-4)
                 end
 
-                @testset "Saturated equilibrium mean (CF = 1)" begin
-                    # excess_mean > 0, q_cond_mean = excess_mean (equilibrium),
-                    # CF = 1 → q_in_cloud = q_cond_mean.
+                @testset "Saturated equilibrium mean" begin
                     q_tot_sat = q_sat_mean + FT(0.002)
-                    excess_sat = q_tot_sat - q_sat_mean  # +0.002
-                    q_lcl_mean = excess_sat
-                    q_icl_mean = FT(0)
-                    λ = TD.liquid_fraction(thp, T_mean, q_lcl_mean, q_icl_mean)
+                    excess_sat = q_tot_sat - q_sat_mean
+                    q_lcl = excess_sat
+                    q_icl = FT(0)
 
                     eval_sat = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
                         mp, thp, ρ, T_mean,
-                        λ * excess_sat, (1 - λ) * excess_sat,  # q_lcl_in_cloud, q_icl_in_cloud
-                        FT(0), FT(0),                          # q_rai, q_sno
-                        true,                                  # has_cloud
-                        λ,                                     # λ
-                        FT(60),                                # dt
+                        q_lcl, q_icl, FT(0), FT(0),  # q_lcl, q_icl, q_rai, q_sno
+                        FT(60),                       # dt
                         nsubs_quad,
                         (),
                     )
 
-                    # At grid mean: equilibrium fluctuation equals in-cloud cap,
-                    # so q_lcl_hat = λ * excess_sat. Should match direct BMT call.
+                    # Evaluator passes fixed condensates straight through to BMT.
                     result_mean = eval_sat(T_mean, q_tot_sat)
                     res_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
-                        q_tot_sat, λ * excess_sat,
-                        (1 - λ) * excess_sat, FT(0), FT(0), FT(60), nsubs_quad,
+                        q_tot_sat, q_lcl, q_icl, FT(0), FT(0), FT(60), nsubs_quad,
                     )
                     @test result_mean.dq_lcl_dt ≈ res_direct.dq_lcl_dt rtol = FT(1e-4)
                     @test result_mean.dq_icl_dt ≈ res_direct.dq_icl_dt rtol = FT(1e-4)

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -237,14 +237,15 @@ import ClimaAtmos: limit_sink
                 nsubs_quad = 1
 
                 @testset "Subsaturated mean" begin
-                    # excess_mean < 0, q_cond_mean = 0
-                    q_tot_sub = q_sat_mean - FT(0.002)
-                    excess_sub = q_tot_sub - q_sat_mean  # -0.002
-
+                    # q_cond_mean = 0 → q_in_cloud = 0, so cap forces q_lcl_hat = 0
+                    # at every quadrature point regardless of local saturation.
                     eval_sub = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
                         mp, thp, ρ, T_mean,
-                        FT(0), FT(0), FT(0), FT(0), FT(0), FT(0), FT(0), FT(0), FT(60),
+                        FT(0), FT(0),       # q_lcl_in_cloud, q_icl_in_cloud
+                        FT(0), FT(0),       # q_rai, q_sno
+                        FT(1),              # λ
+                        FT(60),             # dt
                         nsubs_quad,
                         (),
                     )
@@ -253,6 +254,8 @@ import ClimaAtmos: limit_sink
                     q_tot_hat = q_sat_mean + FT(0.001)
                     result = eval_sub(T_mean, q_tot_hat)
 
+                    # Cap at q_in_cloud=0 forces q_lcl_hat = q_icl_hat = 0,
+                    # so phase-change tendencies match the all-vapor BMT call.
                     res_expected = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
                         q_tot_hat, FT(0), FT(0), FT(0), FT(0), FT(60), nsubs_quad,
@@ -261,22 +264,28 @@ import ClimaAtmos: limit_sink
                     @test result.dq_icl_dt ≈ res_expected.dq_icl_dt rtol = FT(1e-4)
                 end
 
-                @testset "Saturated equilibrium mean" begin
-                    # excess_mean > 0, q_cond_mean = excess_mean (equilibrium)
+                @testset "Saturated equilibrium mean (CF = 1)" begin
+                    # excess_mean > 0, q_cond_mean = excess_mean (equilibrium),
+                    # CF = 1 → q_in_cloud = q_cond_mean.
                     q_tot_sat = q_sat_mean + FT(0.002)
                     excess_sat = q_tot_sat - q_sat_mean  # +0.002
-                    λ = TD.liquid_fraction(thp, T_mean, FT(0), FT(0))
+                    q_lcl_mean = excess_sat
+                    q_icl_mean = FT(0)
+                    λ = TD.liquid_fraction(thp, T_mean, q_lcl_mean, q_icl_mean)
 
                     eval_sat = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
                         mp, thp, ρ, T_mean,
-                        λ * excess_sat, (1 - λ) * excess_sat, FT(0), FT(0),
-                        λ * excess_sat, (1 - λ) * excess_sat, FT(1), FT(1), FT(60),
+                        λ * excess_sat, (1 - λ) * excess_sat,  # q_lcl_in_cloud, q_icl_in_cloud
+                        FT(0), FT(0),                          # q_rai, q_sno
+                        λ,                                     # λ
+                        FT(60),                                # dt
                         nsubs_quad,
                         (),
                     )
 
-                    # At grid mean: should recover q_cond_mean (zero-variance)
+                    # At grid mean: equilibrium fluctuation equals in-cloud cap,
+                    # so q_lcl_hat = λ * excess_sat. Should match direct BMT call.
                     result_mean = eval_sat(T_mean, q_tot_sat)
                     res_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -244,6 +244,7 @@ import ClimaAtmos: limit_sink
                         mp, thp, ρ, T_mean,
                         FT(0), FT(0),       # q_lcl_in_cloud, q_icl_in_cloud
                         FT(0), FT(0),       # q_rai, q_sno
+                        false,              # has_cloud
                         FT(1),              # λ
                         FT(60),             # dt
                         nsubs_quad,
@@ -278,6 +279,7 @@ import ClimaAtmos: limit_sink
                         mp, thp, ρ, T_mean,
                         λ * excess_sat, (1 - λ) * excess_sat,  # q_lcl_in_cloud, q_icl_in_cloud
                         FT(0), FT(0),                          # q_rai, q_sno
+                        true,                                  # has_cloud
                         λ,                                     # λ
                         FT(60),                                # dt
                         nsubs_quad,

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -602,6 +602,7 @@ using ClimaAtmos
                     mp, thp, ρ, T_mean,
                     q_lcl_mean, q_icl_mean,    # q_lcl_in_cloud, q_icl_in_cloud
                     q_rai, q_sno,              # q_rai, q_sno
+                    true,                      # has_cloud
                     FT(1),                     # λ
                     dt, nsubs_quad,
                     (),

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -351,7 +351,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad_1pt, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                     )
 
                     # Direct evaluation at grid mean
@@ -377,7 +377,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), FT(1), dt, nsubs_quad,
                     )
 
                     # Direct evaluation
@@ -399,7 +399,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                     )
 
                     @test haskey(result, :dq_lcl_dt)
@@ -418,7 +418,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.8), dt, nsubs_quad,
+                        FT(4.0), FT(1e-5), FT(0.8), FT(1), dt, nsubs_quad,
                     )
 
                     # Without variance
@@ -426,7 +426,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), FT(1), dt, nsubs_quad,
                     )
 
                     # Results should differ (unless microphysics is perfectly linear)
@@ -496,7 +496,7 @@ using ClimaAtmos
                 result = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                 )
 
                 # Total condensed water tendency
@@ -559,7 +559,7 @@ using ClimaAtmos
                 result = @inferred microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                 )
 
                 # Verify return type
@@ -596,13 +596,15 @@ using ClimaAtmos
                 dt = FT(60)
                 nsubs_quad = 1
 
-                # Create evaluator
+                # Create evaluator (CF = 1 → q_in_cloud = q_mean; λ = 1 here for simplicity)
                 evaluator = Microphysics1MEvaluator(
                     BMT.Microphysics1Moment(),
                     mp, thp, ρ, T_mean,
-                    q_lcl_mean, q_icl_mean, q_rai, q_sno, q_lcl_mean, q_icl_mean, FT(1),
-                    FT(1), dt, nsubs_quad,
-                    (),  # Empty args tuple for 1-moment
+                    q_lcl_mean, q_icl_mean,    # q_lcl_in_cloud, q_icl_in_cloud
+                    q_rai, q_sno,              # q_rai, q_sno
+                    FT(1),                     # λ
+                    dt, nsubs_quad,
+                    (),
                 )
 
                 # Verify it's a proper functor (not a closure)
@@ -668,7 +670,7 @@ using ClimaAtmos
                     BMT.Microphysics1Moment(),
                     quad_gm, mp, tps, ρ,
                     T_mean, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                 )
 
                 # Direct BMT call
@@ -762,7 +764,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), FT(1), dt, nsubs_quad,
                     )
 
                     result_direct = BMT.average_bulk_microphysics_tendencies(
@@ -785,7 +787,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.6), dt, nsubs_quad,
+                        FT(4.0), FT(1e-5), FT(0.6), FT(1), dt, nsubs_quad,
                     )
                     for field in (:dq_lcl_dt, :dq_icl_dt, :dq_rai_dt, :dq_sno_dt)
                         @test isfinite(getfield(result_var, field))
@@ -938,14 +940,14 @@ using ClimaAtmos
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                     )
                 end
                 t = @elapsed for _ in 1:N_bench
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, FT(1), dt, nsubs_quad,
                     )
                 end
                 timings_1m[order] = t

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -318,14 +318,19 @@ using ClimaAtmos
                 tps = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 mp = CMP.Microphysics1MParams(toml_dict)
 
-                # Grid-mean state
+                # Grid-mean state. Choose q_tot so the cell is at saturation
+                # equilibrium (q_v_mean = q_sat); the new microphysics-tendency
+                # decomposition forces q_v = q_sat inside the cloudy fraction,
+                # so the per-quadrature-point and direct-BMT evaluations agree
+                # only when the grid-mean state is itself saturated.
                 ρ = FT(1.2)
                 T_mean = FT(280.0)
-                q_tot_mean = FT(0.01)
                 q_lcl_mean = FT(0.0001)
                 q_icl_mean = FT(0.00005)
                 q_rai = FT(0.0001)
                 q_sno = FT(0.00001)
+                q_sat_mean = TD.q_vap_saturation(tps, T_mean, ρ)
+                q_tot_mean = q_sat_mean + q_lcl_mean + q_icl_mean + q_rai + q_sno
 
                 # Variances and correlation
                 T′T′ = FT(1.0)
@@ -596,14 +601,11 @@ using ClimaAtmos
                 dt = FT(60)
                 nsubs_quad = 1
 
-                # Create evaluator (CF = 1 → q_in_cloud = q_mean; λ = 1 here for simplicity)
+                # Create evaluator with fixed grid-mean condensates
                 evaluator = Microphysics1MEvaluator(
                     BMT.Microphysics1Moment(),
                     mp, thp, ρ, T_mean,
-                    q_lcl_mean, q_icl_mean,    # q_lcl_in_cloud, q_icl_in_cloud
-                    q_rai, q_sno,              # q_rai, q_sno
-                    true,                      # has_cloud
-                    FT(1),                     # λ
+                    q_lcl_mean, q_icl_mean, q_rai, q_sno,  # condensate species
                     dt, nsubs_quad,
                     (),
                 )
@@ -644,14 +646,16 @@ using ClimaAtmos
                 tps = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 mp = CMP.Microphysics1MParams(toml_dict)
 
-                # Grid-mean state
+                # Grid-mean state at saturation equilibrium so the in-cloud
+                # branch (which forces q_v = q_sat) reproduces direct BMT.
                 ρ = FT(1.2)
                 T_mean = FT(280.0)
-                q_tot = FT(0.01)
                 q_liq = FT(0.001)
                 q_ice = FT(0.0005)
                 q_rai = FT(0.0002)
                 q_sno = FT(0.0001)
+                q_sat_mean = TD.q_vap_saturation(tps, T_mean, ρ)
+                q_tot = q_sat_mean + q_liq + q_ice + q_rai + q_sno
 
                 # GridMeanSGS inside SGSQuadrature
                 quad_gm = ClimaAtmos.SGSQuadrature(
@@ -751,11 +755,14 @@ using ClimaAtmos
 
                     ρ = FT(1.0)
                     T = FT(280.0)
-                    q_tot = FT(0.015)
                     q_liq = FT(0.001)
                     q_ice = FT(0.0005)
                     q_rai = FT(0.0001)
                     q_sno = FT(0.00005)
+                    # Grid mean at saturation equilibrium so the cloudy branch
+                    # (which forces q_v = q_sat) matches direct BMT.
+                    q_sat_eq = TD.q_vap_saturation(thp, T, ρ)
+                    q_tot = q_sat_eq + q_liq + q_ice + q_rai + q_sno
                     dt = FT(1.0)
                     nsubs = 1
                     nsubs_quad = 1

--- a/test/parameterized_tendencies/microphysics/sgs_saturation.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_saturation.jl
@@ -16,7 +16,9 @@ import ClimaParams as CP
                 thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 ρ = FT(1.0)
 
-                evaluator = ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ)
+                # The evaluator now carries a fixed grid-mean λ. Each subtest
+                # below constructs an evaluator with λ_mean = ramp(T_hat) so the
+                # test semantics still target the partitioning at T_hat.
 
                 @testset "Unsaturated conditions" begin
                     # T and q where q < q_sat (unsaturated)
@@ -24,6 +26,9 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(0.5) * q_sat  # Half saturation
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     @test haskey(result, :T)
@@ -42,6 +47,9 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(1.5) * q_sat  # 50% supersaturated
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     # Should have condensate
@@ -49,8 +57,7 @@ import ClimaParams as CP
                     @test result.q_liq + result.q_ice ≈ q_cond_expected rtol = FT(1e-5)
 
                     # At warm temperatures, should be mostly liquid
-                    λ = TD.liquid_fraction_ramp(thp, T_hat)
-                    @test result.q_liq ≈ λ * q_cond_expected rtol = FT(1e-5)
+                    @test result.q_liq ≈ λ_mean * q_cond_expected rtol = FT(1e-5)
                 end
 
                 @testset "Saturated conditions (cold)" begin
@@ -59,18 +66,23 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(1.5) * q_sat  # 50% supersaturated
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     # At cold temperatures, should be mostly ice
-                    λ = TD.liquid_fraction_ramp(thp, T_hat)
-                    @test λ < FT(0.5)  # Verify it's actually cold enough
+                    @test λ_mean < FT(0.5)  # Verify it's actually cold enough
                     q_cond_expected = q_hat - q_sat
-                    @test result.q_ice ≈ (1 - λ) * q_cond_expected rtol = FT(1e-5)
+                    @test result.q_ice ≈ (1 - λ_mean) * q_cond_expected rtol = FT(1e-5)
                 end
 
                 @testset "Type stability" begin
                     T_hat = FT(280.0)
                     q_hat = FT(0.01)
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     @test eltype(result.T) == FT


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Replace the SGS condensate-variability quadrature framework (PR #4473) with a
top-hat in-cloud / clear decomposition that follows a more standard GCM approach
(CAM-MG/IFS). Microphysics rates are computed at in-cloud
condensate values (i.e., `q_c/CF`), multiplied by cloud fraction. A separate clear BMT call
captures below-cloud rain evaporation. 

This branch keeps the analytic Sommeria-Deardorff-type cloud fraction (with prognostic-state condensates) and with the activation factor that #4473 introduced.

## What changed

### Microphysics tendencies (`microphysics_wrappers.jl`)

- **Clear cell** (`q_lcl + q_icl ≤ q_min`): full `(T, q_tot)` SGS
  quadrature with grid-mean precipitation. Captures below-cloud rain/snow
  evaporation.
- **Cell with cloud**: top-hat decomposition
  `dq/dt = CF · cloudy_rates + (1 − CF) · clear_rates`.
  - *Cloudy fraction*: single BMT call at `T_mean`.
    - Cloud condensate at in-cloud values: `q_lcl_in_cloud = q_lcl / cf_eff`,
      same for ice (max-overlap of cloud with itself).
    - Precipitation at grid-mean values (random overlap, mass-conserving).
    - In-cloud water vapor `q_v = max(q_v_grid_mean, q_sat(T_mean, ρ))`:
      supersaturated grid cells get the in-cloud condensation source
      restored; subsaturated grid cells are clamped to saturation to avoid
      spurious in-cloud evaporation.
    - `cf_eff = min(1, sqrt(CF² + CF_min²))` is a smooth floor on CF that
      preserves `cf_eff = 1` at CF = 1.
  - *Clear fraction*: Quadrature over `(T, q_tot)` with no cloud condensate
    and grid-mean precipitation. Captures below-cloud rain evaporation at
    partly-cloudy levels.

### Cloud fraction (`cloud_fraction.jl`)

Analytic Sommeria-Deardorff as in paper draft:

- Prognostic-state liquid fraction `λ = q_l / (q_l + q_i)` (cloud condensate
  only; rain/snow excluded).
- Phase-partitioned `q_v_sat = λ q_sat,l + (1 − λ) q_sat,i` and CC slope.
- Activation factor `α = clamp(q_c / sqrt(excess_eq² + q_min²), 0, 1)`,
  `σ_qc = α · σ_s`.
- Effective excess `q_c_eff = q_c + min(0, q_t − q_v_sat)`.
- `f_c = ½[1 + erf(c_f · q_c_eff / (√2 σ_qc))]`, implemented via the
  variance-matched logistic approximation.

### Saturation adjustment (`sgs_saturation.jl`)

The 0M `SaturationAdjustmentEvaluator` now uses a grid-mean liquid fraction
`λ_mean = liquid_fraction_ramp(thermo_params, T_mean)` held fixed across
quadrature points.

## Trade-offs and limitations

- **Accretion amplification lost.** Random precipitation overlap means
  `accretion ∝ q_lcl_in_cloud · q_rai_mean × CF = q_lcl_mean · q_rai_mean`,
  the same as no in-cloud framework. Autoconversion amplification is
  preserved (in-cloud cloud condensate × CF gives threshold-lowering).
- **No tracked precipitation area fraction.** A CAM-MG-style separate
  `f_prec` (rain area > cloud area below cloud) would recover accretion
  amplification while preserving below-cloud evap. Left for later.
- **No cloudy-fraction `(T, q_tot)` quadrature.** Pinning `q_v ≈ q_sat`
  removes the dominant `(T, q_tot)`-dependent source, so the quadrature
  cost is saved in cloudy cells. The minor T-dependent terms (snow melt,
  rate coefficients) are evaluated at T_mean only.

## To do later

- Calibrate `c_σ` (variance closure scaling), `r_h_s, q_t` (correlation
  closure), and `c_f` (cloud-fraction steepness factor) 
- Compute environmental cloud fraction separately (currently uses grid-mean)
- Track precipitation area fraction separately from CF to enable both
  accretion amplification AND below-cloud rain evap at partly-cloudy
  levels.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
