### PR TITLE
Remove CTS backward-compat type usage

### DIFF
--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -110,7 +110,7 @@ function callback_from_affect(affect!)
     return nothing
 end
 function atmos_callbacks(cbs)
-    all_cbs = [cbs.continuous_callbacks..., cbs.discrete_callbacks...]
+    all_cbs = collect(cbs.discrete_callbacks)
     callback_objs = map(cb -> callback_from_affect(cb.affect!), all_cbs)
     filter!(x -> (x isa AtmosCallback), callback_objs)
     return callback_objs

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -323,8 +323,7 @@ function AtmosSimulation{FT}(;
     else
         callbacks
     end
-    continuous_callbacks = ()
-    callback_set = CTS.CallbackSet(continuous_callbacks, discrete_callbacks)
+    callback_set = CTS.CallbackSet(discrete_callbacks...)
 
     integrator_args, integrator_kwargs = args_integrator(
         Y, p, (t_start, t_end), ode_config,

--- a/src/simulation/solve.jl
+++ b/src/simulation/solve.jl
@@ -2,7 +2,7 @@ import ClimaTimeSteppers as CTS
 import Base.Sys: maxrss
 
 # Empty integrator.tstops to stop time-marching.
-function terminate!(integrator::CTS.DistributedODEIntegrator)
+function terminate!(integrator::CTS.TimeStepperIntegrator)
     @info "Gracefully exiting simulation."
     empty!(integrator.tstops)
 end
@@ -121,7 +121,7 @@ end
 
 check_conservation(simulation::AtmosSimulation) =
     check_conservation(simulation.integrator.sol)
-check_conservation(integrator::CTS.DistributedODEIntegrator) =
+check_conservation(integrator::CTS.TimeStepperIntegrator) =
     check_conservation(integrator.sol)
 check_conservation(atmos_sol::AtmosSolveResults) =
     check_conservation(atmos_sol.sol)


### PR DESCRIPTION
Replace deprecated ClimaTimeSteppers backward-compatibility pieces with their canonical names so that CTS can drop the compat aliases:

- CTS.DistributedODEIntegrator → CTS.TimeStepperIntegrator (solve.jl)
- CTS.CallbackSet(continuous_callbacks, discrete_callbacks) → CTS.CallbackSet(discrete_callbacks...) (AtmosSimulations.jl)
- cbs.continuous_callbacks removed from atmos_callbacks (callback_helpers.jl)

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
