### PR TITLE
Fix duplication of enforce physical constraints callback

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -544,9 +544,5 @@ function common_callbacks(
         callbacks = (callbacks..., conservation_checking_callback()...)
     end
 
-    # Enforce physical constraints filter (no-op fallback for non-EDMF models;
-    # keep unconditional so EDMF runs always get it without extra wiring).
-    callbacks = (callbacks..., enforce_physical_constraints_callback(dt))
-
     return callbacks
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I think this caused the performance regression. This callback is already added in `default_model_callbacks`


## To-do
- verify performance diff before and after fix



Looking at this, I also realized that there are further complications from `microphysics_tendencies_1m`. It is probably worth looking into that. I believe this is the main cause of the highly unstable sypd

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
