### PR TITLE
Delete explicit vs implicit options (always implicit)

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -373,23 +373,6 @@ advection_test:
 edmfx_scale_blending:
   help: "Method for blending physical scales in EDMFX mixing length calculation. [`SmoothMinimum` (default), `HardMinimum`]"
   value: "SmoothMinimum"
-implicit_sgs_advection:
-  help: "Whether to treat the subgrid-scale vertical advection tendency implicitly [`false` (default), `true`]"
-  value: false
-implicit_sgs_entr_detr:
-  help: "Whether to treat the subgrid-scale entrainment and detrainment tendency implicitly [`false` (default), `true`]. Setting it to true only works if implicit_sgs_advection is set to true."
-  value: false
-implicit_sgs_nh_pressure:
-  help: "Whether to treat the subgrid-scale nonhydrostatic pressure closure implicitly. Setting it to true only works if
-  `implicit_sgs_advection` is set to true. This flag only controls whether the drag term in the pressure closure is treated implicitly.
-  The buoyancy term is always treated implicitly. [`false` (default), `true`]"
-  value: false
-implicit_sgs_vertdiff:
-  help: "Whether to treat the subgrid-scale vertical diffusion tendency implicitly [`false` (default), `true`]. Setting it to true only works if implicit_sgs_advection is set to true."
-  value: false
-implicit_sgs_mass_flux:
-  help: "Whether to treat the subgrid-scale mass flux tendency implicitly or explicitly in grid-mean equations. Currently updraft only with Jacobian terms 0. [`false` (default), `true`]. Setting it to true only works if both implicit_sgs_advection and implicit_diffusion are set to true."
-  value: false
 edmfx_filter:
   help: "If set to true, it switches on the relaxation of negative velocity in EDMFX.  [`true`, `false` (default)]"
   value: false

--- a/config/longrun_configs/amip_target.yml
+++ b/config/longrun_configs/amip_target.yml
@@ -1,8 +1,3 @@
-implicit_sgs_advection: true
-implicit_sgs_mass_flux: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
 ode_algo: "ARS222"
 dt_save_state_to_disk: "30days"
 t_end: "60days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_0M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_0M.yml
@@ -1,8 +1,3 @@
-implicit_sgs_advection: true
-implicit_sgs_mass_flux: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
 ode_algo: "ARS222"
 dt: "120secs"
 t_end: "240days"

--- a/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_1M.yml
+++ b/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_1M.yml
@@ -1,8 +1,3 @@
-implicit_sgs_advection: true
-implicit_sgs_mass_flux: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
 ode_algo: "ARS222"
 dt: "120secs"
 t_end: "240days"

--- a/config/model_configs/prognostic_edmfx_aquaplanet.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet.yml
@@ -15,11 +15,6 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 microphysics_model: "0M"
 t_end: 1hours

--- a/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_dense_autodiff.yml
@@ -17,11 +17,6 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 use_dense_jacobian: true
 update_jacobian_every: stage
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_gpu.yml
@@ -19,11 +19,6 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 microphysics_model: "0M"
 non_orographic_gravity_wave: true

--- a/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_aquaplanet_sparse_autodiff.yml
@@ -17,11 +17,6 @@ edmfx_filter: true
 edmfx_sgs_mass_flux: true
 edmfx_sgs_diffusive_flux: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 use_auto_jacobian: true
 update_jacobian_every: stage
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -1,7 +1,6 @@
 initial_condition: "Bomex"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
@@ -1,11 +1,6 @@
 initial_condition: "Bomex"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 use_auto_jacobian: true
 update_jacobian_every: stage

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -1,11 +1,6 @@
 initial_condition: "Bomex"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -8,12 +8,6 @@ turbconv: "prognostic_edmfx"
 
 # solve implicitly
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_mass_flux: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-
 approximate_linear_solve_iters: 2
 edmfx_sgsflux_upwinding: first_order
 rayleigh_sponge: true

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -1,11 +1,6 @@
 initial_condition: DYCOMS_RF01
 turbconv: prognostic_edmfx
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -2,11 +2,6 @@ initial_condition: DYCOMS_RF02
 turbconv: "prognostic_edmfx"
 reproducibility_test: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -1,7 +1,6 @@
 initial_condition: GABLS
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
@@ -1,11 +1,6 @@
 initial_condition: GABLS
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 use_auto_jacobian: true
 update_jacobian_every: stage

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -3,7 +3,6 @@ external_forcing_file: artifact"cfsite_gcm_forcing"/HadGEM2-A_amip.2004-2008.07.
 cfsite_number : "site23"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 rayleigh_sponge: true
 edmfx_entr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -2,11 +2,6 @@ initial_condition: "Rico"
 turbconv: "prognostic_edmfx"
 reproducibility_test: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_rico_column_2M.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column_2M.yml
@@ -2,7 +2,6 @@ initial_condition: "Rico"
 turbconv: "prognostic_edmfx"
 tracer_upwinding: first_order
 implicit_diffusion: true
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -2,7 +2,6 @@ initial_condition: "SimplePlume"
 disable_surface_flux_tendency: true
 turbconv: "prognostic_edmfx"
 implicit_diffusion: false
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "SmoothArea"

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -2,8 +2,6 @@ initial_condition: "Soares"
 rayleigh_sponge: true
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "SmoothArea"

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -2,11 +2,6 @@ initial_condition: TRMM_LBA
 turbconv: prognostic_edmfx
 reproducibility_test: true
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -1,11 +1,6 @@
 initial_condition: TRMM_LBA
 turbconv: prognostic_edmfx
 implicit_diffusion: true
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 approximate_linear_solve_iters: 2
 edmfx_entr_model: "PiGroups"
 edmfx_detr_model: "SmoothArea"

--- a/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
+++ b/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
@@ -5,7 +5,6 @@ site_latitude: 17.0
 site_longitude: -149.0
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
-implicit_sgs_advection: false
 approximate_linear_solve_iters: 2
 edmfx_sgsflux_upwinding: first_order
 rayleigh_sponge: true

--- a/config/perf_configs/bm_aquaplanet_progedmf.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf.yml
@@ -4,11 +4,6 @@ dt: 10secs
 t_end: 61mins
 dt_save_state_to_disk: "Inf"
 log_progress: false
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 surface_setup: DefaultMoninObukhov
 rad: allskywithclear
 dt_rad: 1hours

--- a/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_dense_autodiff.yml
@@ -5,11 +5,6 @@ t_end: 16mins
 dt_save_state_to_disk: "Inf"
 log_progress: false
 approximate_linear_solve_iters: 1
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 use_dense_jacobian: true
 update_jacobian_every: stage
 ode_algo: "ARS222"

--- a/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
+++ b/config/perf_configs/bm_aquaplanet_progedmf_sparse_autodiff.yml
@@ -5,11 +5,6 @@ t_end: 31mins
 dt_save_state_to_disk: "Inf"
 log_progress: false
 approximate_linear_solve_iters: 1
-implicit_sgs_advection: true
-implicit_sgs_entr_detr: true
-implicit_sgs_nh_pressure: true
-implicit_sgs_vertdiff: true
-implicit_sgs_mass_flux: true
 use_auto_jacobian: true
 update_jacobian_every: stage
 ode_algo: "ARS222"

--- a/docs/src/config_no_table.md
+++ b/docs/src/config_no_table.md
@@ -70,7 +70,7 @@ ClimaAtmos provides a set of common numerical configurations that can be used as
 ### Sphere Configurations
 - **`numerics_sphere_he6ze10.yml`**: Spherical configuration with 6 horizontal elements (550km), 10 vertical levels, 30km domain top, no sponge, explicit vertical diffusion
 
-- **`numerics_sphere_he6ze31.yml`**: Spherical configuration with 6 horizontal elements (550km) , 31 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
+- **`numerics_sphere_he6ze31.yml`**: Spherical configuration with 6 horizontal elements (550km), 31 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 
 - **`numerics_sphere_he16ze63.yml`**: Spherical configuration with 16 horizontal elements (206km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-345
+346
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+346
+- Remove explicit/implicit options for SGS advection, entr/detr, NH pressure drag,
+  SGS vertical diffusion, and SGS mass flux. All SGS tendencies are now always
+  implicit. DiagnosticEDMFX mass flux tendency moves from explicit to implicit stage.
+
 345
 - Remove duplicate `enforce_physical_constraints_callback` call
 

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -286,16 +286,6 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
         )
 
-        if p.atmos.sgs_entr_detr_mode == Explicit()
-            @. ᶜentrʲs.:($$j) = limit_entrainment(
-                ᶜentrʲs.:($$j),
-                draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-                dt,
-            )
-            @. ᶜturb_entrʲs.:($$j) =
-                limit_turb_entrainment(ᶜentrʲs.:($$j), ᶜturb_entrʲs.:($$j), dt)
-        end
-
         @. ᶜvert_div = ᶜdivᵥ(ᶠinterp(ᶜρʲs.:($$j)) * ᶠu³ʲs.:($$j)) / ᶜρʲs.:($$j)
         @. ᶜmassflux_vert_div =
             ᶜdivᵥ(ᶠinterp(Y.c.sgsʲs.:($$j).ρa) * ᶠu³ʲs.:($$j))
@@ -337,20 +327,12 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             p.atmos.edmfx_model.detr_model,
         )
 
-        if p.atmos.sgs_entr_detr_mode == Explicit()
-            @. ᶜdetrʲs.:($$j) = limit_detrainment(
-                ᶜdetrʲs.:($$j),
-                draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-                dt,
-            )
-        else
-            @. ᶜdetrʲs.:($$j) = limit_detrainment(
-                ᶜdetrʲs.:($$j),
-                ᶜentrʲs.:($$j),
-                draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-                dt,
-            )
-        end
+        @. ᶜdetrʲs.:($$j) = limit_detrainment(
+            ᶜdetrʲs.:($$j),
+            ᶜentrʲs.:($$j),
+            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+            dt,
+        )
 
         # Near the surface, relax the first-cell updraft area toward `surface_area`
         # when the surface buoyancy flux is non-negative:
@@ -388,12 +370,7 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
                 ($(FT(turbconv_params.surface_area)) / ᶜaʲ_int_val - 1) / dt,
             ),
         )
-        if p.atmos.sgs_entr_detr_mode == Explicit()
-            @. entr_int_val = limit_entrainment(entr_int_val, ᶜaʲ_int_val, dt)
-            @. detr_int_val = limit_detrainment(detr_int_val, ᶜaʲ_int_val, dt)
-        else
-            @. detr_int_val = limit_detrainment(detr_int_val, entr_int_val, ᶜaʲ_int_val, dt)
-        end
+        @. detr_int_val = limit_detrainment(detr_int_val, entr_int_val, ᶜaʲ_int_val, dt)
 
         @. ᶠρ_diffʲs.:($$j) = ᶠinterp(ᶜρʲs.:($$j) - Y.c.ρ) / ᶠinterp(ᶜρʲs.:($$j))
     end

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -532,12 +532,7 @@ function check_case_consistency(parsed_args)
         )
         @assert(
             !parsed_args["implicit_microphysics"] &&
-            !parsed_args["implicit_diffusion"] &&
-            !parsed_args["implicit_sgs_advection"] &&
-            !parsed_args["implicit_sgs_entr_detr"] &&
-            !parsed_args["implicit_sgs_nh_pressure"] &&
-            !parsed_args["implicit_sgs_vertdiff"] &&
-            !parsed_args["implicit_sgs_mass_flux"],
+            !parsed_args["implicit_diffusion"],
             "Prescribed flow does not use the implicit solver."
         )
     end
@@ -604,12 +599,6 @@ function AtmosTurbconv(config::AtmosConfig, params, ::Type{FT}) where {FT}
     pa = config.parsed_args
     turbconv_params = CAP.turbconv_params(params)
 
-    implicit_sgs_advection = pa["implicit_sgs_advection"]
-    implicit_sgs_entr_detr = pa["implicit_sgs_entr_detr"]
-    implicit_sgs_nh_pressure = pa["implicit_sgs_nh_pressure"]
-    implicit_sgs_vertdiff = pa["implicit_sgs_vertdiff"]
-    implicit_sgs_mass_flux = pa["implicit_sgs_mass_flux"]
-
     scale_blending_method =
         if pa["edmfx_scale_blending"] == "SmoothMinimum"
             SmoothMinimumBlending()
@@ -646,11 +635,6 @@ function AtmosTurbconv(config::AtmosConfig, params, ::Type{FT}) where {FT}
     return AtmosTurbconv(;
         edmfx_model,
         turbconv_model = get_turbconv_model(FT, pa, turbconv_params),
-        sgs_adv_mode = implicit_sgs_advection ? Implicit() : Explicit(),
-        sgs_entr_detr_mode = implicit_sgs_entr_detr ? Implicit() : Explicit(),
-        sgs_nh_pressure_mode = implicit_sgs_nh_pressure ? Implicit() : Explicit(),
-        sgs_vertdiff_mode = implicit_sgs_vertdiff ? Implicit() : Explicit(),
-        sgs_mf_mode = implicit_sgs_mass_flux ? Implicit() : Explicit(),
         smagorinsky_lilly,
         amd_les,
         constant_horizontal_diffusion,

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -357,45 +357,21 @@ function edmfx_sgs_vertical_advection_tendency!(
     n = n_prognostic_mass_flux_subdomains(turbconv_model)
     (; dt) = p
     (; edmfx_mse_q_tot_upwinding, edmfx_tracer_upwinding) = p.atmos.numerics
-    (; ᶠu³ʲs, ᶠKᵥʲs, ᶜρʲs, ᶠρ_diffʲs) = p.precomputed
-    (; ᶠgradᵥ_ᶜΦ) = p.core
+    (; ᶠu³ʲs, ᶜρʲs) = p.precomputed
 
     FT = eltype(p.params)
-    turbconv_params = CAP.turbconv_params(params)
-    α_b = CAP.pressure_normalmode_buoy_coeff1(turbconv_params)
     ᶠz = Fields.coordinate_field(Y.f).z
-    ᶜu₃ʲ = p.scratch.ᶜtemp_C3
-    ᶜKᵥʲ = p.scratch.ᶜtemp_scalar_2
-    ᶜJ = Fields.local_geometry_field(axes(Y.c)).J
     ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
 
     grav = CAP.grav(params)
     for j in 1:n
-        if p.atmos.sgs_adv_mode == Explicit()
-            # TODO: Add a biased GradientF2F operator in ClimaCore
-            @. ᶜu₃ʲ = ᶜinterp(Y.f.sgsʲs.:($$j).u₃)
-            @. ᶜKᵥʲ = ifelse(
-                ᶜu₃ʲ.components.data.:1 > 0,
-                ᶜleft_bias(ᶠKᵥʲs.:($$j)),
-                ᶜright_bias(ᶠKᵥʲs.:($$j)),
-            )
-            # For the updraft u_3 equation, we assume the grid-mean to be hydrostatic
-            # and calcuate the buoyancy term relative to the grid-mean density.
-            # We also include the buoyancy term in the nonhydrostatic pressure closure here.
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -=
-                (1 - α_b) * ᶠρ_diffʲs.:($$j) * ᶠgradᵥ_ᶜΦ + ᶠgradᵥ(ᶜKᵥʲ)
-        end
-
         # buoyancy term in mse equation
         @. Yₜ.c.sgsʲs.:($$j).mse +=
             adjoint(CT3(ᶜinterp(Y.f.sgsʲs.:($$j).u₃))) *
             (ᶜρʲs.:($$j) - Y.c.ρ) *
             ᶜgradᵥ(grav * ᶠz) / ᶜρʲs.:($$j)
-    end
 
-    for j in 1:n
         ᶜa = (@. lazy(draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))))
-
         # Flux form vertical advection of area farction with the grid mean velocity
         vtt =
             vertical_transport(ᶜρʲs.:($j), ᶠu³ʲs.:($j), ᶜa, dt, edmfx_mse_q_tot_upwinding)

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -633,7 +633,6 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
 
     n = n_mass_flux_subdomains(turbconv_model)
     (; ᶜturb_entrʲs, ᶜentrʲs, ᶜdetrʲs) = p.precomputed
-    (; ᶠu₃⁰) = p.precomputed
 
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)
     ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
@@ -667,12 +666,6 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
             ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
             ᶜχʲₜ = MatrixFields.get_field(Yₜ, χʲ_name)
             @. ᶜχʲₜ += (ᶜentrʲ .+ ᶜturb_entrʲ) * (ᶜχ⁰ - ᶜχʲ)
-        end
-
-        if p.atmos.sgs_entr_detr_mode == Explicit()
-            @. Yₜ.f.sgsʲs.:($$j).u₃ +=
-                (ᶠinterp(ᶜentrʲ) .+ ᶠinterp(ᶜturb_entrʲ)) *
-                (ᶠu₃⁰ - Y.f.sgsʲs.:($$j).u₃)
         end
     end
     return nothing

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -31,15 +31,13 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
         )
     end
 
-    if p.atmos.sgs_adv_mode == Implicit()
-        edmfx_sgs_vertical_advection_tendency!(
-            Yₜ,
-            Y,
-            p,
-            t,
-            p.atmos.turbconv_model,
-        )
-    end
+    edmfx_sgs_vertical_advection_tendency!(
+        Yₜ,
+        Y,
+        p,
+        t,
+        p.atmos.turbconv_model,
+    )
 
     if p.atmos.diff_mode == Implicit()
         vertical_diffusion_boundary_layer_tendency!(
@@ -52,19 +50,12 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
         edmfx_sgs_diffusive_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
     end
 
+    edmfx_entr_detr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+    edmfx_first_interior_entr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
-    if p.atmos.sgs_entr_detr_mode == Implicit()
-        edmfx_entr_detr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-        edmfx_first_interior_entr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
+    edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
-    if p.atmos.sgs_mf_mode == Implicit()
-        edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
-
-    if p.atmos.sgs_vertdiff_mode == Implicit()
-        edmfx_vertical_diffusion_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
+    edmfx_vertical_diffusion_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
     # NOTE: All ρa tendencies should be applied before calling this function
     pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)

--- a/src/prognostic_equations/implicit/initialize_implicit_problem.jl
+++ b/src/prognostic_equations/implicit/initialize_implicit_problem.jl
@@ -115,11 +115,6 @@ In this discretization, the prognostic variable is the covariant vertical
 velocity component `u₃`. The physical vertical velocity `w` is obtained via
 a metric scaling (division by Δz), which is consistently applied when
 forming the quadratic coefficients.
-
-If SGS vertical advection is treated implicitly, the system becomes
-vertically coupled and is solved via a column sweep using
-`Operators.column_accumulate!`. Otherwise, each face-local quadratic
-equation is solved independently.
 """
 function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
 
@@ -161,13 +156,10 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
         @. ᶠc = -1 * (Y.f.sgsʲs.:($$j).u₃.components.data.:1 / dtγ)
 
         # Implicit entrainment/detrainment contributes a linear sink in w.
-        if p.atmos.sgs_entr_detr_mode == Implicit()
-            @. ᶠb += ᶠinterp((ᶜentrʲs.:($$j) + ᶜturb_entrʲs.:($$j)) * ᶜρ_over_ρa⁰)
-        end
+        @. ᶠb += ᶠinterp((ᶜentrʲs.:($$j) + ᶜturb_entrʲs.:($$j)) * ᶜρ_over_ρa⁰)
 
         # Implicit NH pressure drag contributes a quadratic sink in w².
-        if p.atmos.edmfx_model.nh_pressure isa Val{true} &&
-           p.atmos.sgs_nh_pressure_mode == Implicit()
+        if p.atmos.edmfx_model.nh_pressure isa Val{true}
             @. ᶠa += ᶠinterp(drag_coeff * ᶜρ_over_ρa⁰ * ᶜρ_over_ρa⁰) / ᶠdz
         end
 
@@ -178,35 +170,28 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
             @. ᶠb += β_rayleigh_u₃(rayleigh_sponge, ᶠz, zmax)
         end
 
-        if p.atmos.sgs_adv_mode == Implicit()
-            # Implicit advection adds a local w² term and couples each face
-            # to the previously solved face through w_prev².
-            @. ᶠa += (1 / ᶠdz)^2 / 2
-            @. ᶠc += (1 - α_b) * ᶠρ_diffʲs.:($$j) * ᶠgradᵥ_ᶜΦ.components.data.:1
+        # Implicit advection adds a local w² term and couples each face
+        # to the previously solved face through w_prev².
+        @. ᶠa += (1 / ᶠdz)^2 / 2
+        @. ᶠc += (1 - α_b) * ᶠρ_diffʲs.:($$j) * ᶠgradᵥ_ᶜΦ.components.data.:1
 
-            input = @. lazy(tuple(ᶠa, ᶠb, ᶠc, ᶠdz))
-            Operators.column_accumulate!(
-                Y.f.sgsʲs.:($j).u₃,
-                input;
-                init = C3(FT(0)),
-            ) do u₃_prev_face, (a_face, b_face, c_face, dz_face)
+        input = @. lazy(tuple(ᶠa, ᶠb, ᶠc, ᶠdz))
+        Operators.column_accumulate!(
+            Y.f.sgsʲs.:($j).u₃,
+            input;
+            init = C3(FT(0)),
+        ) do u₃_prev_face, (a_face, b_face, c_face, dz_face)
 
-                return C3(
-                    (
-                        -b_face + sqrt(
-                            b_face * b_face -
-                            4 * a_face *
-                            min(0, c_face - (u₃_prev_face[1] / dz_face)^2 / 2),
-                        )
-                    ) / (2 * a_face),
-                )
+            return C3(
+                (
+                    -b_face + sqrt(
+                        b_face * b_face -
+                        4 * a_face *
+                        min(0, c_face - (u₃_prev_face[1] / dz_face)^2 / 2),
+                    )
+                ) / (2 * a_face),
+            )
 
-            end
-        else
-            # Safe quadratic root to avoid cancellation and stay well behaved
-            # when a is small.
-            @. Y.f.sgsʲs.:($$j).u₃ =
-                C3(-2 * min(0, ᶠc) / (ᶠb + sqrt(ᶠb * ᶠb - 4 * ᶠa * min(0, ᶠc))))
         end
     end
 

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -37,29 +37,19 @@ end
 ManualSparseJacobian(; approximate_solve_iters::Int = 1) =
     ManualSparseJacobian(approximate_solve_iters)
 
-# Compute the seven DerivativeFlags that specialize the manual-sparse cache.
-# Flags are dispatch-relevant at cache build time, so we return them as a
-# NamedTuple of concrete `UseDerivative`/`IgnoreDerivative` instances.
+# Topography and diffusion flags specialize the cache at build time.
+# SGS modes (advection, entr/detr, mass flux, NH pressure, vertdiff) are
+# always implicit — no flags needed for them.
 function _derivative_flags(atmos, Y)
     return (;
         topography_flag = DerivativeFlag(has_topography(axes(Y.c))),
         diffusion_flag = DerivativeFlag(atmos.diff_mode),
-        sgs_advection_flag = DerivativeFlag(atmos.sgs_adv_mode),
-        sgs_entr_detr_flag = DerivativeFlag(atmos.sgs_entr_detr_mode),
-        sgs_mass_flux_flag = DerivativeFlag(atmos.sgs_mf_mode),
-        sgs_nh_pressure_flag = DerivativeFlag(atmos.sgs_nh_pressure_mode),
-        sgs_vertdiff_flag = DerivativeFlag(atmos.sgs_vertdiff_mode),
     )
 end
 
 function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     derivative_flags = _derivative_flags(atmos, Y)
-    (;
-        topography_flag,
-        diffusion_flag,
-        sgs_advection_flag,
-        sgs_mass_flux_flag,
-    ) = derivative_flags
+    (; topography_flag, diffusion_flag) = derivative_flags
     approximate_solve_iters = alg.approximate_solve_iters
     FT = Spaces.undertype(axes(Y.c))
 
@@ -185,6 +175,7 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                 name -> (@name(c.ρe_tot), name) => similar(Y.c, TridiagonalRow),
                 available_condensate_mass_names,
             )...,
+            # TODO should we check is_in_Y(@name(c.ρq_tot)) here
             map(
                 name -> (@name(c.ρq_tot), name) => similar(Y.c, TridiagonalRow),
                 available_condensate_mass_names,
@@ -224,52 +215,42 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     end
 
     sgs_advection_blocks = if atmos.turbconv_model isa PrognosticEDMFX
-        if use_derivative(sgs_advection_flag)
-            (
-                map(
-                    name -> (name, name) => similar(Y.c, TridiagonalRow),
-                    available_sgs_scalar_names,
-                )...,
-                map(
-                    name ->
-                        (@name(c.sgsʲs.:(1).q_tot), name) =>
-                            similar(Y.c, TridiagonalRow),
-                    available_sgs_condensate_mass_names,
-                )...,
-                map(
-                    name ->
-                        (@name(c.sgsʲs.:(1).ρa), name) => similar(Y.c, TridiagonalRow),
-                    available_sgs_condensate_mass_names,
-                )...,
-                map(
-                    name ->
-                        (@name(c.sgsʲs.:(1).mse), name) => similar(Y.c, DiagonalRow),
-                    available_sgs_condensate_mass_names,
-                )...,
-                (@name(c.sgsʲs.:(1).mse), @name(c.sgsʲs.:(1).q_tot)) =>
-                    similar(Y.c, DiagonalRow),
-                (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).q_tot)) =>
-                    similar(Y.c, TridiagonalRow),
-                (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).mse)) =>
-                    similar(Y.c, TridiagonalRow),
-                (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) => FT(-1) * I,
-            )
-        else
-            (
-                map(
-                    name ->
-                        (name, name) => FT(-1) * I,
-                    available_sgs_scalar_names,
-                )...,
-                (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) => FT(-1) * I,
-            )
-        end
+        (
+            map(
+                name -> (name, name) => similar(Y.c, TridiagonalRow),
+                available_sgs_scalar_names,
+            )...,
+            map(
+                name ->
+                    (@name(c.sgsʲs.:(1).q_tot), name) =>
+                        similar(Y.c, TridiagonalRow),
+                available_sgs_condensate_mass_names,
+            )...,
+            map(
+                name ->
+                    (@name(c.sgsʲs.:(1).ρa), name) => similar(Y.c, TridiagonalRow),
+                available_sgs_condensate_mass_names,
+            )...,
+            map(
+                name ->
+                    (@name(c.sgsʲs.:(1).mse), name) => similar(Y.c, DiagonalRow),
+                available_sgs_condensate_mass_names,
+            )...,
+            (@name(c.sgsʲs.:(1).mse), @name(c.sgsʲs.:(1).q_tot)) =>
+                similar(Y.c, DiagonalRow),
+            (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).q_tot)) =>
+                similar(Y.c, TridiagonalRow),
+            (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).mse)) =>
+                similar(Y.c, TridiagonalRow),
+            (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) => FT(-1) * I,
+        )
     else
         ()
     end
 
-    sgs_massflux_blocks = if atmos.turbconv_model isa PrognosticEDMFX
-        if use_derivative(sgs_mass_flux_flag)
+    sgs_massflux_blocks =
+        if atmos.turbconv_model isa PrognosticEDMFX &&
+           atmos.edmfx_model.sgs_mass_flux isa Val{true}
             (
                 map(
                     name ->
@@ -293,13 +274,20 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                     similar(Y.c, TridiagonalRow),
                 (@name(c.ρe_tot), @name(c.sgsʲs.:(1).ρa)) =>
                     similar(Y.c, TridiagonalRow),
+                # (ρe_tot, ρ) and (ρq_tot, ρ) are needed for the mass flux Jacobian.
+                # When diffusion is implicit they already appear in diffusion_blocks;
+                # add them here only when diffusion is explicit to avoid duplicates.
+                (
+                    use_derivative(diffusion_flag) ? () :
+                    (
+                        (@name(c.ρe_tot), @name(c.ρ)) => similar(Y.c, TridiagonalRow),
+                        (@name(c.ρq_tot), @name(c.ρ)) => similar(Y.c, TridiagonalRow),
+                    )
+                )...,
             )
         else
             ()
         end
-    else
-        ()
-    end
 
     matrix = MatrixFields.FieldMatrix(
         identity_blocks...,
@@ -324,7 +312,6 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     )
     full_alg =
         if use_derivative(diffusion_flag) ||
-           use_derivative(sgs_advection_flag) ||
            !(atmos.microphysics_model isa DryModel)
             gs_scalar_subalg = if !(atmos.microphysics_model isa DryModel)
                 MatrixFields.BlockLowerTriangularSolve(
@@ -337,8 +324,7 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                 MatrixFields.BlockDiagonalSolve()
             end
             scalar_subalg =
-                if atmos.turbconv_model isa PrognosticEDMFX &&
-                   use_derivative(sgs_advection_flag)
+                if atmos.turbconv_model isa PrognosticEDMFX
                     MatrixFields.BlockLowerTriangularSolve(
                         available_sgs_condensate_names...;
                         alg₂ = MatrixFields.BlockLowerTriangularSolve(
@@ -382,14 +368,7 @@ end
 # TODO: There are a few for loops in this function. This is because
 # using unrolled_foreach allocates (breaks the flame tests)
 function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
-    (;
-        topography_flag,
-        diffusion_flag,
-        sgs_advection_flag,
-        sgs_entr_detr_flag,
-        sgs_mass_flux_flag,
-        sgs_vertdiff_flag,
-    ) = cache.derivative_flags
+    (; topography_flag, diffusion_flag) = cache.derivative_flags
     (; matrix) = cache
     (; params) = p
     (; ᶜΦ) = p.core
@@ -766,7 +745,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
     end
 
     if p.atmos.turbconv_model isa PrognosticEDMFX
-        if use_derivative(sgs_advection_flag)
+        begin # sgs_adv always implicit
             (; ᶜgradᵥ_ᶠΦ) = p.core
             (;
                 ᶜρʲs,
@@ -1022,8 +1001,8 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                 end
             end
 
-            # vertical diffusion of updrafts
-            if use_derivative(sgs_vertdiff_flag)
+            # vertical diffusion of updrafts — uses ᶜK_h computed in diffusion block
+            if use_derivative(diffusion_flag) # sgs_vertdiff always implicit
                 α_vert_diff_tracer = CAP.α_vert_diff_tracer(params)
                 @. ᶜdiffusion_h_matrix =
                     ᶜadvdivᵥ_matrix() ⋅
@@ -1072,7 +1051,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                 end
             end
             # entrainment and detrainment (rates are treated explicitly)
-            if use_derivative(sgs_entr_detr_flag)
+            begin # sgs_entr_detr always implicit
                 (; ᶜentrʲs, ᶜdetrʲs, ᶜturb_entrʲs) = p.precomputed
                 @. ∂ᶜq_totʲ_err_∂ᶜq_totʲ -=
                     dtγ * DiagonalMatrixRow(ᶜentrʲs.:(1) + ᶜturb_entrʲs.:(1))
@@ -1103,8 +1082,17 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
             end
 
             # add updraft mass flux contributions to grid-mean
-            if use_derivative(sgs_mass_flux_flag)
-                # Jacobian contributions of updraft massflux to grid-mean
+            if p.atmos.edmfx_model.sgs_mass_flux isa Val{true}
+
+                # If diffusion is explicit, zero-initialize (ρe_tot, ρ) and 
+                # (ρq_tot, ρ) here so both blocks can safely use +=.
+                if !use_derivative(diffusion_flag)
+                    ∂ᶜρe_tot_err_∂ᶜρ = matrix[@name(c.ρe_tot), @name(c.ρ)]
+                    @. ∂ᶜρe_tot_err_∂ᶜρ = zero(typeof(∂ᶜρe_tot_err_∂ᶜρ))
+                    ∂ᶜρq_tot_err_∂ᶜρ = matrix[@name(c.ρq_tot), @name(c.ρ)]
+                    @. ∂ᶜρq_tot_err_∂ᶜρ = zero(typeof(∂ᶜρq_tot_err_∂ᶜρ))
+                end
+
                 ∂ᶜupdraft_mass_flux_∂ᶜscalar = ᶠbidiagonal_matrix_ct3
                 @. ∂ᶜupdraft_mass_flux_∂ᶜscalar =
                     DiagonalMatrixRow(

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -103,33 +103,6 @@ function ᶠupdraft_nh_pressure_drag(params, ᶠlg, ᶠu3ʲ, ᶠu3⁰, scale_hei
            max(scale_height, H_up_min)
 end
 
-edmfx_nh_pressure_drag_tendency!(Yₜ, Y, p, t, turbconv_model) = nothing
-function edmfx_nh_pressure_drag_tendency!(
-    Yₜ,
-    Y,
-    p,
-    t,
-    turbconv_model::PrognosticEDMFX,
-)
-    if p.atmos.edmfx_model.nh_pressure isa Val{true} &&
-       p.atmos.sgs_nh_pressure_mode == Explicit()
-        (; params) = p
-        n = n_mass_flux_subdomains(turbconv_model)
-        ᶠlg = Fields.local_geometry_field(Y.f)
-        scale_height = CAP.R_d(params) * CAP.T_surf_ref(params) / CAP.grav(params)
-        # assume zero environmental velocity
-        for j in 1:n
-            @. Yₜ.f.sgsʲs.:($$j).u₃ -= ᶠupdraft_nh_pressure_drag(
-                params,
-                ᶠlg,
-                Y.f.sgsʲs.:($$j).u₃,
-                C3(0),
-                scale_height,
-            )
-        end
-    end
-end
-
 edmfx_vertical_diffusion_tendency!(Yₜ, Y, p, t, turbconv_model) = nothing
 
 function edmfx_vertical_diffusion_tendency!(

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -238,16 +238,6 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
     external_forcing_tendency!(Yₜ, Y, p, t, p.atmos.external_forcing)
 
-    if p.atmos.sgs_adv_mode == Explicit()
-        edmfx_sgs_vertical_advection_tendency!(
-            Yₜ,
-            Y,
-            p,
-            t,
-            p.atmos.turbconv_model,
-        )
-    end
-
     if p.atmos.diff_mode == Explicit()
         vertical_diffusion_boundary_layer_tendency!(
             Yₜ,
@@ -262,19 +252,6 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     surface_flux_tendency!(Yₜ, Y, p, t)
 
     radiation_tendency!(Yₜ, Y, p, t, p.atmos.radiation_mode)
-    if p.atmos.sgs_entr_detr_mode == Explicit()
-        edmfx_entr_detr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-        edmfx_first_interior_entr_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
-    if p.atmos.sgs_mf_mode == Explicit()
-        edmfx_sgs_mass_flux_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
-    if p.atmos.sgs_nh_pressure_mode == Explicit()
-        edmfx_nh_pressure_drag_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
-    if p.atmos.sgs_vertdiff_mode == Explicit()
-        edmfx_vertical_diffusion_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
-    end
     edmfx_tke_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
     # Unified microphysics tendencies (cloud condensation + precipitation)

--- a/src/types.jl
+++ b/src/types.jl
@@ -882,14 +882,9 @@ end
 
 Groups turbulence convection-related models and types.
 """
-@kwdef struct AtmosTurbconv{EDMFX, TCM, SAM, SEDM, SNPM, SVM, SMM, SL, AMD, CHD}
+@kwdef struct AtmosTurbconv{EDMFX, TCM, SL, AMD, CHD}
     edmfx_model::EDMFX = nothing
     turbconv_model::TCM = nothing
-    sgs_adv_mode::SAM = Explicit()
-    sgs_entr_detr_mode::SEDM = Explicit()
-    sgs_nh_pressure_mode::SNPM = Explicit()
-    sgs_vertdiff_mode::SVM = Explicit()
-    sgs_mf_mode::SMM = Explicit()
     smagorinsky_lilly::SL = nothing
     amd_les::AMD = nothing
     constant_horizontal_diffusion::CHD = nothing
@@ -1088,7 +1083,6 @@ Internal testing and calibration components for single-column setups:
 ## AtmosTurbconv
 - `edmfx_model`: EDMFXModel()
 - `turbconv_model`: nothing, PrognosticEDMFX(), DiagnosticEDMFX(), EDOnlyEDMFX()
-- `sgs_adv_mode`, `sgs_entr_detr_mode`, `sgs_nh_pressure_mode`, `sgs_vertdiff_mode`, `sgs_mf_mode`: Explicit(), Implicit()
 - `smagorinsky_lilly`: nothing or SmagorinskyLilly()
 - `amd_les`: nothing or AnisotropicMinimumDissipation()
 - `constant_horizontal_diffusion`: nothing or ConstantHorizontalDiffusion()


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Remove SGS explicit/implicit timestepping options (always implicit): 
- SGS advection, 
- entrainment/detrainment, 
- nh pressure drag, 
- SGS vertical diffusion, 
- and SGS mass flux.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
