### PR TITLE
Refactor surface conditions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -192,7 +192,7 @@ steps:
           --job_id diagnostic_edmfx_dycoms_rf02_box
         artifact_paths: "diagnostic_edmfx_dycoms_rf02_box/output_active/*"
         agents:
-          slurm_mem: 20GB
+          slurm_mem: 24GB
 
       - label: ":ghost: Diagnostic EDMF: Precipitating trade wind Cu (RICO)"
         retry: *retry_policy

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,7 @@ makedocs(;
         "Available Diagnostics" => "available_diagnostics.md",
         "Diagnostic EDMF Equations" => "diagnostic_edmf_equations.md",
         "Gravity Wave Drag Parameterizations" => "gravity_wave.md",
+        "Surface Conditions" => "surface_conditions.md",
         "Ocean Surface Albedo Parameterization" => "surface_albedo.md",
         "Topography Representation" => "topography.md",
         "Tracers" => "tracers.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,6 +58,52 @@ ClimaAtmos.SLEVEWarp
 ClimaAtmos.LinearWarp
 ```
 
+## Surface
+
+See the [Surface Conditions](@ref "Surface Conditions") page for a guide to
+these types and how to choose among them.
+
+```@docs
+ClimaAtmos.AtmosSurface
+```
+
+### Flux schemes
+
+```@docs
+ClimaAtmos.SurfaceConditions.SurfaceParameterization
+ClimaAtmos.SurfaceConditions.MoninObukhov
+ClimaAtmos.SurfaceConditions.ExchangeCoefficients
+ClimaAtmos.SurfaceConditions.HeatFluxes
+ClimaAtmos.SurfaceConditions.θAndQFluxes
+ClimaAtmos.SurfaceConditions.DefaultMoninObukhov
+ClimaAtmos.SurfaceConditions.DefaultExchangeCoefficients
+```
+
+### Surface temperature
+
+```@docs
+ClimaAtmos.SurfaceConditions.SurfaceTemperature
+ClimaAtmos.SurfaceConditions.AnalyticTemperature
+ClimaAtmos.SurfaceConditions.SlabOceanTemperature
+ClimaAtmos.SurfaceConditions.ExternalTemperature
+ClimaAtmos.SurfaceConditions.CoupledTemperature
+```
+
+### Boundary overrides
+
+```@docs
+ClimaAtmos.SurfaceConditions.SurfaceBoundaryOverrides
+```
+
+### Surface albedo
+
+```@docs
+ClimaAtmos.SurfaceAlbedoModel
+ClimaAtmos.ConstantAlbedo
+ClimaAtmos.RegressionFunctionAlbedo
+ClimaAtmos.CouplerAlbedo
+```
+
 ## Internals
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -104,6 +104,14 @@ ClimaAtmos.RegressionFunctionAlbedo
 ClimaAtmos.CouplerAlbedo
 ```
 
+### Core functions
+
+```@docs
+ClimaAtmos.SurfaceConditions.update_surface_conditions!
+ClimaAtmos.SurfaceConditions.surface_state_to_conditions
+ClimaAtmos.SurfaceConditions.atmos_surface_conditions
+```
+
 ## Internals
 
 ```@docs

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -41,10 +41,11 @@ ClimaAtmos.Setups.face_initial_condition
 
 ## `surface_condition`
 
-Returns surface boundary data for the setup. The return value can be:
-- A `SurfaceConditions.SurfaceState` (static surface conditions)
-- A callable `(surface_coordinates, interior_z, t) -> SurfaceState` (time-varying)
-- `nothing` (falls through to config-based surface setup)
+Returns surface boundary data for the setup as a NamedTuple
+`(; flux_scheme, temperature, overrides)`. Any field may be `nothing` to fall
+through to the config-based default. See the
+[Surface Conditions](@ref "Surface Conditions") page for what each field means
+and the available options.
 
 Not all setups need this — only those that prescribe case-specific surface
 properties (e.g., roughness length, surface fluxes, surface temperature).

--- a/docs/src/surface_conditions.md
+++ b/docs/src/surface_conditions.md
@@ -100,16 +100,18 @@ Sets the shortwave reflectivity passed to the radiation scheme. Three models:
 `ConstantAlbedo` sets them equal, `RegressionFunctionAlbedo` computes them
 separately.
 
-**Spectral** All three models write a single value across every shortwave band, and the
-Jin scheme treats the refractive index as wavelength-independent. The RRTMGP
+**Spectral** All three models write a single value across every shortwave band,
+and the [`RegressionFunctionAlbedo`](@ref ClimaAtmos.RegressionFunctionAlbedo)
+scheme treats the refractive index as wavelength-independent. The RRTMGP
 interface arrays are band-resolved (`(nbnd_sw, ncol)`), so per-band albedo is a
-supported extension point but it would require a model that fills bands with distinct values.
+supported extension point but it would require a model that fills bands with
+distinct values.
 
 **Longwave surface reflectivity** Albedo is shortwave-only, longwave surface reflectivity is handled
 separately through `surface_emissivity`. 
 
 See the [Ocean Surface Albedo](@ref "Ocean Surface Albedo") page for the
-Jin (2011) formulation.
+Jin (2011) [`RegressionFunctionAlbedo`](@ref ClimaAtmos.RegressionFunctionAlbedo) formulation..
 
 ### Choosing
 
@@ -119,13 +121,13 @@ either/or:
 
 | If you want… | `flux_scheme` | `temperature` |
 |---|---|---|
-| Stability-dependent fluxes over a prescribed SST | `MoninObukhov(; z0 = …)` | `AnalyticTemperature(…)` |
-| Fixed-coefficient bulk fluxes | `ExchangeCoefficients(; Cd, Ch)` | `AnalyticTemperature(…)` |
-| Prescribed heat fluxes (constant or time-varying) | `MoninObukhov(; z0, shf, lhf)` or `MoninObukhov(; z0, fluxes = (t,FT)->…)` | `AnalyticTemperature(…)` |
-| An interactive slab ocean surface | `MoninObukhov(…)` | `SlabOceanTemperature(…)` |
-| Surface temperature from data | `MoninObukhov(…)` | `ExternalTemperature()` |
-| Coupler owns the surface (atmos skips fluxes) | `nothing` | unused — coupler writes `sfc_conditions` |
-| Coupler sets SST; atmos computes fluxes | `MoninObukhov(…)` | `CoupledTemperature(field)` |
+| Stability-dependent fluxes over a prescribed SST  | [`MoninObukhov(; z0 = …)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                    | [`AnalyticTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature)                                                                                     |
+| Fixed-coefficient bulk fluxes                     | [`ExchangeCoefficients(; Cd, Ch)`](@ref ClimaAtmos.SurfaceConditions.ExchangeCoefficients)    | [`AnalyticTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature)                                                                                     |
+| Prescribed heat fluxes (constant or time-varying) | [`MoninObukhov(; z0, shf, lhf)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov) or [`MoninObukhov(; z0, fluxes = (t,FT)->…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov) | [`AnalyticTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature) |
+| An interactive slab ocean surface                 | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                           | [`SlabOceanTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.SlabOceanTemperature)                                                                                   |
+| Surface temperature from data                     | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                           | [`ExternalTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.ExternalTemperature)                                                                                     |
+| Coupler owns the surface (atmos skips fluxes)     | `nothing`                                                                                     | unused — coupler writes `sfc_conditions`                                                                                                                              |
+| Coupler sets SST; atmos computes fluxes           | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                           | [`CoupledTemperature(field)`](@ref ClimaAtmos.SurfaceConditions.CoupledTemperature)                                                                                   |
 
 !!! note "Prescribed fluxes do not use MOST"
     When you set `shf`/`lhf` (or `θ_flux`/`q_flux`), those fluxes are used **as
@@ -135,6 +137,33 @@ either/or:
     solely for the *momentum* closure, and only when `ustar` is not also
     prescribed — when both fluxes and `ustar` are given (as in every idealized
     LES setup), MOST does nothing and the surface is fully prescribed.
+
+### Setting the surface in a runscript
+
+Build an [`AtmosSurface`](@ref ClimaAtmos.AtmosSurface) and hand it to
+`AtmosModel`. For example, Monin–Obukhov fluxes over a fixed 290 K sea surface
+with a constant albedo:
+
+```julia
+import ClimaAtmos as CA
+import ClimaAtmos.SurfaceConditions as SC
+FT = Float64
+
+surface = CA.AtmosSurface(;
+    flux_scheme = SC.MoninObukhov(; z0 = FT(1e-4)),
+    temperature = SC.AnalyticTemperature(Returns(FT(290))),
+    surface_albedo = CA.ConstantAlbedo{FT}(; α = FT(0.07)),
+    # boundary_overrides defaults to all-`nothing` (physical defaults)
+)
+
+model = CA.AtmosModel(; surface, microphysics_model = CA.DryModel())
+```
+
+Omitted fields take their defaults. You can also pass the surface fields
+directly to `AtmosModel` (`CA.AtmosModel(; flux_scheme = …, temperature = …)`),
+which assembles the `AtmosSurface` for you. To swap in an interactive slab
+ocean use `temperature = SC.SlabOceanTemperature{FT}()`; for prescribed heat
+fluxes, `flux_scheme = SC.MoninObukhov(; z0 = FT(1e-4), shf = …, lhf = …)`.
 
 ### Configuring from YAML
 
@@ -149,6 +178,14 @@ take precedence over these defaults:
   `"PrescribedSST"` (default) or `"SlabOceanSST"` (→ `SlabOceanTemperature`).
 - `albedo_model` sets [`surface_albedo`](@ref "Albedo (surface_albedo)"):
   `"ConstantAlbedo"` (default), `"RegressionFunctionAlbedo"`, or `"CouplerAlbedo"`.
+
+For example:
+
+```yaml
+surface_setup: "DefaultMoninObukhov"   # flux_scheme
+prognostic_surface: "PrescribedSST"    # temperature
+albedo_model: "ConstantAlbedo"         # surface_albedo
+```
 
 The fourth field, [`boundary_overrides`](@ref "Boundary overrides (boundary_overrides)"),
 has no YAML key: it is populated by a setup's
@@ -199,17 +236,14 @@ Surface behavior lives entirely on `atmos.surface`. Principles:
 
 ### Data flow
 
-The entry point `update_surface_conditions!` (called from
-`set_precomputed_quantities!`) does four things: (1) early-return if
+The entry point
+[`update_surface_conditions!`](@ref ClimaAtmos.SurfaceConditions.update_surface_conditions!)
+(called from `set_precomputed_quantities!`) does four things: (1) early-return if
 `isnothing(flux_scheme)`; (2) resolve the temperature via `surface_temperature`;
 (3) resolve the flux scheme via `resolve_flux_scheme` (once per update);
-(4) broadcast `surface_state_to_conditions` over every surface point.
-
-```@docs
-ClimaAtmos.SurfaceConditions.update_surface_conditions!
-ClimaAtmos.SurfaceConditions.surface_state_to_conditions
-ClimaAtmos.SurfaceConditions.atmos_surface_conditions
-```
+(4) broadcast
+[`surface_state_to_conditions`](@ref ClimaAtmos.SurfaceConditions.surface_state_to_conditions)
+over every surface point.
 
 !!! note "Why a `DataLayout` broadcast"
     The kernel mixes *surface*-space and *lowest-interior-level* values, which
@@ -348,7 +382,9 @@ redefine it.
   `AtmosSurface`; setup pieces win via `@something`.
 - `build_cache` (`src/cache/cache.jl`) stores `p.sfc_setup =
   atmos.surface.boundary_overrides` (a scalar, or a `Field` for the coupler) and
-  calls `init_sfc_conditions_zero!` when `isnothing(flux_scheme)`.
+  calls
+  [`init_sfc_conditions_zero!`](@ref ClimaAtmos.SurfaceConditions.init_sfc_conditions_zero!)
+  when `isnothing(flux_scheme)`.
 
 ```@docs
 ClimaAtmos.SurfaceConditions.init_sfc_conditions_zero!

--- a/docs/src/surface_conditions.md
+++ b/docs/src/surface_conditions.md
@@ -1,0 +1,368 @@
+# Surface Conditions
+
+The lower boundary is where the atmosphere exchanges momentum, heat, and
+moisture with whatever lies beneath it (ocean, land, sea ice, or an idealized
+slab). ClimaAtmos collects everything controlling this boundary into one object,
+`AtmosSurface`, stored as `atmos.surface`. It is read at each step to fill
+`p.precomputed.sfc_conditions`, the surface fluxes and values consumed as
+boundary conditions by the dynamical core, radiation, and turbulence schemes.
+
+The [User Guide](#User-Guide) covers the options and how to choose; the
+[Developer Guide](#Developer-Guide) covers the design, data flow, and how to
+extend or debug it.
+
+---
+
+## User Guide
+
+### The four knobs
+
+[`AtmosSurface`](@ref ClimaAtmos.AtmosSurface) has four fields, each with one
+purpose:
+
+- `flux_scheme`: computes turbulent fluxes from air–surface differences in
+  temperature, humidity etc.
+- `temperature`: sets the surface temperature `T_sfc`.
+- `boundary_overrides`: pins surface properties at user-specified values.
+- `surface_albedo`: sets the shortwave reflectivity seen by radiation (distinct
+  direct and diffuse components).
+
+Set these directly when building a model, or let them be chosen by a
+[setup](@ref "Setups") or by [YAML keys](#Configuring-from-YAML).
+
+### Flux scheme (`flux_scheme`)
+
+The closure turning the surface–to–lowest-level difference into turbulent
+fluxes of momentum, heat, and moisture:
+
+- **[`MoninObukhov`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)**:
+  Monin–Obukhov Similarity Theory (MOST); fluxes follow from roughness length and
+  near-surface stability. Heat fluxes (`shf`/`lhf` or `θ_flux`/`q_flux`) or
+  `ustar` may instead be prescribed (common for LES). For *time-varying*
+  prescribed fluxes, pass `fluxes` as a callable
+  `(t, FT) -> HeatFluxes/θAndQFluxes` — it is resolved once per update (e.g.
+  TRMM_LBA's diurnal SHF/LHF), while `z0`/`ustar` stay constant.
+- **[`ExchangeCoefficients`](@ref ClimaAtmos.SurfaceConditions.ExchangeCoefficients)**:
+  bulk fluxes with fixed `Cd`/`Ch`; simpler and cheaper, for idealized constant
+  exchange coefficients (rather than coefficients determined by MOST).
+- **`nothing`**: no atmos-side computation; an external driver supplies the
+  conditions (see [Coupling](#Coupling-to-an-external-driver)).
+
+### Temperature source (`temperature`)
+
+What `T_sfc` is; the flux scheme then uses it (and surface humidity) for the
+air–surface gradients:
+
+- **[`AnalyticTemperature`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature)**:
+  `T_sfc = f(coordinates, params, t)`, per point. Covers a uniform constant
+  (`AnalyticTemperature(Returns(FT(300)))`), a zonally-symmetric SST, or a
+  time-varying profile (e.g., GABLS).
+- **[`SlabOceanTemperature`](@ref ClimaAtmos.SurfaceConditions.SlabOceanTemperature)**:
+  *prognostic*; `T_sfc` read from `Y.sfc.T`, evolved by a slab-ocean energy
+  budget. The only type that adds a prognostic state.
+- **[`ExternalTemperature`](@ref ClimaAtmos.SurfaceConditions.ExternalTemperature)**:
+  read from a time-varying external input; valid only when the setup populates
+  `external_forcing.surface_inputs`.
+- **[`CoupledTemperature`](@ref ClimaAtmos.SurfaceConditions.CoupledTemperature)**:
+  read from a `Field` the coupler writes into (see
+  [Coupling](#Coupling-to-an-external-driver)).
+
+!!! note "Constant temperature"
+    There is no dedicated constant type. Use
+    `AnalyticTemperature(Returns(FT(300)))`, wrapping the value in `FT(...)` to
+    keep the broadcast type-stable.
+
+### Boundary overrides (`boundary_overrides`)
+
+By default, surface values come from physics (pressure hydrostatically
+extrapolated, humidity saturated at `T_sfc`, zero winds, unit gustiness/moisture
+availability).
+[`SurfaceBoundaryOverrides`](@ref ClimaAtmos.SurfaceConditions.SurfaceBoundaryOverrides)
+pins any of these to a fixed value;
+each field defaults to `nothing` (use the physical default). Most idealized LES
+setups override `p` and `q_vap`.
+
+### Albedo (`surface_albedo`)
+
+Sets the shortwave reflectivity passed to the radiation scheme. Three models:
+
+- **[`ConstantAlbedo`](@ref ClimaAtmos.ConstantAlbedo)**: a single value applied
+  to both direct and diffuse shortwave.
+- **[`RegressionFunctionAlbedo`](@ref ClimaAtmos.RegressionFunctionAlbedo)**: the
+  Jin et al. (2011) ocean parameterization — a solar-zenith-angle-dependent
+  *direct* albedo plus a separate *diffuse* albedo, with wind-speed-dependent
+  surface roughness.
+- **[`CouplerAlbedo`](@ref ClimaAtmos.CouplerAlbedo)**: albedo supplied by an
+  external driver (the coupler).
+
+**Direct vs. diffuse** The model carries distinct
+`direct_sw_surface_albedo` and `diffuse_sw_surface_albedo` fields.
+`ConstantAlbedo` sets them equal, `RegressionFunctionAlbedo` computes them
+separately.
+
+**Spectral** All three models write a single value across every shortwave band, and the
+Jin scheme treats the refractive index as wavelength-independent. The RRTMGP
+interface arrays are band-resolved (`(nbnd_sw, ncol)`), so per-band albedo is a
+supported extension point but it would require a model that fills bands with distinct values.
+
+**Longwave surface reflectivity** Albedo is shortwave-only, longwave surface reflectivity is handled
+separately through `surface_emissivity`. 
+
+See the [Ocean Surface Albedo](@ref "Ocean Surface Albedo") page for the
+Jin (2011) formulation.
+
+### Choosing
+
+`flux_scheme` and `temperature` are independent axes, and you set **both** (the
+other two fields take defaults). Each row below is a compatible *pair*, not an
+either/or:
+
+| If you want… | `flux_scheme` | `temperature` |
+|---|---|---|
+| Stability-dependent fluxes over a prescribed SST | `MoninObukhov(; z0 = …)` | `AnalyticTemperature(…)` |
+| Fixed-coefficient bulk fluxes | `ExchangeCoefficients(; Cd, Ch)` | `AnalyticTemperature(…)` |
+| Prescribed heat fluxes (constant or time-varying) | `MoninObukhov(; z0, shf, lhf)` or `MoninObukhov(; z0, fluxes = (t,FT)->…)` | `AnalyticTemperature(…)` |
+| An interactive slab ocean surface | `MoninObukhov(…)` | `SlabOceanTemperature(…)` |
+| Surface temperature from data | `MoninObukhov(…)` | `ExternalTemperature()` |
+| Coupler owns the surface (atmos skips fluxes) | `nothing` | unused — coupler writes `sfc_conditions` |
+| Coupler sets SST; atmos computes fluxes | `MoninObukhov(…)` | `CoupledTemperature(field)` |
+
+!!! note "Prescribed fluxes do not use MOST"
+    When you set `shf`/`lhf` (or `θ_flux`/`q_flux`), those fluxes are used **as
+    prescribed**: MOST does not compute them. They appear under `MoninObukhov`
+    only because the prescribed-flux path currently lives inside that type (a
+    historical conflation; see the Developer Guide). The required `z0` is used
+    solely for the *momentum* closure, and only when `ustar` is not also
+    prescribed — when both fluxes and `ustar` are given (as in every idealized
+    LES setup), MOST does nothing and the surface is fully prescribed.
+
+### Configuring from YAML
+
+Three of the four `AtmosSurface` fields are YAML-configurable (resolved by
+`AtmosSurface(::AtmosConfig, params, FT; setup_type)`); setup-provided pieces
+take precedence over these defaults:
+
+- `surface_setup` sets [`flux_scheme`](@ref "Flux scheme (flux_scheme)"):
+  `"DefaultExchangeCoefficients"` (default), `"DefaultMoninObukhov"`, or
+  `"PrescribedSurface"` (→ `nothing`).
+- `prognostic_surface` sets [`temperature`](@ref "Temperature source (temperature)"):
+  `"PrescribedSST"` (default) or `"SlabOceanSST"` (→ `SlabOceanTemperature`).
+- `albedo_model` sets [`surface_albedo`](@ref "Albedo (surface_albedo)"):
+  `"ConstantAlbedo"` (default), `"RegressionFunctionAlbedo"`, or `"CouplerAlbedo"`.
+
+The fourth field, [`boundary_overrides`](@ref "Boundary overrides (boundary_overrides)"),
+has no YAML key: it is populated by a setup's
+[`surface_condition`](@ref ClimaAtmos.Setups.surface_condition) (its `overrides`
+field), or left at the all-`nothing` default.
+
+The two `surface_setup` markers,
+[`DefaultMoninObukhov`](@ref ClimaAtmos.SurfaceConditions.DefaultMoninObukhov) and
+[`DefaultExchangeCoefficients`](@ref ClimaAtmos.SurfaceConditions.DefaultExchangeCoefficients),
+are lightweight placeholders that the config-driven constructor resolves into a
+concrete `flux_scheme` against `params` (a default roughness length or exchange
+coefficient).
+
+### Coupling to an external driver
+
+The coupler still builds a complete `AtmosSurface` (all four fields are present);
+the two patterns differ only in the `flux_scheme`/`temperature` pair:
+
+1. **Atmosphere skips surface computation**: `flux_scheme = nothing` (YAML
+   `"PrescribedSurface"`). `update_surface_conditions!` early-returns, so
+   `temperature` is never read (leave it at its default).
+   `init_sfc_conditions_zero!` pre-fills safe defaults at cache-build so RRTMGP /
+   diagnostic EDMF never see uninitialized memory, and the coupler overwrites
+   `sfc_conditions` directly.
+2. **Atmosphere computes fluxes from a coupler-supplied SST**: a real
+   `flux_scheme` (e.g. `MoninObukhov(…)`) *together with*
+   `temperature = CoupledTemperature(field)`. The coupler writes `T_sfc` into
+   `field` between steps; the atmosphere reads it and computes the surface
+   fluxes. Per-cell boundary overrides can be a
+   `Fields.Field{<:SurfaceBoundaryOverrides}` on the cache. See
+   `test/coupler_compatibility.jl`.
+
+---
+
+## Developer Guide
+
+### Design: one source of truth
+
+Surface behavior lives entirely on `atmos.surface`. Principles:
+
+- **Orthogonality**: `flux_scheme`, `temperature`, `boundary_overrides`, and
+  `surface_albedo` are independent axes. Adding an option on one shouldn't touch
+  the others.
+- **Dispatch over branching**: behavior is selected by dispatch on concrete
+  types, not `if/elseif` on config strings.
+- **Eager resolution**: YAML markers and `Default*` placeholders resolve to
+  concrete structs at construction, so the hot path sees only concrete types.
+
+### Data flow
+
+The entry point `update_surface_conditions!` (called from
+`set_precomputed_quantities!`) does four things: (1) early-return if
+`isnothing(flux_scheme)`; (2) resolve the temperature via `surface_temperature`;
+(3) resolve the flux scheme via `resolve_flux_scheme` (once per update);
+(4) broadcast `surface_state_to_conditions` over every surface point.
+
+```@docs
+ClimaAtmos.SurfaceConditions.update_surface_conditions!
+ClimaAtmos.SurfaceConditions.surface_state_to_conditions
+ClimaAtmos.SurfaceConditions.atmos_surface_conditions
+```
+
+!!! note "Why a `DataLayout` broadcast"
+    The kernel mixes *surface*-space and *lowest-interior-level* values, which
+    live on different spaces, so a normal `Field` broadcast would error. The
+    code drops to `Fields.field_values(...)` (raw `DataLayout`s) so the values
+    broadcast as plain same-shape arrays.
+
+### Dispatch chains
+
+Three small families cover all behavior:
+
+**`surface_temperature`** (`surface_temperature.jl`): temperature type → value:
+
+| Type | Returns |
+|---|---|
+| `AnalyticTemperature` | the struct itself (deferred) |
+| `ExternalTemperature` | `field_values` of the evaluated input |
+| `SlabOceanTemperature` | `field_values(Y.sfc.T)` |
+| `CoupledTemperature` | `field_values(t.field)` |
+
+**`resolve_T_sfc`** (`surface_conditions.jl`): in the per-cell kernel, an
+`AnalyticTemperature` is evaluated as `t.f(coordinates, surface_temp_params,
+t_time)`; scalars and `DataLayout`s pass through. This two-step design lets
+analytic formulas see each cell's local coordinates while field-valued
+temperatures resolve once up front.
+
+**Flux scheme → flux specs** (in `surface_state_to_conditions`): branches on
+`ExchangeCoefficients` vs `MoninObukhov`, and within `MoninObukhov` on whether
+fluxes are prescribed (`HeatFluxes`/`θAndQFluxes`) or derived from roughness.
+
+### Constraints
+
+- **Scalars must broadcast.** `Base.broadcastable(x) = tuple(x)` is defined once
+  on the abstract supertypes `SurfaceParameterization` and `SurfaceTemperature`,
+  so every concrete subtype inherits it for free. A new subtype needs nothing
+  extra; the only ways to break this are introducing a parallel hierarchy that
+  isn't a subtype, or removing the supertype method.
+- **`surface_temperature` returns a `DataLayout`, an `AnalyticTemperature`, or a
+  scalar**: nothing else. Return `Fields.field_values(...)`, not a `Field`. A
+  scalar is permitted — it passes through `resolve_T_sfc` unchanged — but no
+  built-in type currently returns one; the four in-tree types return either the
+  struct (`AnalyticTemperature`) or `field_values(...)`.
+- **Time-varying fluxes resolve per-update, not per-cell**: a `MoninObukhov`
+  with a callable `fluxes` has it evaluated once by `resolve_flux_scheme`, then
+  the resulting numeric scheme is broadcast everywhere.
+- **`isnothing(flux_scheme)` is a supported state**: any reader of
+  `atmos.surface.flux_scheme` must handle it.
+- **Only `SlabOceanTemperature` adds prognostic state**: `Y.sfc` exists only for
+  slab runs, so guard `Y.sfc.T` access on that type.
+
+### Extending
+
+Both extension points follow the same shape: define a concrete subtype, then add
+the handful of methods the pipeline dispatches on. Because
+`Base.broadcastable(::SurfaceTemperature)` and
+`Base.broadcastable(::SurfaceParameterization)` are defined on the *abstract*
+supertypes, your subtype inherits broadcastability for free — you do not need to
+redefine it.
+
+#### A new temperature source
+
+1. **Define the type** as a subtype of `SurfaceConditions.SurfaceTemperature`.
+   Store whatever it needs (a function, a `Field`, parameters):
+
+   ```julia
+   struct MyTemperature{F} <: SurfaceConditions.SurfaceTemperature
+       data::F
+   end
+   ```
+
+2. **Add a `surface_temperature` method**, the per-update resolver. It must
+   return one of the three broadcastable shapes: a scalar, a
+   `Fields.DataLayout` of per-cell values, or the struct itself (deferred to the
+   per-cell kernel):
+
+   ```julia
+   # field-valued: resolve once per update
+   SurfaceConditions.surface_temperature(t::MyTemperature, Y, p, t_time) =
+       Fields.field_values(t.data)
+   ```
+
+3. **(Optional) Add a `resolve_T_sfc` method** if you returned the struct in
+   step 2 because `T_sfc` depends on each cell's coordinates (this is how
+   `AnalyticTemperature` works). It runs inside the broadcast kernel and receives
+   the local coordinates:
+
+   ```julia
+   SurfaceConditions.surface_temperature(t::MyTemperature, Y, p, _) = t  # defer
+   SurfaceConditions.resolve_T_sfc(t::MyTemperature, coords, surface_temp_params, t_time) =
+       t.data(coords, surface_temp_params, t_time)
+   ```
+
+4. **(Optional) Wire in prognostic state** if `T_sfc` should evolve, mirroring
+   `SlabOceanTemperature`: add a `surface_prognostic_variables(local_geometry,
+   ::MyTemperature)` initializer and a `surface_kwargs(surface_space,
+   ::MyTemperature)` method (so `Y.sfc` is allocated), a `surface_temp_tendency!`
+   method for the time evolution, and any conservation-diagnostic dispatch in
+   `diagnostics/conservation_diagnostics.jl`.
+
+5. **(Optional) Expose it to configs** by extending
+   `AtmosSurface(::AtmosConfig, ...)` in `src/config/model_getters.jl` (or have a
+   setup return it from `surface_condition`).
+
+#### A new flux scheme
+
+1. **Define the type** as a subtype of
+   `SurfaceConditions.SurfaceParameterization{FT}` (the `{FT}` parameter lets
+   `float_type` recover the element type):
+
+   ```julia
+   struct MyScheme{FT} <: SurfaceConditions.SurfaceParameterization{FT}
+       coefficient::FT
+   end
+   ```
+
+2. **Handle it in `surface_state_to_conditions`**: extend the
+   `parameterization isa …` branch that maps the scheme onto the `SurfaceFluxes`
+   call (building the appropriate `FluxSpecs`/`SurfaceFluxConfig`). This is the
+   one place flux schemes are interpreted.
+
+3. **(Optional) Add a `resolve_flux_scheme` method** if the scheme varies in
+   time, mirroring how `MoninObukhov` resolves a callable `fluxes`. It runs once
+   per update (not per-cell) and must return a concrete, time-independent scheme:
+
+   ```julia
+   SurfaceConditions.resolve_flux_scheme(p::MyScheme, t, ::Type{FT}) where {FT} =
+       MyScheme{FT}(p.coefficient * cos(t))
+   ```
+
+4. **(Optional) Expose it to configs/setups** as in step 5 above.
+
+### Config and cache wiring
+
+- `AtmosSurface(::AtmosConfig, params, FT; setup_type)`
+  (`src/config/model_getters.jl`) maps YAML keys + setup pieces into a concrete
+  `AtmosSurface`; setup pieces win via `@something`.
+- `build_cache` (`src/cache/cache.jl`) stores `p.sfc_setup =
+  atmos.surface.boundary_overrides` (a scalar, or a `Field` for the coupler) and
+  calls `init_sfc_conditions_zero!` when `isnothing(flux_scheme)`.
+
+```@docs
+ClimaAtmos.SurfaceConditions.init_sfc_conditions_zero!
+```
+
+### Debugging checklist
+
+- **`sfc_conditions` NaN/uninitialized under the coupler**: `init_sfc_conditions_zero!`
+  only fires when `isnothing(flux_scheme)`.
+- **`T_sfc` uniform when it should vary**: the temperature must return per-cell
+  values, or be an `AnalyticTemperature` whose `f` actually reads `coordinates`.
+- **Space-mismatch error in `update_surface_conditions!`**: something returned a
+  `Field` instead of a `DataLayout`/scalar, or a type is missing `broadcastable`.
+- **`Y.sfc` not found**: not a `SlabOceanTemperature` run; guard slab-only code.
+- **Time-varying flux not updating**: `MoninObukhov.fluxes` must be a callable
+  `(t, FT) -> PrescribedFluxes` (resolved each update), not a fixed `HeatFluxes`
+  captured at construction.

--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -56,8 +56,9 @@ params = CA.ClimaAtmosParameters(
 
 ## RCEMIP-II model prescriptions
 insolation = CA.RCEMIPIIInsolation()
-sfc_temperature = CA.RCEMIPIISST()
 setup = CA.Setups.RCEMIPIIProfile_300()
+# TODO: Clean this up, it's difficult to use a setup with the `AtmosModel` constructor
+temperature = CA.Setups.surface_temperature_model(setup)
 
 
 ## Construct the model
@@ -77,8 +78,8 @@ model = CA.AtmosModel(;
     rayleigh_sponge = CA.RayleighSponge{FT}(; zd = 30_000),
 
     # AtmosSurface
-    sfc_temperature,
-    surface_model = CA.PrescribedSST(),
+    temperature,
+    flux_scheme = CA.SurfaceConditions.DefaultMoninObukhov()(params),
     surface_albedo = CA.ConstantAlbedo{FT}(; α = 0.07),
 
     # numerics
@@ -138,7 +139,6 @@ end
 simulation = CA.AtmosSimulation{FT}(; job_id,
     model, params, context, grid,
     setup,
-    surface_setup = CA.SurfaceConditions.DefaultMoninObukhov(),
     dt, t_end,
     ode_config,
     output_dir,

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -87,7 +87,6 @@ function build_cache(
     Y,
     atmos,
     params,
-    surface_setup,
     dt,
     start_date,
     aerosol_names,
@@ -163,7 +162,7 @@ function build_cache(
         ),
     )
     external_forcing = external_forcing_cache(Y, atmos, params, start_date)
-    sfc_setup = surface_setup(params)
+    sfc_setup = atmos.surface.boundary_overrides
     scratch = temporary_quantities(Y, atmos)
 
     precomputed = precomputed_quantities(Y, atmos)
@@ -179,9 +178,10 @@ function build_cache(
         external_forcing,
     )
 
-    # Coupler compatibility
-    isnothing(precomputing_arguments.sfc_setup) &&
-        SurfaceConditions.set_dummy_surface_conditions!(precomputing_arguments)
+    # When flux_scheme is nothing, the surface conditions are entirely
+    # supplied by an external driver, so we pre-fill safe defaults
+    isnothing(atmos.surface.flux_scheme) &&
+        SurfaceConditions.init_sfc_conditions_zero!(precomputing_arguments)
 
     set_precomputed_quantities!(Y, precomputing_arguments, FT(0))
 

--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -1,6 +1,21 @@
 # we are ignoring the volume reflectance for now
+"""
+    SurfaceAlbedoModel
+
+Abstract supertype for surface shortwave albedo models. Concrete subtypes
+([`ConstantAlbedo`](@ref), [`RegressionFunctionAlbedo`](@ref),
+[`CouplerAlbedo`](@ref)) set the direct and diffuse shortwave reflectivities
+seen by the radiation scheme (via `set_surface_albedo!`).
+"""
 abstract type SurfaceAlbedoModel end
 
+"""
+    CouplerAlbedo()
+
+Surface albedo supplied by an external driver (the coupler), which writes the
+direct/diffuse shortwave albedos into the radiation cache. ClimaAtmos performs
+no albedo computation of its own in this mode.
+"""
 struct CouplerAlbedo <: SurfaceAlbedoModel end
 
 """

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -28,7 +28,7 @@ function flux_accumulation!(integrator)
         net_energy_flux_toa[] +=
             horizontal_integral_at_boundary(ᶠradiation_flux, nlevels + half) *
             FT(Δt)
-        if p.atmos.surface_model isa PrescribedSST
+        if !(p.atmos.surface.temperature isa SurfaceConditions.SlabOceanTemperature)
             net_energy_flux_sfc[] +=
                 horizontal_integral_at_boundary(ᶠradiation_flux, half) *
                 FT(Δt)
@@ -64,7 +64,7 @@ function external_driven_single_column!(integrator)
     p = integrator.p
     t = integrator.t
 
-    @assert p.atmos.sfc_temperature isa ExternalTVColumnSST (
+    @assert p.atmos.surface.temperature isa SurfaceConditions.ExternalTemperature (
         "SCM reanalysis timevarying setup requires `initial_condition` " *
         "and `external_forcing` to be set to `ReanalysisTimeVarying`"
     )

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -669,19 +669,33 @@ function AtmosSurface(
 ) where {FT}
     pa = config.parsed_args
 
-    sfc_temperature = Setups.surface_temperature_model(setup_type)
+    # Resolve setup-provided surface pieces (flux_scheme, temperature, overrides)
+    setup_pieces =
+        isnothing(setup_type) ?
+        (; flux_scheme = nothing, temperature = nothing, overrides = nothing) :
+        Setups.surface_condition(setup_type, params)
 
-    ps_name = pa["prognostic_surface"]
-    surface_model =
-        if ps_name == "PrescribedSST"
-            PrescribedSST()
-        elseif ps_name == "SlabOceanSST"
-            SlabOceanSST()
-        else
-            error(
-                """Uncaught prognostic_surface `$ps_name`. Expected: "PrescribedSST" | "SlabOceanSST".""",
-            )
-        end
+    temperature = if pa["prognostic_surface"] == "SlabOceanSST"
+        SurfaceConditions.SlabOceanTemperature{FT}()
+    elseif pa["prognostic_surface"] == "PrescribedSST"
+        @something(setup_pieces.temperature, Setups.surface_temperature_model(setup_type))
+    else
+        error(
+            """Uncaught prognostic_surface `$(pa["prognostic_surface"])`. Expected: "PrescribedSST" | "SlabOceanSST".""",
+        )
+    end
+
+    flux_scheme = if !isnothing(setup_pieces.flux_scheme)
+        setup_pieces.flux_scheme
+    elseif pa["surface_setup"] == "PrescribedSurface"
+        nothing
+    else
+        getproperty(SurfaceConditions, Symbol(pa["surface_setup"]))()(params)
+    end
+
+    boundary_overrides = @something(
+        setup_pieces.overrides, SurfaceConditions.SurfaceBoundaryOverrides()
+    )
 
     surface_albedo =
         if pa["albedo_model"] == "ConstantAlbedo"
@@ -697,5 +711,7 @@ function AtmosSurface(
             error("Uncaught surface albedo model `$(pa["albedo_model"])`.")
         end
 
-    return AtmosSurface(; sfc_temperature, surface_model, surface_albedo)
+    return AtmosSurface(;
+        flux_scheme, temperature, boundary_overrides, surface_albedo,
+    )
 end

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -243,23 +243,6 @@ function get_steady_state_velocity(params, Y, topo, initial_condition, mesh_warp
     return (; ᶜu, ᶠu)
 end
 
-function get_surface_setup(parsed_args; setup_type = nothing)
-    if !isnothing(setup_type)
-        return function (params)
-            result = Setups.surface_condition(setup_type, params)
-            if !isnothing(result)
-                return result
-            end
-            return _config_surface_setup(parsed_args)(params)
-        end
-    end
-    return _config_surface_setup(parsed_args)
-end
-
-function _config_surface_setup(parsed_args)
-    return getproperty(SurfaceConditions, Symbol(parsed_args["surface_setup"]))()
-end
-
 # Translate YAML config keys into a user-facing JacobianAlgorithm stub.
 function jacobian_from_parsed_args(parsed_args)
     approximate_solve_iters = parsed_args["approximate_linear_solve_iters"]
@@ -542,7 +525,6 @@ function get_simulation(config::AtmosConfig)
         context = config.comms_ctx,
         grid,
         setup,
-        surface_setup = get_surface_setup(pa; setup_type = setup),
         steady_state_velocity = steady_state_velocity_from_config(config, params),
         dt = pa["dt"],
         start_date = parse_date(pa["start_date"]),

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -50,8 +50,9 @@ import ..DiagnosticEDMFX
 import ..NonOrographicGravityWave
 import ..OrographicGravityWave
 
-# surface_model
-import ..SlabOceanSST
+# surface temperature
+import ..SurfaceConditions
+import ..SurfaceConditions: SlabOceanTemperature
 
 # functions used to calculate diagnostics
 import ..draft_area

--- a/src/diagnostics/conservation_diagnostics.jl
+++ b/src/diagnostics/conservation_diagnostics.jl
@@ -53,10 +53,10 @@ add_diagnostic_variable!(
 # Total energy of the slab ocean (scalar)
 ###
 compute_energyo!(out, state, cache, time) =
-    compute_energyo!(out, state, cache, time, cache.atmos.surface_model)
+    compute_energyo!(out, state, cache, time, cache.atmos.surface.temperature)
 compute_energyo!(_, _, _, _, model) = error_diagnostic_variable("energyo", model)
 
-function compute_energyo!(out, state, _, _, surface_model::SlabOceanSST)
+function compute_energyo!(out, state, _, _, surface_model::SlabOceanTemperature)
     sfc_cρh = surface_model.ρ_ocean * surface_model.cp_ocean * surface_model.depth_ocean
     energyo = horizontal_integral_at_boundary(state.sfc.T .* sfc_cρh)
     isnothing(out) && return [energyo]
@@ -72,13 +72,14 @@ add_diagnostic_variable!(short_name = "energyo", units = "J",
 # Total water of the slab ocean (scalar)
 ###
 compute_watero!(out, state, cache, time) = compute_watero!(
-    out, state, cache, time, cache.atmos.microphysics_model, cache.atmos.surface_model,
+    out, state, cache, time, cache.atmos.microphysics_model,
+    cache.atmos.surface.temperature,
 )
 compute_watero!(_, _, _, _, microphysics_model, surface_model) =
     error_diagnostic_variable("Can only compute total water of the ocean \
-                               with a moist model and with SlabOceanSST")
+                               with a moist model and with SlabOceanTemperature")
 
-function compute_watero!(out, state, _, _, ::MoistMicrophysics, ::SlabOceanSST)
+function compute_watero!(out, state, _, _, ::MoistMicrophysics, ::SlabOceanTemperature)
     watero = horizontal_integral_at_boundary(state.sfc.water)
     isnothing(out) && return [watero]
     out .= watero

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -8,8 +8,7 @@ import ..DryModel
 import ..EquilibriumMicrophysics0M
 import ..NonEquilibriumMicrophysics1M
 import ..GridScaleCloud
-import ..PrescribedSST
-import ..ZonallySymmetricSST
+import ..SurfaceConditions
 import ..IdealizedInsolation
 import ..Explicit
 import ..DiagnosticEDMFX, ..PrognosticEDMFX
@@ -43,8 +42,9 @@ function equil_moist_0m(; kwargs...)
     defaults = (;
         microphysics_model = EquilibriumMicrophysics0M(),
         cloud_model = GridScaleCloud(),
-        surface_model = PrescribedSST(),
-        sfc_temperature = ZonallySymmetricSST(),
+        temperature = SurfaceConditions.AnalyticTemperature(
+            Setups.zonally_symmetric_temperature,
+        ),
         insolation = IdealizedInsolation(),
     )
     return AtmosModel(; defaults..., kwargs...)
@@ -64,8 +64,9 @@ function nonequil_moist_1m(; kwargs...)
         microphysics_model = NonEquilibriumMicrophysics1M(),
         microphysics_tendency_timestepping = Explicit(),
         cloud_model = GridScaleCloud(),
-        surface_model = PrescribedSST(),
-        sfc_temperature = ZonallySymmetricSST(),
+        temperature = SurfaceConditions.AnalyticTemperature(
+            Setups.zonally_symmetric_temperature,
+        ),
         insolation = IdealizedInsolation(),
     )
     return AtmosModel(; defaults..., kwargs...)

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -26,7 +26,7 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
             Y,
             p,
             t,
-            p.atmos.surface_model,
+            p.atmos.surface.temperature,
             p.atmos.microphysics_model,
         )
     end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -284,14 +284,14 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
     # NOTE: Microphysics tendencies should be applied before calling this function,
     # because precipitation cache is used in this function
-    surface_temp_tendency!(Yₜ, Y, p, t, p.atmos.surface_model)
+    surface_temp_tendency!(Yₜ, Y, p, t, p.atmos.surface.temperature)
     if p.atmos.microphysics_tendency_timestepping == Explicit()
         surface_precipitation_tendency!(
             Yₜ,
             Y,
             p,
             t,
-            p.atmos.surface_model,
+            p.atmos.surface.temperature,
             p.atmos.microphysics_model,
         )
     end

--- a/src/prognostic_equations/surface_temp.jl
+++ b/src/prognostic_equations/surface_temp.jl
@@ -1,9 +1,11 @@
 #####
-##### Couples the atmospheric model with a slab surface model 
+##### Couples the atmospheric model with a slab surface model
 #####
 
+using .SurfaceConditions: SurfaceTemperature, SlabOceanTemperature
+
 """
-    surface_precipitation_tendency!(Yₜ, Y, p, t, surface_model, microphysics_model)
+    surface_precipitation_tendency!(Yₜ, Y, p, t, temperature, microphysics_model)
 
 Applies the surface water and energy deposition from precipitation.
 
@@ -14,10 +16,10 @@ removal, preserving conservation across IMEX stages.
 """
 surface_precipitation_tendency!(Yₜ, Y, p, t, _, _) = nothing
 
-surface_precipitation_tendency!(Yₜ, Y, p, t, ::SlabOceanSST, ::DryModel) = nothing
+surface_precipitation_tendency!(Yₜ, Y, p, t, ::SlabOceanTemperature, ::DryModel) = nothing
 
 function surface_precipitation_tendency!(
-    Yₜ, Y, p, t, slab::SlabOceanSST, microphysics_model,
+    Yₜ, Y, p, t, slab::SlabOceanTemperature, microphysics_model,
 )
     FT = eltype(Y)
 
@@ -36,16 +38,16 @@ function surface_precipitation_tendency!(
 end
 
 """
-    surface_temp_tendency!(Yₜ, Y, p, t, surface_model)
+    surface_temp_tendency!(Yₜ, Y, p, t, temperature)
 
 Computes the tendency for the prognostic surface temperature (`Y.sfc.T`) and,
 if applicable, prognostic surface water content (`Y.sfc.water`), based on
 surface energy and water fluxes. All fluxes are defined as positive when directed
 from the surface to the atmosphere (upward).
 
-This function is dispatched based on the type of `surface_model`:
-- `::PrescribedSST`: No tendency is computed (surface temperature is fixed).
-- `::SlabOceanSST` (slab model): Calculates tendencies due to:
+Dispatched on the surface temperature type:
+- Anything other than `SlabOceanTemperature`: no tendency (T is fixed/diagnosed).
+- `SlabOceanTemperature` (slab model): calculates tendencies due to:
     - Net upward radiative flux at the surface.
     - Net upward turbulent surface energy flux (sensible + latent heat).
     - Net ocean heat flux divergence in the slab (Q-flux), if enabled.
@@ -55,9 +57,9 @@ Precipitation surface deposition (energy and water) is handled separately by
 `surface_precipitation_tendency!`, which is called from both the implicit and
 explicit tendency paths.
 """
-surface_temp_tendency!(Yₜ, Y, p, t, ::PrescribedSST) = nothing
+surface_temp_tendency!(Yₜ, Y, p, t, ::SurfaceTemperature) = nothing
 
-function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanSST)
+function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanTemperature)
     FT = eltype(Y)
     params = p.params
 
@@ -72,7 +74,7 @@ function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanSST)
 
     # 1. Radiative energy surface fluxes
     if !isnothing(p.atmos.radiation_mode)
-        # ᶠradiation_flux is positive for net upward flux at the surface 
+        # ᶠradiation_flux is positive for net upward flux at the surface
         # (SW_up - SW_down + LW_up - LW_down)
         (; ᶠradiation_flux) = p.radiation
         sfc_rad_e_flux = Spaces.level(ᶠradiation_flux, half).components.data.:1
@@ -91,7 +93,7 @@ function surface_temp_tendency!(Yₜ, Y, p, t, slab::SlabOceanSST)
     end
 
     # 3. Idealized Q-fluxes (parameterization of horizontal ocean energy flux divergence),
-    # following Merlis et al. (2013), "Hadley Circulation Response to Orbital Precession. 
+    # following Merlis et al. (2013), "Hadley Circulation Response to Orbital Precession.
     # Part II: Subtropical Continent.", J. Climate, 26, https://doi.org/10.1175/JCLI-D-12-00149.1
     if q_flux_enabled
         ϕ₀ = slab.ϕ₀

--- a/src/setups/Bomex.jl
+++ b/src/setups/Bomex.jl
@@ -67,14 +67,16 @@ end
 
 function surface_condition(::Bomex, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(;
+    flux_scheme = MoninObukhov(;
         z0 = FT(1e-4),
         θ_flux = FT(8e-3),
         q_flux = FT(5.2e-5),
         ustar = FT(0.28),
     )
-    return SurfaceState(;
-        parameterization, T = FT(300.4), p = FT(101500), q_vap = FT(0.02245),
+    return (;
+        flux_scheme,
+        temperature = AnalyticTemperature(Returns(FT(300.4))),
+        overrides = SurfaceBoundaryOverrides(p = FT(101500), q_vap = FT(0.02245)),
     )
 end
 

--- a/src/setups/DYCOMS.jl
+++ b/src/setups/DYCOMS.jl
@@ -69,11 +69,12 @@ end
 
 function surface_condition(setup::DYCOMS, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(;
-        z0 = FT(1e-4), shf = setup.shf, lhf = setup.lhf, ustar = FT(0.25),
-    )
-    return SurfaceState(;
-        parameterization, T = FT(292.5), p = FT(101780), q_vap = FT(0.01384),
+    return (;
+        flux_scheme = MoninObukhov(;
+            z0 = FT(1e-4), shf = setup.shf, lhf = setup.lhf, ustar = FT(0.25),
+        ),
+        temperature = AnalyticTemperature(Returns(FT(292.5))),
+        overrides = SurfaceBoundaryOverrides(p = FT(101780), q_vap = FT(0.01384)),
     )
 end
 

--- a/src/setups/GABLS.jl
+++ b/src/setups/GABLS.jl
@@ -44,20 +44,15 @@ end
 
 function surface_condition(::GABLS, params)
     FT = eltype(params)
-    p = FT(1e5)
-    q_vap = FT(0)
-    z0 = FT(0.1)
-    parameterization = MoninObukhov(; z0)
-    function surface_state(surface_coordinates, interior_z, t)
-        _FT = eltype(surface_coordinates)
-        SurfaceState(;
-            parameterization,
-            T = 265 - _FT(0.25) * _FT(t) / 3600,
-            p,
-            q_vap,
-        )
-    end
-    return surface_state
+    gabls_T(coords, _, t) =
+        let _FT = eltype(coords)
+            265 - _FT(0.25) * _FT(t) / 3600
+        end
+    return (;
+        flux_scheme = MoninObukhov(; z0 = FT(0.1)),
+        temperature = AnalyticTemperature(gabls_T),
+        overrides = SurfaceBoundaryOverrides(p = FT(1e5), q_vap = FT(0)),
+    )
 end
 
 coriolis_forcing(::GABLS, ::Type{FT}) where {FT} =

--- a/src/setups/GCMDriven.jl
+++ b/src/setups/GCMDriven.jl
@@ -63,8 +63,11 @@ center_initial_condition(setup::GCMDriven, local_geometry, params) =
 
 function surface_condition(setup::GCMDriven, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(; z0 = FT(1e-4))
-    return SurfaceState(; parameterization, T = FT(setup.T_sfc))
+    return (;
+        flux_scheme = MoninObukhov(; z0 = FT(1e-4)),
+        temperature = AnalyticTemperature(Returns(FT(setup.T_sfc))),
+        overrides = nothing,
+    )
 end
 
 external_forcing(setup::GCMDriven, ::Type{FT}) where {FT} =

--- a/src/setups/ISDAC.jl
+++ b/src/setups/ISDAC.jl
@@ -60,9 +60,10 @@ end
 
 function surface_condition(::ISDAC, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(; z0 = FT(4e-4))
-    return SurfaceState(;
-        parameterization, T = FT(267), p = FT(102000),
+    return (;
+        flux_scheme = MoninObukhov(; z0 = FT(4e-4)),
+        temperature = AnalyticTemperature(Returns(FT(267))),
+        overrides = SurfaceBoundaryOverrides(p = FT(102000)),
     )
 end
 

--- a/src/setups/InterpolatedColumnProfile.jl
+++ b/src/setups/InterpolatedColumnProfile.jl
@@ -45,9 +45,12 @@ end
 
 function surface_condition(::InterpolatedColumnProfile, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(; z0 = FT(1e-4))
-    return SurfaceState(; parameterization)
+    return (;
+        flux_scheme = MoninObukhov(; z0 = FT(1e-4)),
+        temperature = nothing,
+        overrides = nothing,
+    )
 end
 
 insolation_model(::InterpolatedColumnProfile) = ExternalTVInsolation()
-surface_temperature_model(::InterpolatedColumnProfile) = ExternalTVColumnSST()
+surface_temperature_model(::InterpolatedColumnProfile) = ExternalTemperature()

--- a/src/setups/RCEMIPIIProfile.jl
+++ b/src/setups/RCEMIPIIProfile.jl
@@ -57,4 +57,26 @@ function center_initial_condition(setup::RCEMIPIIProfile, local_geometry, params
 end
 
 insolation_model(::RCEMIPIIProfile) = RCEMIPIIInsolation()
-surface_temperature_model(::RCEMIPIIProfile) = RCEMIPIISST()
+
+# Sphere SST distribution from Wing et al. (2023) https://gmd.copernicus.org/preprints/gmd-2023-235/
+function rcemipii_temperature(
+    coordinates::Union{Geometry.LatLongZPoint, Geometry.LatLongPoint},
+    surface_temp_params, _,
+)
+    (; lat) = coordinates
+    (; SST_mean, SST_delta, SST_wavelength_latitude) = surface_temp_params
+    return SST_mean + SST_delta / 2 * cosd(360 * lat / SST_wavelength_latitude)
+end
+
+# Box SST distribution from Wing et al. (2023)
+function rcemipii_temperature(
+    coordinates::Union{Geometry.XZPoint, Geometry.XYZPoint},
+    surface_temp_params, _,
+)
+    (; x) = coordinates
+    (; SST_mean, SST_delta, SST_wavelength) = surface_temp_params
+    return SST_mean - SST_delta / 2 * cospi(2 * x / SST_wavelength)
+end
+
+surface_temperature_model(::RCEMIPIIProfile) =
+    AnalyticTemperature(rcemipii_temperature)

--- a/src/setups/Rico.jl
+++ b/src/setups/Rico.jl
@@ -71,9 +71,10 @@ function surface_condition(::Rico, params)
     p_sat = TD.saturation_vapor_pressure(thermo_params, T_surface, TD.Liquid())
     ϵ_v = TD.Parameters.R_d(thermo_params) / TD.Parameters.R_v(thermo_params)
     q_vap = ϵ_v * p_sat / (p_surface - p_sat * (1 - ϵ_v))
-    parameterization = MoninObukhov(; z0 = FT(1.5e-4))
-    return SurfaceState(;
-        parameterization, T = T_surface, p = p_surface, q_vap = FT(q_vap),
+    return (;
+        flux_scheme = MoninObukhov(; z0 = FT(1.5e-4)),
+        temperature = AnalyticTemperature(Returns(T_surface)),
+        overrides = SurfaceBoundaryOverrides(p = p_surface, q_vap = FT(q_vap)),
     )
 end
 

--- a/src/setups/Setups.jl
+++ b/src/setups/Setups.jl
@@ -37,20 +37,20 @@ import ..PrognosticEDMFX
 import ..DiagnosticEDMFX
 import ..EDOnlyEDMFX
 import ..n_mass_flux_subdomains
-import ..PrescribedSST
-import ..SlabOceanSST
 import ..Parameters.ClimaAtmosParameters
 import Thermodynamics.Parameters.ThermodynamicsParameters
 
 # Model types returned by setup interface methods
-import ..ZonallySymmetricSST
 import ..GCMForcing, ..ISDACForcing
 import ..GCMDrivenInsolation, ..ExternalTVInsolation
-import ..RCEMIPIIInsolation, ..RCEMIPIISST
-import ..ExternalTVColumnSST
+import ..RCEMIPIIInsolation
 import ..ShipwayHill2012VelocityProfile
 import ..RadiationDYCOMS, ..RadiationTRMM_LBA, ..RadiationISDAC
-import ..SurfaceConditions: MoninObukhov, SurfaceState
+import ..SurfaceConditions
+import ..SurfaceConditions:
+    MoninObukhov, ExchangeCoefficients, HeatFluxes,
+    SurfaceBoundaryOverrides,
+    AnalyticTemperature, ExternalTemperature
 
 # ============================================================================
 # Layer 1 interface — implemented by each setup
@@ -114,16 +114,12 @@ coriolis_forcing(setup, ::Type{FT}) where {FT} = nothing
 """
     surface_condition(setup, params)
 
-Return the surface state for this setup, or `nothing`.
-
-The return value may be:
-- A `SurfaceState` (static surface conditions)
-- A callable `(surface_coordinates, interior_z, t) -> SurfaceState` (time-varying)
-- `nothing` (falls through to config-based surface condition)
-
-Default: `nothing`.
+Return a NamedTuple `(; flux_scheme, temperature, overrides)` describing the
+surface for this setup. Any field can be `nothing` to fall through to the
+config/default. Used by `AtmosSurface(::AtmosConfig, params, FT; setup_type)`.
 """
-surface_condition(setup, params) = nothing
+surface_condition(setup, params) =
+    (; flux_scheme = nothing, temperature = nothing, overrides = nothing)
 
 # ============================================================================
 # Model interface — optional, returns model objects directly
@@ -148,13 +144,36 @@ Default: `nothing`.
 insolation_model(setup) = nothing
 
 """
+    zonally_symmetric_temperature(coordinates, surface_temp_params, t)
+
+Default analytic surface-temperature formula. For LatLongZPoint coordinates,
+returns the canonical aquaplanet profile from Neale and Hoskins (2000); for
+other geometries it returns a constant 300 K (assume latitude-0 box).
+"""
+function zonally_symmetric_temperature(coordinates, surface_temp_params, _)
+    (; z) = coordinates
+    FT = eltype(z)
+    return FT(300)
+end
+function zonally_symmetric_temperature(
+    coordinates::Geometry.LatLongZPoint, surface_temp_params, _,
+)
+    (; lat, z) = coordinates
+    FT = eltype(lat)
+    return FT(271) + FT(29) * exp(-coordinates.lat^2 / (2 * 26^2)) - FT(6.5e-3) * z
+end
+
+"""
     surface_temperature_model(setup)
 
-Return the surface temperature model for this setup.
+Return the default `SurfaceConditions.SurfaceTemperature` for this setup,
+used when `prognostic_surface == "PrescribedSST"` and the setup itself does
+not provide a `temperature` via `surface_condition`.
 
-Default: `ZonallySymmetricSST()`.
+Default: an `AnalyticTemperature` using `zonally_symmetric_temperature`.
 """
-surface_temperature_model(setup) = ZonallySymmetricSST()
+surface_temperature_model(setup) =
+    AnalyticTemperature(zonally_symmetric_temperature)
 
 """
     prescribed_flow_model(setup, ::Type{FT})
@@ -222,7 +241,7 @@ function initial_state(
     return Fields.FieldVector(;
         c = center_ic.(Fields.local_geometry_field(center_space)),
         f = face_ic.(Fields.local_geometry_field(face_space)),
-        surface_kwargs(surface_space, atmos_model.surface_model)...,
+        surface_kwargs(surface_space, atmos_model.surface.temperature)...,
     )
 end
 

--- a/src/setups/ShipwayHill2012.jl
+++ b/src/setups/ShipwayHill2012.jl
@@ -44,16 +44,14 @@ function center_initial_condition(setup::ShipwayHill2012, local_geometry, params
 end
 
 function surface_condition(::ShipwayHill2012, params)
-    function surface_state(surface_coordinates, interior_z, t)
-        FT = eltype(surface_coordinates)
-        T = FT(297.9)
-        p = FT(100700)
-        rv_0 = FT(0.015)
-        q_vap = rv_0 / (1 + rv_0)
-        parameterization = SurfaceConditions.ExchangeCoefficients(; Cd = FT(0), Ch = FT(0))
-        return SurfaceState(; parameterization, T, p, q_vap)
-    end
-    return surface_state
+    FT = eltype(params)
+    rv_0 = FT(0.015)
+    q_vap = rv_0 / (1 + rv_0)
+    return (;
+        flux_scheme = ExchangeCoefficients(; Cd = FT(0), Ch = FT(0)),
+        temperature = AnalyticTemperature(Returns(FT(297.9))),
+        overrides = SurfaceBoundaryOverrides(p = FT(100700), q_vap = q_vap),
+    )
 end
 
 prescribed_flow_model(::ShipwayHill2012, ::Type{FT}) where {FT} =

--- a/src/setups/SimplePlume.jl
+++ b/src/setups/SimplePlume.jl
@@ -28,10 +28,11 @@ end
 
 function surface_condition(::SimplePlume, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(;
-        z0 = FT(1e-4), θ_flux = FT(8e-2), q_flux = FT(0), ustar = FT(0.28),
-    )
-    return SurfaceState(;
-        parameterization, T = FT(310), p = FT(101500), q_vap = FT(0.02245),
+    return (;
+        flux_scheme = MoninObukhov(;
+            z0 = FT(1e-4), θ_flux = FT(8e-2), q_flux = FT(0), ustar = FT(0.28),
+        ),
+        temperature = AnalyticTemperature(Returns(FT(310))),
+        overrides = SurfaceBoundaryOverrides(p = FT(101500), q_vap = FT(0.02245)),
     )
 end

--- a/src/setups/Soares.jl
+++ b/src/setups/Soares.jl
@@ -44,13 +44,14 @@ end
 
 function surface_condition(::Soares, params)
     FT = eltype(params)
-    parameterization = MoninObukhov(;
-        z0 = FT(0.16),
-        θ_flux = FT(0.06),
-        q_flux = FT(2.5e-5),
-        ustar = FT(0.28),
-    )
-    return SurfaceState(;
-        parameterization, T = FT(300), p = FT(1e5), q_vap = FT(5e-3),
+    return (;
+        flux_scheme = MoninObukhov(;
+            z0 = FT(0.16),
+            θ_flux = FT(0.06),
+            q_flux = FT(2.5e-5),
+            ustar = FT(0.28),
+        ),
+        temperature = AnalyticTemperature(Returns(FT(300))),
+        overrides = SurfaceBoundaryOverrides(p = FT(1e5), q_vap = FT(5e-3)),
     )
 end

--- a/src/setups/TRMM_LBA.jl
+++ b/src/setups/TRMM_LBA.jl
@@ -72,20 +72,21 @@ end
 
 function surface_condition(::TRMM_LBA, params)
     FT = eltype(params)
-    T = FT(296.85)
-    p = FT(99130)
-    q_vap = FT(0.02245)
-    z0 = FT(1e-4)
-    ustar = FT(0.28)
-    function surface_state(surface_coordinates, interior_z, t)
-        _FT = eltype(surface_coordinates)
+    # Prescribed SHF/LHF follow a diurnal cycle resolved once per surface update
+    # by `resolve_flux_scheme`, while z0 and ustar stay constant.
+    function trmm_lba_fluxes(t, ::Type{_FT}) where {_FT}
         value = cos(_FT(π) / 2 * (1 - _FT(t) / (_FT(5.25) * 3600)))
         shf = 270 * max(0, value)^_FT(1.5)
         lhf = 554 * max(0, value)^_FT(1.3)
-        parameterization = MoninObukhov(; z0, shf, lhf, ustar)
-        return SurfaceState(; parameterization, T, p, q_vap)
+        HeatFluxes(; shf, lhf)
     end
-    return surface_state
+    return (;
+        flux_scheme = MoninObukhov(;
+            z0 = FT(1e-4), fluxes = trmm_lba_fluxes, ustar = FT(0.28),
+        ),
+        temperature = AnalyticTemperature(Returns(FT(296.85))),
+        overrides = SurfaceBoundaryOverrides(p = FT(99130), q_vap = FT(0.02245)),
+    )
 end
 
 radiation_model(::TRMM_LBA, ::Type{FT}) where {FT} = RadiationTRMM_LBA(FT)

--- a/src/setups/common/prognostic_variables.jl
+++ b/src/setups/common/prognostic_variables.jl
@@ -208,18 +208,14 @@ end
 # ============================================================================
 
 """
-    surface_prognostic_variables(local_geometry, surface_model)
+    surface_prognostic_variables(local_geometry, temperature)
 
 Pointwise function returning a NamedTuple of surface prognostic variables.
-Follows the same broadcast-over-local-geometry pattern as
-`center_prognostic_variables` and `face_prognostic_variables`.
-
-- `PrescribedSST`: returns empty NamedTuple (no surface prognostic state)
-- `SlabOceanSST`: returns `(; T, water)` — latitude-dependent SST if available,
-  otherwise constant 300K; water depth initialized to zero.
+Only `SlabOceanTemperature` introduces surface prognostic state (`T`, `water`).
 """
-surface_prognostic_variables(local_geometry, ::PrescribedSST) = (;)
-function surface_prognostic_variables(local_geometry, ::SlabOceanSST)
+function surface_prognostic_variables(
+    local_geometry, ::SurfaceConditions.SlabOceanTemperature,
+)
     FT = Geometry.float_type(local_geometry.coordinates)
     coord = local_geometry.coordinates
     T = if :lat in propertynames(coord)
@@ -230,10 +226,13 @@ function surface_prognostic_variables(local_geometry, ::SlabOceanSST)
     return (; T, water = FT(0))
 end
 
-# PrescribedSST has no prognostic surface state, so omit sfc from FieldVector
-surface_kwargs(surface_space, ::PrescribedSST) = (;)
-function surface_kwargs(surface_space, sm)
-    sfc_ic(lg) = surface_prognostic_variables(lg, sm)
+# Only SlabOceanTemperature carries prognostic surface state, other
+# temperature types omit `sfc` from the FieldVector entirely.
+surface_kwargs(surface_space, ::SurfaceConditions.SurfaceTemperature) = (;)
+function surface_kwargs(
+    surface_space, t::SurfaceConditions.SlabOceanTemperature,
+)
+    sfc_ic(lg) = surface_prognostic_variables(lg, t)
     return (; sfc = sfc_ic.(Fields.local_geometry_field(surface_space)))
 end
 

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -168,8 +168,6 @@ Construct an atmospheric simulation with floating-point type `FT` (default: Floa
   Use [`ColumnGrid`](@ref), [`BoxGrid`](@ref), [`PlaneGrid`](@ref), or [`SphereGrid`](@ref).
 - `setup = Setups.DecayingProfile(; perturb=true, params)`: Setup defining the
   initial state. See [Setups](@ref "Setups") for available options.
-- `surface_setup = DefaultExchangeCoefficients()`: Surface exchange parameterization.
-
 ### Time
 - `dt = 600`: Timestep in seconds.
 - `t_start = 0`: Start time in seconds.
@@ -241,7 +239,6 @@ function AtmosSimulation{FT}(;
             update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
         ),
     ),
-    surface_setup = SurfaceConditions.DefaultExchangeCoefficients(),
     steady_state_velocity = nothing, # Predicted steady-state velocity for diagnostics
     job_id = "atmos_sim",
     output_dir = nothing,
@@ -301,7 +298,7 @@ function AtmosSimulation{FT}(;
         steady_state_velocity
 
     p = build_cache(
-        Y, model, params, surface_setup, dt, start_date, aerosol_names,
+        Y, model, params, dt, start_date, aerosol_names,
         time_varying_trace_gases, resolved_steady_state_velocity,
         vertical_water_borrowing_species,
     )

--- a/src/simulation/solve.jl
+++ b/src/simulation/solve.jl
@@ -141,8 +141,8 @@ function check_conservation(sol)
     energy_total = sum(sol.u[1].c.ρe_tot)
     energy_atmos_change = sum(sol.u[end].c.ρe_tot) - sum(sol.u[1].c.ρe_tot)
     p = sol.prob.p
-    sfc = p.atmos.surface_model
-    if sfc isa SlabOceanSST
+    sfc = p.atmos.surface.temperature
+    if sfc isa SurfaceConditions.SlabOceanTemperature
         sfc_cρh = sfc.ρ_ocean * sfc.cp_ocean * sfc.depth_ocean
         energy_total +=
             horizontal_integral_at_boundary(sol.u[1].sfc.T .* sfc_cρh)
@@ -165,7 +165,7 @@ function check_conservation(sol)
     if :ρq_tot in propertynames(sol.u[1].c)
         water_total = sum(sol.u[end].c.ρq_tot)
         water_atmos_change = sum(sol.u[end].c.ρq_tot) - sum(sol.u[1].c.ρq_tot)
-        if sfc isa SlabOceanSST
+        if sfc isa SurfaceConditions.SlabOceanTemperature
             water_surface_change = horizontal_integral_at_boundary(
                 sol.u[end].sfc.water .- sol.u[1].sfc.water,
             )

--- a/src/surface_conditions/SurfaceConditions.jl
+++ b/src/surface_conditions/SurfaceConditions.jl
@@ -2,11 +2,6 @@ module SurfaceConditions
 
 import ..Parameters as CAP
 import ..DryModel
-import ..ZonallySymmetricSST
-import ..RCEMIPIISST
-import ..ExternalTVColumnSST
-import ..SlabOceanSST
-import ..PrescribedSST
 import ..CT1, ..CT2, ..C12, ..CT12, ..C3
 import ..unit_basis_vector_data, ..projected_vector_data
 import ..geopotential
@@ -24,6 +19,7 @@ import Interpolations
 import StaticArrays as SA
 
 include("surface_state.jl")
+include("surface_temperature.jl")
 include("surface_conditions.jl")
 include("surface_setups.jl")
 

--- a/src/surface_conditions/surface_conditions.jl
+++ b/src/surface_conditions/surface_conditions.jl
@@ -1,11 +1,14 @@
 """
     update_surface_conditions!(Y, p, t)
 
-Updates the value of `p.precomputed.sfc_conditions` based on the current state `Y` and time
-`t`. This function will only update the surface conditions if the surface_setup
-is not a PrescribedSurface.
+Updates `p.precomputed.sfc_conditions` based on the current state `Y` and time
+`t`. Skips work if the surface model has no flux parameterization
+(`isnothing(atmos.surface.flux_scheme)`), which is the coupler-handoff case.
 """
 function update_surface_conditions!(Y, p, t)
+    atmos = p.atmos
+    isnothing(atmos.surface.flux_scheme) && return nothing
+
     # Need to extract the field values so that we can do
     # a DataLayout broadcast rather than a Field broadcast
     # because we are mixing surface and interior fields
@@ -15,7 +18,7 @@ function update_surface_conditions!(Y, p, t)
     int_local_geometry_values =
         Fields.field_values(Fields.level(Fields.local_geometry_field(Y.c), 1))
     (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice, ᶜu, sfc_conditions) = p.precomputed
-    (; params, sfc_setup, atmos) = p
+    (; params, sfc_setup) = p
     thermo_params = CAP.thermodynamics_params(params)
     surface_fluxes_params = CAP.surface_fluxes_params(params)
     surface_temp_params = CAP.surface_temp_params(params)
@@ -27,19 +30,15 @@ function update_surface_conditions!(Y, p, t)
     int_u_values = Fields.field_values(Fields.level(ᶜu, 1))
     int_z_values = Fields.field_values(Fields.level(Fields.coordinate_field(Y.c).z, 1))
     sfc_conditions_values = Fields.field_values(sfc_conditions)
-    wrapped_sfc_setup = sfc_setup_wrapper(sfc_setup)
-    if p.atmos.sfc_temperature isa ExternalTVColumnSST
-        (; surface_inputs, surface_timevaryinginputs) = p.external_forcing
-        evaluate!(surface_inputs.ts, surface_timevaryinginputs.ts, t)
-        sfc_temp_var = Fields.field_values(surface_inputs.ts)
-    elseif p.atmos.surface_model isa SlabOceanSST
-        sfc_temp_var = Fields.field_values(Y.sfc.T)
-    else
-        sfc_temp_var = nothing
-    end
+
+    overrides = boundary_overrides_wrapper(sfc_setup)
+    T_sfc_values = surface_temperature(atmos.surface.temperature, Y, p, t)
+    flux_scheme = resolve_flux_scheme(atmos.surface.flux_scheme, t, eltype(params))
 
     @. sfc_conditions_values = surface_state_to_conditions(
-        wrapped_sfc_setup,
+        overrides,
+        flux_scheme,
+        T_sfc_values,
         sfc_local_geometry_values,
         int_T_values,
         int_ρ_values,
@@ -53,39 +52,47 @@ function update_surface_conditions!(Y, p, t)
         surface_fluxes_params,
         surface_temp_params,
         atmos,
-        sfc_temp_var,
         t,
     )
     return nothing
 end
 
+# Resolve time-varying prescribed fluxes once per update (not per-cell): a
+# `MoninObukhov` whose `fluxes` is a callable `(t, FT) -> PrescribedFluxes` is
+# evaluated here, before the per-cell broadcast. Everything else passes through.
+function resolve_flux_scheme(p::MoninObukhov, t, ::Type{FT}) where {FT}
+    p.fluxes isa Function || return p
+    return MoninObukhov(p.z0m, p.z0b, p.fluxes(t, FT), p.ustar)
+end
+resolve_flux_scheme(p, t, ::Type{FT}) where {FT} = p
 
-# default case
-sfc_setup_wrapper(sfc_setup::SurfaceState) = (sfc_setup,)
-
-# case when surface setup is func
-sfc_setup_wrapper(sfc_setup::Function) = (sfc_setup,)
-
-#this is the case for the coupler
-function sfc_setup_wrapper(sfc_setup::Fields.Field)
-    @assert eltype(sfc_setup) <: SurfaceState
-    return Fields.field_values(sfc_setup)
+# Allow the cache `sfc_setup` to be either a scalar `SurfaceBoundaryOverrides`
+# or a `Fields.Field{<:SurfaceBoundaryOverrides}` (coupler case). Both broadcast
+# correctly inside `update_surface_conditions!`.
+boundary_overrides_wrapper(o::SurfaceBoundaryOverrides) = tuple(o)
+function boundary_overrides_wrapper(o::Fields.Field)
+    @assert eltype(o) <: SurfaceBoundaryOverrides
+    return Fields.field_values(o)
 end
 
-surface_state(sfc_setup_wrapper::SurfaceState, _, _, _) = sfc_setup_wrapper
+# Resolve an AnalyticTemperature to a scalar at the broadcast point. Scalars
+# and Field values pass through unchanged.
+resolve_T_sfc(t::AnalyticTemperature, coords, surface_temp_params, t_time) =
+    t.f(coords, surface_temp_params, t_time)
+resolve_T_sfc(t, coords, surface_temp_params, t_time) = t
 
-surface_state(
-    wrapped_sfc_setup::F, sfc_local_geometry_values, int_z_values, t,
-) where {F <: Function} =
-    wrapped_sfc_setup(sfc_local_geometry_values.coordinates, int_z_values, t)
+ifelsenothing(x, default) = x
+ifelsenothing(::Nothing, default) = default
 
-# This is a hack for meeting the August 7th deadline. It is to ensure that the
-# coupler will be able to construct an integrator before overwriting its surface
-# conditions, but without throwing an error during the computation of
-# precomputed quantities for diagnostic EDMF due to uninitialized surface
-# conditions.
-# TODO: Refactor the surface conditions API to avoid needing to do this.
-function set_dummy_surface_conditions!(p)
+"""
+    init_sfc_conditions_zero!(p)
+
+Zero-initialize `p.precomputed.sfc_conditions` with safe defaults. Used when
+the surface flux scheme is nothing (the atmos side does not compute surface
+conditions) so that the first `set_precomputed_quantities!` call does not see
+uninitialized memory in downstream consumers like RRTMGP and diagnostic EDMF.
+"""
+function init_sfc_conditions_zero!(p)
     (; params, atmos) = p
     (; sfc_conditions) = p.precomputed
     FT = eltype(params)
@@ -98,42 +105,29 @@ function set_dummy_surface_conditions!(p)
         @. sfc_conditions.ρ_flux_q_tot = C3(FT(0))
     end
     @. sfc_conditions.ρ_flux_h_tot = C3(FT(0))
-
-    # Zero out the surface momentum flux
     c = p.scratch.ᶠtemp_scalar
-    # elsewhere known as 𝒢
     sfc_local_geometry = Fields.level(Fields.local_geometry_field(c), half)
     @. sfc_conditions.ρ_flux_uₕ = tensor_from_components(0, 0, sfc_local_geometry)
+    return nothing
 end
-
-ifelsenothing(x, default) = x
-ifelsenothing(x::Nothing, default) = default
 
 """
     surface_state_to_conditions(
-        wrapped_sfc_setup,
+        overrides, flux_scheme, T_sfc_in,
         surface_local_geometry,
-        T_int,
-        ρ_int,
-        q_tot_int,
-        q_liq_int,
-        q_ice_int,
-        u_int,
-        v_int,
-        z_int,
-        thermo_params,
-        surface_fluxes_params,
-        surface_temp_params,
+        T_int, ρ_int, q_tot_int, q_liq_int, q_ice_int, u_int, v_int, z_int,
+        thermo_params, surface_fluxes_params, surface_temp_params,
         atmos,
-        sfc_prognostic_temp,
-        t,
     )
 
-Computes the surface conditions, given information about the surface and the
-first interior point. Implements the assumptions listed for `SurfaceState`.
+Compute the surface conditions at one point. `T_sfc_in` is either a scalar,
+the resolved temperature field value, or an `AnalyticTemperature` to evaluate
+against the local `coordinates`.
 """
 function surface_state_to_conditions(
-    wrapped_sfc_setup::WSS,
+    overrides::SurfaceBoundaryOverrides,
+    parameterization::SurfaceParameterization,
+    T_sfc_in,
     surface_local_geometry,
     T_int,
     ρ_int,
@@ -147,30 +141,19 @@ function surface_state_to_conditions(
     surface_fluxes_params,
     surface_temp_params,
     atmos,
-    sfc_temp_var,
-    t,
-) where {WSS}
-    surf_state = surface_state(wrapped_sfc_setup, surface_local_geometry, z_int, t)
-    parameterization = surf_state.parameterization
+    t_time,
+)
     (; coordinates) = surface_local_geometry
     Φ_sfc = geopotential(SFP.grav(surface_fluxes_params), coordinates.z)
     Δz = z_int - coordinates.z
 
     FT = eltype(thermo_params)
-    (!isnothing(surf_state.q_vap) && atmos.microphysics_model isa DryModel) &&
+    (!isnothing(overrides.q_vap) && atmos.microphysics_model isa DryModel) &&
         error("surface q_vap cannot be specified when using a DryModel")
 
-    T_sfc = if isnothing(sfc_temp_var)
-        if isnothing(surf_state.T)
-            surface_temperature(atmos.sfc_temperature, coordinates, surface_temp_params)
-        else
-            surf_state.T
-        end
-    else
-        sfc_temp_var
-    end
-    u = ifelsenothing(surf_state.u, FT(0))
-    v = ifelsenothing(surf_state.v, FT(0))
+    T_sfc = resolve_T_sfc(T_sfc_in, coordinates, surface_temp_params, t_time)
+    u = ifelsenothing(overrides.u, FT(0))
+    v = ifelsenothing(overrides.v, FT(0))
 
     uv_int = SA.SVector(u_int, v_int)
     uv_sfc = SA.SVector(u, v)
@@ -191,10 +174,10 @@ function surface_state_to_conditions(
         # Assume that the surface is water with saturated air directly
         # above it.
         q_vap_sat = TD.q_vap_saturation(thermo_params, T_sfc, ρ_sfc, TD.Liquid())
-        q_vap = ifelsenothing(surf_state.q_vap, q_vap_sat)
+        q_vap = ifelsenothing(overrides.q_vap, q_vap_sat)
     end
 
-    gustiness = ifelsenothing(surf_state.gustiness, FT(1))
+    gustiness = ifelsenothing(overrides.gustiness, FT(1))
 
     if parameterization isa ExchangeCoefficients
         flux_specs = SF.FluxSpecs(Cd = parameterization.Cd, Ch = parameterization.Ch)
@@ -240,52 +223,6 @@ function surface_state_to_conditions(
         ρ_sfc,
         surface_local_geometry,
     )
-end
-
-#Sphere SST distribution from Wing et al. (2023) https://gmd.copernicus.org/preprints/gmd-2023-235/
-function surface_temperature(
-    ::RCEMIPIISST,
-    coordinates::Union{Geometry.LatLongZPoint, Geometry.LatLongPoint},
-    surface_temp_params,
-)
-    (; lat) = coordinates
-    (; SST_mean, SST_delta, SST_wavelength_latitude) = surface_temp_params
-    T = SST_mean + SST_delta / 2 * cosd(360 * lat / SST_wavelength_latitude)
-    return T
-end
-
-#Box SST distribution from Wing et al. (2023) https://gmd.copernicus.org/preprints/gmd-2023-235/
-function surface_temperature(
-    ::RCEMIPIISST,
-    coordinates::Union{Geometry.XZPoint, Geometry.XYZPoint},
-    surface_temp_params,
-)
-    (; x) = coordinates
-    (; SST_mean, SST_delta, SST_wavelength) = surface_temp_params
-    T = SST_mean - SST_delta / 2 * cospi(2 * x / SST_wavelength)
-    return T
-end
-
-#For non-RCEMIPII box models with prescribed surface temp, assume that the latitude is 0.
-function surface_temperature(
-    ::ZonallySymmetricSST,
-    coordinates,
-    surface_temp_params,
-)
-    (; z) = coordinates
-    FT = eltype(z)
-    return FT(300)
-end
-
-function surface_temperature(
-    ::ZonallySymmetricSST,
-    coordinates::Geometry.LatLongZPoint,
-    surface_temp_params,
-)
-    (; lat, z) = coordinates
-    FT = eltype(lat)
-    T = FT(271) + FT(29) * exp(-coordinates.lat^2 / (2 * 26^2)) - FT(6.5e-3) * z
-    return T
 end
 
 """

--- a/src/surface_conditions/surface_setups.jl
+++ b/src/surface_conditions/surface_setups.jl
@@ -1,23 +1,13 @@
-# Surface types
-"""
-    PrescribedSurface()
-
-Used to indicate that there is no surface parameterization and
-that the surface conditions will be explicitly prescribed (e.g. by the coupler).
-"""
-struct PrescribedSurface end
-(surface_setup::PrescribedSurface)(params) = nothing
 """
     DefaultMoninObukhov()
 
-Monin-Obukhov surface, see the link below for more information
-https://clima.github.io/SurfaceFluxes.jl/dev/SurfaceFluxes/#Monin-Obukhov-Similarity-Theory-(MOST)
+Monin-Obukhov surface with a default roughness length
+(see https://clima.github.io/SurfaceFluxes.jl/dev/SurfaceFluxes/#Monin-Obukhov-Similarity-Theory-(MOST)).
 """
 struct DefaultMoninObukhov end
 function (::DefaultMoninObukhov)(params)
     FT = eltype(params)
-    z0 = FT(1e-5)
-    return SurfaceState(; parameterization = MoninObukhov(; z0))
+    return MoninObukhov(; z0 = FT(1e-5))
 end
 
 """
@@ -26,5 +16,4 @@ end
 Bulk surface, parameterized only by a default exchange coefficient.
 """
 struct DefaultExchangeCoefficients end
-(::DefaultExchangeCoefficients)(params) =
-    SurfaceState(; parameterization = ExchangeCoefficients(params.C_H))
+(::DefaultExchangeCoefficients)(params) = ExchangeCoefficients(params.C_H)

--- a/src/surface_conditions/surface_state.jl
+++ b/src/surface_conditions/surface_state.jl
@@ -4,56 +4,55 @@
 
 abstract type PrescribedFluxes{FT} end
 
+"""
+    SurfaceParameterization
+
+Abstract supertype for surface flux closures. Concrete subtypes
+([`MoninObukhov`](@ref), [`ExchangeCoefficients`](@ref)) determine how
+`surface_state_to_conditions` turns the air–surface state difference into the
+turbulent surface fluxes.
+"""
 abstract type SurfaceParameterization{FT} end
 
-"""
-    SurfaceState(; parametrization, T, p, q_vap, u, v, gustiness, beta)
-
-A container for state variables at the ground level, for use with SurfaceFluxes.
-"""
-struct SurfaceState{
-    FT,
-    SFP <: SurfaceParameterization{FT},
-    FTN1 <: Union{FT, Nothing},
-    FTN2 <: Union{FT, Nothing},
-    FTN3 <: Union{FT, Nothing},
-    FTN4 <: Union{FT, Nothing},
-    FTN5 <: Union{FT, Nothing},
-    FTN6 <: Union{FT, Nothing},
-    FTN7 <: Union{FT, Nothing},
-}
-    parameterization::SFP
-    T::FTN1
-    p::FTN2
-    q_vap::FTN3
-    u::FTN4
-    v::FTN5
-    gustiness::FTN6
-    beta::FTN7
-end
+Base.broadcastable(p::SurfaceParameterization) = tuple(p)
 
 float_type(::Type{<:SurfaceParameterization{FT}}) where {FT} = FT
 
-SurfaceState(;
-    parameterization::SFP,
-    T::FTN1 = nothing,
-    p::FTN2 = nothing,
-    q_vap::FTN3 = nothing,
-    u::FTN4 = nothing,
-    v::FTN5 = nothing,
-    gustiness::FTN6 = nothing,
-    beta::FTN7 = nothing,
-) where {SFP <: SurfaceParameterization, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7} =
-    SurfaceState{float_type(SFP), SFP, FTN1, FTN2, FTN3, FTN4, FTN5, FTN6, FTN7}(
-        parameterization, T, p, q_vap, u, v, gustiness, beta,
-    )
+"""
+    SurfaceBoundaryOverrides(; p, q_vap, u, v, gustiness, beta)
+
+Per-point overrides for surface boundary values used by `SurfaceFluxes`. Fields
+default to `nothing`, in which case sensible defaults are used:
+
+- `p`: surface pressure (default: hydrostatic from interior)
+- `q_vap`: surface specific humidity (default: `q_vap_sat` at `T_sfc`)
+- `u`, `v`: surface horizontal winds (default: 0)
+- `gustiness`: turbulent gustiness (default: 1)
+- `beta`: moisture availability (default: 1)
+
+For the coupler use case, a `Fields.Field{<:SurfaceBoundaryOverrides}` may be
+stored on the cache so that the coupler can override per-cell values.
+"""
+Base.@kwdef struct SurfaceBoundaryOverrides{PN, QN, UN, VN, GN, BN}
+    p::PN = nothing
+    q_vap::QN = nothing
+    u::UN = nothing
+    v::VN = nothing
+    gustiness::GN = nothing
+    beta::BN = nothing
+end
 
 """
-    HeatFluxes(; shf, lhf)
+    HeatFluxes(; shf, lhf = nothing)
 
-Container for heat fluxes
- - shf: Sensible heat flux
- - lhf: Latent heat flux
+Prescribed surface turbulent energy fluxes, used as the `fluxes` field of a
+[`MoninObukhov`](@ref) closure. Both use the sign convention that positive is
+*upward* (directed from the surface into the atmosphere).
+
+- `shf`: sensible heat flux (W/m²).
+- `lhf`: latent heat flux (W/m²). Optional — `nothing` is treated as zero, and
+  `lhf` must be left unset for a `DryModel` (specifying it with a dry model is an
+  error).
 """
 Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     shf::FT
@@ -61,9 +60,17 @@ Base.@kwdef struct HeatFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes
 end
 
 """
-    θAndQFluxes(; θ_flux, q_flux)
+    θAndQFluxes(; θ_flux, q_flux = nothing)
 
-Container for quantities used to calculate sensible and latent heat fluxes.
+Prescribed surface *kinematic* fluxes of potential temperature and total
+specific humidity, used as the `fluxes` field of a [`MoninObukhov`](@ref)
+closure. They are converted per surface point into the sensible/latent heat
+fluxes actually applied, via `shf = θ_flux * ρ_sfc * cp_m` and
+`lhf = q_flux * ρ_sfc * Lᵥ`. Positive is *upward* (surface into atmosphere).
+
+- `θ_flux`: potential-temperature flux (K·m/s).
+- `q_flux`: total-specific-humidity flux (kg/kg·m/s). Optional — `nothing` is
+  treated as zero, and `q_flux` must be left unset for a `DryModel`.
 """
 Base.@kwdef struct θAndQFluxes{FT, FTN <: Union{FT, Nothing}} <: PrescribedFluxes{FT}
     θ_flux::FT
@@ -72,11 +79,18 @@ end
 
 """
     ExchangeCoefficients(; Cd, Ch)
-    ExchangeCoefficients(; C)
+    ExchangeCoefficients(C)
 
-Exchange coefficients
- - Cd: Momentum Exchange Coefficient
- - Ch: Thermal Exchange Coefficient
+Bulk-aerodynamic surface flux closure with fixed, dimensionless exchange
+coefficients — a [`SurfaceParameterization`](@ref) alternative to
+[`MoninObukhov`](@ref) in which the turbulent fluxes scale linearly with the
+near-surface wind speed and the air–surface differences (rather than being
+derived from Monin–Obukhov stability).
+
+- `Cd`: momentum (drag) exchange coefficient.
+- `Ch`: thermal/scalar (heat and moisture) exchange coefficient.
+
+The single-argument form `ExchangeCoefficients(C)` sets `Cd = Ch = C`.
 """
 Base.@kwdef struct ExchangeCoefficients{FT} <: SurfaceParameterization{FT}
     Cd::FT
@@ -88,14 +102,18 @@ ExchangeCoefficients(C) = ExchangeCoefficients(Cd = C, Ch = C)
     MoninObukhov(; z0, z0m, z0b, fluxes, shf, lhf, θ_flux, q_flux, ustar)
 
 Container for storing values used to calculate surface conditions using
-Monin-Obukhov Similarity Theory. See SurfaceFluxes docs for more information.
+Monin-Obukhov Similarity Theory. See the
+[SurfaceFluxes.jl MOST documentation](https://clima.github.io/SurfaceFluxes.jl/dev/SurfaceFluxes/#Monin-Obukhov-Similarity-Theory-(MOST))
+for more information.
 
 ## Roughness (required)
 - `z0`: Roughness (sets both `z0m` and `z0b`)
 - `z0m`, `z0b`: Roughness for momentum and scalars (specify both, or use `z0`)
 
 ## Prescribed fluxes (optional) — specify via one of:
-- `fluxes`: A `HeatFluxes` or `θAndQFluxes` struct directly
+- `fluxes`: A [`HeatFluxes`](@ref)/[`θAndQFluxes`](@ref) struct, or a callable
+  `(t, FT) -> HeatFluxes/θAndQFluxes` for time-varying fluxes (resolved once per
+  surface update by `resolve_flux_scheme`, before the per-cell broadcast)
 - `shf`, `lhf`: Sensible/latent heat fluxes (W/m²) — constructs `HeatFluxes`
 - `θ_flux`, `q_flux`: θ and q fluxes (K·m/s, kg/kg·m/s) — constructs `θAndQFluxes`
 
@@ -110,7 +128,7 @@ Valid combinations:
 """
 struct MoninObukhov{
     FT,
-    PFN <: Union{PrescribedFluxes{FT}, Nothing},
+    PFN <: Union{PrescribedFluxes, Nothing, Function},
     FTN <: Union{FT, Nothing},
 } <: SurfaceParameterization{FT}
     z0m::FT
@@ -156,7 +174,9 @@ function MoninObukhov(;
         MoninObukhov(z0m, z0b, fluxes, nothing)
     m_o(z0m::Number, z0b::Number, ::Nothing, ustar::Number) =
         MoninObukhov(z0m, z0b, nothing, ustar)
-    m_o(z0m::Number, z0b::Number, fluxes::PrescribedFluxes, ustar::Number) =
+    # `fluxes` may be a `PrescribedFluxes` struct or a time-varying callable
+    # `(t, FT) -> PrescribedFluxes` (resolved later by `resolve_flux_scheme`).
+    m_o(z0m::Number, z0b::Number, fluxes::Union{PrescribedFluxes, Function}, ustar::Number) =
         MoninObukhov(z0m, z0b, fluxes, ustar)
     return m_o(z0m, z0b, fluxes, ustar)
 end

--- a/src/surface_conditions/surface_state.jl
+++ b/src/surface_conditions/surface_state.jl
@@ -176,7 +176,12 @@ function MoninObukhov(;
         MoninObukhov(z0m, z0b, nothing, ustar)
     # `fluxes` may be a `PrescribedFluxes` struct or a time-varying callable
     # `(t, FT) -> PrescribedFluxes` (resolved later by `resolve_flux_scheme`).
-    m_o(z0m::Number, z0b::Number, fluxes::Union{PrescribedFluxes, Function}, ustar::Number) =
+    m_o(
+        z0m::Number,
+        z0b::Number,
+        fluxes::Union{PrescribedFluxes, Function},
+        ustar::Number,
+    ) =
         MoninObukhov(z0m, z0b, fluxes, ustar)
     return m_o(z0m, z0b, fluxes, ustar)
 end

--- a/src/surface_conditions/surface_temperature.jl
+++ b/src/surface_conditions/surface_temperature.jl
@@ -1,0 +1,92 @@
+"""
+    SurfaceTemperature
+
+Abstract supertype for ways of obtaining the surface temperature `T_sfc` used
+when computing surface conditions. Concrete subtypes:
+
+- [`AnalyticTemperature`](@ref): a function `(coordinates, params, t) -> T_sfc`. A
+  spatially and temporally constant `T_sfc` is simply constructed as
+  `AnalyticTemperature(Returns(T_sfc))`.
+- [`ExternalTemperature`](@ref): time-varying input read from a cached Field.
+- [`SlabOceanTemperature`](@ref): prognostic, reads `Y.sfc.T`. Carries slab params.
+- [`CoupledTemperature`](@ref): a Field owned by an external driver (e.g. coupler).
+
+`surface_temperature(t, Y, p, t_time)` produces the value(s) that
+[`update_surface_conditions!`](@ref) will broadcast across the surface.
+"""
+abstract type SurfaceTemperature end
+
+Base.broadcastable(t::SurfaceTemperature) = tuple(t)
+
+"""
+    AnalyticTemperature(f)
+
+A surface temperature given by `f(coordinates, params, t)`. Used for the
+analytic SST formulas (zonally-symmetric, RCEMIPII), time-varying setups
+(e.g. GABLS), and spatially-uniform constants (`AnalyticTemperature(Returns(T))`).
+`f` is broadcast per-coordinate inside the surface update; if the formula does
+not depend on time, simply ignore the `t` argument.
+"""
+struct AnalyticTemperature{F} <: SurfaceTemperature
+    f::F
+end
+
+"""
+    ExternalTemperature()
+
+A surface temperature read from a time-varying external input.
+`surface_temperature(::ExternalTemperature, Y, p, t)` evaluates the field
+from `p.external_forcing.surface_inputs.ts` (driven by
+`surface_timevaryinginputs.ts`), so this temperature is only valid when the
+setup populates `external_forcing.surface_inputs` (e.g. `InterpolatedColumnProfile`).
+"""
+struct ExternalTemperature <: SurfaceTemperature end
+
+"""
+    SlabOceanTemperature{FT}()
+
+Prognostic slab-ocean surface temperature, read from `Y.sfc.T`. Carries the
+slab-ocean parameters used by `surface_temp_tendency!` and conservation
+diagnostics.
+"""
+@kwdef struct SlabOceanTemperature{FT} <: SurfaceTemperature
+    depth_ocean::FT = 40        # ocean mixed-layer depth (m)
+    ρ_ocean::FT = 1020          # ocean density (kg/m³)
+    cp_ocean::FT = 4184         # ocean heat capacity (J/(kg·K))
+    q_flux::Bool = false        # use Q-flux (horizontal ocean energy flux div.)
+    Q₀::FT = -20                # Q-flux amplitude (W/m²)
+    ϕ₀::FT = 16                 # Q-flux meridional scale (deg)
+end
+
+"""
+    CoupledTemperature(field)
+
+A surface temperature owned by an external driver (the coupler). The driver
+writes into `field` between steps; ClimaAtmos reads from it.
+"""
+struct CoupledTemperature{F} <: SurfaceTemperature
+    field::F
+end
+
+# ============================================================================
+# surface_temperature: dispatch from temperature type to the value used in
+# update_surface_conditions!. Returns either the temperature struct itself
+# (AnalyticTemperature, evaluated per-coordinate downstream via resolve_T_sfc)
+# or a DataLayout of per-cell values that broadcasts across the surface.
+# ============================================================================
+
+# AnalyticTemperature must be evaluated per-coordinate downstream; we return
+# the temperature struct so update_surface_conditions! can dispatch on it.
+surface_temperature(t::AnalyticTemperature, Y, p, _) = t
+
+function surface_temperature(::ExternalTemperature, Y, p, t_time)
+    (; surface_inputs, surface_timevaryinginputs) = p.external_forcing
+    evaluate!(surface_inputs.ts, surface_timevaryinginputs.ts, t_time)
+    return Fields.field_values(surface_inputs.ts)
+end
+
+surface_temperature(::SlabOceanTemperature, Y, p, _) =
+    Fields.field_values(Y.sfc.T)
+
+surface_temperature(t::CoupledTemperature, Y, p, _) =
+    Fields.field_values(t.field)

--- a/src/types.jl
+++ b/src/types.jl
@@ -148,11 +148,6 @@ function MLCloud_constructor(model)
     return MLCloud{typeof(static_model)}(static_model)
 end
 
-abstract type AbstractSST end
-struct ZonallySymmetricSST <: AbstractSST end
-struct RCEMIPIISST <: AbstractSST end
-struct ExternalTVColumnSST <: AbstractSST end
-
 abstract type AbstractInsolation end
 struct IdealizedInsolation <: AbstractInsolation end
 struct TimeVaryingInsolation <: AbstractInsolation
@@ -185,19 +180,6 @@ struct InteractiveCloudInRadiation <: AbstractCloudInRadiation end
 Use monthly-average cloud properties from ERA5.
 """
 struct PrescribedCloudInRadiation <: AbstractCloudInRadiation end
-
-abstract type AbstractSurfaceTemperature end
-struct PrescribedSST <: AbstractSurfaceTemperature end
-@kwdef struct SlabOceanSST{FT} <: AbstractSurfaceTemperature
-    # optional slab ocean parameters:
-    depth_ocean::FT = 40 # ocean mixed layer depth [m]
-    ρ_ocean::FT = 1020 # ocean density [kg / m³]
-    cp_ocean::FT = 4184 # ocean heat capacity [J/(kg * K)]
-    q_flux::Bool = false # use Q-flux (parameterization of horizontal ocean mixing of energy)
-    Q₀::FT = -20 # Q-flux maximum mplitude [W/m²]
-    ϕ₀::FT = 16 # Q-flux meridional scale [deg]
-end
-
 
 ### -------------------- ###
 ### Hyperdiffusion model ###
@@ -927,11 +909,40 @@ end
     AtmosSurface
 
 Groups surface-related models and types.
+
+- `flux_scheme`: a
+  [`SurfaceConditions.SurfaceParameterization`](@ref ClimaAtmos.SurfaceConditions.SurfaceParameterization)
+  describing the surface flux closure
+  ([`MoninObukhov`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov),
+  [`ExchangeCoefficients`](@ref ClimaAtmos.SurfaceConditions.ExchangeCoefficients);
+  `MoninObukhov` may carry a time-varying `fluxes` callable), or `nothing` to
+  skip atmos-side surface updates (e.g. when an external driver overwrites
+  `sfc_conditions`). YAML configs may also use
+  [`DefaultMoninObukhov`](@ref ClimaAtmos.SurfaceConditions.DefaultMoninObukhov)/[`DefaultExchangeCoefficients`](@ref ClimaAtmos.SurfaceConditions.DefaultExchangeCoefficients)
+  markers, which the config-driven `AtmosSurface` constructor resolves against
+  `params` eagerly.
+- `temperature`: a
+  [`SurfaceConditions.SurfaceTemperature`](@ref ClimaAtmos.SurfaceConditions.SurfaceTemperature)
+  ([`AnalyticTemperature`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature),
+  [`ExternalTemperature`](@ref ClimaAtmos.SurfaceConditions.ExternalTemperature),
+  [`SlabOceanTemperature`](@ref ClimaAtmos.SurfaceConditions.SlabOceanTemperature),
+  [`CoupledTemperature`](@ref ClimaAtmos.SurfaceConditions.CoupledTemperature)).
+- `boundary_overrides`: a
+  [`SurfaceConditions.SurfaceBoundaryOverrides`](@ref ClimaAtmos.SurfaceConditions.SurfaceBoundaryOverrides)
+  carrying per-cell defaults for surface pressure / humidity / winds / gustiness
+  / beta.
+- `albedo`: surface albedo model.
 """
-@kwdef struct AtmosSurface{ST, SM, SA}
-    sfc_temperature::ST = ZonallySymmetricSST()
-    surface_model::SM = PrescribedSST()
-    surface_albedo::SA = ConstantAlbedo{Float32}(; α = 0.07)
+@kwdef struct AtmosSurface{FS, ST, BO, AL}
+    flux_scheme::FS = SurfaceConditions.ExchangeCoefficients{Float32}(
+        Cd = 0.0044, Ch = 0.0044,
+    )
+    temperature::ST =
+        SurfaceConditions.AnalyticTemperature(
+            Setups.zonally_symmetric_temperature,
+        )
+    boundary_overrides::BO = SurfaceConditions.SurfaceBoundaryOverrides()
+    surface_albedo::AL = ConstantAlbedo{Float32}(; α = 0.07)
 end
 
 # Add broadcastable for the new grouped types
@@ -1064,7 +1075,7 @@ model = AtmosModel(;
 # Default Configuration
 The default AtmosModel provides:
 - **Dry atmosphere**: DryModel()
-- **Basic surface**: PrescribedSST() with ZonallySymmetricSST()
+- **Basic surface**: AnalyticTemperature (zonally-symmetric SST) with default exchange coefficients
 - **Cloud model**: QuadratureCloud() with SGS quadrature
 - **Idealized insolation**: IdealizedInsolation()
 - **Conservative numerics**: First-order upwinding with Explicit() timestepping
@@ -1111,8 +1122,9 @@ Internal testing and calibration components for single-column setups:
 - `rayleigh_sponge`: nothing or RayleighSponge()
 
 ## AtmosSurface
-- `sfc_temperature`: ZonallySymmetricSST(), RCEMIPIISST(), ExternalTVColumnSST()
-- `surface_model`: PrescribedSST(), SlabOceanSST()
+- `flux_scheme`: SurfaceConditions.MoninObukhov, SurfaceConditions.ExchangeCoefficients, or a default marker (DefaultMoninObukhov/DefaultExchangeCoefficients), or `nothing` to disable.
+- `temperature`: SurfaceConditions.AnalyticTemperature, ExternalTemperature, SlabOceanTemperature, or CoupledTemperature.
+- `boundary_overrides`: SurfaceConditions.SurfaceBoundaryOverrides
 - `surface_albedo`: ConstantAlbedo(), RegressionFunctionAlbedo(), CouplerAlbedo()
 
 ## AtmosNumerics

--- a/test/config/atmos_model_constructor.jl
+++ b/test/config/atmos_model_constructor.jl
@@ -37,8 +37,7 @@ end
             # Core physics defaults
             :microphysics_model => CA.DryModel,
             :cloud_model => Union{CA.GridScaleCloud, CA.QuadratureCloud},
-            :surface_model => CA.PrescribedSST,
-            :sfc_temperature => CA.ZonallySymmetricSST,
+            :surface => CA.AtmosSurface,
             :insolation => CA.IdealizedInsolation,
             :disable_surface_flux_tendency => false,
 
@@ -89,7 +88,7 @@ end
         @test model.disable_surface_flux_tendency == true
 
         # Test that non-overridden defaults are preserved
-        @test model.surface_model isa CA.PrescribedSST
+        @test model.surface.temperature isa CA.SurfaceConditions.AnalyticTemperature
         @test model.insolation isa CA.IdealizedInsolation
         @test model.numerics.diff_mode isa CA.Explicit
     end
@@ -98,12 +97,9 @@ end
 @testset "Documentation Examples" begin
     @testset "Basic configurations work as documented" begin
         # Test basic dry model
-        dry_model = CA.AtmosModel(;
-            microphysics_model = CA.DryModel(),
-            surface_model = CA.PrescribedSST(),
-        )
+        dry_model = CA.AtmosModel(; microphysics_model = CA.DryModel())
         @test dry_model.microphysics_model isa CA.DryModel
-        @test dry_model.surface_model isa CA.PrescribedSST
+        @test dry_model.surface isa CA.AtmosSurface
 
         # Test moist model with radiation
         moist_model = CA.AtmosModel(;

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -74,11 +74,11 @@ const T2 = 290
         typeof(a.water), typeof(a.scm_setup), typeof(a.radiation),
         typeof(a.turbconv), typeof(a.prescribed_flow), typeof(a.gravity_wave),
         typeof(a.vertical_diffusion), typeof(a.sponge), typeof(new_surface),
-        typeof(a.numerics),
+        typeof(a.numerics), typeof(a.chemistry),
     }(
         a.water, a.scm_setup, a.radiation, a.turbconv, a.prescribed_flow,
         a.gravity_wave, a.vertical_diffusion, a.sponge, new_surface, a.numerics,
-        a.disable_surface_flux_tendency,
+        a.chemistry, a.disable_surface_flux_tendency,
     )
     p_overwritten = CA.AtmosCache(
         p.dt,

--- a/test/coupler_compatibility.jl
+++ b/test/coupler_compatibility.jl
@@ -47,26 +47,46 @@ const T2 = 290
     FT = eltype(Y)
     thermo_params = CAP.thermodynamics_params(p.params)
 
-    # Override p.sfc_setup with a Field of SurfaceStates. The value of T is
-    # irrelevant, since it will get updated.
-    surface_state = CA.SurfaceConditions.SurfaceState(;
-        parameterization = CA.SurfaceConditions.MoninObukhov(;
-            z0m = FT(z0m),
-            z0b = FT(z0b),
-        ),
-        T = FT(NaN),
-        gustiness = FT(gustiness),
-        beta = FT(beta),
+    # Coupler pattern: build an AtmosSurface with a CoupledTemperature whose
+    # field the driver writes into between steps, plus per-cell boundary
+    # overrides for gustiness/beta. Re-build the atmos with this surface and
+    # overwrite p.atmos / p.sfc_setup.
+    sfc_space = Spaces.level(Y.f, half)
+    T_field = similar(sfc_space, FT)
+    @. T_field = FT(NaN)
+    overrides = CA.SurfaceConditions.SurfaceBoundaryOverrides(;
+        gustiness = FT(gustiness), beta = FT(beta),
     )
-    sfc_setup = similar(Spaces.level(Y.f, half), typeof(surface_state))
-    @. sfc_setup = (surface_state,)
+    overrides_field = similar(sfc_space, typeof(overrides))
+    @. overrides_field = (overrides,)
+
+    new_surface = CA.AtmosSurface(
+        CA.SurfaceConditions.MoninObukhov(; z0m = FT(z0m), z0b = FT(z0b)),
+        CA.SurfaceConditions.CoupledTemperature(T_field),
+        overrides_field,
+        p.atmos.surface.surface_albedo,
+    )
+    # AtmosModel is immutable, so swapping in `new_surface` requires rebuilding
+    # the whole struct positionally — the kwarg form would reset every other
+    # field (microphysics, radiation, ...) to its default and lose the config.
+    a = p.atmos
+    new_atmos = CA.AtmosModel{
+        typeof(a.water), typeof(a.scm_setup), typeof(a.radiation),
+        typeof(a.turbconv), typeof(a.prescribed_flow), typeof(a.gravity_wave),
+        typeof(a.vertical_diffusion), typeof(a.sponge), typeof(new_surface),
+        typeof(a.numerics),
+    }(
+        a.water, a.scm_setup, a.radiation, a.turbconv, a.prescribed_flow,
+        a.gravity_wave, a.vertical_diffusion, a.sponge, new_surface, a.numerics,
+        a.disable_surface_flux_tendency,
+    )
     p_overwritten = CA.AtmosCache(
         p.dt,
-        p.atmos,
+        new_atmos,
         p.numerics,
         p.params,
         p.core,
-        sfc_setup,
+        overrides_field,
         p.ghost_buffer,
         p.precomputed,
         p.scratch,
@@ -82,15 +102,13 @@ const T2 = 290
         p.conservation_check,
     )
 
-    # Test that set_precomputed_quantities! can be used to update the surface
-    # temperature to T1 and then to T2.
-    @. sfc_setup.T = FT(T1)
+    @. T_field = FT(T1)
     CA.set_precomputed_quantities!(Y, p_overwritten, t)
-    sfc_T = p.precomputed.sfc_conditions.T_sfc
+    sfc_T = p_overwritten.precomputed.sfc_conditions.T_sfc
     @test all(isequal(T1), parent(sfc_T))
-    @. sfc_setup.T = FT(T2)
+    @. T_field = FT(T2)
     CA.set_precomputed_quantities!(Y, p_overwritten, t)
-    sfc_T = p.precomputed.sfc_conditions.T_sfc
+    sfc_T = p_overwritten.precomputed.sfc_conditions.T_sfc
     @test all(isequal(T2), parent(sfc_T))
 end
 

--- a/test/diagnostics/unit_diagnostics.jl
+++ b/test/diagnostics/unit_diagnostics.jl
@@ -95,7 +95,6 @@ under test actually requires (e.g. `aerosol_names` for aerosol diagnostics,
 function build_state_cache(FT, model; grid,
     params = CA.ClimaAtmosParameters(FT),
     ic = CA.Setups.DecayingProfile(; params),
-    surface_setup = CA.SurfaceConditions.DefaultExchangeCoefficients(),
     dt = FT(1.0), start_date = DateTime(2010, 1, 1),
     aerosol_names = [], time_varying_trace_gas_names = (),
     set_steady_state_velocity = false,
@@ -110,7 +109,7 @@ function build_state_cache(FT, model; grid,
             params, Y, CA.NoTopography(), "ConstantBuoyancyFrequencyProfile", "Linear",
         ) : nothing
     p = CA.build_cache(
-        Y, model, params, surface_setup, dt, start_date,
+        Y, model, params, dt, start_date,
         aerosol_names, time_varying_trace_gas_names, steady_state_velocity, vwb_species,
     )
     return Y, p
@@ -156,7 +155,10 @@ column = CA.ColumnGrid(FT)
 
 ## Dry model, also tests slab ocean
 model_dry =
-    CA.AtmosModel(; microphysics_model = CA.DryModel(), surface_model = CA.SlabOceanSST())
+    CA.AtmosModel(;
+        microphysics_model = CA.DryModel(),
+        temperature = CA.SurfaceConditions.SlabOceanTemperature{FT}(),
+    )
 (Y_dry, p_dry) = build_state_cache(FT, model_dry; grid = column);
 
 ## Sphere with dry model
@@ -192,7 +194,7 @@ model_nogw = CA.AtmosModel(; microphysics_model, non_orographic_gravity_wave)
 ## Sphere with moist model + slab ocean (watero needs MoistMicrophysics + SpectralElementSpace2D)
 model_0m_slab = CA.AtmosModel(;
     microphysics_model = CA.EquilibriumMicrophysics0M(),
-    surface_model = CA.SlabOceanSST(),
+    temperature = CA.SurfaceConditions.SlabOceanTemperature{FT}(),
 )
 (Y_0m_slab_sphere, p_0m_slab_sphere) = build_state_cache(FT, model_0m_slab; grid = sphere);
 

--- a/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/compute_preprocessed_topography.jl
+++ b/test/parameterized_tendencies/gravity_wave/orographic_gravity_wave/compute_preprocessed_topography.jl
@@ -31,7 +31,6 @@ setup_type = CA.get_setup_type(config.parsed_args, params.thermodynamics_params)
 atmos = CA.get_atmos(config, params; setup_type)
 grid = CA.get_grid(config.parsed_args, params, config.comms_ctx)
 spaces = CA.get_spaces(grid)
-surface_setup = CA.get_surface_setup(config.parsed_args; setup_type)
 hspace = Spaces.horizontal_space(spaces.center_space)
 
 Y = CA.Setups.initial_state(

--- a/test/presets.jl
+++ b/test/presets.jl
@@ -17,15 +17,13 @@ const FT = Float32
     equil = CA.Presets.equil_moist_0m()
     @test equil.microphysics_model isa CA.EquilibriumMicrophysics0M
     @test equil.cloud_model isa CA.GridScaleCloud
-    @test equil.surface_model isa CA.PrescribedSST
-    @test equil.sfc_temperature isa CA.ZonallySymmetricSST
+    @test equil.surface.temperature isa CA.SurfaceConditions.AnalyticTemperature
     @test equil.insolation isa CA.IdealizedInsolation
 
     nonequil = CA.Presets.nonequil_moist_1m()
     @test nonequil.microphysics_model isa CA.NonEquilibriumMicrophysics1M
     @test nonequil.cloud_model isa CA.GridScaleCloud
-    @test nonequil.surface_model isa CA.PrescribedSST
-    @test nonequil.sfc_temperature isa CA.ZonallySymmetricSST
+    @test nonequil.surface.temperature isa CA.SurfaceConditions.AnalyticTemperature
     @test nonequil.insolation isa CA.IdealizedInsolation
 end
 
@@ -38,7 +36,7 @@ end
     m = CA.Presets.equil_moist_0m(; microphysics_model = CA.DryModel())
     @test m.microphysics_model isa CA.DryModel
     # Other equil defaults should still be in place:
-    @test m.sfc_temperature isa CA.ZonallySymmetricSST
+    @test m.surface.temperature isa CA.SurfaceConditions.AnalyticTemperature
 end
 
 @testset "Diagnostic/prognostic EDMF presets" begin

--- a/test/restart_AtmosSimulation.jl
+++ b/test/restart_AtmosSimulation.jl
@@ -65,8 +65,6 @@ function amip_target(context, output_dir)
 
     insolation = CA.TimeVaryingInsolation(start_date)
 
-    surface_setup = CA.SurfaceConditions.DefaultMoninObukhov()
-
     n_updrafts = 1
     prognostic_tke = true
     turbconv_model = CA.DiagnosticEDMFX{n_updrafts, prognostic_tke}(1e-5)
@@ -129,7 +127,6 @@ function amip_target(context, output_dir)
         jacobian,
         callback_kwargs,
         ode_config,
-        surface_setup,
         context,
         job_id = "amip_target",
         output_dir)


### PR DESCRIPTION
Previously, surface behavior was controlled by three overlapping mechanisms: the `surface_setup` kwarg on AtmosSimulation, an AbstractSST hierarchy on `atmos.sfc_temperature`, and a separate AbstractSurfaceTemperature hierarchy on `atmos.surface_model`. Temperature could come from `Y.sfc.T` (slab ocean), a coupler-injected Field via `p.sfc_setup`, an `ExternalTVColumnSST` time-varying input, or an analytic formula. This closes #4462 

## Core changes: one source of truth in `atmos.surface`:
```julia
@kwdef struct AtmosSurface{FS, ST, BO, AL}
    flux_scheme::FS         # MoninObukhov | ExchangeCoefficients | TimeVaryingMoninObukhov | nothing
    temperature::ST         # SurfaceTemperature subtype
    boundary_overrides::BO  # SurfaceBoundaryOverrides or Field thereof
    surface_albedo::AL
end
```
1. New unified `SurfaceTemperature` hierarchy replaces both `AbstractSST` and `AbstractSurfaceTemperature`:

- AnalyticTemperature: scalar or function `f(coords, params, t) -> T`  for zonally-symmetric SST, RCEMIPII, time-varying GABLS
- ExternalTemperature: reads from `p.external_forcing.surface_inputs.ts`
- SlabOceanTemperature: reads `Y.sfc.T`, carries slab params
- CoupledTemperature: holds a field the coupler writes into

These are dispatched via `surface_temperature` in `src/surface_conditions/surface_temperature.jl`

2. The `SurfaceState` struct has been replaced by:

- `SurfaceBoundaryOverrides`:  overrides for p, q_vap, u, v, gustiness, beta
- temperature moved to `AtmosSurface.temperature`
- flux parameterization moved to `AtmosSurface.flux_scheme`

Additionally, a new `TimeVaryingMoninObukhov` parameterization (`f(t, FT) -> MoninObukhov`) supports time-varying-flux setups like TRMM_LBA.

3. Eliminated the coupler hack `set_dummy_surface_conditions` and replaced it with a smaller function `init_sfc_conditions_zero!` that pre-fills the cache when the AtmosSurface flux scheme is nothing.

4. Removed AbstractSST, ZonallySymmetricSST, RCEMIPIISST, ExternalTVColumnSST, AbstractSurfaceTemperature, PrescribedSST, SlabOceanSST, SurfaceConditions.SurfaceState, set_dummy_surface_conditions!, get_surface_setup/_config_surface_setup

This PR should not require coupler code changes.