### PR TITLE
Modify dependabot versioning-strat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       patterns:
       - "*"
   package-ecosystem: julia
+  versioning-strategy: increase-if-necessary
   schedule:
     day: wednesday
     interval: weekly


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Dependabot adds new compat entries when upgrading packages. We do not want this for the .buildkite env. I think this might fix it, but I'm not sure how to test. [dependabot docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)


