### PR TITLE
Remove duplicate callback, add coupler perf pipeline

### DIFF
--- a/.buildkite/coupler_perf/check-sypd.sh
+++ b/.buildkite/coupler_perf/check-sypd.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+SYPD_FILE=output/gpu_amip_progedmf_1M_land_he16/artifacts/sypd.txt
+
+if [[ ! -f "$SYPD_FILE" ]]; then
+    echo "❌ SYPD file not found: $SYPD_FILE"
+    exit 1
+fi
+
+SYPD=$(cat "$SYPD_FILE" | tr -d '[:space:]')
+
+if [[ -z "$SYPD" ]]; then
+    echo "❌ SYPD file is empty"
+    exit 1
+fi
+
+echo "SYPD: $SYPD"
+
+PERCENT_CHANGE=$(echo "scale=2; (($SYPD - $BASELINE_SYPD) / $BASELINE_SYPD) * 100" | bc)
+
+if (( $(echo "$PERCENT_CHANGE <= $MIN_PERCENT_CHANGE" | bc -l) )); then
+    echo "❌ SYPD changed by $PERCENT_CHANGE% (threshold: $MIN_PERCENT_CHANGE%)"
+    exit 1
+else
+    echo "✅ SYPD change ($PERCENT_CHANGE%) is okay (threshold: $MIN_PERCENT_CHANGE%)"
+fi

--- a/.buildkite/coupler_perf/pipeline.yml
+++ b/.buildkite/coupler_perf/pipeline.yml
@@ -1,0 +1,55 @@
+# A pipeline for downstream performance checks
+agents:
+  queue: clima
+  slurm_time: 14:00:00
+  modules: climacommon/2025_05_15
+
+env:
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
+  JULIA_MAX_NUM_PRECOMPILE_FILES: 100
+  GKSwstype: 100
+  SLURM_KILL_BAD_EXIT: 1
+  COUPLER_PATH: ".buildkite/perf/ClimaCoupler.jl"
+  COUPLER_COMMIT: "6beb62031cb6a8a8a18a4fcd81008d93e1ff0a8f"
+  CONFIG_PATH: "$COUPLER_PATH/config/nightly_configs"
+  BENCHMARK_CONFIG_PATH: "$COUPLER_PATH/config/benchmark_configs"
+
+timeout_in_minutes: 840
+
+steps:
+  - label: "init :GPU:"
+    key: "init_gpu_env"
+    command:
+      - git clone https://github.com/CliMA/ClimaCoupler.jl.git $COUPLER_PATH && bash -c "cd $COUPLER_PATH && git checkout $COUPLER_COMMIT"
+      - "echo $$JULIA_DEPOT_PATH"
+      - echo "--- Instantiate AMIP env"
+      # Instantiate and dev install ClimaCore
+      - "julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - 'julia --project=$COUPLER_PATH/experiments/AMIP/ -e ''using Pkg; Pkg.develop(path=".")'''
+      - 'julia --project=$COUPLER_PATH/experiments/AMIP/ -e ''using Pkg; Pkg.add("MPI")'''
+      - "julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=$COUPLER_PATH/experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
+    agents:
+      slurm_gpus: 1
+      slurm_cpus_per_task: 8
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+
+  - label: "Flagship AMIP GPU with prognostic EDMF + 1M + integrated land (16 helems)"
+    key: "gpu_amip_progedmf_1M_land_he16"
+    depends_on: "init_gpu_env"
+    command:
+      - "srun julia --threads=3 --color=yes --project=$COUPLER_PATH/experiments/AMIP/ $COUPLER_PATH/experiments/AMIP/run_simulation.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he16.yml --job_id gpu_amip_progedmf_1M_land_he16"
+      - echo "--- Checking SYPD from artifacts"
+      - bash .buildkite/coupler_perf/check-sypd.sh
+    artifact_paths: "output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
+    env:
+      CLIMACOMMS_DEVICE: "CUDA"
+      BASELINE_SYPD: "0.24"
+      MIN_PERCENT_CHANGE: "-1"
+    agents:
+      slurm_gpus_per_task: 1
+      slurm_cpus_per_task: 4
+      slurm_ntasks: 1
+      slurm_mem: 16GB

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-344
+345
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+345
+- Remove duplicate `enforce_physical_constraints_callback` call
+
 344
 - Unify cloud fraction and microphysics quadrature via a shared sgs_moments
   pre-pass; replace Sommeria-Deardorff cloud fraction with hybrid logistic-CDF;

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -543,10 +543,5 @@ function common_callbacks(
     if check_conservation
         callbacks = (callbacks..., conservation_checking_callback()...)
     end
-
-    # Enforce physical constraints filter (no-op fallback for non-EDMF models;
-    # keep unconditional so EDMF runs always get it without extra wiring).
-    callbacks = (callbacks..., enforce_physical_constraints_callback(dt))
-
     return callbacks
 end


### PR DESCRIPTION
This PR removes the duplicate `enforce_physical_constraints_callback` callback, which was duplicated  in `common_callbacks` and `default_model_callbacks` by PR #4469. 
To catch future performance regressions, this PR also adds an end-to-end coupler performance pipeline. This pipeline runs the flagship `amip_progedmf_1m_land_he16` config on clima and checks that the SYPD has not decreased by more than 1%. This pipeline is adapted from the ClimaCore end to end perf [pipeline](https://github.com/CliMA/ClimaCore.jl/tree/main/.buildkite/perf). It is not designed to block PRs, but to track performance regressions in the coupler. It will run on every merged PR and can be manually triggered by adding [perf] to the commit message. This PR increases the SYPD of the pipeline by ~10%, from 0.22 to 0.24 ([job](https://buildkite.com/clima/climaatmos-end-to-end-performance/builds/2#019e4688-1f17-4e34-986d-1fae3bf91735)).