### PR TITLE
docs: Improve first simulations page, fix examples

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -6,6 +6,20 @@
 ClimaAtmos.AtmosSimulation
 ```
 
+## Presets
+
+```@docs
+ClimaAtmos.Presets.aquaplanet
+ClimaAtmos.Presets.baroclinic_wave
+ClimaAtmos.Presets.bomex
+ClimaAtmos.Presets.dry
+ClimaAtmos.Presets.equil_moist_0m
+ClimaAtmos.Presets.nonequil_moist_1m
+ClimaAtmos.Presets.diagnostic_edmf
+ClimaAtmos.Presets.prognostic_edmf
+ClimaAtmos.Presets.prognostic_edmf_1m
+```
+
 ## Grids
 
 ```@docs

--- a/docs/src/first_simulation.md
+++ b/docs/src/first_simulation.md
@@ -32,45 +32,60 @@ simulation = CA.AtmosSimulation{Float32}(; grid, t_end = 3600 * 6)
 nothing # hide
 ```
 
-Other grid types: [`SphereGrid`](@ref), [`BoxGrid`](@ref), [`PlaneGrid`](@ref).
-
-### Change the setup
-
-A *setup* defines the initial conditions, boundary conditions, and (optionally)
-forcing for a simulation case. For example, the BOMEX shallow cumulus case:
-
-```julia
-simulation = CA.AtmosSimulation{Float32}(;
-    grid = CA.ColumnGrid(Float32; z_elem = 60, z_max = 3000.0),
-    initial_condition = CA.Setups.Bomex(),
-    dt = 5,
-    t_end = 3600 * 6,
-    job_id = "my_bomex",
-)
-CA.solve_atmos!(simulation)
-```
-
-See the [Setups](setups.md) page for the full list of available setups and how to create
-your own.
+See the [Grids](api.md#Grids) section of the API for all grid types and their options.
 
 ### Change the timestep and duration
 
 `dt` is the timestep in seconds. `t_end` is the total simulation time in
 seconds:
 
-```julia
+```@example first_sim
 simulation = CA.AtmosSimulation{Float32}(;
     dt = 300,           # 5-minute timestep
     t_end = 86400 * 10, # 10 days
 )
+nothing # hide
 ```
+
+### Change the setup
+
+A *setup* defines the initial conditions, boundary conditions, and (optionally)
+forcing for a simulation case. For example, the BOMEX shallow cumulus case:
+
+```@example first_sim
+simulation = CA.AtmosSimulation{Float32}(;
+    grid = CA.ColumnGrid(Float32; z_elem = 60, z_max = 3000.0, z_stretch = false),
+    setup = CA.Setups.Bomex(),
+    dt = 5,
+    t_end = 3600,
+    job_id = "my_bomex",
+)
+nothing # hide
+```
+
+See the [Setups](setups.md) page for the full list of available setups and how to create
+your own.
+
+
+## Presets
+
+Common configurations are available as one-line presets in `CA.Presets`:
+
+```@example first_sim
+simulation = CA.Presets.bomex(Float32; t_end = 600)
+nothing # hide
+```
+
+See the [Presets](api.md#Presets) section of the API for the full list of
+simulation and model presets.
+
 
 ## Inspecting results
 
 After a simulation completes, access the prognostic state through the
 integrator:
 
-```julia
+```@example first_sim
 Y = simulation.integrator.u
 
 # Center (cell-center) variables

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -25,7 +25,7 @@ import ..SmoothMinimumBlending
     dry(; kwargs...)
 
 Dry atmosphere preset (`microphysics_model = DryModel()`).
-Keyword arguments are forwarded to [`AtmosModel`](@ref).
+Keyword arguments are forwarded to `AtmosModel`.
 """
 function dry(; kwargs...)
     defaults = (; microphysics_model = DryModel())
@@ -37,7 +37,7 @@ end
 
 Equilibrium-moisture preset with 0-moment microphysics, grid-scale cloud,
 prescribed zonally-symmetric SST, and idealized insolation.
-Keyword arguments are forwarded to [`AtmosModel`](@ref).
+Keyword arguments are forwarded to `AtmosModel`.
 """
 function equil_moist_0m(; kwargs...)
     defaults = (;
@@ -57,7 +57,7 @@ Non-equilibrium-moisture preset with 1-moment microphysics, explicit
 microphysics tendency timestepping, grid-scale cloud, prescribed
 zonally-symmetric SST, and idealized insolation. Mirrors [`equil_moist_0m`](@ref)
 but with 1-moment non-equilibrium microphysics in place of 0-moment equilibrium.
-Keyword arguments are forwarded to [`AtmosModel`](@ref).
+Keyword arguments are forwarded to `AtmosModel`.
 """
 function nonequil_moist_1m(; kwargs...)
     defaults = (;
@@ -74,14 +74,14 @@ end
 """
     diagnostic_edmf([FT = Float32]; area_fraction, n_updrafts, prognostic_tke, kwargs...)
 
-Equilibrium-moist model with the [`DiagnosticEDMFX`](@ref) turbulence-convection
+Equilibrium-moist model with the `DiagnosticEDMFX` turbulence-convection
 scheme wired in with `Generalized` entrainment/detrainment, SGS mass & diffusive
 fluxes, and non-hydrostatic pressure drag (matches the canonical
 `diagnostic_edmfx_*` configs).
 
 `area_fraction` defaults to 1e-5.
 Override `microphysics_model` to pair EDMF with a dry or non-equilibrium scheme.
-All remaining keyword arguments are forwarded to [`AtmosModel`](@ref).
+All remaining keyword arguments are forwarded to `AtmosModel`.
 """
 function diagnostic_edmf(
     ::Type{FT} = Float32;
@@ -111,12 +111,12 @@ end
 """
     prognostic_edmf([FT = Float32]; area_fraction, n_updrafts, prognostic_tke, kwargs...)
 
-Equilibrium-moist model with the [`PrognosticEDMFX`](@ref) turbulence-convection
+Equilibrium-moist model with the `PrognosticEDMFX` turbulence-convection
 scheme. In addition to the [`diagnostic_edmf`](@ref) EDMF settings, this also
 enables prognostic updraft vertical diffusion and the relaxation filter on
 negative updraft velocities (matches the canonical `prognostic_edmfx_*` configs).
 
-All remaining keyword arguments are forwarded to [`AtmosModel`](@ref).
+All remaining keyword arguments are forwarded to `AtmosModel`.
 """
 function prognostic_edmf(
     ::Type{FT} = Float32;
@@ -151,7 +151,7 @@ end
 [`prognostic_edmf`](@ref) with 1-moment non-equilibrium microphysics and explicit
 microphysics tendency timestepping (matches the canonical `prognostic_edmfx_*`
 configs that use `microphysics_model: "1M"`). All keyword arguments are
-forwarded to [`prognostic_edmf`](@ref) and on to [`AtmosModel`](@ref).
+forwarded to [`prognostic_edmf`](@ref) and on to `AtmosModel`.
 """
 function prognostic_edmf_1m(::Type{FT} = Float32; kwargs...) where {FT}
     defaults = (;
@@ -170,7 +170,7 @@ end
 
 Aquaplanet simulation preset: global [`SphereGrid`](@ref) with
 [`equil_moist_0m`](@ref) physics (0M microphysics, prescribed zonally-symmetric
-SST, idealized insolation). Uses the default [`DecayingProfile`](@ref) initial
+SST, idealized insolation). Uses the default `DecayingProfile` initial
 condition from [`AtmosSimulation`](@ref).
 Keyword arguments are forwarded to [`AtmosSimulation`](@ref).
 """
@@ -183,7 +183,7 @@ end
     baroclinic_wave([FT = Float32]; kwargs...)
 
 Dry baroclinic-wave simulation preset: global [`SphereGrid`](@ref),
-[`DryBaroclinicWave`](@ref) setup, and a dry model with
+`DryBaroclinicWave` setup, and a dry model with
 `disable_surface_flux_tendency = true`. For the moist variant, pass
 `setup = Setups.MoistBaroclinicWave()` and
 `model = Presets.equil_moist_0m(; disable_surface_flux_tendency = true)`.

--- a/src/setups/Bomex.jl
+++ b/src/setups/Bomex.jl
@@ -9,20 +9,25 @@ at construction time before broadcasting).
 
 ## Example
 ```julia
-import Thermodynamics as TD
-import ClimaParams as CP
-FT = Float64
-toml_dict = CP.create_toml_dict(FT)
-thermo_params = TD.Parameters.ThermodynamicsParameters(toml_dict)
-setup = Bomex(; prognostic_tke = true, thermo_params)
+setup = Bomex()                       # Float32 defaults
+setup = Bomex(Float64)                # specify floating-point type
+setup = Bomex(; prognostic_tke = false)
 ```
+
+To use thermodynamics parameters from a non-default `ClimaAtmosParameters`,
+pass them explicitly via `thermo_params`.
 """
 struct Bomex{P}
     prognostic_tke::Bool
     profiles::P
 end
-Bomex(; prognostic_tke, thermo_params) =
-    Bomex(prognostic_tke, bomex_profiles(thermo_params))
+function Bomex(
+    ::Type{FT} = Float32;
+    prognostic_tke = true,
+    thermo_params = ThermodynamicsParameters(FT),
+) where {FT}
+    return Bomex(prognostic_tke, bomex_profiles(thermo_params))
+end
 
 """
     bomex_profiles(thermo_params)

--- a/src/setups/Setups.jl
+++ b/src/setups/Setups.jl
@@ -5,6 +5,7 @@ import ClimaCore: Fields
 import Thermodynamics as TD
 import Thermodynamics.TemperatureProfiles: DecayingTemperatureProfile, DryAdiabaticProfile
 import AtmosphericProfilesLibrary as APL
+import ClimaParams
 
 import ..Parameters as CAP
 import ..geopotential


### PR DESCRIPTION
Docs changes
- updated first simulation examples to be runnable
- added presets to API section, with a link from the first simulation page

Src changes
- Improved Bomex constructor with defaults
- Removed unresolvable docstring links in presets