### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,6 +59,9 @@ makedocs(;
 deploydocs(
     repo = "github.com/CliMA/ClimaAtmos.jl.git",
     devbranch = "main",
-    push_preview = true,
+    push_preview = all(
+        !isempty,
+        (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+    ),
     forcepush = true,
 )


### PR DESCRIPTION
See [issue](https://github.com/JuliaDocs/Documenter.jl/issues/2048) in Documenter.jl. This is the solution suggested there.

For example #4495 

If this works, it should be copied to other repos

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
