### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -19,12 +19,12 @@ jobs:
     - uses: julia-actions/setup-julia@v3
       with:
         version: '1.10'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.repository.default_branch }}
     - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       TEST_GROUP: ${{ matrix.test_group }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -56,7 +56,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           file: lcov.info
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1.11'

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         version: ['1.10', '1.11']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -26,14 +26,14 @@ jobs:
           - '1.10'
           - '1.11'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
 
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'CliMA/ClimaCoupler.jl'
           path: ClimaCoupler.jl


### PR DESCRIPTION
This bump actions/checkout from 4 to 6 and bump codecov/codecov-action from 5 to 6. This PR doesn't update the downgrade tests to v2 as that requires a little bit more effort.