### PR TITLE
Make cloud formulation consistent with quadrature and resolution-adaptive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ Artifacts.toml
 AGENTS.md
 MEMORY.md
 .agents
+# Claude Code worktrees
 .claude/worktrees/

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- ![][badge-🔥behavioralΔ] Unify cloud fraction and microphysics SGS quadrature via a shared `sgs_moments` pre-pass. Replace the Sommeria–Deardorff cloud fraction with a hybrid CDF formula, with variances from quadratures, and introduce a mass-conserving shape-function partition in the `Microphysics1MEvaluator`.
+
 v0.39.0
 -------
 - [#4486](https://github.com/CliMA/ClimaAtmos.jl/pull/4486) [badge-💥breaking]
@@ -19,6 +21,7 @@ v0.38.4
 
 v0.38.3
 -------
+
 - Added a `Presets` module with convenience constructors for common module/simulation configurations.
 - Add a keyword-based constructor `AtmosSimulation(; kwargs)` that always runs with Float32.
 - Set the existing keyword-based constructor `AtmosSimulation{FT}(;kwargs)` to always use ITime. Removed the `itime` kwarg.
@@ -31,12 +34,14 @@ v0.38.1
 
 v0.38.0
 ----
+
 - Refactor names in 1M microphysics q_liq -> q_lcl, q_ice -> q_icl
 - Refactor names in 0M microphysics q_liq_rai -> q_liq, q_ice_sno -> q_ice
 - Refactor names in 0M microphysics q_tot_safe -> q_tot_nonneg
 
 v0.37
 ----
+
 - Replace `InitialConditions` module with `Setups` module. Remove `surface_temperature` config key.
 
 - [#4361](https://github.com/CliMA/ClimaAtmos.jl/pull/4361) Refactor reproducibility infrastructure to use rms deviations in prognostic variables and only fail when rms deviation exceeds tolerance.
@@ -65,10 +70,12 @@ v0.35.2
 
 v0.35.1
 -------
+
 - [4276](https://github.com/CliMA/ClimaAtmos.jl/pull/4276) Create IC type to allow initializing AMIP with ERA5 on model levels. Add artifact which corresponds to default AMIP start date (Jan 1, 2010). Also removes unused ᶜspecific in the precomputed cache.
 
 v0.35.0
 -------
+
 - [#4225](https://github.com/CliMA/ClimaAtmos.jl/pull/4225) Add an option for vertical water borrowing limiter. Configure via `tracer_nonnegativity_method: "vertical_water_borrowing"`
   and optionally `vertical_water_borrowing_species` (defaults to all tracers if not specified).
   The limiter enforces non-negativity using a single threshold (0.0) that applies uniformly to all selected tracers.
@@ -91,6 +98,7 @@ thermo state, including ᶜts in p.precomputed.sfc_conditions.
 
 v0.34.0
 -------
+
 - [#4198](https://github.com/CliMA/ClimaAtmos.jl/pull/4198) [badge-💥breaking] modifies surface conditions
 to use SurfaceFluxes v0.15.
 
@@ -101,6 +109,7 @@ v0.33.2
 
 v0.33.1
 -------
+
 - PR [#4185](https://github.com/CliMA/ClimaAtmos.jl/pull/4185) adds a new cloud fraction parameterization `MLCloud`. It can be set in the toml under `cloud_model`.
 
 - PR [#4191](https://github.com/CliMA/ClimaAtmos.jl/pull/4191) renames ρatke to ρtke and move it out of sgs⁰.
@@ -109,6 +118,7 @@ v0.33.1
 
 v0.33.0
 -------
+
 - ![#4169](https://github.com/CliMA/ClimaAtmos.jl/pull/4169) [badge-💥breaking]
 Remove the options `co2_model` and `prescribe_ozone`. These are both fixed by
 default now, and can be set to time-varying by including one or both in the
@@ -116,6 +126,7 @@ option `time_varying_trace_gases: ["CO2", "O3]`.
 
 v0.32.0
 -------
+
 - PR [#4162](https://github.com/CliMA/ClimaAtmos.jl/pull/4162) adds an option for
 reproducible restart. It is set to false by default. This shouldn't affect restart
 in the coupler as the coupler save the cache for restarting.
@@ -137,6 +148,7 @@ v0.31.6
 
 v0.31.5
 -------
+
 PR [#3975](https://github.com/CliMA/ClimaAtmos.jl/pull/3975) updates the pressure gradient formulation to subtract a reference state and use the Exner pressure.
 
 v0.31.4
@@ -149,6 +161,7 @@ v0.31.2
 -------
 
 ### Add RWP diagnostic
+
 PR [#3946](https://github.com/CliMA/ClimaAtmos.jl/pull/3946) adds rainwater path diagnostic variable.
 
 v0.31.1
@@ -170,28 +183,31 @@ factor speedup. The associated documentation section, "Single Column Model", was
 
 v0.30.4
 -------
+
 PR [#3856](https://github.com/CliMA/ClimaAtmos.jl/pull/3856) adds number adjustment tendencies to the two-moment microphysics scheme.
 
 v0.30.3
 -------
 
 ### Add diagnostic for CAPE
+
 PR [#3820](https://github.com/CliMA/ClimaAtmos.jl/pull/3820) adds support for computing convective available potential energy (CAPE), or the vertical integral of the buoyancy differential between a parcel lifted from the surface and the environment. Exemplified in the TRMM deep convection case.
 
 v0.30.2
 -------
 
 ### Add limiting by max Prandtl number
+
 This is part of a larger refactoring of the Eddy Diffusivity code for EDMF
 
 v0.30.1
 -------
 
-
 v0.30.0
 -------
 
 ### Add support for reanalysis-driven single column model with time-varying forcing
+
 PR [#3758](https://github.com/CliMA/ClimaAtmos.jl/pull/3758) adds support for driving single-column model (SCM) simulations with time-varying ERA5 reanalysis data. This extends the existing GCM-driven SCM interface to allow site-specific simulations that resolve the diurnal cycle and are suited for calibration against observations. Users can now run reanalysis-driven cases globally using only a date and lat/lon, thanks to integrated data handling via ClimaArtifacts.jl. See the updated “Single Column Model” docs page for details on setup, variable requirements, and how to prepare ERA5 input files.
 
 ### Non-orographic gravity wave tendency as a callback
@@ -207,6 +223,7 @@ v0.29.1
 -------
 
 ### Remove contribution from condensate, precip diffusion in mass tendency
+
 PR[#3721](https://github.com/CliMA/ClimaAtmos.jl/pull/3721)
 Diffusion of condensate (liq, ice) and precip (rai, sno) vars no longer
 contributes to the mass tendency terms (updates in vert diffusion boundary layer,
@@ -222,6 +239,7 @@ v0.29.0
 -------
 
 ### Remove precipitation from cache
+
 And move all the fields into precomputed
 
 v0.28.6
@@ -230,6 +248,7 @@ v0.28.6
 ### Features
 
 ### Add a flag for disabling surface flux tendency
+
 Surface flux tendency is not controlled by `vert_diff` or `edmfx_sgs_diffusive_flux` anymore.
 Instead, it is controlled by the new flag `disable_surface_flux_tendency`. When it is set to
 true, no surface flux tendency is applied, no matter what `surface_setup` is.
@@ -259,8 +278,8 @@ PR [3622](https://github.com/CliMA/ClimaAtmos.jl/pull/3622) adds a new
 simplified EDMF model that only implements the Eddy-Diffusivity part of the
 scheme (not the Mass-Flux).
 
-
 ### Update default configuration to use deep-atmosphere eqns, fix diagnostic bug
+
 PR [3422](https://github.com/CliMA/ClimaAtmos.jl/pull/3422)
 Updates the `default_config` to set `deep_atmosphere=true`, and updates the
 `rv` relative vorticity diagnostic to store the curl of horizontal velocity.
@@ -280,10 +299,12 @@ PR [3592](https://github.com/CliMA/ClimaAtmos.jl/pull/3592)
 
 v0.28.4
 -------
+
 ### Development
 
 The `.dev` was deprecated. The two utilities in this folder can be replaced with
 more established and better developed tools:
+
 - instead of `clima_format`, use `JuliaFormatter`,
 - instead of `up_deps`, use `PkgDevTools`.
 See the [documentation](https://clima.github.io/ClimaAtmos.jl/dev/contributor_guide/#Formatting) for more information.
@@ -301,6 +322,7 @@ See [ClimaComms documentation](https://clima.github.io/ClimaComms.jl/dev/logging
 
 v0.28.3
 -------
+
 ### Read CO2 from file
 
 `ClimaAtmos` now support using data from the Mauna Loa CO2 measurements to set
@@ -317,6 +339,7 @@ toml. PR [3534](https://github.com/CliMA/ClimaAtmos.jl/pull/3534)
 
 v0.28.2
 -------
+
 ### Features
 
 ### Add van Leer class operator
@@ -332,6 +355,7 @@ interpolated NetCDF datasets.
 
 To use this feature from the YAML interface, just pass the path of the file.
 We expect the file to contain the following variables:
+
 - `p`, for pressure,
 - `t`, for temperature,
 - `q`, for humidity,
@@ -339,9 +363,11 @@ We expect the file to contain the following variables:
 - `cswc, crwc` for snow and rain water content (for 1 moment microphysics).
 
 For example, to use the DYAMONDSummer initial condition, set
+
 ```
 initial_condition: "artifact\"DYAMONDSummer\"/DYAMOND_SUMMER_ICS_p98deg.nc"
 ```
+
 in your configuration file.
 
 ### Write diagnostics to text files
@@ -375,7 +401,7 @@ When `prescribe_clouds_in_radiation` is set to true, clouds in radiation
 is prescribed from a file (monthly cloud properties in 2010 from ERA5).
 PR [3405](https://github.com/CliMA/ClimaAtmos.jl/pull/3405)
 
-### ETOPO2022 60arc-second topography dataset.
+### ETOPO2022 60arc-second topography dataset
 
 - Update artifacts to use 60arc-second ETOPO2022 ice-surface topography
   dataset. Update surface smoothing functions to rely only on spectral
@@ -448,26 +474,30 @@ more information.
 
 v0.27.5
 -------
+
 - Update RRTMGP and allow multiple aerosols for radiation.
   Note: Don't use sea salt as there is an issue with the lookup
   table. PR [#3264](https://github.com/CliMA/ClimaAtmos.jl/pull/3264)
 
 v0.27.4
 -------
+
 - Add artifact decoding from YAML
   PR [#3256](https://github.com/CliMA/ClimaAtmos.jl/pull/3256)
 
 v0.27.3
 -------
+
 - Add support for monthly calendar diagnostics
   PR [#3235](https://github.com/CliMA/ClimaAtmos.jl/pull/3241)
 - Use period filling interpolation for aerosol time series
-  PR [#3246] (https://github.com/CliMA/ClimaAtmos.jl/pull/3246)
+  PR [#3246] (<https://github.com/CliMA/ClimaAtmos.jl/pull/3246>)
 - Add prescribe time and spatially varying ozone
   PR [#3241](https://github.com/CliMA/ClimaAtmos.jl/pull/3241)
 
 v0.27.2
 -------
+
 - Use new aerosol artifact and change start date
   PR [#3216](https://github.com/CliMA/ClimaAtmos.jl/pull/3216)
 - Add a gpu scaling job with diagnostics
@@ -475,6 +505,7 @@ v0.27.2
 
 v0.27.1
 -------
+
 - Allow different aerosol types for radiation.
   PR [#3180](https://github.com/CliMA/ClimaAtmos.jl/pull/3180)
 - ![][badge-🔥behavioralΔ] Switch from `Dierckz` to `Interpolations`. `Interpolations`
@@ -483,6 +514,7 @@ v0.27.1
 
 v0.27.0
 -------
+
 - ![][badge-💥breaking] Change `radiation_model` in the radiation cache to `rrtmgp_model`.
   PR [#3167](https://github.com/CliMA/ClimaAtmos.jl/pull/3167)
 - ![][badge-💥breaking] Change the `idealized_insolation` argument to `insolation`,
@@ -492,6 +524,7 @@ v0.27.0
 
 v0.26.3
 -------
+
 - Add ClimaCoupler downstream test.
   PR [#3152](https://github.com/CliMA/ClimaAtmos.jl/pull/3152)
 - Add an option to use aerosol radiation. This is not fully working yet.
@@ -503,11 +536,13 @@ v0.26.3
 
 v0.26.2
 -------
+
 - Limit temperature input to RRTMGP within the lookup table range.
   PR [#3124](https://github.com/CliMA/ClimaAtmos.jl/pull/3124)
 
 v0.26.1
 -------
+
 - Updated RRTMGP compat from 0.15 to 0.16
   PR [#3114](https://github.com/CliMA/ClimaAtmos.jl/pull/3114)
 - ![][badge-🔥behavioralΔ] Removed the filter for shortwave radiative fluxes.
@@ -515,12 +550,14 @@ v0.26.1
 
 v0.26.0
 -------
+
 - ![][badge-💥breaking] Add precipitation fluxes to 1M microphysics output.
   Rename col_integrated_rain (and snow) to surface_rain_flux (and snow)
   PR [#3084](https://github.com/CliMA/ClimaAtmos.jl/pull/3084).
 
 v0.25.0
 -------
+
 - ![][badge-💥breaking] Remove reference state from the dycore and the
   relevant config. PR [#3074](https://github.com/CliMA/ClimaAtmos.jl/pull/3074).
 - Make prognostic and diagnostic EDMF work with 1-moment microphysics on GPU
@@ -530,20 +567,23 @@ v0.25.0
 
 v0.24.2
 -------
+
 - ![][badge-🔥behavioralΔ] Fixed incorrect surface fluxes for uh. PR [#3064]
-  (https://github.com/CliMA/ClimaAtmos.jl/pull/3064).
+  (<https://github.com/CliMA/ClimaAtmos.jl/pull/3064>).
 
 v0.24.1
 -------
 
 v0.24.0
 -------
+
 - ![][badge-💥breaking]. CPU/GPU runs can now share the same yaml files. The driver now calls `AtmosConfig` via `(; config_file, job_id) = ClimaAtmos.commandline_kwargs(); config = ClimaAtmos.AtmosConfig(config_file; job_id)`, which recovers the original behavior. PR [#2994](https://github.com/CliMA/ClimaAtmos.jl/pull/2994), issue [#2651](https://github.com/CliMA/ClimaAtmos.jl/issues/2651).
 - Move config files for gpu jobs on ci to config/model_configs/.
   PR [#2948](https://github.com/CliMA/ClimaAtmos.jl/pull/2948).
 
 v0.23.0
 -------
+
 - ![][badge-✨feature/enhancement]![][badge-💥breaking]. Use
   [ClimaUtilities](https://github.com/CliMA/ClimaUtilities.jl) for
   `TimeVaryingInputs` to read in prescribed aerosol mass concentrations. This PR
@@ -561,6 +601,7 @@ v0.23.0
 
 v0.22.1
 -------
+
 - ![][badge-🚀performance] Reduced the number of allocations in the NetCDF
   writer. PRs [#2772](https://github.com/CliMA/ClimaAtmos.jl/pull/2772),
   [#2773](https://github.com/CliMA/ClimaAtmos.jl/pull/2773).
@@ -581,7 +622,6 @@ Contributors are welcome to begin the description of changelog items with badge(
 -->
 
 [badge-🔥behavioralΔ]: https://img.shields.io/badge/🔥behavioralΔ-orange.svg
-[badge-🤖precisionΔ]: https://img.shields.io/badge/🤖precisionΔ-black.svg
 [badge-💥breaking]: https://img.shields.io/badge/💥BREAKING-red.svg
 [badge-🚀performance]: https://img.shields.io/badge/🚀performance-green.svg
 [badge-✨feature/enhancement]: https://img.shields.io/badge/feature/enhancement-blue.svg

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-343
+344
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+344
+- Unify cloud fraction and microphysics quadrature via a shared sgs_moments
+  pre-pass; replace Sommeria-Deardorff cloud fraction with hybrid logistic-CDF;
+  use shape-function partition in 1M microphysics for exact mass conservation.
+
 343
 - Add three new reproducibility tests for 1M prognostic EDMFX SCM cases
   (RICO, TRMM, DYCOMS-RF02); unify and clean up their configurations.

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -927,12 +927,12 @@ function set_microphysics_tendency_cache!(
             ᶜT, cmp, thp, dt, nsubs,
         )
     else
-        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        (; ᶜT′T′, ᶜq′q′, ᶜsgs_moments_mp) = p.precomputed
         corr_Tq = correlation_Tq(p.params)
         @. ᶜmp_tendency = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, Y.c.ρ, ᶜT,
             ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments_mp, dt, nsubs_quad,
         )
     end
 
@@ -967,12 +967,12 @@ function set_microphysics_tendency_cache!(
             dt, nsubs,
         )
     else
-        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        (; ᶜT′T′, ᶜq′q′, ᶜsgs_moments_mp) = p.precomputed
         corr_Tq = correlation_Tq(p.params)
         @. ᶜmp_tendency = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cm1, thp, Y.c.ρ, ᶜT,
             ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments_mp, dt, nsubs_quad,
         )
     end
 
@@ -1019,12 +1019,12 @@ function set_microphysics_tendency_cache!(
             ᶜT⁰, cmp, thp, dt, nsubs,
         )
     else
-        (; ᶜT′T′, ᶜq′q′) = p.precomputed # T-based variances from cache
+        (; ᶜT′T′, ᶜq′q′, ᶜsgs_moments_mp) = p.precomputed
         corr_Tq = correlation_Tq(p.params)
         @. ᶜmp_tendency⁰ = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, ᶜρ⁰, ᶜT⁰,
             ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
-            ᶜT′T′, ᶜq′q′, corr_Tq, dt, nsubs_quad,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments_mp, dt, nsubs_quad,
         )
     end
 

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -151,7 +151,7 @@ function precomputed_quantities(Y, atmos)
     ᶜcloud_fraction = similar(Y.c, FT)
     @. ᶜcloud_fraction = FT(0)
 
-    # SGS covariances for cloud fraction (Sommeria & Deardorff closure) and microphysics quadrature.
+    # SGS covariances for hybrid cloud fraction and microphysics quadrature.
     # NonEquilibriumMicrophysics1M/2M always route through the quadrature API
     # internally (with GridMeanSGS), so they also need covariance fields allocated.
     uses_sgs_quadrature =
@@ -159,12 +159,26 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    covariance_quantities =
-        uses_sgs_quadrature ?
-        (;
+    # `ᶜsgs_moments_mp` caches the SGS-mean equilibrium cloud condensate
+    # `(M_l, M_i)` used by the `Microphysics1MEvaluator` shape-function
+    # partition. It is allocated only for schemes that consume it. The
+    # `(μ_S, σ_S²)` moments needed by `compute_cloud_fraction_hybrid` are
+    # computed inline in the cloud-fraction broadcast and never stored.
+    uses_microphysics_quadrature_moments =
+        atmos.microphysics_model isa
+        Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
+    SGSMomentsMPNT = @NamedTuple{M_l::FT, M_i::FT}
+    covariance_quantities = if uses_sgs_quadrature
+        base = (;
             ᶜT′T′ = zeros(axes(Y.c)),
             ᶜq′q′ = zeros(axes(Y.c)),
-        ) : (;)
+        )
+        uses_microphysics_quadrature_moments ?
+        (; base..., ᶜsgs_moments_mp = similar(Y.c, SGSMomentsMPNT)) :
+        base
+    else
+        (;)
+    end
     surface_precip_fluxes = (;
         surface_rain_flux = zeros(axes(Fields.level(Y.f, half))),
         surface_snow_flux = zeros(axes(Fields.level(Y.f, half))),

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -61,6 +61,13 @@ function set_covariance_cache_and_cloud_fraction!(Y, p)
 
     # One Picard step: use the current cloud fraction to update buoyancy
     # gradient and covariance cache, then recompute cloud fraction.
+    #
+    # The hybrid cloud fraction reads `(μ_S, σ_S²)` from a Gauss-Hermite
+    # pre-pass, but those moments are computed inline inside the CF broadcast
+    # (see `compute_cloud_fraction_hybrid`) — there is no separate
+    # `set_sgs_moments!` call during Picard. The microphysics-only moments
+    # `(M_l, M_i)` are written once after Picard converges, in
+    # `set_sgs_moments_mp!`.
     function picard_step!()
         @. ᶜlinear_buoygrad = buoyancy_gradients(
             BuoyGradMean(), # TODO: modify for NonEq + 1M tracers if needed
@@ -123,6 +130,12 @@ function set_covariance_cache_and_cloud_fraction!(Y, p)
     )
     set_covariance_cache!(Y, p, thermo_params)
 
+    # Write the microphysics moments `(M_l, M_i)` once against the post-Aitken
+    # variance closure. The downstream microphysics tendency reads
+    # `ᶜsgs_moments_mp` for the shape-function partition. No-op when that
+    # cache is not allocated (e.g. 0M / dry).
+    set_sgs_moments_mp!(Y, p)
+
     return nothing
 end
 
@@ -166,14 +179,10 @@ function compute_∂T_∂θ!(dest, Y, p, thermo_params)
     ᶜρ = Y.c.ρ
     if p.atmos.microphysics_model isa Union{DryModel, EquilibriumMicrophysics0M}
         (; ᶜq_liq, ᶜq_ice, ᶜq_tot_nonneg) = p.precomputed
-        # TODO - follow up with renaming the cached variables to liq and ice
-        ᶜq_liq = ᶜq_liq
-        ᶜq_ice = ᶜq_ice
         ᶜq_tot = ᶜq_tot_nonneg
     else
-        # TODO - change in the next PR. Keeping this non behavior changing
-        ᶜq_liq = @. lazy(specific(Y.c.ρq_lcl, Y.c.ρ)) # TODO + specific(Y.c.ρq_rai, Y.c.ρ))
-        ᶜq_ice = @. lazy(specific(Y.c.ρq_icl, Y.c.ρ)) # TODO + specific(Y.c.ρq_sno, Y.c.ρ))
+        ᶜq_liq = @. lazy(specific(Y.c.ρq_lcl, Y.c.ρ))
+        ᶜq_ice = @. lazy(specific(Y.c.ρq_icl, Y.c.ρ))
         ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
     end
     ᶜθ_li = @. lazy(
@@ -246,176 +255,438 @@ end
 
 
 # ============================================================================
-# Cloud Fraction: Sommeria-Deardorff Moment Matching
+# SGS Moments — pre-pass quadrature
 # ============================================================================
+#
+# A Gauss-Hermite pass over the SGS PDF (no BMT calls) supplies the moments
+# consumed by the cloud fraction and microphysics tendency closures. Two
+# specialized evaluators run separately so each consumer pays for only the
+# moments it uses:
+#
+#   - `SGSMomentsCFEvaluator` returns `(μ_S, S²)` for the smooth logistic-CDF
+#     cloud fraction (used inline in the CF broadcast — never materialized
+#     to a Field).
+#
+#   - `SGSMomentsMPEvaluator` returns `(M_l, M_i)` for the
+#     `Microphysics1MEvaluator` shape-function partition. Cached once per
+#     time step in `p.precomputed.ᶜsgs_moments_mp`.
+#
+# Both consumers share the same SGS PDF, so the closures remain mutually
+# consistent.
 
 """
-    compute_cloud_fraction_sd(
-        thermo_params, T, ρ, q_tot, q_liq, q_ice, T′T′, q′q′, corr_Tq,
-        cf_steepness_scale, q_min, sgs_dist
+    SGSMomentsType{FT}
+
+NamedTuple type alias for the full per-cell SGS moments NamedTuple returned
+by [`compute_sgs_moments`](@ref). Field semantics:
+
+- `mu_S`: Mean of the saturation variable `S(ξ)` over the SGS PDF.
+- `sigma_S_sq`: Variance of `S(ξ)` over the SGS PDF.
+- `M_l`: Mean of the equilibrium cloud-liquid condensate over the SGS PDF
+  (`⟨max(0, λ·(q_tot_hat − q_sat(T_hat)) − q_rai)⟩`).
+- `M_i`: Mean of the equilibrium cloud-ice condensate over the SGS PDF.
+
+The saturation variable `S` depends on the SGS distribution:
+- `GaussianSGS`, `GridMeanSGS`: `S = q_tot − q_sat(T)` (linear saturation excess; units of `q`).
+- `LogNormalSGS`: `S = log(q_tot / q_sat(T))` (dimensionless log-ratio).
+
+`M_l` and `M_i` are always in linear units of specific humidity, regardless
+of the SGS distribution.
+"""
+const SGSMomentsType{FT} = @NamedTuple{
+    mu_S::FT, sigma_S_sq::FT, M_l::FT, M_i::FT,
+} where {FT}
+
+"""
+    SGSMomentsMPType{FT}
+
+NamedTuple type alias for the per-cell SGS microphysics-moments cache used
+by `Microphysics1MEvaluator`. Fields:
+
+- `M_l`: SGS-mean equilibrium cloud-liquid condensate `⟨q_lcl_eq⟩`.
+- `M_i`: SGS-mean equilibrium cloud-ice condensate `⟨q_icl_eq⟩`.
+"""
+const SGSMomentsMPType{FT} = @NamedTuple{M_l::FT, M_i::FT} where {FT}
+
+# Linear saturation excess (Gaussian / GridMean SGS distributions)
+@inline _saturation_variable(
+    ::Union{GaussianSGS, GridMeanSGS}, q_tot, q_sat, q_min,
+) = q_tot - q_sat
+# Log saturation ratio (Lognormal SGS distribution); arguments regularized
+# at `q_min` to prevent `log(0)` in dry / extreme states.
+@inline _saturation_variable(::LogNormalSGS, q_tot, q_sat, q_min) =
+    log(max(q_tot, q_min) / max(q_sat, q_min))
+
+"""
+    SGSMomentsCFEvaluator(dist, tps, ρ, q_min)
+
+GPU-safe functor for the cloud-fraction-only quadrature integrand. Returns
+`(mu_S = S(ξ), s_sq = S(ξ)²)` at each quadrature point. The CF closure does
+not need the equilibrium-condensate moments, so this evaluator skips the
+`(M_l, M_i)` arithmetic entirely.
+"""
+struct SGSMomentsCFEvaluator{D, TPS, FT}
+    dist::D
+    tps::TPS
+    ρ::FT
+    q_min::FT
+end
+
+@inline function (eval::SGSMomentsCFEvaluator)(T_hat, q_tot_hat)
+    q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
+    s = _saturation_variable(eval.dist, q_tot_hat, q_sat_hat, eval.q_min)
+    return (mu_S = s, s_sq = s * s)
+end
+
+"""
+    SGSMomentsMPEvaluator(tps, ρ, λ, q_rai, q_sno)
+
+GPU-safe functor for the microphysics-only quadrature integrand. Returns
+`(M_l, M_i) = (q_lcl_eq(ξ), q_icl_eq(ξ))` at each quadrature point. The
+partition is linear in the saturation excess (independent of `dist`), so the
+log-saturation arithmetic is skipped.
+"""
+struct SGSMomentsMPEvaluator{TPS, FT}
+    tps::TPS
+    ρ::FT
+    λ::FT
+    q_rai::FT
+    q_sno::FT
+end
+
+@inline function (eval::SGSMomentsMPEvaluator)(T_hat, q_tot_hat)
+    FT = typeof(eval.ρ)
+    q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
+    excess = max(zero(FT), q_tot_hat - q_sat_hat)
+    M_l = max(zero(FT), eval.λ * excess - eval.q_rai)
+    M_i = max(zero(FT), (one(FT) - eval.λ) * excess - eval.q_sno)
+    return (; M_l, M_i)
+end
+
+"""
+    SGSMomentsEvaluator(dist, tps, ρ, λ, q_rai, q_sno, q_min)
+
+Combined functor returning all four moment integrands
+`(mu_S, s_sq, M_l, M_i)` for `compute_sgs_moments`. Retained mainly for the
+test surface — production paths use the specialized CF or MP evaluators.
+"""
+struct SGSMomentsEvaluator{D, TPS, FT}
+    dist::D
+    tps::TPS
+    ρ::FT
+    λ::FT
+    q_rai::FT
+    q_sno::FT
+    q_min::FT
+end
+
+@inline function (eval::SGSMomentsEvaluator)(T_hat, q_tot_hat)
+    FT = typeof(eval.ρ)
+    q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
+    s = _saturation_variable(eval.dist, q_tot_hat, q_sat_hat, eval.q_min)
+    excess = max(zero(FT), q_tot_hat - q_sat_hat)
+    q_lcl_eq = max(zero(FT), eval.λ * excess - eval.q_rai)
+    q_icl_eq = max(zero(FT), (one(FT) - eval.λ) * excess - eval.q_sno)
+    return (mu_S = s, s_sq = s * s, M_l = q_lcl_eq, M_i = q_icl_eq)
+end
+
+"""
+    _cf_moments_inline(thp, ρ, T_mean, q_tot_mean, sgs_quad, T′T′, q′q′,
+                       corr_Tq, q_min)
+
+Compute `(mu_S, sigma_S_sq)` via a single quadrature pass over the SGS PDF.
+Used inline by `compute_cloud_fraction_hybrid` so the CF broadcast fuses the
+moments calculation with the CDF evaluation into a single GPU kernel and never
+materializes a moments Field.
+"""
+@inline function _cf_moments_inline(
+    thp, ρ, T_mean, q_tot_mean,
+    sgs_quad, T′T′, q′q′, corr_Tq, q_min,
+)
+    FT = typeof(ρ)
+    sgs_quad_eff = isnothing(sgs_quad) ? GridMeanSGS() : sgs_quad
+    dist = sgs_quad_eff isa SGSQuadrature ? sgs_quad_eff.dist : sgs_quad_eff
+    evaluator = SGSMomentsCFEvaluator(dist, thp, ρ, q_min)
+    raw = integrate_over_sgs(
+        evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
+    )
+    sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, ϵ_numerics(FT))
+    return (mu_S = raw.mu_S, sigma_S_sq = sigma_S_sq)
+end
+
+"""
+    compute_sgs_moments_mp(thp, ρ, T_mean, q_tot_mean,
+                           q_lcl, q_icl, q_rai, q_sno,
+                           sgs_quad, T′T′, q′q′, corr_Tq)
+
+Compute the microphysics moments `(M_l, M_i)` via one quadrature pass.
+Linear in the saturation excess, independent of the SGS distribution.
+Used by [`set_sgs_moments_mp!`](@ref) to populate `p.precomputed.ᶜsgs_moments_mp`
+once per time step.
+"""
+@inline function compute_sgs_moments_mp(
+    thp, ρ, T_mean, q_tot_mean,
+    q_lcl, q_icl, q_rai, q_sno,
+    sgs_quad, T′T′, q′q′, corr_Tq,
+)
+    FT = typeof(ρ)
+    sgs_quad_eff = isnothing(sgs_quad) ? GridMeanSGS() : sgs_quad
+    q_lcl_nn = max(zero(FT), q_lcl)
+    q_icl_nn = max(zero(FT), q_icl)
+    q_rai_nn = max(zero(FT), q_rai)
+    q_sno_nn = max(zero(FT), q_sno)
+    λ = TD.liquid_fraction(thp, T_mean, q_lcl_nn, q_icl_nn)
+    evaluator = SGSMomentsMPEvaluator(thp, ρ, λ, q_rai_nn, q_sno_nn)
+    return integrate_over_sgs(
+        evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
+    )::SGSMomentsMPType{FT}
+end
+
+"""
+    compute_sgs_moments(thp, ρ, T_mean, q_tot_mean,
+                          q_lcl, q_icl, q_rai, q_sno,
+                          sgs_quad, T′T′, q′q′, corr_Tq, q_min)
+
+Compute all four SGS moments `(mu_S, sigma_S_sq, M_l, M_i)` via one quadrature
+pass. Retained as a single building block for tests and external callers;
+production code uses [`_cf_moments_inline`](@ref) (for the cloud fraction) and
+[`compute_sgs_moments_mp`](@ref) (for microphysics) instead, so neither pays for
+unused moments.
+"""
+@inline function compute_sgs_moments(
+    thp, ρ, T_mean, q_tot_mean,
+    q_lcl, q_icl, q_rai, q_sno,
+    sgs_quad, T′T′, q′q′, corr_Tq, q_min,
+)
+    FT = typeof(ρ)
+    sgs_quad_eff = isnothing(sgs_quad) ? GridMeanSGS() : sgs_quad
+    dist = sgs_quad_eff isa SGSQuadrature ? sgs_quad_eff.dist : sgs_quad_eff
+    q_lcl_nn = max(zero(FT), q_lcl)
+    q_icl_nn = max(zero(FT), q_icl)
+    q_rai_nn = max(zero(FT), q_rai)
+    q_sno_nn = max(zero(FT), q_sno)
+    λ = TD.liquid_fraction(thp, T_mean, q_lcl_nn, q_icl_nn)
+    evaluator = SGSMomentsEvaluator(dist, thp, ρ, λ, q_rai_nn, q_sno_nn, q_min)
+    raw = integrate_over_sgs(
+        evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
+    )
+    sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, ϵ_numerics(FT))
+    return (
+        mu_S = raw.mu_S,
+        sigma_S_sq = sigma_S_sq,
+        M_l = raw.M_l,
+        M_i = raw.M_i,
+    )::SGSMomentsType{FT}
+end
+
+
+# ============================================================================
+# Cloud Fraction: Hybrid (quadrature-moment + analytic CDF)
+# ============================================================================
+#
+# Smooth logistic-CDF approximation evaluated against the cached SGS moments
+# `(μ_S, σ_S²)` produced by `compute_sgs_moments`. The variance and saturation
+# mean come directly from the Gauss-Hermite quadrature over the same SGS PDF
+# that microphysics integrates over, giving consistency between the cloud
+# fraction and the microphysics tendencies by construction. 
+#
+# Dispatched on the SGS distribution via `_effective_excess_hybrid`:
+#   - Gaussian/GridMean: linear coords, `Q_eff = q_c + min(0, μ_S)`.
+#   - Lognormal: log coords, `Q_eff = log(1 + q_c/q_v_sat) + min(0, μ_S)`.
+# The lognormal branch handles the heavy upper tail of `q_tot` in a
+# principled way.
+
+"""
+    compute_cloud_fraction_hybrid(
+        thermo_params, T, ρ, q_tot, q_liq, q_ice,
+        moments, cf_guess, cf_steepness_scale, q_min, sgs_dist,
     )
 
-Compute cloud fraction using the Sommeria & Deardorff (1977) approach, but with 
-moment-matching to obtain the cloud fraction given condensate specific humidities 
-(rather than jointly determining condensate specific humidities and cloud fraction, 
-as in the original approach).
-
-Given grid-mean condensate (`q_liq`, `q_ice`) and the subgrid variances and
-correlation of `(T, q_tot)`, the cloud fraction is determined by approximately
-matching the predicted condensate to the width of the subgrid saturation deficit PDF.
+Compute cloud fraction from cached SGS moments. The variance and mean of
+the saturation variable are taken from the pre-pass quadrature
+(`compute_sgs_moments`); only the smooth CDF approximation and the
+activation factor are evaluated here.
 
 # Algorithm
-1. Compute phase-specific saturation specific humidities and
-   Clausius-Clapeyron slopes `b = ∂q_sat/∂T = L·q_sat / (R_v·T²)`.
-2. Compute the SGS variance of the saturation deficit:
-   `σ_s² = σ_q² + b²·σ_T² − 2b·corr(T,q)·σ_T·σ_q`
-3. Normalize grid-mean condensate by the PDF width: `Q̂ = q_cond / σ_s`.
-4. Approximate the Gaussian CDF with `tanh(π/√6 · Q̂)` and match implied condensate 
-   from supersaturation to obtain cloud fraction.
-5. Merge liquid and ice via maximum overlap: `cf = max(cf_l, cf_i)`.
-6. Enforce zero cloud fraction when no condensate exists.
-
-With zero variance the function returns 0 when no condensate exists and
-1 when condensate is present, recovering the grid-scale behaviour.
+1. Activation factor on linear excess from cached moments:
+   `α = clamp(q_c / √((μ_{lin})_+² + q_min²), 0, 1)` where `μ_{lin}` is
+   the saturation excess (kg/kg) derived from `μ_S`.
+2. Effective activation-scaled SGS standard deviation:
+   `σ_qc = α √(σ_S²)`,
+   - Gaussian/GridMean (linear coordinates):
+   `σ_eff = √(σ_qc^2 + c_f (1-c_f) (q_c / c_f - min(0, μ_S) / (1-c_f))^2)`
+   - Lognormal:
+   `σ_eff = √(σ_qc^2 + c_f (1-c_f) (log(1 + q_c/q_v_sat) / c_f - min(0, μ_S) / (1-c_f))^2)`
+3. Effective excess `Q_eff` from cached `μ_S`, dispatched on `sgs_dist`:
+   - Gaussian/GridMean: `Q_eff = q_c + min(0, μ_S)` (linear coordinates).
+   - Lognormal: `Q_eff = log(1 + q_c/q_v_sat) + min(0, μ_S)` (log coordinates).
+4. Cloud fraction via variance-matched logistic CDF
+   (`erf(x/√2) ≈ tanh((π/(2√3)) x)`):
+   `c_f = ½ [1 + tanh(coeff · Q_eff / σ_eff)]` with
+   `coeff = (π/(2√3)) · cf_steepness_scale`.
+5. Enforce zero cloud fraction when no condensate exists.
 
 # Arguments
-- `thermo_params`: Thermodynamics parameters
-- `T`: Grid-mean temperature [K]
-- `ρ`: Air density [kg/m³]
-- `q_tot`: Grid-mean total specific humidity [kg/kg]
-- `q_liq`: Grid-mean cloud liquid [kg/kg]
-- `q_ice`: Grid-mean cloud ice [kg/kg]
-- `T′T′`: Temperature variance [K²]
-- `q′q′`: Moisture variance [(kg/kg)²]
-- `corr_Tq`: Correlation coefficient corr(T', q')
-- `cf_steepness_scale`: Scaling factor for the steepness of the cloud fraction transition versus condensate (default 1).
-- `q_min`: Minimum specific humidity threshold [kg/kg] (from ClimaParams `specific_humidity_minimum`).
-- `sgs_dist`: Assumed sub-grid scale distribution type (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`).
+- `thermo_params`: Thermodynamics parameters.
+- `T`: Grid-mean temperature [K].
+- `ρ`: Air density [kg/m³].
+- `q_tot`: Grid-mean total specific humidity [kg/kg].
+- `q_liq`, `q_ice`: Grid-mean cloud condensate [kg/kg].
+- `moments`: Cached `SGSMomentsType` `(mu_S, sigma_S_sq, M_l, M_i)`.
+- `cf_guess`: Previous-step cloud fraction used in the effective variance estimate.
+- `cf_steepness_scale`: Tunable steepness factor `coeff` (default 1).
+- `q_min`: Minimum specific humidity threshold [kg/kg].
+- `sgs_dist`: SGS distribution (`GaussianSGS`, `LogNormalSGS`, `GridMeanSGS`).
 
 # Returns
-Cloud fraction ∈ [0, 1]
+Cloud fraction ∈ [0, 1].
 """
-@inline function compute_cloud_fraction_sd(
+@inline function compute_cloud_fraction_hybrid(
     thermo_params,
     T,
     ρ,
     q_tot,
     q_liq,
     q_ice,
-    T′T′,
-    q′q′,
-    corr_Tq,
+    moments,
+    cf_guess,
     cf_steepness_scale,
     q_min,
     sgs_dist::AbstractSGSDistribution,
 )
-    FT = eltype(thermo_params)
+    FT = typeof(T)
 
-    # --- 1. Thermodynamic sensitivities (Clausius-Clapeyron) ---
-    qsat_l = TD.q_vap_saturation(thermo_params, T, ρ, TD.Liquid())
-    qsat_i = TD.q_vap_saturation(thermo_params, T, ρ, TD.Ice())
+    q_c = q_liq + q_ice
 
-    R_v = TD.Parameters.R_v(thermo_params)
-    L_v = TD.latent_heat_vapor(thermo_params, T)
-    L_s = TD.latent_heat_sublim(thermo_params, T)
+    # --- 1. Activation factor: linear excess from cached quadrature moments
+    # We recover the linear excess (kg/kg) from the distribution-specific μ_S.
+    q_sat = TD.q_vap_saturation(thermo_params, T, ρ)
+    linear_mu = _linear_mu(sgs_dist, moments.mu_S, q_sat)
+    excess_eq = max(zero(FT), linear_mu)
+    α = min(one(FT), q_c / sqrt(excess_eq * excess_eq + q_min * q_min))
 
-    # b = ∂q_sat/∂T  (Clausius-Clapeyron slope, assuming constant pressure)
-    b_l = L_v * qsat_l / (R_v * T^2)
-    b_i = L_s * qsat_i / (R_v * T^2)
+    # --- 2. Effective activation-scaled SGS standard deviation
+    σ_S = sqrt(max(moments.sigma_S_sq, ϵ_numerics(FT)))
+    σ_qc = α * σ_S
+    σ_eff = _effective_std_hybrid(σ_qc, cf_guess, q_c, q_sat, moments.mu_S, q_min, sgs_dist)
 
-    # Standard deviations
-    σ_q = sqrt(max(q′q′, zero(FT)))
-    σ_T = sqrt(max(T′T′, zero(FT)))
+    # --- 3. Effective excess Q_eff in the coordinate of the SGS distribution
+    Q_eff =
+        _effective_excess_hybrid(q_c, q_sat, moments.mu_S, q_min, sgs_dist)
 
-    # --- 2. SGS variance of saturation deficit ---
-    # σ_s² = σ_q² + b²·σ_T² − 2b·corr(T', q')·σ_T·σ_q
-    sig2_l = q′q′ + b_l * b_l * T′T′ - FT(2) * b_l * corr_Tq * σ_T * σ_q
-    sig2_i = q′q′ + b_i * b_i * T′T′ - FT(2) * b_i * corr_Tq * σ_T * σ_q
+    # --- 4. Logistic-CDF approximation
+    coeff = (FT(π) / (FT(2) * sqrt(FT(3)))) * cf_steepness_scale
+    σ_safe = max(σ_eff, ϵ_numerics(FT))
+    cf = FT(0.5) * (one(FT) + tanh(coeff * Q_eff / σ_safe))
 
-    # Safety floor
-    sig_l = sqrt(max(sig2_l, ϵ_numerics(FT)))
-    sig_i = sqrt(max(sig2_i, ϵ_numerics(FT)))
-
-    # --- 3. Normalize condensate by PDF width ---
-    Q_hat_l = q_liq / sig_l
-    Q_hat_i = q_ice / sig_i
-
-    # --- 4. Formulation-Specific Cloud Fraction Helpers ---
-    cf_l =
-        _cloud_fraction_helper(Q_hat_l, sig_l, q_tot, cf_steepness_scale, q_min, sgs_dist)
-    cf_i =
-        _cloud_fraction_helper(Q_hat_i, sig_i, q_tot, cf_steepness_scale, q_min, sgs_dist)
-
-    # --- 5. Maximum overlap ---
-    cf = max(cf_l, cf_i)
-
-    # --- 6. No condensate → no cloud (branchless) ---
-    has_cond = TD.has_condensate(thermo_params, q_liq + q_ice)
+    # --- 5. No condensate → no cloud (branchless) ---
+    has_cond = TD.has_condensate(thermo_params, q_c)
     return ifelse(has_cond, cf, zero(FT))
 end
 
+# Recover the linear saturation excess (kg/kg) from the distribution-specific
+# saturation variable. Used by the hybrid cloud fraction activation factor.
+@inline _linear_mu(::Union{GaussianSGS, GridMeanSGS}, μ_S, q_sat) = μ_S
+@inline _linear_mu(::LogNormalSGS, μ_S, q_sat) =
+    q_sat * (exp(μ_S) - one(typeof(μ_S)))
+
 """
-    _cloud_fraction_helper(Q_hat, sig_s, q_tot, cf_steepness_scale, q_min, sgs_dist)
+    compute_cloud_fraction_hybrid(
+        thermo_params, T, ρ, q_tot, q_liq, q_ice,
+        sgs_quad, T′T′, q′q′, corr_Tq, cf_guess,
+        cf_steepness_scale, q_min, sgs_dist,
+    )
 
-Compute the phase-specific cloud fraction from normalized condensate.
-
-# Arguments
-- `Q_hat`: Condensate normalized by the standard deviation of saturation deficit
-- `sig_s`: Standard deviation of saturation deficit [kg/kg]
-- `q_tot`: Grid-mean total specific humidity [kg/kg]
-- `cf_steepness_scale`: Scaling factor for the steepness of the cloud fraction transition versus condensate
-- `q_min`: Minimum specific humidity threshold [kg/kg]
-- `sgs_dist`: Assumed sub-grid scale distribution type (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`)
-
-# Returns
-- Phase-specific cloud fraction ∈ [0, 1]
+Fused production overload: compute the hybrid cloud fraction in a single
+inlined call that runs the `(μ_S, σ_S²)` quadrature pass and the logistic-CDF
+evaluation in one broadcast kernel. Used by `set_cloud_fraction!(QuadratureCloud)`
+so the moments are never materialized to a Field.
 """
-@inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
+@inline function compute_cloud_fraction_hybrid(
+    thermo_params,
+    T,
+    ρ,
     q_tot,
+    q_liq,
+    q_ice,
+    sgs_quad,
+    T′T′,
+    q′q′,
+    corr_Tq,
+    cf_guess,
     cf_steepness_scale,
     q_min,
-    ::GaussianSGS,
+    sgs_dist::AbstractSGSDistribution,
 )
-    FT = typeof(Q_hat)
-    # Analytical CDF approximation: π/√6 matches the variance of the logistic distribution to the normal distribution
-    coeff = (FT(π) / sqrt(FT(6))) * cf_steepness_scale
-    return tanh(coeff * Q_hat)
+    moments = _cf_moments_inline(
+        thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq, q_min,
+    )
+    return compute_cloud_fraction_hybrid(
+        thermo_params, T, ρ, q_tot, q_liq, q_ice, moments,
+        cf_guess, cf_steepness_scale, q_min, sgs_dist,
+    )
 end
 
-@inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
-    q_tot,
-    cf_steepness_scale,
-    q_min,
-    ::LogNormalSGS,
+"""
+    _effective_excess_hybrid(q_c, q_sat, μ_S, q_min, sgs_dist)
+
+Distribution-specific effective excess `Q_eff` used by the hybrid cloud
+fraction. Combines the prognostic condensate with the quadrature-derived
+mean of the saturation variable so that `cf → 0` smoothly in subsaturated
+states even when a numerical trace of prognostic condensate remains.
+
+- `GaussianSGS`, `GridMeanSGS`: linear coordinates,
+  `Q_eff = q_c + min(0, μ_S)`.
+- `LogNormalSGS`: log coordinates,
+  `Q_eff = log(1 + q_c/q_v_sat) + min(0, μ_S)` (regularized at `q_min`).
+"""
+@inline _effective_excess_hybrid(
+    q_c, q_sat, μ_S, q_min, ::Union{GaussianSGS, GridMeanSGS},
+) = q_c + min(zero(typeof(q_c)), μ_S)
+
+@inline function _effective_excess_hybrid(
+    q_c, q_sat, μ_S, q_min, ::LogNormalSGS,
 )
-    FT = typeof(Q_hat)
-    # Coefficient of variation (protect against division by zero)
-    C_v = sig_s / max(q_tot, q_min)
-
-    # Base coefficient corresponds to Gaussian limit (Cv -> 0)
-    coeff = (FT(π) / sqrt(FT(6))) * cf_steepness_scale
-
-    # Modulate coefficient with Cv based on offline optimal fits to lognormal 
-    # distribution for q_tot (RMSE < 5% for C_v in [0, 1])
-    c = coeff * (FT(1) + FT(0.3) * C_v)
-
-    return tanh(c * Q_hat)
+    FT = typeof(q_c)
+    q_v_sat_safe = max(q_sat, q_min)
+    return log(FT(1) + q_c / q_v_sat_safe) + min(zero(FT), μ_S)
 end
 
-@inline function _cloud_fraction_helper(
-    Q_hat,
-    sig_s,
-    q_tot,
-    cf_steepness_scale,
-    q_min,
-    ::GridMeanSGS,
+"""
+    _effective_std_hybrid(σ_qc, cf, q_c, q_sat, μ_S, q_min, sgs_dist)
+
+Distribution-specific effective standard deviation `σ_eff` used by the hybrid
+cloud fraction. The formulation augments the activation-scaled SGS variance
+with a between-state variance term arising from the separation between the
+prognostic condensate contribution and the quadrature-derived saturation-state
+mean.
+
+- Gaussian/GridMean (linear coordinates):
+`σ_eff = √(σ_qc^2 + c_f (1-c_f) (qc / c_f - min(0, μ_S) / (1-c_f))^2)`
+- Lognormal:
+`σ_eff = √(σ_qc^2 + c_f (1-c_f) (log(1 + q_c/q_v_sat) / c_f - min(0, μ_S) / (1-c_f))^2)`
+"""
+@inline function _effective_std_hybrid(
+    σ_qc, cf, q_c, q_sat, μ_S, q_min, ::Union{GaussianSGS, GridMeanSGS},
 )
-    FT = typeof(Q_hat)
-    return Q_hat > zero(FT) ? FT(1) : zero(FT)
+    FT = typeof(q_c)
+    # clamp cf between 0.01 and 0.99 to avoid division by small numbers
+    cf = clamp(cf, FT(0.01), FT(0.99))
+    return sqrt(σ_qc^2 + cf * (1 - cf) * (q_c / cf - min(zero(FT), μ_S) / (1 - cf))^2)
+end
+
+@inline function _effective_std_hybrid(
+    σ_qc, cf, q_c, q_sat, μ_S, q_min, ::LogNormalSGS,
+)
+    FT = typeof(q_c)
+    # clamp cf between 0.01 and 0.99 to avoid division by small numbers
+    cf = clamp(cf, FT(0.01), FT(0.99))
+    q_v_sat_safe = max(q_sat, q_min)
+    return sqrt(
+        σ_qc^2 +
+        cf * (1 - cf) *
+        (log(FT(1) + q_c / q_v_sat_safe) / cf - min(zero(FT), μ_S) / (1 - cf))^2,
+    )
 end
 
 # ============================================================================
@@ -430,7 +701,8 @@ Compute and store grid-scale cloud fraction based on sub-grid scale properties.
 Dispatches on `microphysics_model` and `cloud_model`:
 - `DryModel`: Cloud fraction and cloud condensate are zero.
 - `GridScaleCloud`: Cloud fraction is 1 if grid-scale condensate exists, 0 otherwise.
-- `QuadratureCloud`: Cloud fraction from Sommeria-Deardorff moment matching.
+- `QuadratureCloud`: Cloud fraction from the hybrid quadrature-moment formula
+  (`compute_cloud_fraction_hybrid`).
 - `MLCloud`: Cloud fraction from neural network.
 
 For EDMF turbulence models, updraft contributions are added to the environment values.
@@ -471,30 +743,36 @@ NVTX.@annotate function set_cloud_fraction!(
     # Get condensate means (dispatches on microphysics_model)
     ᶜq_lcl, ᶜq_icl = _get_condensate_means(Y, p, turbconv_model, microphysics_model)
 
-    # Get T-based variances from cache
-    (; ᶜT′T′, ᶜq′q′) = p.precomputed
-
+    sgs_quad = p.atmos.sgs_quadrature
     sgs_dist =
-        isnothing(p.atmos.sgs_quadrature) ? GaussianSGS() :
-        p.atmos.sgs_quadrature.dist
+        isnothing(sgs_quad) ? GaussianSGS() : sgs_quad.dist
 
-    corr_Tq = correlation_Tq(p.params)
     cf_steepness_scale = CAP.cloud_fraction_steepness_scale(p.params)
     q_min = CAP.q_min(p.params)
+    corr_Tq = correlation_Tq(p.params)
 
-    @. p.precomputed.ᶜcloud_fraction = compute_cloud_fraction_sd(
+    (; ᶜT′T′, ᶜq′q′) = p.precomputed
+    cf_guess = p.precomputed.ᶜcloud_fraction
+    # Hybrid cloud fraction: the `(μ_S, σ_S²)` quadrature pass is fused into
+    # this broadcast kernel via the production `compute_cloud_fraction_hybrid`
+    # overload, so the moments stay in registers and are never written to a
+    # Field. The `Microphysics1MEvaluator` consumes a separately-cached
+    # `(M_l, M_i)` populated once per time step by `set_sgs_moments_mp!`.
+    @. p.precomputed.ᶜcloud_fraction = compute_cloud_fraction_hybrid(
         thermo_params,
         ᶜT_mean,
         ᶜρ_env,
         ᶜq_mean,
         ᶜq_lcl,
         ᶜq_icl,
+        $(sgs_quad),
         ᶜT′T′,
         ᶜq′q′,
         corr_Tq,
+        cf_guess,
         cf_steepness_scale,
         q_min,
-        sgs_dist,
+        $(sgs_dist),
     )
 
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)
@@ -528,8 +806,49 @@ NVTX.@annotate function set_cloud_fraction!(
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)
 end
 
+"""
+    set_sgs_moments_mp!(Y, p)
+
+Cache the microphysics moments `(M_l, M_i)` into `p.precomputed.ᶜsgs_moments_mp`
+via one Gauss-Hermite pass over the SGS PDF (no BMT calls). The cached moments
+are consumed by `Microphysics1MEvaluator` (via `microphysics_tendencies_1m`):
+the shape-function partition `q_lcl_hat = q_lcl_mean + q_lcl_mean · γ_l ·
+(q_lcl_eq_hat − M_l)` exactly conserves `⟨q_lcl_hat⟩ = q_lcl_mean` provided
+`M_l = ⟨q_lcl_eq⟩` over the same PDF.
+
+Called once per time step after the Picard-accelerated cloud fraction update
+in `set_covariance_cache_and_cloud_fraction!`. The cloud-fraction-specific
+moments `(μ_S, σ_S²)` are computed inline inside the CF broadcast and are
+never written to a Field, so this function does not compute them.
+
+No-op when `ᶜsgs_moments_mp` is not allocated (i.e. configurations without
+1M / 2M microphysics — 0M and dry).
+
+Uses grid-mean `(ρ, T, q_tot, q_rai, q_sno)`; for EDMF configurations this
+currently uses grid-mean covariances and state. A future refinement could use
+environment-only covariances and state.
+"""
+NVTX.@annotate function set_sgs_moments_mp!(Y, p)
+    hasproperty(p.precomputed, :ᶜsgs_moments_mp) || return nothing
+
+    thermo_params = CAP.thermodynamics_params(p.params)
+    (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+    (; ᶜT′T′, ᶜq′q′, ᶜsgs_moments_mp) = p.precomputed
+    sgs_quad = p.atmos.sgs_quadrature
+    corr_Tq = correlation_Tq(p.params)
+
+    ᶜq_rai = @. lazy(specific(Y.c.ρq_rai, Y.c.ρ))
+    ᶜq_sno = @. lazy(specific(Y.c.ρq_sno, Y.c.ρ))
+    @. ᶜsgs_moments_mp = compute_sgs_moments_mp(
+        thermo_params, Y.c.ρ, ᶜT, ᶜq_tot_nonneg,
+        ᶜq_liq, ᶜq_ice, ᶜq_rai, ᶜq_sno,
+        $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq,
+    )
+    return nothing
+end
+
 # ============================================================================
-# Internal Helper Functions  
+# Internal Helper Functions
 # ============================================================================
 
 """
@@ -692,7 +1011,7 @@ function _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)
 
     # Weight by environment area fraction if using PrognosticEDMFX (assumed 1 otherwise)
     if turbconv_model isa PrognosticEDMFX
-        ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, p.atmos.turbconv_model))
+        ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
         (; ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
         ᶜρ⁰ = @. lazy(
             TD.air_density(

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -61,8 +61,12 @@ struct Microphysics0MEvaluator{CMP, SAE, FT}
     sat_eval::SAE
     Φ::FT
 end
-function Microphysics0MEvaluator(cm_params, thermo_params, ρ, Φ)
-    sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ)
+function Microphysics0MEvaluator(cm_params, thermo_params, ρ, T_mean, Φ)
+    # Grid-mean liquid fraction, held fixed across quadrature points.
+    # The 0M scheme has no prognostic phase memory, so we use a
+    # temperature-based ramp at the grid mean.
+    λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
+    sat_eval = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)
     return Microphysics0MEvaluator(cm_params, sat_eval, Φ)
 end
 @inline function (eval::Microphysics0MEvaluator)(T_hat, q_hat)
@@ -125,7 +129,7 @@ NamedTuple with `dq_tot_dt` and `e_tot_hlpr`.
     # Create GPU-safe functor (Φ is constant within a grid cell)
     # The evaluator does saturation adjustment, computes saturation vapor pressure
     # and computes the total water sink and energy helper from 0M microphysics
-    evaluator = Microphysics0MEvaluator(cmp, thp, ρ, Φ)
+    evaluator = Microphysics0MEvaluator(cmp, thp, ρ, T, Φ)
     # Integrate over quadrature points; both dq_tot_dt and e_tot_hlpr
     # are averaged over the SGS distribution.
     (; dq_tot_dt, e_tot_hlpr) = integrate_over_sgs(
@@ -161,17 +165,48 @@ end
 """
     (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
 
-GPU-safe functor for computing 1-moment microphysics tendencies at quadrature
-points. Computes bulk microphysics tendencies at a perturbed thermodynamic
-state `(T_hat, q_tot_hat)` for use in SGS quadrature integration. The condensate
-at each quadrature point is assumed to equal its mean value.
+GPU-safe functor for computing 1-moment microphysics tendencies at SGS
+quadrature points using a **shape-function partition** of cloud condensate.
+
+At each quadrature point `(T_hat, q_tot_hat)` sampled from the SGS PDF,
+the local cloud condensate is constructed as
+
+    q_lcl_hat = q_lcl_mean + γ_l · (q_lcl_eq_hat - M_l)
+
+where
+- `q_lcl_eq_hat = max(0, λ·(q_tot_hat − q_sat(T_hat)) − q_rai)` is the
+  *local* equilibrium cloud liquid at the quadrature point, with `λ` held
+  fixed at the grid-mean liquid fraction.
+- `γ_l = min(1, q_lcl_mean ⋅ M_l / (M_scale² + M_l²))` guarantees **exact mass conservation by
+  construction**: `⟨q_lcl_hat⟩ = q_lcl_mean + γ_l · (⟨q_lcl_eq⟩ - M_l) = q_lcl_mean`.
+  `M_l = ⟨q_lcl_eq⟩` is the SGS-mean equilibrium liquid moment supplied by
+  the `compute_sgs_moments` pre-pass.
+- `M_scale = q_min` sets the blending crossover. In the typical regime
+  `M_l ≫ q_min`, `γ_l ≈ min(1, q_lcl_mean/M_l)` and `q_lcl_hat ≈ min(1, q_lcl_mean/M_l) · q_lcl_eq_hat`
+  (pure shape function); in the stale-cloud edge case `M_l → 0` while
+  `q_lcl_mean > 0`, `γ_l → 0` and `q_lcl_hat → q_lcl_mean` (uniform
+  fallback). The ice channel is symmetric.
+
+The shape-function formulation unifies the cloudy and clear contributions
+into a single quadrature pass. When `q_lcl_mean ≲ M_l`, the condensate is
+primarily distributed according to the local equilibrium structure
+`q_lcl_eq_hat`, so saturated quadrature points receive most of the cloud
+water while subsaturated points contain little or none. When
+`q_lcl_mean > M_l`, the clipping `γ_l ≤ 1` limits the shape-function
+amplitude and the excess condensate is represented as a uniform background
+offset distributed across all quadrature points. Consequently, saturated
+points still preferentially carry the equilibrium-shaped condensate
+component, while subsaturated points retain the uniform remnant, which can
+evaporate or sublimate against the local subsaturated `q_v_hat`,
+capturing below-cloud rain evaporation and snow sublimation within the
+same quadrature integration.
 
 # Arguments
 - `T_hat`: Temperature at quadrature point [K]
 - `q_tot_hat`: Total specific humidity at quadrature point [kg/kg]
 
 # Returns
-`NamedTuple` from `BMT.bulk_microphysics_tendencies` with fields:
+`NamedTuple` from `BMT.average_bulk_microphysics_tendencies` with fields:
 - `dq_lcl_dt`: Cloud liquid tendency [kg/kg/s]
 - `dq_icl_dt`: Cloud ice tendency [kg/kg/s]
 - `dq_rai_dt`: Rain tendency [kg/kg/s]
@@ -182,27 +217,40 @@ struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     mp::MP
     tps::TPS
     ρ::FT
-    # Grid-mean state
-    T_mean::FT
-    q_lcl::FT
-    q_icl::FT
+    # Grid-mean prognostic state (held fixed across quadrature points)
+    q_lcl_mean::FT
+    q_icl_mean::FT
     q_rai::FT
     q_sno::FT
+    # Shape-function inputs from the SGS moments pre-pass
+    λ::FT          # liquid fraction (held fixed across quadrature)
+    γ_l::FT        # precomputed shape-function coefficient for liquid
+    M_l::FT        # SGS-mean equilibrium liquid condensate
+    γ_i::FT        # precomputed shape-function coefficient for ice
+    M_i::FT        # SGS-mean equilibrium ice condensate
+    # Numerical parameters
     dt::FT
     nsubs::Int
     args::Args
 end
 @inline function (eval::Microphysics1MEvaluator)(T_hat, q_tot_hat)
     FT = typeof(eval.ρ)
-
-    # Ensure non-negative and clamp to physical bounds
     q_tot_hat = max(FT(0), q_tot_hat)
 
-    # Call CloudMicrophysics point-wise tendencies
-    # Average tendencies over dt with nsubs substeps
+    # Local equilibrium condensate at the quadrature point (same partition
+    # form as the SGS moments pre-pass, with the prognostic λ held fixed).
+    q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
+    excess_hat = max(FT(0), q_tot_hat - q_sat_hat)
+    q_lcl_eq_hat = max(FT(0), eval.λ * excess_hat - eval.q_rai)
+    q_icl_eq_hat = max(FT(0), (FT(1) - eval.λ) * excess_hat - eval.q_sno)
+
+    q_lcl_hat = eval.q_lcl_mean + eval.γ_l * (q_lcl_eq_hat - eval.M_l)
+    q_icl_hat = eval.q_icl_mean + eval.γ_i * (q_icl_eq_hat - eval.M_i)
+
     return BMT.average_bulk_microphysics_tendencies(
         eval.scheme, eval.mp, eval.tps, eval.ρ, T_hat, q_tot_hat,
-        eval.q_lcl, eval.q_icl, eval.q_rai, eval.q_sno, eval.dt, eval.nsubs, eval.args...,
+        q_lcl_hat, q_icl_hat, eval.q_rai, eval.q_sno,
+        eval.dt, eval.nsubs, eval.args...,
     )
 end
 
@@ -210,28 +258,41 @@ end
     microphysics_tendencies_1m(ρ, q_tot, q_lcl, q_icl, q_rai, q_sno, T, cmp, thp, dt, nsubs,)
     microphysics_tendencies_1m(
         scheme, sgs_quad, cmp, thp, ρ, T, q_tot,
-        q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, dt,
+        q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+        moments, dt, nsubs,
     )
 
-Computes time-averaged 1-moment microphysics tendencies. When using SGS-quadratures,
-the tendencies are integrated over the joint PDF of (T, q_tot).
-```math
-\\bar{S} = \\int\\int S(T, q, \\dots) P(T, q) \\, dT \\, dq
-```
-The option without SGS-quadratures can be used in the EDMF updrafts, or to compute
-grid-mean tendency without taking account of fluctuations.
+Computes time-averaged 1-moment microphysics tendencies.
+
+The 11-argument (no `sgs_quad`) form takes condensate inputs as-is and is
+used in EDMF updrafts or wherever a grid-mean state is to be evaluated
+directly (single BMT call, no SGS averaging).
+
+The quadrature form uses a **single quadrature pass with a shape-function
+partition** of cloud condensate (see [`Microphysics1MEvaluator`](@ref)).
+At each quadrature point `(T_hat, q_tot_hat)` sampled from the SGS PDF,
+the local cloud condensate is reconstructed as
+`q_lcl_hat = q_lcl_mean + γ_l (q_lcl_eq_hat - M_l)`, where `M_l = ⟨q_lcl_eq⟩`
+is precomputed in the `compute_sgs_moments` pre-pass. This gives **exact mass 
+conservation by construction** and unifies the cloudy and clear regimes into one
+quadrature: subsaturated quadrature points contribute below-cloud
+rain evaporation / snow sublimation; saturated points carry the bulk
+of the cloud condensate and drive autoconversion / accretion.
 
 # Arguments
 - `scheme`: Microphysics scheme type (from CloudMicrophysics.BulkMicrophysicsTendencies)
 - `sgs_quad`: SGSQuadrature configuration
 - `cmp`, `thp`: Microphysics and thermodynamics parameters
-- `ρ`, `T`: Air density [kg/m³] and temperature [K]
-- `q_tot`: Total water [kg/kg]
-- `q_lcl`, `q_icl`: Cloud liquid water and cloud ice [kg/kg]
-- `q_rai`, `q_sno`: Rain and snow [kg/kg]
+- `ρ`, `T`: Air density [kg/m³] and temperature [K] (grid-mean)
+- `q_tot`: Grid-mean total water [kg/kg]
+- `q_lcl`, `q_icl`: Grid-mean cloud liquid water and cloud ice [kg/kg]
+- `q_rai`, `q_sno`: Grid-mean rain and snow [kg/kg]
 - `T′T′`: Variance of temperature ``\\langle T'^2 \\rangle``
 - `q′q′`: Variance of q_tot ``\\langle q'^2 \\rangle``
 - `corr_Tq`: Correlation coefficient ρ(T', q') obtained from `correlation_Tq(params)`.
+- `moments`: Cached `SGSMomentsType` `(mu_S, sigma_S_sq, M_l, M_i)` from
+  the `compute_sgs_moments` pre-pass. Only `M_l` and `M_i` are used by
+  the shape-function partition; `mu_S` and `sigma_S_sq` are ignored here.
 - `args...`: Additional arguments (e.g., N_lcl for 2M)
 - `dt`: Model timestep [s] (for tendency averaging)
 - `nsubs`: Number of substeps for computing average tendencies over time
@@ -254,24 +315,47 @@ NamedTuple with microphysics source terms:
 end
 @inline function microphysics_tendencies_1m( #microphysics_tendencies_quadrature_1m
     scheme, sgs_quad, cmp, thp, ρ, T, q_tot_nonneg,
-    q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq, dt, nsubs, args...,
+    q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
+    moments, dt, nsubs, args...,
 )
-    # Clamp species humidities to prevent negativity in quadratures
-    q_lcl_nonneg = max(0, q_lcl)
-    q_icl_nonneg = max(0, q_icl)
-    q_rai_nonneg = max(0, q_rai)
-    q_sno_nonneg = max(0, q_sno)
+    FT = typeof(ρ)
+    # Clamp specific humidities to non-negative.
+    q_lcl_nonneg = max(FT(0), q_lcl)
+    q_icl_nonneg = max(FT(0), q_icl)
+    q_rai_nonneg = max(FT(0), q_rai)
+    q_sno_nonneg = max(FT(0), q_sno)
 
-    # Create functor
+    # Liquid fraction held fixed across quadrature (paper Eq. 3.31). When
+    # both cloud condensates are zero, `TD.liquid_fraction` falls back to a
+    # smooth temperature ramp internally.
+    λ = TD.liquid_fraction(thp, T, q_lcl_nonneg, q_icl_nonneg)
+
+    # β-blending crossover scale: when the cached equilibrium moments
+    # `M_l, M_i` fall below `q_min`, the shape function reverts smoothly
+    # to a uniform `q_lcl_mean`/`q_icl_mean` fallback (stale-cloud edge
+    # case). For `M_l ≫ q_min` (typical), β ≈ 0 and the pure shape
+    # function `q_lcl_hat = (q_lcl_mean/M_l)·q_lcl_eq_hat` applies.
+    q_min = TD.Parameters.q_min(thp)
+
+    # Precompute shape-function coefficients once per grid cell (saving
+    # divisions and multiplications inside the quadrature loop).
+    M_l = max(FT(0), moments.M_l)
+    M_i = max(FT(0), moments.M_i)
+    M_sq = q_min * q_min
+    denom_l = M_sq + M_l * M_l
+    denom_i = M_sq + M_i * M_i
+    γ_l = min(FT(1), q_lcl_nonneg * M_l / denom_l)
+    γ_i = min(FT(1), q_icl_nonneg * M_i / denom_i)
+
     evaluator = Microphysics1MEvaluator(
-        scheme, cmp, thp, ρ, T, q_lcl_nonneg, q_icl_nonneg,
-        q_rai_nonneg, q_sno_nonneg, dt, nsubs, args,
+        scheme, cmp, thp, ρ,
+        q_lcl_nonneg, q_icl_nonneg, q_rai_nonneg, q_sno_nonneg,
+        λ, γ_l, M_l, γ_i, M_i,
+        dt, nsubs, args,
     )
-    # Integrate over quadrature points using functor (GPU-safe, no closure)
-    local_tendency = integrate_over_sgs(
+    return integrate_over_sgs(
         evaluator, sgs_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
     )
-    return local_tendency
 end
 
 ###

--- a/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -193,7 +193,7 @@ Subgrid-scale quadrature configuration for integrating over thermodynamic fluctu
 
 # Constructors
 
-    SGSQuadrature(FT; quadrature_order=3, distribution=GaussianSGS(), T_min=150.0, q_max=0.1)
+    SGSQuadrature(FT; quadrature_order=3, distribution=GaussianSGS(), T_min=150.0, q_max=0.05)
 
 Create an `SGSQuadrature` with the specified floating-point type `FT`,
 quadrature order, distribution type, minimum temperature, and maximum humidity.
@@ -214,8 +214,8 @@ struct SGSQuadrature{N, A, W, D <: AbstractSGSDistribution, FT} <: AbstractSGSam
         ::Type{FT};
         quadrature_order = 3,
         distribution::D = GaussianSGS(),
-        T_min = FT(150),  # Reasonable default for atmospheric applications
-        q_max = FT(0.1),  # Maximum humidity: ~100 g/kg (well above physical max)
+        T_min = FT(150),   # Reasonable default for atmospheric applications
+        q_max = FT(0.05),  # Maximum humidity: 50 g/kg (above any physical value)
     ) where {FT, D <: AbstractSGSDistribution}
         # GridMeanSGS always uses N=1 (single point at origin)
         N = distribution isa GridMeanSGS ? 1 : quadrature_order
@@ -401,178 +401,104 @@ Tuple `(σ_q, σ_T, corr)` of standard deviations and clamped correlation.
 end
 
 # ============================================================================
-# Physical Point Computation
+# Physical Point Transform Functors
 # ============================================================================
 
-"""
-    get_physical_point(dist, χ1, χ2, μ_q, μ_T, σ_q, σ_T, corr, T_min, q_max)
+abstract type AbstractPhysicalPointTransform end
 
-Transform quadrature points ``(\\chi_1, \\chi_2)`` to physical space ``(T, q)``.
-
-Temperature is always Gaussian, clamped to ``T \\geq T_{min}``.
-Specific humidity is clamped to ``0 \\leq q \\leq q_{max}``.
-Sampling depends on `dist`:
-
-**`GaussianSGS`**: correlated bivariate Gaussian
-```math
-q = \\clamp(\\mu_q + \\sqrt{2} \\sigma_q \\chi_1, \\; 0, \\; q_{max})
-```
-```math
-T = \\max(T_{min}, \\; \\mu_T + \\sqrt{2} \\sigma_T (\\rho \\chi_1 + \\sqrt{1-\\rho^2} \\chi_2))
-```
-
-**`LogNormalSGS`**: log-normal for `q`, Gaussian for `T`, linked by a Gaussian copula
-```math
-q = \\min(q_{max}, \\; \\exp(\\mu_{\\ln} + \\sqrt{2} \\sigma_{\\ln} z_q))
-```
-where ``z_q = \\chi_1`` and ``z_T = \\rho \\chi_1 + \\sqrt{1-\\rho^2} \\chi_2``.
-
-# Arguments
-- `dist`: Distribution type (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`)
-- `χ1`, `χ2`: Quadrature abscissae
-- `μ_q`, `μ_T`: Mean specific humidity [kg/kg] and temperature [K]
-- `σ_q`, `σ_T`: Standard deviations of `q` and `T`
-- `corr`: Correlation coefficient ``\\rho(T', q')``
-- `T_min`: Minimum temperature floor [K]
-- `q_max`: Maximum specific humidity ceiling [kg/kg]
-
-# Returns
-Tuple `(T_hat, q_hat)` of physical values.
-"""
-@inline function get_physical_point(
-    ::GaussianSGS,
-    χ1,
-    χ2,
-    μ_q,
-    μ_T,
-    σ_q,
-    σ_T,
-    corr,
-    T_min,
-    q_max,
-)
-    FT = typeof(μ_q)
-    sqrt2 = sqrt(FT(2))
-
-    # Clamp q to physically valid ranges
-    q_hat = clamp(μ_q + sqrt2 * σ_q * χ1, zero(FT), q_max)
-
-    # Re-infer effective χ1 from clamped q to maintain physical T-q correlation.
-    # If a negative q fluctuation was truncated to 0, T should only be conditioned
-    # on the q=0 state, not the "phantom" negative q.
-    χ1_eff = (q_hat - μ_q) / (sqrt2 * max(σ_q, ϵ_numerics(FT)))
-
-    # Conditional mean and std for T given *clamped* q
-    σ_c = sqrt(max(one(FT) - corr^2, zero(FT))) * σ_T
-    μ_c = μ_T + sqrt2 * corr * σ_T * χ1_eff
-
-    # Clamp T to physically valid ranges
-    T_hat = max(T_min, μ_c + sqrt2 * σ_c * χ2)
-
-    return (T_hat, q_hat)
-end
-
-@inline function get_physical_point(
-    ::LogNormalSGS,
-    χ1,
-    χ2,
-    μ_q,
-    μ_T,
-    σ_q,
-    σ_T,
-    corr,
-    T_min,
-    q_max,
-)
-    FT = typeof(μ_q)
-    sqrt2 = sqrt(FT(2))
-    ε = ϵ_numerics(FT)
-
-    # Step 1: Generate correlated Gaussian variables using copula approach
-    z_q = χ1
-    z_T = corr * χ1 + sqrt(max(zero(FT), one(FT) - corr^2)) * χ2
-
-    # Step 2: Transform z_q to log-normal for q
-    # For log-normal: σ_ln = √log(1 + σ²/μ²), μ_ln = log(μ) - σ_ln²/2
-    ratio = σ_q / max(μ_q, ε)
-    σ_ln = sqrt(log(one(FT) + ratio^2))
-    μ_ln = log(max(μ_q, ε)) - σ_ln^2 / 2
-    q_lognormal = exp(μ_ln + sqrt2 * σ_ln * z_q)
-
-    # Use log-normal only if both mean and variance are positive
-    use_lognormal = (μ_q > ε) & (σ_q > zero(FT))
-    q_hat = clamp(ifelse(use_lognormal, q_lognormal, μ_q), zero(FT), q_max)
-
-    # Step 3: Keep Gaussian for T using correlated z_T, clamped to T_min
-    T_hat = max(T_min, μ_T + sqrt2 * σ_T * z_T)
-
-    return (T_hat, q_hat)
-end
-
-# GridMeanSGS: evaluates only at the grid mean, ignoring variance
-@inline function get_physical_point(
-    ::GridMeanSGS,
-    χ1,
-    χ2,
-    μ_q,
-    μ_T,
-    σ_q,
-    σ_T,
-    corr,
-    T_min,
-    q_max,
-)
-    # Return grid mean directly, ignoring quadrature points, variance, and bounds
-    # χ1, χ2, σ_q, σ_T, corr, T_min, q_max are all ignored
-    (μ_T, μ_q)
-end
-
-# ============================================================================
-# Physical Point Transform Functor
-# ============================================================================
-
-"""
-    PhysicalPointTransform
-
-GPU-safe functor wrapping `get_physical_point` to avoid heap-allocated closures.
-
-Captures all parameters needed by `get_physical_point(dist, χ1, χ2, ...)` in a
-struct. Field order matches return order `(T, q)` for consistency.
-
-# Fields
-- `dist`: Distribution type (`GaussianSGS`, `LogNormalSGS`, or `GridMeanSGS`)
-- `μ_T`: Mean temperature [K]
-- `μ_q`: Mean specific humidity [kg/kg]
-- `σ_T`: Standard deviation of T [K]
-- `σ_q`: Standard deviation of q [kg/kg]
-- `corr`: Correlation coefficient [-1, 1]
-- `T_min`: Minimum temperature floor [K]
-- `q_max`: Maximum specific humidity ceiling [kg/kg]
-"""
-struct PhysicalPointTransform{D, FT}
-    dist::D
+struct GaussianPhysicalPointTransform{FT} <: AbstractPhysicalPointTransform
     μ_T::FT
     μ_q::FT
-    σ_T::FT
     σ_q::FT
-    corr::FT
+    σ_c::FT      # precomputed conditional std of T: σ_T * sqrt(1 - corr^2)
+    fac::FT      # precomputed factor: corr * σ_T / max(σ_q, ϵ)
     T_min::FT
     q_max::FT
 end
 
-@inline function (t::PhysicalPointTransform)(χ1, χ2)
-    return get_physical_point(
-        t.dist,
-        χ1,
-        χ2,
-        t.μ_q,
-        t.μ_T,
-        t.σ_q,
-        t.σ_T,
-        t.corr,
-        t.T_min,
-        t.q_max,
+@inline function (t::GaussianPhysicalPointTransform)(χ1, χ2)
+    FT = typeof(t.μ_q)
+    sqrt2 = sqrt(FT(2))
+
+    q_hat = clamp(t.μ_q + sqrt2 * t.σ_q * χ1, zero(FT), t.q_max)
+    μ_c = t.μ_T + t.fac * (q_hat - t.μ_q)
+    T_hat = max(t.T_min, μ_c + sqrt2 * t.σ_c * χ2)
+
+    return (T_hat, q_hat)
+end
+
+struct LogNormalPhysicalPointTransform{FT} <: AbstractPhysicalPointTransform
+    μ_T::FT
+    μ_q::FT
+    σ_T::FT
+    μ_ln::FT
+    σ_ln::FT
+    c1::FT       # corr
+    c2::FT       # sqrt(1 - corr^2)
+    use_lognormal::Bool
+    T_min::FT
+    q_max::FT
+end
+
+@inline function (t::LogNormalPhysicalPointTransform)(χ1, χ2)
+    FT = typeof(t.μ_q)
+    sqrt2 = sqrt(FT(2))
+
+    z_q = χ1
+    z_T = t.c1 * χ1 + t.c2 * χ2
+
+    q_lognormal = exp(t.μ_ln + sqrt2 * t.σ_ln * z_q)
+    q_hat = clamp(ifelse(t.use_lognormal, q_lognormal, t.μ_q), zero(FT), t.q_max)
+    T_hat = max(t.T_min, t.μ_T + sqrt2 * t.σ_T * z_T)
+
+    return (T_hat, q_hat)
+end
+
+struct GridMeanPhysicalPointTransform{FT} <: AbstractPhysicalPointTransform
+    μ_T::FT
+    μ_q::FT
+end
+
+@inline function (t::GridMeanPhysicalPointTransform)(χ1, χ2)
+    return (t.μ_T, t.μ_q)
+end
+
+"""
+    create_physical_transform(dist, μ_q, μ_T, σ_q, σ_T, corr, T_min, q_max)
+
+Create a `PhysicalPointTransform` functor that precomputes loop-invariant constants
+for the given distribution type, avoiding redundant `sqrt`, `log`, and `div`
+operations inside the `N²` quadrature loop.
+"""
+@inline function create_physical_transform(
+    ::GaussianSGS, μ_q::FT, μ_T::FT, σ_q::FT, σ_T::FT, corr::FT, T_min::FT, q_max::FT,
+) where {FT}
+    σ_c = sqrt(max(one(FT) - corr^2, zero(FT))) * σ_T
+    fac = corr * σ_T / max(σ_q, ϵ_numerics(FT))
+    return GaussianPhysicalPointTransform(μ_T, μ_q, σ_q, σ_c, fac, T_min, q_max)
+end
+
+@inline function create_physical_transform(
+    ::LogNormalSGS, μ_q::FT, μ_T::FT, σ_q::FT, σ_T::FT, corr::FT, T_min::FT, q_max::FT,
+) where {FT}
+    ε = ϵ_numerics(FT)
+    c1 = corr
+    c2 = sqrt(max(zero(FT), one(FT) - corr^2))
+
+    ratio = σ_q / max(μ_q, ε)
+    σ_ln = sqrt(log(one(FT) + ratio^2))
+    μ_ln = log(max(μ_q, ε)) - σ_ln^2 / 2
+    use_lognormal = (μ_q > ε) & (σ_q > zero(FT))
+
+    return LogNormalPhysicalPointTransform(
+        μ_T, μ_q, σ_T, μ_ln, σ_ln, c1, c2, use_lognormal, T_min, q_max,
     )
+end
+
+@inline function create_physical_transform(
+    ::GridMeanSGS, μ_q::FT, μ_T::FT, σ_q::FT, σ_T::FT, corr::FT, T_min::FT, q_max::FT,
+) where {FT}
+    return GridMeanPhysicalPointTransform(μ_T, μ_q)
 end
 
 # ============================================================================
@@ -604,20 +530,29 @@ function sum_over_quadrature_points(f, get_x_hat, quad::SGSQuadrature{N}) where 
 
     inv_sqrt_pi = one(FT) / sqrt(FT(π))
 
-    # Use loops instead of ntuple for register reuse across iterations
-    # Each loop iteration can release registers from the previous iteration,
-    # dramatically reducing peak register usage (from holding all N² evaluations to just a few)
-    outer_sum = rzero(f(get_x_hat(χ[1], χ[1])...))
-
-    @inbounds for i in 1:N
-        inner_sum = rzero(f(get_x_hat(χ[1], χ[1])...))
-        @inbounds for j in 1:N
-            x_hat = get_x_hat(χ[i], χ[j])
-            contribution = f(x_hat...) ⊠ (weights[j] * inv_sqrt_pi)
-            inner_sum = inner_sum ⊞ contribution
+    # Use loops (not ntuple) for register reuse across iterations: each loop
+    # iteration releases registers from the previous one, dramatically reducing
+    # peak register usage. Seed both accumulators from real (i, j) = (1, 1)
+    # evaluations rather than a separate `rzero(f(...))` dummy call — that
+    # saves one full evaluation of `f` per cell (≈ 11% of work at N = 3).
+    @inbounds begin
+        x_hat = get_x_hat(χ[1], χ[1])
+        inner_sum = f(x_hat...) ⊠ (weights[1] * inv_sqrt_pi)
+        for j in 2:N
+            x_hat = get_x_hat(χ[1], χ[j])
+            inner_sum = inner_sum ⊞ (f(x_hat...) ⊠ (weights[j] * inv_sqrt_pi))
         end
-        weighted_inner = inner_sum ⊠ (weights[i] * inv_sqrt_pi)
-        outer_sum = outer_sum ⊞ weighted_inner
+        outer_sum = inner_sum ⊠ (weights[1] * inv_sqrt_pi)
+
+        for i in 2:N
+            x_hat = get_x_hat(χ[i], χ[1])
+            inner_sum = f(x_hat...) ⊠ (weights[1] * inv_sqrt_pi)
+            for j in 2:N
+                x_hat = get_x_hat(χ[i], χ[j])
+                inner_sum = inner_sum ⊞ (f(x_hat...) ⊠ (weights[j] * inv_sqrt_pi))
+            end
+            outer_sum = outer_sum ⊞ (inner_sum ⊠ (weights[i] * inv_sqrt_pi))
+        end
     end
 
     return outer_sum
@@ -652,12 +587,12 @@ function integrate_over_sgs(f, quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
     # Promote μ_T and μ_q to the widest type: with autodiff, either may
     # independently be a Dual (when ρe_tot or ρq_tot is perturbed).
     μ_T_p, μ_q_p = promote(μ_T, μ_q)
-    transform = PhysicalPointTransform(
+    transform = create_physical_transform(
         quad.dist,
-        μ_T_p,
         μ_q_p,
-        oftype(μ_T_p, σ_T),
+        μ_T_p,
         oftype(μ_T_p, σ_q),
+        oftype(μ_T_p, σ_T),
         oftype(μ_T_p, corr),
         oftype(μ_T_p, quad.T_min),
         oftype(μ_T_p, quad.q_max),

--- a/src/parameterized_tendencies/microphysics/sgs_saturation.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_saturation.jl
@@ -22,15 +22,18 @@ saturation adjustment and 0-moment microphysics.
 Given (T_hat, q_hat) at a quadrature point, computes:
 1. Saturation specific humidity q_sat from Clausius-Clapeyron
 2. Condensate as saturation excess: q_cond = max(0, q_hat - q_sat)
-3. Liquid/ice partition using temperature-based ramp function
+3. Liquid/ice partition using a grid-mean liquid fraction `λ_mean`,
+   held fixed across all quadrature points
 
 # Fields
 - `thermo_params`: Thermodynamics parameters
 - `ρ`: Air density [kg/m³]
+- `λ_mean`: Grid-mean liquid fraction, fixed across quadrature points
 """
 struct SaturationAdjustmentEvaluator{TPS, T1}
     thermo_params::TPS
     ρ::T1
+    λ_mean::T1
 end
 
 """
@@ -61,11 +64,12 @@ NamedTuple with:
     # Condensate is the saturation excess (positive only)
     q_cond = max(FT(0), q_hat - q_sat)
 
-    # Partition condensate using liquid fraction based on temperature ramp
-    # liquid_fraction_ramp is appropriate for equilibrium thermodynamics
-    λ = TD.liquid_fraction_ramp(thp, T_hat)
-    q_liq = λ * q_cond
-    q_ice = (FT(1) - λ) * q_cond
+    # Partition condensate using a grid-mean liquid fraction held fixed across
+    # quadrature points. The 0M / saturation-adjustment scheme has no
+    # prognostic phase memory, so `λ_mean` is supplied by the caller using a
+    # temperature-based ramp evaluated at the grid-mean temperature.
+    q_liq = eval.λ_mean * q_cond
+    q_ice = (FT(1) - eval.λ_mean) * q_cond
 
     # Return q_tot_quad = q_hat so the caller can compute the effective
     # integrated mean of the (possibly truncated) q_tot distribution.
@@ -126,8 +130,10 @@ NamedTuple with SGS-averaged:
 )
     FT = typeof(T_mean)
     q_min = TD.Parameters.q_min(thermo_params)
+    # Grid-mean liquid fraction, held fixed across all quadrature points.
+    λ_mean = TD.liquid_fraction_ramp(thermo_params, T_mean)
     # Create GPU-safe functor (not a closure)
-    evaluator = SaturationAdjustmentEvaluator(thermo_params, ρ)
+    evaluator = SaturationAdjustmentEvaluator(thermo_params, ρ, λ_mean)
 
     # Integrate over quadrature points
     result =

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -129,7 +129,7 @@ struct GridScaleCloud <: AbstractCloudModel end
 """
     QuadratureCloud
 
-Compute the cloud fraction using Sommeria-Deardorff moment matching.
+Compute the cloud fraction using the hybrid quadrature-moment formula.
 """
 struct QuadratureCloud <: AbstractCloudModel end
 

--- a/test/parameterized_tendencies/microphysics/allocations.jl
+++ b/test/parameterized_tendencies/microphysics/allocations.jl
@@ -84,18 +84,23 @@ end
 
 # --- Function barrier helpers ---
 
-function _allocs_cloud_fraction_sd(thp)
+function _allocs_cloud_fraction_hybrid(thp)
     FT = Float64
     T = FT(280.0)
     ρ = FT(1.0)
     q_min = FT(1e-10)
-    CA.compute_cloud_fraction_sd(
-        thp, T, ρ, FT(0.011), FT(1e-3), FT(0), FT(1), FT(1e-6), FT(0), FT(1),
-        q_min, CA.GaussianSGS(),
+    q_tot = FT(0.011)
+    moments = (
+        mu_S = FT(1e-3), sigma_S_sq = FT(1e-7),
+        M_l = FT(1e-3), M_i = FT(0),
     )
-    return @allocated CA.compute_cloud_fraction_sd(
-        thp, T, ρ, FT(0.011), FT(1e-3), FT(0), FT(1), FT(1e-6), FT(0), FT(1),
-        q_min, CA.GaussianSGS(),
+    CA.compute_cloud_fraction_hybrid(
+        thp, T, ρ, q_tot, FT(1e-3), FT(0), moments, FT(0), FT(1), q_min,
+        CA.GaussianSGS(),
+    )
+    return @allocated CA.compute_cloud_fraction_hybrid(
+        thp, T, ρ, q_tot, FT(1e-3), FT(0), moments, FT(0), FT(1), q_min,
+        CA.GaussianSGS(),
     )
 end
 
@@ -195,7 +200,7 @@ end
         quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
 
         # Warm up the barrier functions themselves (JIT)
-        _allocs_cloud_fraction_sd(thp)
+        _allocs_cloud_fraction_hybrid(thp)
         _allocs_coupled_sink()
         _allocs_bmt_0m(mp, thp)
         _allocs_energy_helper(thp)
@@ -203,8 +208,8 @@ end
         _allocs_sgs_sat_adj(thp, quad)
         _allocs_integrate_sgs_functor(quad, FT)
 
-        @testset "compute_cloud_fraction_sd" begin
-            @test _allocs_cloud_fraction_sd(thp) == 0
+        @testset "compute_cloud_fraction_hybrid" begin
+            @test _allocs_cloud_fraction_hybrid(thp) == 0
         end
 
         @testset "coupled_sink_limit_factor" begin

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -2,7 +2,7 @@
 Unit tests for cloud_fraction.jl
 
 Tests cover:
-1. compute_cloud_fraction_sd - Sommeria-Deardorff moment-matching cloud fraction
+1. compute_cloud_fraction_hybrid - hybrid CF using cached SGS moments
 =#
 
 using Test
@@ -14,160 +14,159 @@ import ClimaParams as CP
 
 @testset "Cloud Fraction" begin
 
-    @testset "compute_cloud_fraction_sd" begin
+    @testset "compute_cloud_fraction_hybrid" begin
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
                 toml_dict = CP.create_toml_dict(FT)
                 thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
-
                 T = FT(280.0)
                 ρ = FT(1.0)
-                # For tests we need a nominal q_tot. Let's assume q_tot = q_cond + 0.01
-                q_tot_base = FT(0.01)
+                q_sat = TD.q_vap_saturation(thp, T, ρ)
                 q_min = FT(1e-10)
+                cf_guess = FT(1.0)
+                coeff = FT(1)
+
+                # Helper to build a moments NamedTuple of the right type.
+                make_moments(mu_S, sigma_S_sq, M_l, M_i) =
+                    (mu_S = FT(mu_S), sigma_S_sq = FT(sigma_S_sq),
+                        M_l = FT(M_l), M_i = FT(M_i))
 
                 for sgs_dist in (CA.GaussianSGS(), CA.LogNormalSGS())
                     @testset "No condensate → zero cloud fraction ($sgs_dist)" begin
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, q_tot_base,
-                            FT(0), FT(0),              # q_liq, q_ice
-                            FT(1.0), FT(1e-6), FT(0),  # T'T', q'q', T'q'
-                            FT(1), q_min, sgs_dist,
+                        # μ_S < 0 (subsaturated) and q_c = 0 → has_condensate
+                        # gate fires regardless of moments.
+                        moments = make_moments(-1e-3, 1e-8, 0, 0)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T, ρ, q_sat - FT(1e-3),
+                            FT(0), FT(0), moments, cf_guess, coeff, q_min, sgs_dist,
                         )
                         @test cf == FT(0)
                     end
 
-                    @testset "Liquid condensate → positive cloud fraction ($sgs_dist)" begin
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, q_tot_base + FT(1e-3),
-                            FT(1e-3), FT(0),           # q_liq present
-                            FT(1.0), FT(1e-6), FT(0),
-                            FT(1), q_min, sgs_dist,
+                    @testset "Liquid condensate, saturated mean → cf > 0 ($sgs_dist)" begin
+                        excess = FT(1e-3)
+                        q_tot = q_sat + excess
+                        mu_S = sgs_dist isa CA.LogNormalSGS ?
+                               log(q_tot / q_sat) : excess
+                        moments = make_moments(mu_S, 1e-7, 1e-3, 0)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T, ρ, q_tot,
+                            FT(1e-3), FT(0), moments, cf_guess, coeff, q_min, sgs_dist,
                         )
-                        @test cf > FT(0)
-                        @test cf <= FT(1)
+                        @test FT(0) < cf <= FT(1)
+                    end
+
+                    @testset "Zero variance, condensate present → cf ≈ 1 ($sgs_dist)" begin
+                        excess = FT(1e-3)
+                        q_tot = q_sat + excess
+                        mu_S = sgs_dist isa CA.LogNormalSGS ?
+                               log(q_tot / q_sat) : excess
+                        moments = make_moments(mu_S, 0, excess, 0)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T, ρ, q_tot,
+                            FT(1e-3), FT(0), moments, cf_guess, coeff, q_min, sgs_dist,
+                        )
+                        @test cf > FT(0.99)
+                    end
+
+                    @testset "Large condensate, small variance → cf ≈ 1 ($sgs_dist)" begin
+                        excess = FT(1e-2)
+                        q_tot = q_sat + excess
+                        mu_S = sgs_dist isa CA.LogNormalSGS ?
+                               log(q_tot / q_sat) : excess
+                        moments = make_moments(mu_S, 1e-10, excess, 0)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T, ρ, q_tot,
+                            FT(1e-2), FT(0), moments, cf_guess, coeff, q_min, sgs_dist,
+                        )
+                        @test cf > FT(0.99)
                     end
 
                     @testset "Ice condensate → positive cloud fraction ($sgs_dist)" begin
                         T_cold = FT(240.0)
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T_cold, ρ, q_tot_base + FT(1e-3),
-                            FT(0), FT(1e-3),           # q_ice present
-                            FT(1.0), FT(1e-6), FT(0),
-                            FT(1), q_min, sgs_dist,
+                        q_sat_cold = TD.q_vap_saturation(thp, T_cold, ρ)
+                        excess = FT(1e-4)
+                        q_tot = q_sat_cold + excess
+                        mu_S =
+                            sgs_dist isa CA.LogNormalSGS ?
+                            log(q_tot / q_sat_cold) : excess
+                        moments = make_moments(mu_S, 1e-9, 0, 1e-3)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T_cold, ρ, q_tot,
+                            FT(0), FT(1e-3), moments, cf_guess, coeff, q_min, sgs_dist,
                         )
-                        @test cf > FT(0)
-                        @test cf <= FT(1)
-                    end
-
-                    @testset "Large condensate, small variance → cf ≈ 1 ($sgs_dist)" begin
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, q_tot_base + FT(1e-2),
-                            FT(1e-2), FT(0),           # large q_liq
-                            FT(0.01), FT(1e-10), FT(0),# small variance
-                            FT(1), q_min, sgs_dist,
-                        )
-                        @test cf > FT(0.99)
-                    end
-
-                    @testset "Zero variance, nonzero condensate → cf = 1 ($sgs_dist)" begin
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, q_tot_base + FT(1e-3),
-                            FT(1e-3), FT(0),
-                            FT(0), FT(0), FT(0),
-                            FT(1), q_min, sgs_dist,
-                        )
-                        @test cf > FT(0.99)
-                    end
-
-                    @testset "Both liquid and ice → max overlap ($sgs_dist)" begin
-                        cf_both = CA.compute_cloud_fraction_sd(
-                            thp, FT(260.0), ρ, q_tot_base + FT(1.5e-3),
-                            FT(1e-3), FT(5e-4),
-                            FT(1.0), FT(1e-6), FT(0),
-                            FT(1), q_min, sgs_dist,
-                        )
-                        cf_liq = CA.compute_cloud_fraction_sd(
-                            thp, FT(260.0), ρ, q_tot_base + FT(1.5e-3),
-                            FT(1e-3), FT(0),
-                            FT(1.0), FT(1e-6), FT(0),
-                            FT(1), q_min, sgs_dist,
-                        )
-                        # Max overlap: combined cf ≥ liquid-only cf
-                        @test cf_both >= cf_liq
+                        @test FT(0) < cf <= FT(1)
                     end
 
                     @testset "Type stability ($sgs_dist)" begin
-                        cf = CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, q_tot_base + FT(1e-3),
-                            FT(1e-3), FT(0),
-                            FT(1.0), FT(1e-6), FT(0),
-                            FT(1), q_min, sgs_dist,
+                        moments = make_moments(1e-3, 1e-7, 1e-3, 0)
+                        cf = CA.compute_cloud_fraction_hybrid(
+                            thp, T, ρ, q_sat + FT(1e-3),
+                            FT(1e-3), FT(0), moments, cf_guess, coeff, q_min, sgs_dist,
                         )
                         @test cf isa FT
                     end
 
-                    @testset "Cloud fraction increases with T-q correlation ($sgs_dist)" begin
-                        # Physical reasoning: positive corr(T',q') means T and q
-                        # perturbations partially cancel in the saturation deficit
-                        # s = q − q_sat(T).  The PDF width σ_s² = σ_q² + b²σ_T²
-                        # − 2b·corr·σ_T·σ_q shrinks when corr increases (b > 0),
-                        # so Q̂ = q_cond / σ_s grows ⇒ cf grows.
-                        corr_vals = FT[-0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9]
-
-                        # Liquid-only case
-                        cf_liq = [
-                            CA.compute_cloud_fraction_sd(
-                                thp, T, ρ, q_tot_base + FT(1e-3),
-                                FT(1e-3), FT(0),
-                                FT(1.0), FT(1e-6), c,
-                                FT(1), q_min, sgs_dist,
-                            ) for c in corr_vals
+                    @testset "CF monotone in σ_S² at fixed (q_c, μ_S) ($sgs_dist)" begin
+                        # Saturated mean (μ_S > 0): as σ_S² grows, cloud
+                        # fraction approaches 0.5 from above (broader PDF
+                        # spills more of its mass into the clear branch).
+                        excess = FT(1e-3)
+                        q_tot = q_sat + excess
+                        mu_S = sgs_dist isa CA.LogNormalSGS ?
+                               log(q_tot / q_sat) : excess
+                        sig_vals = FT[1e-9, 1e-8, 1e-7, 1e-6]
+                        cfs = [
+                            CA.compute_cloud_fraction_hybrid(
+                                thp, T, ρ, q_tot, FT(1e-3), FT(0),
+                                make_moments(mu_S, σ², 1e-3, 0),
+                                cf_guess, coeff, q_min, sgs_dist,
+                            ) for σ² in sig_vals
                         ]
-                        for i in 2:length(cf_liq)
-                            @test cf_liq[i] > cf_liq[i - 1]
-                        end
-
-                        # Ice-only case (cold temperature)
-                        T_cold = FT(240.0)
-                        cf_ice = [
-                            CA.compute_cloud_fraction_sd(
-                                thp, T_cold, ρ, q_tot_base + FT(1e-3),
-                                FT(0), FT(1e-3),
-                                FT(1.0), FT(1e-6), c,
-                                FT(1), q_min, sgs_dist,
-                            ) for c in corr_vals
-                        ]
-                        for i in 2:length(cf_ice)
-                            @test cf_ice[i] > cf_ice[i - 1]
+                        for i in 2:length(cfs)
+                            @test cfs[i] <= cfs[i - 1] + FT(1e-6)
                         end
                     end
                 end
 
-                @testset "LogNormalSGS: CF decreases as Cv increases (constant absolute condensate and q_tot)" begin
-                    # Hold q_cond and q_tot constant. 
-                    # Vary absolute variance q_var to vary sig_s, which varies Cv = sig_s / q_tot.
-                    # Larger variance -> larger Cv -> more skewed tail & smaller Q_hat -> smaller CF.
+                @testset "GridMeanSGS: degenerate (binary) limit" begin
+                    # σ_S² → 0, μ_S < 0, q_c > 0 but |μ_S| > q_c → Q_eff < 0 → cf → 0.
+                    moments = make_moments(-2e-3, 0, 0, 0)
+                    cf_dry = CA.compute_cloud_fraction_hybrid(
+                        thp, T, ρ, q_sat - FT(2e-3),
+                        FT(1e-4), FT(0), moments, FT(0.1), coeff, q_min,
+                        CA.GridMeanSGS(),
+                    )
+                    @test cf_dry < FT(0.05)
 
-                    q_cond = FT(1e-3)
-                    qt = FT(0.01)
+                    # Saturated, q_c > 0 → Q_eff > 0 → cf → 1.
+                    moments = make_moments(1e-3, 0, 1e-3, 0)
+                    cf_wet = CA.compute_cloud_fraction_hybrid(
+                        thp, T, ρ, q_sat + FT(1e-3),
+                        FT(1e-3), FT(0), moments, cf_guess, coeff, q_min,
+                        CA.GridMeanSGS(),
+                    )
+                    @test cf_wet > FT(0.99)
+                end
 
-                    # Increasing q_var array to increase Cv and sig_s
-                    q_var_vals = FT[1e-6, 1e-5, 1e-4, 1e-3]
-
-                    cfs = [
-                        CA.compute_cloud_fraction_sd(
-                            thp, T, ρ, qt,
-                            q_cond, FT(0),
-                            FT(0), q_var, FT(0),
-                            FT(1), q_min, CA.LogNormalSGS(),
-                        ) for q_var in q_var_vals
-                    ]
-
-                    # As variance (and Cv) increases, CF should decrease
-                    for i in 2:length(cfs)
-                        @test cfs[i] < cfs[i - 1]
-                    end
+                @testset "Gaussian vs Lognormal agree in σ → 0 limit" begin
+                    # At σ → 0, both distributions collapse to a single-point
+                    # evaluation; with q_c equal to the linear excess the
+                    # hybrid CF saturates at 1 in both coordinates.
+                    excess = FT(2e-3)
+                    q_tot = q_sat + excess
+                    moments_g = make_moments(excess, 1e-12, excess, 0)
+                    moments_ln = make_moments(log(q_tot / q_sat), 1e-12, excess, 0)
+                    cf_g = CA.compute_cloud_fraction_hybrid(
+                        thp, T, ρ, q_tot, excess, FT(0),
+                        moments_g, cf_guess, coeff, q_min, CA.GaussianSGS(),
+                    )
+                    cf_ln = CA.compute_cloud_fraction_hybrid(
+                        thp, T, ρ, q_tot, excess, FT(0),
+                        moments_ln, cf_guess, coeff, q_min, CA.LogNormalSGS(),
+                    )
+                    @test cf_g > FT(0.99)
+                    @test cf_ln > FT(0.99)
                 end
             end
         end

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -218,7 +218,7 @@ import ClimaAtmos: limit_sink
         end
     end
 
-    @testset "Microphysics1MEvaluator Condensate Logic" begin
+    @testset "Microphysics1MEvaluator Shape-Function Logic" begin
         import CloudMicrophysics.Parameters as CMP
         import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
         import Thermodynamics as TD
@@ -234,22 +234,37 @@ import ClimaAtmos: limit_sink
                 ρ = FT(1.0)
                 T_mean = FT(280.0)
                 q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                q_min = FT(1e-10)
                 nsubs_quad = 1
 
-                @testset "Subsaturated mean" begin
-                    # excess_mean < 0, q_cond_mean = 0
-                    q_tot_sub = q_sat_mean - FT(0.002)
-                    excess_sub = q_tot_sub - q_sat_mean  # -0.002
+                # Helper to precompute shape-function coefficients from
+                # (M_l, M_i, q_min), matching the production code in
+                # microphysics_tendencies_1m.
+                function _shape_coeffs(M_l, M_i, q_min_val)
+                    M_sq = q_min_val * q_min_val
+                    denom_l = M_sq + M_l * M_l
+                    denom_i = M_sq + M_i * M_i
+                    return (
+                        γ_l = M_l / denom_l,
+                        M_l = M_l,
+                        γ_i = M_i / denom_i,
+                        M_i = M_i,
+                    )
+                end
 
+                @testset "Subsaturated mean (no condensate) → q_lcl_hat = 0" begin
+                    # q_lcl_mean = q_icl_mean = 0 makes the shape-function
+                    # output identically zero regardless of the equilibrium
+                    # moments, so BMT is called with no cloud condensate.
+                    sc = _shape_coeffs(FT(0), FT(0), q_min)
                     eval_sub = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
-                        mp, thp, ρ, T_mean,
-                        FT(0), FT(0), FT(0), FT(0), FT(60),
-                        nsubs_quad,
-                        (),
+                        mp, thp, ρ,
+                        FT(0), FT(0), FT(0), FT(0),  # q_lcl_mean, q_icl_mean, q_rai, q_sno
+                        FT(1), sc.γ_l, sc.M_l, sc.γ_i, sc.M_i, # λ, γ_l, M_l, γ_i, M_i
+                        FT(60), nsubs_quad, (),
                     )
 
-                    # Quadrature point slightly supersaturated
                     q_tot_hat = q_sat_mean + FT(0.001)
                     result = eval_sub(T_mean, q_tot_hat)
 
@@ -261,29 +276,56 @@ import ClimaAtmos: limit_sink
                     @test result.dq_icl_dt ≈ res_expected.dq_icl_dt rtol = FT(1e-4)
                 end
 
-                @testset "Saturated equilibrium mean" begin
-                    # excess_mean > 0, q_cond_mean = excess_mean (equilibrium)
+                @testset "Saturated mean at equilibrium → shape-function recovers q_lcl_mean" begin
+                    # When q_lcl_mean = M_l (current state equals SGS-mean
+                    # equilibrium condensate), the shape function at the
+                    # quadrature point (T_mean, q_tot_sat) where
+                    # q_lcl_eq_hat = M_l reduces to q_lcl_hat = q_lcl_mean.
                     q_tot_sat = q_sat_mean + FT(0.002)
-                    excess_sat = q_tot_sat - q_sat_mean  # +0.002
-                    λ = TD.liquid_fraction(thp, T_mean, FT(0), FT(0))
+                    excess_sat = q_tot_sat - q_sat_mean
+                    q_lcl = excess_sat
 
+                    sc = _shape_coeffs(excess_sat, FT(0), q_min)
                     eval_sat = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(),
-                        mp, thp, ρ, T_mean,
-                        λ * excess_sat, (1 - λ) * excess_sat, FT(0), FT(0), FT(60),
-                        nsubs_quad,
-                        (),
+                        mp, thp, ρ,
+                        q_lcl, FT(0), FT(0), FT(0),  # q_lcl_mean, q_icl_mean, q_rai, q_sno
+                        FT(1), sc.γ_l, sc.M_l, sc.γ_i, sc.M_i, # λ, γ_l, M_l, γ_i, M_i
+                        FT(60), nsubs_quad, (),
                     )
 
-                    # At grid mean: should recover q_cond_mean (zero-variance)
+                    # M_l = excess and q_lcl_eq_hat(T_mean, q_tot_sat) = excess
+                    # so q_lcl_hat = q_lcl_mean exactly.
                     result_mean = eval_sat(T_mean, q_tot_sat)
                     res_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
-                        q_tot_sat, λ * excess_sat,
-                        (1 - λ) * excess_sat, FT(0), FT(0), FT(60), nsubs_quad,
+                        q_tot_sat, q_lcl, FT(0), FT(0), FT(0), FT(60), nsubs_quad,
                     )
                     @test result_mean.dq_lcl_dt ≈ res_direct.dq_lcl_dt rtol = FT(1e-4)
-                    @test result_mean.dq_icl_dt ≈ res_direct.dq_icl_dt rtol = FT(1e-4)
+                end
+
+                @testset "Stale-cloud edge case (M_l → 0) → β fallback" begin
+                    # q_lcl_mean > 0 but M_l ≈ 0 (no equilibrium condensate
+                    # anywhere in the SGS PDF). γ ≈ 0, so q_lcl_hat ≈ q_lcl_mean
+                    # — recovering the uniform-condensate fallback.
+                    q_lcl_stale = FT(1e-4)
+                    sc = _shape_coeffs(FT(0), FT(0), q_min) # M_l = 0 ⇒ γ = 0
+                    eval_stale = Microphysics1MEvaluator(
+                        BMT.Microphysics1Moment(),
+                        mp, thp, ρ,
+                        q_lcl_stale, FT(0), FT(0), FT(0),
+                        FT(1), sc.γ_l, sc.M_l, sc.γ_i, sc.M_i,
+                        FT(60), nsubs_quad, (),
+                    )
+                    # Subsaturated quadrature point: q_lcl_eq_hat = 0.
+                    q_tot_dry = q_sat_mean - FT(1e-4)
+                    result = eval_stale(T_mean, q_tot_dry)
+                    res_expected = BMT.average_bulk_microphysics_tendencies(
+                        BMT.Microphysics1Moment(), mp, thp, ρ, T_mean,
+                        q_tot_dry, q_lcl_stale, FT(0), FT(0), FT(0),
+                        FT(60), nsubs_quad,
+                    )
+                    @test result.dq_lcl_dt ≈ res_expected.dq_lcl_dt rtol = FT(1e-3)
                 end
             end
         end

--- a/test/parameterized_tendencies/microphysics/sgs_moments.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_moments.jl
@@ -1,0 +1,268 @@
+#=
+Unit tests for SGS Moments pre-pass (Stage A of the scale-aware unified
+microphysics framework, see docs/src/sgs_microphysics_redesign.md).
+
+Tests the SGSMomentsEvaluator functor and the compute_sgs_moments driver,
+verifying:
+  - moment finiteness and non-negativity (M_l, M_i ≥ 0; σ_S² ≥ 0)
+  - high-resolution limit: at σ → 0, moments collapse to grid-mean values
+  - low-resolution behavior: σ_S² > 0 and M_l grows as the PDF widens
+  - distribution dispatch: Gaussian uses linear S = q_tot - q_sat; lognormal
+    uses log S = log(q_tot / q_sat)
+  - grid-mean fallback: works with GridMeanSGS / nothing
+=#
+
+using Test
+using ClimaAtmos
+import Thermodynamics as TD
+import CloudMicrophysics.Parameters as CMP
+import ClimaParams as CP
+
+const CA = ClimaAtmos
+
+@testset "SGS Moments" begin
+
+    @testset "SGSMomentsEvaluator dispatch and basic properties" begin
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                ρ = FT(1.2)
+                T_mean = FT(280.0)
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+
+                # Construct an in-equilibrium grid state
+                q_tot_mean = q_sat_mean + FT(2e-3)
+                excess = q_tot_mean - q_sat_mean
+                λ = FT(1.0)            # warm: pure liquid
+                q_rai = FT(1e-4)
+                q_sno = FT(1e-5)
+                q_min = FT(1e-10)
+
+                # Build evaluators for each distribution
+                eval_g = CA.SGSMomentsEvaluator(
+                    CA.GaussianSGS(), thp, ρ, λ, q_rai, q_sno, q_min,
+                )
+                eval_ln = CA.SGSMomentsEvaluator(
+                    CA.LogNormalSGS(), thp, ρ, λ, q_rai, q_sno, q_min,
+                )
+                eval_gm = CA.SGSMomentsEvaluator(
+                    CA.GridMeanSGS(), thp, ρ, λ, q_rai, q_sno, q_min,
+                )
+
+                # Evaluate at the grid mean point — should give well-defined results
+                out_g = eval_g(T_mean, q_tot_mean)
+                out_ln = eval_ln(T_mean, q_tot_mean)
+                out_gm = eval_gm(T_mean, q_tot_mean)
+
+                # Gaussian / GridMean: S = q_tot - q_sat (linear)
+                @test out_g.mu_S ≈ excess rtol = FT(1e-5)
+                @test out_gm.mu_S ≈ excess rtol = FT(1e-5)
+                # Lognormal: S = log(q_tot / q_sat)
+                @test out_ln.mu_S ≈ log(q_tot_mean / q_sat_mean) rtol = FT(1e-5)
+
+                # M_l and M_i should be non-negative
+                @test out_g.M_l ≥ 0
+                @test out_g.M_i ≥ 0
+                @test out_ln.M_l ≥ 0
+                @test out_ln.M_i ≥ 0
+
+                # When the max(0, ·) clamp does not bind, the equilibrium
+                # partition is mass-conserving against the saturation excess:
+                # M_l + q_rai = λ · excess.  Here λ = 1 (pure liquid), so the
+                # liquid relation holds.  M_i is clamped to zero in this
+                # pure-liquid case (since (1−λ)·excess = 0 but q_sno > 0).
+                @test out_g.M_l + q_rai ≈ λ * excess rtol = FT(1e-5)
+                @test out_g.M_i == FT(0)
+            end
+        end
+    end
+
+    @testset "compute_sgs_moments high-resolution limit (σ → 0)" begin
+        # At zero variance, the quadrature collapses to a single point at the
+        # grid mean, and moments reduce to: μ_S = S(T_mean, q_tot_mean),
+        # σ_S² = 0, M_l = q_lcl_eq_at_mean, M_i = q_icl_eq_at_mean.
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                ρ = FT(1.2)
+                T_mean = FT(280.0)
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                q_tot_mean = q_sat_mean + FT(2e-3)
+                q_lcl = FT(1.5e-3)
+                q_icl = FT(0)
+                q_rai = FT(1e-4)
+                q_sno = FT(0)
+                q_min = FT(1e-10)
+                T′T′ = FT(0)
+                q′q′ = FT(0)
+                corr_Tq = FT(0)
+
+                quad_g = CA.SGSQuadrature(
+                    FT; distribution = CA.GaussianSGS(), quadrature_order = 3,
+                )
+                quad_ln = CA.SGSQuadrature(
+                    FT; distribution = CA.LogNormalSGS(), quadrature_order = 3,
+                )
+
+                # Gaussian
+                m_g = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_tot_mean,
+                    q_lcl, q_icl, q_rai, q_sno,
+                    quad_g, T′T′, q′q′, corr_Tq, q_min,
+                )
+                @test m_g.mu_S ≈ q_tot_mean - q_sat_mean rtol = FT(1e-5)
+                @test m_g.sigma_S_sq ≥ 0
+                @test m_g.sigma_S_sq < FT(1e-10)  # essentially zero at σ → 0
+                # M_l at grid mean: max(0, λ × excess − q_rai)
+                λ_mean = TD.liquid_fraction(thp, T_mean, q_lcl, q_icl)
+                excess = q_tot_mean - q_sat_mean
+                M_l_expected = max(FT(0), λ_mean * excess - q_rai)
+                @test m_g.M_l ≈ M_l_expected rtol = FT(1e-5)
+
+                # Lognormal: same structure but μ_S is log-ratio
+                m_ln = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_tot_mean,
+                    q_lcl, q_icl, q_rai, q_sno,
+                    quad_ln, T′T′, q′q′, corr_Tq, q_min,
+                )
+                @test m_ln.mu_S ≈ log(q_tot_mean / q_sat_mean) rtol = FT(1e-5)
+                @test m_ln.sigma_S_sq ≥ 0
+                @test m_ln.sigma_S_sq < FT(1e-10)
+                # M_l does not depend on the SGS distribution choice in the
+                # σ → 0 limit (single-point evaluation): linear excess used.
+                @test m_ln.M_l ≈ M_l_expected rtol = FT(1e-5)
+            end
+        end
+    end
+
+    @testset "compute_sgs_moments low-resolution behavior (σ > 0)" begin
+        # At nonzero variance, σ_S² should be positive; M_l should generally
+        # increase with σ because more of the PDF tail extends into the
+        # saturated regime.
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                ρ = FT(1.2)
+                T_mean = FT(280.0)
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                q_tot_mean = q_sat_mean - FT(1e-4)  # slightly subsaturated
+                q_lcl = FT(0)
+                q_icl = FT(0)
+                q_rai = FT(0)
+                q_sno = FT(0)
+                q_min = FT(1e-10)
+                corr_Tq = FT(0)
+
+                quad = CA.SGSQuadrature(
+                    FT; distribution = CA.GaussianSGS(), quadrature_order = 3,
+                )
+
+                # Sweep over σ_q
+                σ_q_vals = FT[1e-4, 5e-4, 1e-3, 2e-3]
+                M_l_vals = FT[]
+                for σ_q in σ_q_vals
+                    q′q′ = σ_q * σ_q
+                    m = CA.compute_sgs_moments(
+                        thp, ρ, T_mean, q_tot_mean,
+                        q_lcl, q_icl, q_rai, q_sno,
+                        quad, FT(0), q′q′, corr_Tq, q_min,
+                    )
+                    @test m.sigma_S_sq ≥ 0
+                    @test m.M_l ≥ 0
+                    @test m.M_i ≥ 0
+                    @test isfinite(m.mu_S)
+                    @test isfinite(m.sigma_S_sq)
+                    push!(M_l_vals, m.M_l)
+                end
+                # Monotonically nondecreasing as σ grows (more of PDF crosses
+                # saturation)
+                for i in 2:length(M_l_vals)
+                    @test M_l_vals[i] >= M_l_vals[i - 1] - FT(1e-12)
+                end
+            end
+        end
+    end
+
+    @testset "compute_sgs_moments handles nothing / GridMean SGS" begin
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                ρ = FT(1.0)
+                T_mean = FT(285.0)
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                q_tot_mean = q_sat_mean + FT(1e-3)
+                q_lcl = FT(1e-3)
+                q_icl = FT(0)
+                q_rai = FT(0)
+                q_sno = FT(0)
+                q_min = FT(1e-10)
+
+                # Should not error with nothing
+                m1 = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_tot_mean,
+                    q_lcl, q_icl, q_rai, q_sno,
+                    nothing, FT(1), FT(1e-6), FT(0), q_min,
+                )
+                @test isfinite(m1.mu_S)
+                @test m1.sigma_S_sq ≥ 0
+                @test m1.M_l ≥ 0
+
+                # GridMeanSGS — should give the same as nothing (single-point
+                # evaluation at the mean)
+                m2 = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_tot_mean,
+                    q_lcl, q_icl, q_rai, q_sno,
+                    CA.GridMeanSGS(), FT(1), FT(1e-6), FT(0), q_min,
+                )
+                @test m2.mu_S ≈ m1.mu_S rtol = FT(1e-6)
+                @test m2.M_l ≈ m1.M_l rtol = FT(1e-6)
+            end
+        end
+    end
+
+    @testset "compute_sgs_moments fully-clear / fully-cloudy limits" begin
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                ρ = FT(1.2)
+                T_mean = FT(280.0)
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                q_lcl = FT(0)
+                q_icl = FT(0)
+                q_rai = FT(0)
+                q_sno = FT(0)
+                q_min = FT(1e-10)
+
+                quad = CA.SGSQuadrature(
+                    FT; distribution = CA.GaussianSGS(), quadrature_order = 3,
+                )
+
+                # Deep subsaturation, small σ: M_l should be ≈ 0
+                m_dry = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_sat_mean - FT(5e-3),
+                    q_lcl, q_icl, q_rai, q_sno,
+                    quad, FT(0), FT(1e-8), FT(0), q_min,
+                )
+                @test m_dry.M_l < FT(1e-6)
+                @test m_dry.mu_S < 0
+
+                # Deeply saturated, small σ: M_l should be ≈ excess
+                excess = FT(5e-3)
+                m_wet = CA.compute_sgs_moments(
+                    thp, ρ, T_mean, q_sat_mean + excess,
+                    q_lcl, q_icl, q_rai, q_sno,
+                    quad, FT(0), FT(1e-8), FT(0), q_min,
+                )
+                # λ_at_grid_mean uses (0, 0) condensate → T-ramp fallback
+                λ_mean = TD.liquid_fraction(thp, T_mean, q_lcl, q_icl)
+                @test m_wet.M_l ≈ λ_mean * excess rtol = FT(1e-3)
+                @test m_wet.mu_S > 0
+            end
+        end
+    end
+end

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -219,28 +219,26 @@ using ClimaAtmos
                 q_max = FT(1.0)
 
                 # GaussianSGS at χ = 0 should return means
-                T_hat, q_hat = ClimaAtmos.get_physical_point(
-                    ClimaAtmos.GaussianSGS(), FT(0), FT(0), μ_q, μ_T, σ_q, σ_T, corr,
-                    T_min, q_max,
+                gauss_t = ClimaAtmos.create_physical_transform(
+                    ClimaAtmos.GaussianSGS(), μ_q, μ_T, σ_q, σ_T, corr, T_min, q_max,
                 )
+                T_hat, q_hat = gauss_t(FT(0), FT(0))
                 @test T_hat ≈ μ_T atol = FT(0.1)
                 @test q_hat ≈ μ_q atol = FT(0.001)
 
                 # LogNormalSGS
-                T_hat_ln, q_hat_ln = ClimaAtmos.get_physical_point(
-                    ClimaAtmos.LogNormalSGS(), FT(0), FT(0), μ_q, μ_T, σ_q, σ_T, corr,
-                    T_min, q_max,
+                ln_t = ClimaAtmos.create_physical_transform(
+                    ClimaAtmos.LogNormalSGS(), μ_q, μ_T, σ_q, σ_T, corr, T_min, q_max,
                 )
+                T_hat_ln, q_hat_ln = ln_t(FT(0), FT(0))
                 @test T_hat_ln ≈ μ_T atol = FT(0.1)
                 @test q_hat_ln > 0  # log-normal is always positive
 
-
-
                 # GridMeanSGS always returns grid mean regardless of χ values
-                T_hat_gm, q_hat_gm = ClimaAtmos.get_physical_point(
-                    ClimaAtmos.GridMeanSGS(), FT(999), FT(999), μ_q, μ_T, σ_q, σ_T,
-                    corr, T_min, q_max,
+                gm_t = ClimaAtmos.create_physical_transform(
+                    ClimaAtmos.GridMeanSGS(), μ_q, μ_T, σ_q, σ_T, corr, T_min, q_max,
                 )
+                T_hat_gm, q_hat_gm = gm_t(FT(999), FT(999))
                 @test T_hat_gm == μ_T  # Exact equality, not approximate
                 @test q_hat_gm == μ_q  # Exact equality, not approximate
             end
@@ -318,14 +316,32 @@ using ClimaAtmos
                 tps = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 mp = CMP.Microphysics1MParams(toml_dict)
 
-                # Grid-mean state
+                # Grid-mean state at saturation equilibrium. With Stage C the
+                # shape-function partition recovers the grid-mean state exactly
+                # at a single quadrature point provided the cached moments
+                # `(M_l, M_i)` equal the local equilibrium condensate at the
+                # mean — which we compute below to keep the tests self-contained.
                 ρ = FT(1.2)
                 T_mean = FT(280.0)
-                q_tot_mean = FT(0.01)
                 q_lcl_mean = FT(0.0001)
                 q_icl_mean = FT(0.00005)
                 q_rai = FT(0.0001)
                 q_sno = FT(0.00001)
+                q_sat_mean = TD.q_vap_saturation(tps, T_mean, ρ)
+                q_tot_mean = q_sat_mean + q_lcl_mean + q_icl_mean + q_rai + q_sno
+
+                # Cached SGS moments consistent with a 1-point quadrature: at
+                # the grid mean `(T_mean, q_tot_mean)`, the equilibrium
+                # partition matches the prognostic condensate exactly, so
+                # M_l = q_lcl_mean, M_i = q_icl_mean.
+                λ = TD.liquid_fraction(tps, T_mean, q_lcl_mean, q_icl_mean)
+                excess_mean = q_tot_mean - q_sat_mean
+                M_l_eq = max(FT(0), λ * excess_mean - q_rai)
+                M_i_eq = max(FT(0), (FT(1) - λ) * excess_mean - q_sno)
+                moments_eq = (
+                    mu_S = excess_mean, sigma_S_sq = FT(0),
+                    M_l = M_l_eq, M_i = M_i_eq,
+                )
 
                 # Variances and correlation
                 T′T′ = FT(1.0)
@@ -339,29 +355,25 @@ using ClimaAtmos
 
                 # Test 1: Single quadrature point should match grid-mean evaluation
                 @testset "Single Point = Grid Mean" begin
-                    # Use GaussianSGS: only Gaussian has χ=0 → (μ_T, μ_q)
                     quad_1pt = ClimaAtmos.SGSQuadrature(
                         FT;
                         quadrature_order = 1,
                         distribution = ClimaAtmos.GaussianSGS(),
                     )
 
-                    # Quadrature result (no limiting)
                     result_quad = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad_1pt, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, moments_eq, dt, nsubs_quad,
                     )
 
-                    # Direct evaluation at grid mean
                     result_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(),
                         mp, tps, ρ, T_mean,
                         q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno, dt, nsubs_quad,
                     )
 
-                    # Compare all fields
                     @test result_quad.dq_lcl_dt ≈ result_direct.dq_lcl_dt rtol = FT(1e-5)
                     @test result_quad.dq_icl_dt ≈ result_direct.dq_icl_dt rtol = FT(1e-5)
                     @test result_quad.dq_rai_dt ≈ result_direct.dq_rai_dt rtol = FT(1e-5)
@@ -372,15 +384,13 @@ using ClimaAtmos
                 @testset "Zero Variance = Grid Mean" begin
                     quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
 
-                    # Zero variances
                     result_quad = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), moments_eq, dt, nsubs_quad,
                     )
 
-                    # Direct evaluation
                     result_direct = BMT.average_bulk_microphysics_tendencies(
                         BMT.Microphysics1Moment(),
                         mp, tps, ρ, T_mean,
@@ -399,7 +409,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, moments_eq, dt, nsubs_quad,
                     )
 
                     @test haskey(result, :dq_lcl_dt)
@@ -409,28 +419,24 @@ using ClimaAtmos
                     @test result.dq_lcl_dt isa FT
                 end
 
-                # Test 4: Non-zero variance produces different result
+                # Test 4: Non-zero variance produces a finite result
                 @testset "Variance Effect" begin
                     quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
 
-                    # With variance
                     result_var = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.8), dt, nsubs_quad,
+                        FT(4.0), FT(1e-5), FT(0.8), moments_eq, dt, nsubs_quad,
                     )
 
-                    # Without variance
                     result_no_var = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), moments_eq, dt, nsubs_quad,
                     )
 
-                    # Results should differ (unless microphysics is perfectly linear)
-                    # At minimum, they should both be finite
                     @test isfinite(result_var.dq_lcl_dt)
                     @test isfinite(result_no_var.dq_lcl_dt)
                 end
@@ -493,10 +499,20 @@ using ClimaAtmos
                 dt = FT(1.0)
                 nsubs_quad = 1
 
+                # Cached SGS moments consistent with the grid-mean equilibrium.
+                q_sat = TD.q_vap_saturation(thp, T, ρ)
+                λ = TD.liquid_fraction(thp, T, q_liq, q_ice)
+                excess = max(FT(0), q_tot - q_sat)
+                M_l = max(FT(0), λ * excess - q_rai)
+                M_i = max(FT(0), (FT(1) - λ) * excess - q_sno)
+                moments = (
+                    mu_S = excess, sigma_S_sq = FT(0), M_l = M_l, M_i = M_i,
+                )
+
                 result = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, moments, dt, nsubs_quad,
                 )
 
                 # Total condensed water tendency
@@ -555,11 +571,21 @@ using ClimaAtmos
                 dt = FT(1.0)
                 nsubs_quad = 1
 
+                # Cached SGS moments (any consistent value works for type test).
+                q_sat = TD.q_vap_saturation(thp, T, ρ)
+                λ = TD.liquid_fraction(thp, T, q_liq, q_ice)
+                excess = max(FT(0), q_tot - q_sat)
+                moments = (
+                    mu_S = excess, sigma_S_sq = FT(0),
+                    M_l = max(FT(0), λ * excess - q_rai),
+                    M_i = max(FT(0), (FT(1) - λ) * excess - q_sno),
+                )
+
                 # Test type stability
                 result = @inferred microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, moments, dt, nsubs_quad,
                 )
 
                 # Verify return type
@@ -596,12 +622,31 @@ using ClimaAtmos
                 dt = FT(60)
                 nsubs_quad = 1
 
-                # Create evaluator
+                # Cached SGS moments consistent with grid mean.
+                q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
+                λ = TD.liquid_fraction(thp, T_mean, q_lcl_mean, q_icl_mean)
+                # Use a generic excess for this functor-pattern smoke test.
+                excess = FT(1e-3)
+                M_l = max(FT(0), λ * excess - q_rai)
+                M_i = max(FT(0), (FT(1) - λ) * excess - q_sno)
+                M_scale = FT(1e-10)
+
+                # Precompute shape-function coefficients, matching
+                # microphysics_tendencies_1m production code.
+                M_sq = M_scale * M_scale
+                denom_l = M_sq + M_l * M_l
+                denom_i = M_sq + M_i * M_i
+                γ_l = M_l / denom_l
+                γ_i = M_i / denom_i
+
+                # Create evaluator with precomputed shape-function coefficients
                 evaluator = Microphysics1MEvaluator(
                     BMT.Microphysics1Moment(),
-                    mp, thp, ρ, T_mean,
-                    q_lcl_mean, q_icl_mean, q_rai, q_sno, dt, nsubs_quad,
-                    (),  # Empty args tuple for 1-moment
+                    mp, thp, ρ,
+                    q_lcl_mean, q_icl_mean, q_rai, q_sno,
+                    λ, γ_l, M_l, γ_i, M_i,
+                    dt, nsubs_quad,
+                    (),
                 )
 
                 # Verify it's a proper functor (not a closure)
@@ -640,14 +685,16 @@ using ClimaAtmos
                 tps = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 mp = CMP.Microphysics1MParams(toml_dict)
 
-                # Grid-mean state
+                # Grid-mean state at saturation equilibrium so the in-cloud
+                # branch (which forces q_v = q_sat) reproduces direct BMT.
                 ρ = FT(1.2)
                 T_mean = FT(280.0)
-                q_tot = FT(0.01)
                 q_liq = FT(0.001)
                 q_ice = FT(0.0005)
                 q_rai = FT(0.0002)
                 q_sno = FT(0.0001)
+                q_sat_mean = TD.q_vap_saturation(tps, T_mean, ρ)
+                q_tot = q_sat_mean + q_liq + q_ice + q_rai + q_sno
 
                 # GridMeanSGS inside SGSQuadrature
                 quad_gm = ClimaAtmos.SGSQuadrature(
@@ -662,12 +709,21 @@ using ClimaAtmos
                 dt = FT(1.0)
                 nsubs_quad = 1
 
+                # Cached SGS moments consistent with the grid-mean equilibrium.
+                λ_gm = TD.liquid_fraction(tps, T_mean, q_liq, q_ice)
+                excess_gm = max(FT(0), q_tot - q_sat_mean)
+                moments_gm = (
+                    mu_S = excess_gm, sigma_S_sq = FT(0),
+                    M_l = max(FT(0), λ_gm * excess_gm - q_rai),
+                    M_i = max(FT(0), (FT(1) - λ_gm) * excess_gm - q_sno),
+                )
+
                 # Quadrature path
                 result_quad = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad_gm, mp, tps, ρ,
                     T_mean, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, moments_gm, dt, nsubs_quad,
                 )
 
                 # Direct BMT call
@@ -747,21 +803,33 @@ using ClimaAtmos
 
                     ρ = FT(1.0)
                     T = FT(280.0)
-                    q_tot = FT(0.015)
                     q_liq = FT(0.001)
                     q_ice = FT(0.0005)
                     q_rai = FT(0.0001)
                     q_sno = FT(0.00005)
+                    # Grid mean at saturation equilibrium so the cloudy branch
+                    # (which forces q_v = q_sat) matches direct BMT.
+                    q_sat_eq = TD.q_vap_saturation(thp, T, ρ)
+                    q_tot = q_sat_eq + q_liq + q_ice + q_rai + q_sno
                     dt = FT(1.0)
                     nsubs = 1
                     nsubs_quad = 1
+
+                    # Cached SGS moments consistent with the grid-mean equilibrium.
+                    λ_gm = TD.liquid_fraction(thp, T, q_liq, q_ice)
+                    excess_gm = max(FT(0), q_tot - q_sat_eq)
+                    moments_gm = (
+                        mu_S = excess_gm, sigma_S_sq = FT(0),
+                        M_l = max(FT(0), λ_gm * excess_gm - q_rai),
+                        M_i = max(FT(0), (FT(1) - λ_gm) * excess_gm - q_sno),
+                    )
 
                     # With zero variances, quadrature should match direct BMT
                     result_quad = ClimaAtmos.microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), moments_gm, dt, nsubs_quad,
                     )
 
                     result_direct = BMT.average_bulk_microphysics_tendencies(
@@ -784,7 +852,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.6), dt, nsubs_quad,
+                        FT(4.0), FT(1e-5), FT(0.6), moments_gm, dt, nsubs_quad,
                     )
                     for field in (:dq_lcl_dt, :dq_icl_dt, :dq_rai_dt, :dq_sno_dt)
                         @test isfinite(getfield(result_var, field))
@@ -836,6 +904,16 @@ using ClimaAtmos
         dt = FT(1.0)
         nsubs = 1
         nsubs_quad = 1
+
+        # Cached SGS moments for the perf test (any consistent value works).
+        q_sat_perf = TD.q_vap_saturation(thp, T, ρ)
+        λ_perf = TD.liquid_fraction(thp, T, q_lcl, q_icl)
+        excess_perf = max(FT(0), q_tot - q_sat_perf)
+        moments_perf = (
+            mu_S = excess_perf, sigma_S_sq = FT(0),
+            M_l = max(FT(0), λ_perf * excess_perf - q_rai),
+            M_i = max(FT(0), (FT(1) - λ_perf) * excess_perf - q_sno),
+        )
 
         N_warmup = 100
         N_bench = 10_000
@@ -937,14 +1015,14 @@ using ClimaAtmos
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, moments_perf, dt, nsubs_quad,
                     )
                 end
                 t = @elapsed for _ in 1:N_bench
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, moments_perf, dt, nsubs_quad,
                     )
                 end
                 timings_1m[order] = t

--- a/test/parameterized_tendencies/microphysics/sgs_saturation.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_saturation.jl
@@ -16,7 +16,9 @@ import ClimaParams as CP
                 thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
                 ρ = FT(1.0)
 
-                evaluator = ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ)
+                # The evaluator now carries a fixed grid-mean λ. Each subtest
+                # below constructs an evaluator with λ_mean = ramp(T_hat) so the
+                # test semantics still target the partitioning at T_hat.
 
                 @testset "Unsaturated conditions" begin
                     # T and q where q < q_sat (unsaturated)
@@ -24,6 +26,9 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(0.5) * q_sat  # Half saturation
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     @test haskey(result, :T)
@@ -42,6 +47,9 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(1.5) * q_sat  # 50% supersaturated
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     # Should have condensate
@@ -49,8 +57,7 @@ import ClimaParams as CP
                     @test result.q_liq + result.q_ice ≈ q_cond_expected rtol = FT(1e-5)
 
                     # At warm temperatures, should be mostly liquid
-                    λ = TD.liquid_fraction_ramp(thp, T_hat)
-                    @test result.q_liq ≈ λ * q_cond_expected rtol = FT(1e-5)
+                    @test result.q_liq ≈ λ_mean * q_cond_expected rtol = FT(1e-5)
                 end
 
                 @testset "Saturated conditions (cold)" begin
@@ -59,18 +66,23 @@ import ClimaParams as CP
                     q_sat = TD.q_vap_saturation(thp, T_hat, ρ)
                     q_hat = FT(1.5) * q_sat  # 50% supersaturated
 
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     # At cold temperatures, should be mostly ice
-                    λ = TD.liquid_fraction_ramp(thp, T_hat)
-                    @test λ < FT(0.5)  # Verify it's actually cold enough
+                    @test λ_mean < FT(0.5)  # Verify it's actually cold enough
                     q_cond_expected = q_hat - q_sat
-                    @test result.q_ice ≈ (1 - λ) * q_cond_expected rtol = FT(1e-5)
+                    @test result.q_ice ≈ (1 - λ_mean) * q_cond_expected rtol = FT(1e-5)
                 end
 
                 @testset "Type stability" begin
                     T_hat = FT(280.0)
                     q_hat = FT(0.01)
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_hat)
+                    evaluator =
+                        ClimaAtmos.SaturationAdjustmentEvaluator(thp, ρ, λ_mean)
                     result = evaluator(T_hat, q_hat)
 
                     @test eltype(result.T) == FT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,7 @@ if TEST_GROUP in ("parameterizations", "all")
     @safetestset "Microphysics tendency tests" begin @time include("parameterized_tendencies/microphysics/tendency.jl") end
     @safetestset "Microphysics wrappers tests" begin @time include("parameterized_tendencies/microphysics/microphysics_wrappers.jl") end
     @safetestset "SGS quadrature tests" begin @time include("parameterized_tendencies/microphysics/sgs_quadrature.jl") end
+    @safetestset "SGS moments tests" begin @time include("parameterized_tendencies/microphysics/sgs_moments.jl") end
     @safetestset "Tendency limiters tests" begin @time include("parameterized_tendencies/microphysics/tendency_limiters.jl") end
     @safetestset "Moisture fixers tests" begin @time include("parameterized_tendencies/microphysics/moisture_fixers.jl") end
     @safetestset "Cloud fraction tests" begin @time include("parameterized_tendencies/microphysics/cloud_fraction.jl") end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Unifies the cloud fraction and microphysics quadrature pipelines so they share the same SGS moments, eliminating physical inconsistencies between the two.

## Changes

* New `sgs_moments pre-pass` (`compute_sgs_moments` / `set_sgs_moments!`): A Gauss–Hermite quadrature pass to compute (`μ_S`, `σ_S²`, `M_l`, `M_i`): the mean and variance of the saturation variable (saturation excess in Gaussian case) plus the SGS-mean equilibrium condensates. Both cloud fraction and microphysics consume these cached moments, guaranteeing they operate on identical physics.

* Hybrid cloud fraction (`compute_cloud_fraction_hybrid`): Replaces the former Sommeria–Deardorff approximation with a smooth logistic-CDF formula evaluated on the quadrature-derived (`μ_S`, `σ_S²`). An activation factor `α` gates the cloud fraction to zero in clear states. Dispatches on `GaussianSGS`, `LogNormalSGS`, and `GridMeanSGS`.
* Shape-function partition in `Microphysics1MEvaluator` (similar to @sajjadazimi's approach): Distributes prognostic grid-mean condensate across quadrature points via `q_lcl_hat = q_lcl_mean · (γ_l · q_lcl_eq_hat + β_l)` where `γ_l · M_l + β_l = 1`, giving exact mass conservation by construction. The β-factor provides a smooth fallback when equilibrium moments vanish. The shape-function coefficients (`γ`, `β`) are precomputed once per grid cell.

## To-do (later)

* Symmetric subdomain treatment: give each EDMF subdomain its own cloud fraction and SGS quadrature, using environment-only covariances for the environment. Currently, grid-mean covariances and state are used for all subdomains, which can double-count updraft variance.
* Calibrate cf_steepness_scale and (and check sensitibity to `q_min`) on cloud fraction and precipitation in DYCOMS/TRMM.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
