### PR TITLE
Standardize YAML config parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+- [#4486](https://github.com/CliMA/ClimaAtmos.jl/pull/4486) [badge-💥breaking]
+  Updated YAML config schema:
+  - `vert_diff: true` → `"VerticalDiffusion"`; `false` → `~`.
+  - `hyperdiff: false` → `~`.
+  - `prognostic_surface: true` → `"SlabOceanSST"`; `false` → `"PrescribedSST"`.
+  - Removed keys: `subsidence`, `ls_adv`, `scm_coriolis`.
+  - `rad`: dropped `"nothing"` string alias; use `~`.
 
 v0.38.4
 -------

--- a/config/common_configs/numerics_column_ze63.yml
+++ b/config/common_configs/numerics_column_ze63.yml
@@ -4,4 +4,4 @@ z_max: 60000.0
 dz_bottom: 30.0
 dt: 120secs
 ode_algo: ARS343
-hyperdiff: "false"
+hyperdiff: ~

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -97,7 +97,7 @@ debug_jacobian:
   value: false
 # Radiation
 rad:
-  help: "Radiation model [`nothing` (default), `gray`, `clearsky`, `allsky`, `allskywithclear`]"
+  help: "Radiation model [`nothing` (default), `gray`, `clearsky`, `allsky`, `allskywithclear`, `held_suarez`, `DYCOMS`, `TRMM_LBA`, `ISDAC`]"
   value: ~
 idealized_h2o:
   help: "Use idealized H2O in radiation model [`false` (default), `true`]"
@@ -149,8 +149,8 @@ reference_job_id:
     Identifier of job to use as the "reference" solution in the quicklook plot; the current job's results get compared to the results of the quicklook job on the main branch
   value: ~
 vert_diff:
-  help: "Vertical diffusion [`false` (default), `VerticalDiffusion`, `true` (defaults to `VerticalDiffusion`), `DecayWithHeightDiffusion`]"
-  value: "false"
+  help: "Vertical diffusion [`~` (no diffusion, default), `VerticalDiffusion`, `DecayWithHeightDiffusion`]"
+  value: ~
 hyperdiff:
   help: |
     Fourth-order hyperdiffusion. Options:
@@ -158,7 +158,7 @@ hyperdiff:
       set these with the `vorticity_hyperdiffusion_coefficient`, `hyperdiffusion_prandtl_number`,
       `divergence_damping_factor` config options.
     - `CAM_SE` (Lauritzen et al. 2018): Use CAM_SE coefficients for hyperdiffusion
-    - `false`: Disable hyperdiffusion
+    - `~`: Disable hyperdiffusion
   value: "Hyperdiffusion"
 amd_les:
   help: "AMD LES closure [`true`, `false` (default)]"
@@ -287,9 +287,6 @@ check_conservation:
 check_steady_state:
   help: "Compare steady-state velocity to analytic solution; only available for certain choices of `topography` [`false` (default), `true`]"
   value: false
-ls_adv:
-  help: "Large-scale advection [`nothing` (default), `Bomex`, `Rico`]"
-  value: ~
 external_forcing:
   help: "External forcing for single column experiments [`nothing` (default), `GCM`, `Reanalysis`, `ReanalysisTimeVarying`, `ReanalysisMonthlyAveragedDiurnal`]"
   value: ~
@@ -308,9 +305,6 @@ site_longitude:
 era5_diurnal_warming:
   help: Applies a warming scenario by adding a constant temperature offset (in Kelvin). Supported only by the `ReanalysisMonthlyAveragedDiurnal` forcing model. This affects the target surface temperature for the entire simulation, the initial atmospheric temperature profile, and the relaxation temperature profile above `gcmdriven_relaxation_minimum_height`. Specific humidity is increased to hold relative humidity constant in the initial and relaxation profiles.
   value: ~
-subsidence:
-  help: "Subsidence [`nothing` (default), `Bomex`, `Rico`, `DYCOMS`, `ISDAC`]"
-  value: ~
 toml:
   help: "TOML file(s) used to override model parameters"
   value: []
@@ -321,8 +315,8 @@ prognostic_tke:
   help: "A flag for prognostic TKE [`false` (default), `true`]"
   value: false
 prognostic_surface:
-  help: "Determines if surface temperature is prognostic [`false` (default), , `true`, `SlabOceanSST`, `PrescribedSST`]"
-  value: "false"
+  help: "Surface temperature model [`PrescribedSST` (default), `SlabOceanSST`]"
+  value: "PrescribedSST"
 albedo_model:
   help: "Variable surface albedo [`ConstantAlbedo` (default), `RegressionFunctionAlbedo`, `CouplerAlbedo`]"
   value: "ConstantAlbedo"
@@ -338,6 +332,9 @@ output_default_diagnostics:
 enable_diagnostics:
   help: "Set to false to fully disable the diagnostics"
   value: true
+diagnostics:
+  help: "User-specified diagnostics, as a list of dicts each containing at least `short_name` and `period`. See https://clima.github.io/ClimaAtmos.jl/dev/diagnostics/ for the full schema."
+  value: []
 netcdf_output_at_levels:
   help: "Do not perform any vertical interpolation in the output NetCDF files. Instead, interpolate horizontally and output the level. "
   value: true
@@ -396,9 +393,6 @@ implicit_sgs_vertdiff:
 implicit_sgs_mass_flux:
   help: "Whether to treat the subgrid-scale mass flux tendency implicitly or explicitly in grid-mean equations. Currently updraft only with Jacobian terms 0. [`false` (default), `true`]. Setting it to true only works if both implicit_sgs_advection and implicit_diffusion are set to true."
   value: false
-scm_coriolis:
-  help: "SCM Coriolis [`nothing` (default), `Bomex`, `Rico`,`DYCOMS_RF01`,`DYCOMS_RF02`,`GABLS`]"
-  value: ~
 edmfx_filter:
   help: "If set to true, it switches on the relaxation of negative velocity in EDMFX.  [`true`, `false` (default)]"
   value: false

--- a/config/longrun_configs/longrun_moist_held_suarez.yml
+++ b/config/longrun_configs/longrun_moist_held_suarez.yml
@@ -2,7 +2,7 @@ implicit_diffusion: false
 approximate_linear_solve_iters: 1
 t_end: "360days"
 microphysics_model: "0M"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 forcing: "held_suarez"
 dt_save_state_to_disk: "10days"
 toml: [toml/longrun_held_suarez.toml]

--- a/config/model_configs/aquaplanet_equil_allsky_gw_raw.yml
+++ b/config/model_configs/aquaplanet_equil_allsky_gw_raw.yml
@@ -9,7 +9,7 @@ dt: "400secs"
 surface_setup: "DefaultMoninObukhov"
 t_end: "15hours"
 non_orographic_gravity_wave: true
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 insolation: "timevarying"
 microphysics_model: "0M"
 cloud_model: "grid_scale"

--- a/config/model_configs/baroclinic_wave_equil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_equil_conservation_source.yml
@@ -4,7 +4,7 @@ surface_setup: DefaultMoninObukhov
 prognostic_surface: "SlabOceanSST"
 rad: "clearsky"
 microphysics_model: "0M"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 dt_save_state_to_disk: "5days"
 check_conservation: true
 # Implicit 0M + SGS quadrature produces nonlinear precipitation

--- a/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_nonequil_conservation_source.yml
@@ -6,7 +6,7 @@ surface_setup: DefaultMoninObukhov
 prognostic_surface: "SlabOceanSST"
 rad: "clearsky"
 microphysics_model: "1M"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 dt_save_state_to_disk: "5days"
 check_conservation: true
 diagnostics:

--- a/config/model_configs/box_density_current_test.yml
+++ b/config/model_configs/box_density_current_test.yml
@@ -2,7 +2,7 @@ reference_job_id: "les_box"
 initial_condition: "DryDensityCurrentProfile"
 config: "box"
 smagorinsky_lilly: "UVW"
-hyperdiff: "false"
+hyperdiff: ~
 x_max: 51200.0
 y_max: 51200.0
 z_max: 6400.0

--- a/config/model_configs/column_nogw_3d_test.yml
+++ b/config/model_configs/column_nogw_3d_test.yml
@@ -2,7 +2,7 @@ dt_save_state_to_disk: "400secs"
 initial_condition: "IsothermalProfile"
 t_end: "1secs"
 config: "column"
-hyperdiff: false
+hyperdiff: ~
 dt: "1secs"
 disable_surface_flux_tendency: true
 non_orographic_gravity_wave: true

--- a/config/model_configs/held_suarez_equil.yml
+++ b/config/model_configs/held_suarez_equil.yml
@@ -3,7 +3,7 @@ implicit_diffusion: false
 approximate_linear_solve_iters: 1
 dt_save_state_to_disk: "1days"
 t_end: "1days"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 forcing: "held_suarez"
 microphysics_model: "0M"
 reproducibility_test: true

--- a/config/model_configs/hydrostatic_balance_ft64.yml
+++ b/config/model_configs/hydrostatic_balance_ft64.yml
@@ -1,7 +1,7 @@
 dt: "300secs"
 dt_save_state_to_disk: "8days"
 t_end: "8days"
-hyperdiff: "false"
+hyperdiff: ~
 perturb_initstate: false
 disable_surface_flux_tendency: true
 FLOAT_TYPE: "Float64"

--- a/config/model_configs/kinematic_driver.yml
+++ b/config/model_configs/kinematic_driver.yml
@@ -9,7 +9,7 @@ use_sgs_quadrature: false
 #sgs_distribution: "lognormal"
 #quadrature_order: 3
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 ## Simulation
 # z_max: 2e3  # TODO: Update top boundary condition for ρu₃qₜ to allow lower z_max
 # z_elem: 128

--- a/config/model_configs/les_isdac_box.yml
+++ b/config/model_configs/les_isdac_box.yml
@@ -7,7 +7,7 @@ microphysics_model: "1M"
 # diffusion
 implicit_diffusion: false
 approximate_linear_solve_iters: 2
-hyperdiff: "false"
+hyperdiff: ~
 smagorinsky_lilly: "UVW"
 # time- and spatial discretization
 x_elem: 10

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -17,7 +17,7 @@ edmfx_filter: true
 prognostic_tke: true
 microphysics_model: "0M"
 config: column
-hyperdiff: "false"
+hyperdiff: ~
 z_max: 1500
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -13,7 +13,7 @@ edmfx_filter: true
 prognostic_tke: true
 microphysics_model: "0M"
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 z_max: 400
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
@@ -21,7 +21,7 @@ edmfx_filter: true
 prognostic_tke: true
 microphysics_model: "0M"
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 z_max: 400
 x_elem: 2
 y_elem: 2

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -15,7 +15,7 @@ edmfx_filter: true
 prognostic_tke: true
 microphysics_model: "0M"
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 z_max: 3750
 z_elem: 75
 z_stretch: false

--- a/config/model_configs/rcemipii_box_CRM_1M.yml
+++ b/config/model_configs/rcemipii_box_CRM_1M.yml
@@ -9,7 +9,7 @@ approximate_linear_solve_iters: 2  # only valid when implicit_diffusion=true
 rayleigh_sponge: true  # set sponge level in toml file
 
 # Diffusion
-hyperdiff: "false"
+hyperdiff: ~
 implicit_diffusion: false
 smagorinsky_lilly: "UV_W"  # horizontal + vertical
 # smagorinsky_lilly: "UV"  # horizontal

--- a/config/model_configs/single_column_hydrostatic_balance_ft64.yml
+++ b/config/model_configs/single_column_hydrostatic_balance_ft64.yml
@@ -4,7 +4,7 @@ dz_bottom: 30.0
 dt_save_state_to_disk: "5days"
 initial_condition: "IsothermalProfile"
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 disable_surface_flux_tendency: true
 dt: "3hours"
 FLOAT_TYPE: "Float64"

--- a/config/model_configs/single_column_nonorographic_gravity_wave.yml
+++ b/config/model_configs/single_column_nonorographic_gravity_wave.yml
@@ -2,7 +2,7 @@ dt_save_state_to_disk: "400secs"
 initial_condition: "IsothermalProfile"
 t_end: "1500secs"
 config: "column"
-hyperdiff: "false"
+hyperdiff: ~
 dt: "400secs"
 disable_surface_flux_tendency: true
 non_orographic_gravity_wave: true

--- a/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
+++ b/config/model_configs/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.yml
@@ -6,5 +6,5 @@ dt: "3hours"
 dt_rad: "3hours"
 dt_save_state_to_disk: "100days"
 disable_surface_flux_tendency: true
-prognostic_surface: true
+prognostic_surface: "SlabOceanSST"
 toml: [toml/single_column_radiative_equilibrium_clearsky_prognostic_surface_temp.toml]

--- a/config/perf_configs/bm_callbacks.yml
+++ b/config/perf_configs/bm_callbacks.yml
@@ -10,5 +10,5 @@ dt_save_state_to_disk: "1secs"
 log_progress: false
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 microphysics_model: "0M"

--- a/config/perf_configs/bm_default.yml
+++ b/config/perf_configs/bm_default.yml
@@ -7,6 +7,6 @@ t_end: "10secs"
 log_progress: false
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 microphysics_model: "0M"
 perf_summary: true

--- a/config/perf_configs/bm_default_1m.yml
+++ b/config/perf_configs/bm_default_1m.yml
@@ -8,5 +8,5 @@ t_end: "10secs"
 log_progress: false
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 microphysics_model: "1M"

--- a/config/perf_configs/bm_diagnostics.yml
+++ b/config/perf_configs/bm_diagnostics.yml
@@ -8,7 +8,7 @@ t_end: "10secs"
 log_progress: false
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 microphysics_model: "0M"
 diagnostics:
   - reduction_time: "average"

--- a/config/perf_configs/bm_gravity_wave.yml
+++ b/config/perf_configs/bm_gravity_wave.yml
@@ -8,7 +8,7 @@ t_end: "10secs"
 log_progress: false
 surface_setup: "DefaultMoninObukhov"
 rad: "allskywithclear"
-vert_diff: true
+vert_diff: "VerticalDiffusion"
 microphysics_model: "0M"
 orographic_gravity_wave: "raw_topo"
 non_orographic_gravity_wave: true

--- a/reproducibility_tests/reproducibility_test_job_ids.jl
+++ b/reproducibility_tests/reproducibility_test_job_ids.jl
@@ -7,4 +7,7 @@ reproducibility_test_job_ids() = [
     "single_column_hydrostatic_balance_ft64",
     "prognostic_edmfx_aquaplanet",
     "rcemipii_box_CRM_1M",
+    "prognostic_edmfx_dycoms_rf02_column",
+    "prognostic_edmfx_rico_column",
+    "prognostic_edmfx_trmm_column",
 ]

--- a/src/solver/model_getters.jl
+++ b/src/solver/model_getters.jl
@@ -82,10 +82,12 @@ function get_hyperdiffusion_model(parsed_args, ::Type{FT}) where {FT}
             @assert isapprox(cam_coef, config_val, atol = 1e-8) "CAM_SE hyperdiffusion overwrites $config_coef, use `hyperdiff: Hyperdiffusion` to set this value manually in the config instead."
         end
         return cam_se_hyperdiff
-    elseif hyperdiff_name ∈ ("false", false, nothing)
+    elseif isnothing(hyperdiff_name)
         return nothing
     else
-        error("Uncaught hyperdiffusion model type.")
+        error(
+            "Uncaught hyperdiff `$hyperdiff_name`. Expected: ~ | \"Hyperdiffusion\" | \"CAM_SE\".",
+        )
     end
 end
 
@@ -97,19 +99,21 @@ function get_vertical_diffusion_model(
 ) where {FT}
     vert_diff_name = parsed_args["vert_diff"]
     vdp = CAP.vert_diff_params(params)
-    return if vert_diff_name in ("false", false, "none")
+    return if isnothing(vert_diff_name)
         nothing
-    elseif vert_diff_name in ("true", true, "VerticalDiffusion")
+    elseif vert_diff_name == "VerticalDiffusion"
         VerticalDiffusion{disable_momentum_vertical_diffusion, FT}(;
             C_E = vdp.C_E,
         )
-    elseif vert_diff_name in ("DecayWithHeightDiffusion",)
+    elseif vert_diff_name == "DecayWithHeightDiffusion"
         DecayWithHeightDiffusion{disable_momentum_vertical_diffusion, FT}(;
             H = vdp.H,
             D₀ = vdp.D₀,
         )
     else
-        error("Uncaught diffusion model `$vert_diff_name`.")
+        error(
+            "Uncaught vert_diff `$vert_diff_name`. Expected: ~ | \"VerticalDiffusion\" | \"DecayWithHeightDiffusion\".",
+        )
     end
 end
 
@@ -224,7 +228,6 @@ function get_radiation_mode(parsed_args, ::Type{FT}; setup_type = nothing) where
     deep_atmosphere = parsed_args["deep_atmosphere"]
     @assert radiation_name in (
         nothing,
-        "nothing",
         "clearsky",
         "gray",
         "allsky",
@@ -364,62 +367,22 @@ function get_cloud_in_radiation(parsed_args)
 end
 
 
-function get_subsidence_model(parsed_args, radiation_mode, FT; setup_type = nothing)
-    subsidence = parsed_args["subsidence"]
-    if isnothing(subsidence) && !isnothing(setup_type)
-        profile = Setups.subsidence_forcing(setup_type, FT)
-        !isnothing(profile) && return Subsidence(profile)
-    end
-    isnothing(subsidence) && return nothing
-
-    prof = if subsidence == "Bomex"
-        APL.Bomex_subsidence(FT)
-    elseif subsidence == "Rico"
-        APL.Rico_subsidence(FT)
-    elseif subsidence == "DYCOMS"
-        @assert radiation_mode isa RadiationDYCOMS
-        # For DYCOMS case, subsidence is linearly proportional to height
-        # with slope equal to the divergence rate specified in radiation mode
-        z -> -z * radiation_mode.divergence
-    elseif subsidence == "ISDAC"
-        APL.ISDAC_subsidence(FT)
-    else
-        error("Uncaught case")
-    end
-    return Subsidence(prof)
+function get_subsidence_model(::Type{FT}; setup_type = nothing) where {FT}
+    isnothing(setup_type) && return nothing
+    profile = Setups.subsidence_forcing(setup_type, FT)
+    return isnothing(profile) ? nothing : Subsidence(profile)
 end
 
 function get_large_scale_advection_model(
-    parsed_args, ::Type{FT}; setup_type = nothing,
+    ::Type{FT}; setup_type = nothing,
 ) where {FT}
-    ls_adv = parsed_args["ls_adv"]
-    if isnothing(ls_adv) && !isnothing(setup_type)
-        data = Setups.large_scale_advection_forcing(setup_type, FT)
-        if !isnothing(data)
-            prof_dqtdt = (thermo_params, p, t, z) -> data.prof_dqtdt(z)
-            prof_dTdt =
-                (thermo_params, p, t, z) ->
-                    data.prof_dTdt(TD.exner_given_pressure(thermo_params, p), z)
-            return LargeScaleAdvection(prof_dTdt, prof_dqtdt)
-        end
-    end
-    ls_adv == nothing && return nothing
-
-    (prof_dTdt₀, prof_dqtdt₀) = if ls_adv == "Bomex"
-        (APL.Bomex_dTdt(FT), APL.Bomex_dqtdt(FT))
-    elseif ls_adv == "Rico"
-        (APL.Rico_dTdt(FT), APL.Rico_dqtdt(FT))
-    else
-        error("Uncaught case")
-    end
-    # See https://clima.github.io/AtmosphericProfilesLibrary.jl/dev/
-    # for which functions accept which arguments.
-    # TODO: do not assume dry air?
-    prof_dqtdt = (thermo_params, ᶜp, t, z) -> prof_dqtdt₀(z)
+    isnothing(setup_type) && return nothing
+    data = Setups.large_scale_advection_forcing(setup_type, FT)
+    isnothing(data) && return nothing
+    prof_dqtdt = (_, _, _, z) -> data.prof_dqtdt(z)
     prof_dTdt =
-        (thermo_params, ᶜp, t, z) ->
-            prof_dTdt₀(TD.exner_given_pressure(thermo_params, ᶜp), z)
-
+        (thermo_params, p, _, z) ->
+            data.prof_dTdt(TD.exner_given_pressure(thermo_params, p), z)
     return LargeScaleAdvection(prof_dTdt, prof_dqtdt)
 end
 
@@ -488,35 +451,9 @@ function get_external_forcing_model(
     end
 end
 
-function get_scm_coriolis(parsed_args, ::Type{FT}; setup_type = nothing) where {FT}
-    scm_coriolis = parsed_args["scm_coriolis"]
-    if isnothing(scm_coriolis) && !isnothing(setup_type)
-        data = Setups.coriolis_forcing(setup_type, FT)
-        !isnothing(data) && return data
-    end
-    isnothing(scm_coriolis) && return nothing
-    (prof_u, prof_v) = if scm_coriolis == "Bomex"
-        (APL.Bomex_geostrophic_u(FT), z -> FT(0))
-    elseif scm_coriolis == "Rico"
-        (APL.Rico_geostrophic_ug(FT), APL.Rico_geostrophic_vg(FT))
-    elseif scm_coriolis == "DYCOMS_RF01"
-        (z -> FT(7), z -> FT(-5.5))
-    elseif scm_coriolis == "DYCOMS_RF02"
-        (z -> FT(5), z -> FT(-5.5))
-    elseif scm_coriolis == "GABLS"
-        (APL.GABLS_geostrophic_ug(FT), APL.GABLS_geostrophic_vg(FT))
-    else
-        error("Uncaught case")
-    end
-
-    coriolis_params = Dict()
-    coriolis_params["Bomex"] = FT(0.376e-4)
-    coriolis_params["Rico"] = FT(4.5e-5)
-    coriolis_params["DYCOMS_RF01"] = FT(0) # TODO: check this
-    coriolis_params["DYCOMS_RF02"] = FT(0) # TODO: check this
-    coriolis_params["GABLS"] = FT(1.39e-4)
-    coriolis_param = coriolis_params[scm_coriolis]
-    return (; prof_ug = prof_u, prof_vg = prof_v, coriolis_param)
+function get_scm_coriolis(::Type{FT}; setup_type = nothing) where {FT}
+    isnothing(setup_type) && return nothing
+    return Setups.coriolis_forcing(setup_type, FT)
 end
 
 function get_turbconv_model(FT, parsed_args, turbconv_params)
@@ -578,15 +515,11 @@ function get_tracers(parsed_args)
 end
 
 function check_case_consistency(parsed_args)
-    # if any flags is ISDAC, check that all are ISDAC
     ic = parsed_args["initial_condition"]
-    subs = parsed_args["subsidence"]
     surf = parsed_args["surface_setup"]
     rad = parsed_args["rad"]
-    cor = parsed_args["scm_coriolis"]
     forc = parsed_args["forcing"]
     microphysics = parsed_args["microphysics_model"]
-    ls_adv = parsed_args["ls_adv"]
     extf = parsed_args["external_forcing"]
     imp_vert_diff = parsed_args["implicit_diffusion"]
     vert_diff = parsed_args["vert_diff"]
@@ -594,11 +527,14 @@ function check_case_consistency(parsed_args)
     topography = parsed_args["topography"]
     prescribed_flow = parsed_args["prescribed_flow"]
 
-    ISDAC_mandatory = (ic, subs, surf, rad, extf)
+    # ISDAC consistency: when initial_condition is ISDAC, surface/rad/external
+    # forcing must all be set to the matching ISDAC variants. Subsidence,
+    # scm_coriolis, and ls_adv are owned by the setup, not the YAML schema.
+    ISDAC_mandatory = (ic, surf, rad, extf)
     if "ISDAC" in ISDAC_mandatory
         @assert(
             allequal(ISDAC_mandatory) &&
-            all(isnothing, (cor, forc, ls_adv)) &&
+            isnothing(forc) &&
             microphysics != "dry",
             "ISDAC setup not consistent"
         )

--- a/src/solver/type_getters.jl
+++ b/src/solver/type_getters.jl
@@ -78,8 +78,7 @@ function get_atmos(config::AtmosConfig, params; setup_type = nothing)
 
     atmos = AtmosModel(;
         water = AtmosWater(config, params, FT),
-        scm_setup = SCMSetup(config, FT;
-            setup_type, radiation_mode = radiation.radiation_mode),
+        scm_setup = SCMSetup(config, FT; setup_type),
         prescribed_flow,
         radiation,
         turbconv = AtmosTurbconv(config, params, FT),

--- a/src/solver/types.jl
+++ b/src/solver/types.jl
@@ -1567,18 +1567,18 @@ AtmosNumerics(config::AtmosConfig, ::Type{FT}) where {FT} =
     get_numerics(config.parsed_args, FT)
 
 function SCMSetup(config::AtmosConfig, ::Type{FT};
-    setup_type = nothing, radiation_mode = nothing) where {FT}
+    setup_type = nothing) where {FT}
     pa = config.parsed_args
 
     advection_test = pa["advection_test"]
     @assert advection_test in (false, true)
 
     return SCMSetup(;
-        subsidence = get_subsidence_model(pa, radiation_mode, FT; setup_type),
+        subsidence = get_subsidence_model(FT; setup_type),
         external_forcing = get_external_forcing_model(pa, FT; setup_type),
-        ls_adv = get_large_scale_advection_model(pa, FT; setup_type),
+        ls_adv = get_large_scale_advection_model(FT; setup_type),
         advection_test,
-        scm_coriolis = get_scm_coriolis(pa, FT; setup_type),
+        scm_coriolis = get_scm_coriolis(FT; setup_type),
     )
 end
 

--- a/src/solver/yaml_helper.jl
+++ b/src/solver/yaml_helper.jl
@@ -60,39 +60,99 @@ function override_default_config(::Nothing)
     return default_config_dict()
 end
 
+# Keys that bypass scalar coercion: `named String | nothing` unions
+# (hyperdiff has a String default but accepts `~` to disable) and structured
+# values (`diagnostics` is a list of dicts).
+const EXCEPTED_KEYS = Set([
+    "hyperdiff",
+    "diagnostics",
+])
+
+"""
+    coerce_to_default(::Type{T}, v) -> T
+
+Coerce a user-supplied YAML value `v` to the type `T` of the corresponding
+default in `default_config.yml`. Used by [`override_default_config`](@ref) to
+enforce a single canonical type per key.
+
+Dispatch order, most specific first:
+
+1. `coerce_to_default(::Type{T}, v::T) = v` — same type, identity. The
+   common path; most YAML values already load with the expected type.
+2. `coerce_to_default(::Type{Bool}, v::AbstractString)` — `"true"`/`"false"`
+   → `true`/`false` via `parse(Bool, v)`. Anything else throws
+   `ArgumentError`.
+3. `coerce_to_default(::Type{<:Integer}, v::AbstractString)` — `"42"` → `42`.
+4. `coerce_to_default(::Type{<:AbstractFloat}, v::AbstractString)` — `"3.14"`
+   → `3.14`. Note `"42"` also parses as a `Float64` here if the schema
+   default is float.
+5. `coerce_to_default(::Type{T}, v) = convert(T, v)` — fallback. Catches
+   things like `Int → Float64` (schema default `1.0`, user wrote `1`).
+   For unrelated types this throws `MethodError`.
+
+# Examples
+
+```julia-repl
+julia> coerce_to_default(Bool, "true")       # 2
+true
+
+julia> coerce_to_default(Int, "42")          # 3
+42
+
+julia> coerce_to_default(Float64, "3.14")    # 4
+3.14
+
+julia> coerce_to_default(Float64, 1)         # 5 (Int → Float)
+1.0
+
+julia> coerce_to_default(Bool, true)         # 1 (identity)
+true
+
+julia> coerce_to_default(Bool, "yes")        # 2, throws
+ERROR: ArgumentError: invalid value for Bool: "yes"
+```
+
+Keys whose schema default is `nothing` or that appear in [`EXCEPTED_KEYS`]
+bypass coercion entirely and pass through unchanged.
+"""
+coerce_to_default(::Type{T}, v::T) where {T} = v
+coerce_to_default(::Type{Bool}, v::AbstractString) = parse(Bool, v)
+coerce_to_default(::Type{T}, v::AbstractString) where {T <: Integer} =
+    parse(T, v)
+coerce_to_default(::Type{T}, v::AbstractString) where {T <: AbstractFloat} =
+    parse(T, v)
+coerce_to_default(::Type{T}, v) where {T} = convert(T, v)
+
 function override_default_config(config_dict::AbstractDict;)
     default_config = default_config_dict()
     config = deepcopy(default_config)
     # Allow unused keys in config_dict for coupler
     for k in intersect(keys(config_dict), keys(default_config))
-        default_type = typeof(default_config[k])
         v = config_dict[k]
-
-        # Attempt to convert user value `v` to the same type as
-        # the default. If that fails, throw an informative warning.
-        config[k] = try
-            isnothing(default_config[k]) ? v : convert(default_type, v)
-        catch e
-            # A failed conversion should result in a MethodError
-            e isa MethodError || rethrow(e)
-            @warn """Failed to convert `config_dict["$k"] = $v` to default type $default_type, keeping original value"""
-            v
+        # `nothing` defaults and excepted keys pass through unchanged;
+        # everything else must coerce cleanly to the default's type.
+        if isnothing(default_config[k]) || k in EXCEPTED_KEYS
+            config[k] = v
+        else
+            default_type = typeof(default_config[k])
+            config[k] = try
+                coerce_to_default(default_type, v)
+            catch e
+                e isa Union{MethodError, ArgumentError} || rethrow(e)
+                error(
+                    "Cannot coerce `$k = $(repr(v))` to expected type $default_type.",
+                )
+            end
         end
     end
 
-    excluded_keys = ("diagnostics", "job_id")
+    # `job_id` is set by the AtmosConfig constructor, not the YAML schema.
     unused_keys = filter(
-        k -> !haskey(default_config, k) && !(k in excluded_keys),
+        k -> !haskey(default_config, k) && k != "job_id",
         keys(config_dict),
     )
     if !isempty(unused_keys)
         @warn "The configuration passed to ClimaAtmos contains unused keys: $(join(unused_keys, ", "))"
-    end
-
-    # The "diagnostics" entry is a more complex type that doesn't fit the schema described in
-    # the previous lines. So, we manually add it.
-    if haskey(config_dict, "diagnostics")
-        config["diagnostics"] = config_dict["diagnostics"]
     end
 
     config == default_config && @info "Using default configuration"


### PR DESCRIPTION
This PR standardizes the YAML config parsing. Closes #4176. This is a breaking change for the coupler.


Content:
- Strict coercion in override_default_config: error on type mismatch instead of silently keeping the wrong-typed value. Added EXCEPTED_KEYS bypass for this, restricted to `hyperdiff` (String|nothing union) and `diagnostics` (structured list).
- Schema cleanup: 
  - vert_diff/hyperdiff default to ~ (was "false")
  - prognostic_surface defaults to "PrescribedSST" (was "false")
  - diagnostics now declared in the schema instead of bypassed
- Drop dead keys: subsidence, ls_adv, scm_coriolis. Setups own these via dispatch and this was never updated.
- Simplify get_vertical_diffusion_model, get_hyperdiffusion_model, get_subsidence_model, get_large_scale_advection_model, get_scm_coriolis, and check_case_consistency to match.
- Migrate 22 user configs (vert_diff: true --> "VerticalDiffusion", hyperdiff: "false" --> ~, prognostic_surface: true --> "SlabOceanSST").
