### PR TITLE
Osaj/musica helloworld

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.9"
+julia_version = "1.11.6"
 manifest_format = "2.0"
 project_hash = "6dc55dcd2743828c52d667c059aa8515e72171ce"
 
@@ -410,7 +410,7 @@ version = "0.5.22"
     Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [[deps.ClimaAtmos]]
-deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
+deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "Musica", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 version = "0.39.2"
@@ -653,6 +653,12 @@ deps = ["Distances", "LinearAlgebra", "Printf", "Random", "Statistics", "TaylorS
 git-tree-sha1 = "6ffea589cf350b1582722e57a8de787907d59454"
 uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
 version = "0.3.4"
+
+[[deps.CxxWrap]]
+deps = ["Libdl", "MacroTools", "libcxxwrap_julia_jll"]
+git-tree-sha1 = "f7a997d3959648a818c45dda059a45844300b94d"
+uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+version = "0.17.5"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -1777,6 +1783,18 @@ weakdeps = ["Adapt", "CUDA"]
 
     [deps.MultiBroadcastFusion.extensions]
     MultiBroadcastFusionCUDAExt = ["CUDA", "Adapt"]
+
+[[deps.Musica]]
+deps = ["CxxWrap", "Musica_jll"]
+git-tree-sha1 = "a01eb86f9f8b0af5d089e3147c999418cceeb7fa"
+uuid = "d3d182ee-e566-4962-9279-3a9916be1802"
+version = "0.15.0"
+
+[[deps.Musica_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "libcxxwrap_julia_jll"]
+git-tree-sha1 = "ebebb1d709e4a99af9af66669849a6fcc49a7392"
+uuid = "f5e5459d-1a87-5129-97d9-bab22ca84fbb"
+version = "0.15.0+0"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
@@ -2959,6 +2977,12 @@ version = "0.17.4+0"
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.11.0+0"
+
+[[deps.libcxxwrap_julia_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a0b6eb05dde4ededa688ecf05e33caa5bffd42a5"
+uuid = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
+version = "0.14.9+0"
 
 [[deps.libdrm_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: Artifacts, Dates, Downloads, LazyArtifacts, LinearAlgebra, Logging, Printf, Test, Statistics, Random, Pkg, Glib_jll
+          skip: Artifacts, Dates, Downloads, LazyArtifacts, LinearAlgebra, Logging, Printf, Test, Statistics, Random, Pkg, Glib_jll, Musica
 
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,12 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 UnrolledUtilities = "0fe1646c-419e-43be-ac14-22321958931b"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
+[weakdeps]
+Musica = "d3d182ee-e566-4962-9279-3a9916be1802"
+
+[extensions]
+ClimaAtmosMusica = "Musica"
+
 [compat]
 Adapt = "4.1"
 Aqua = "0.8.9"
@@ -67,6 +73,7 @@ LazyArtifacts = "1"
 LazyBroadcast = "1"
 LinearAlgebra = "1"
 Logging = "1"
+Musica = "0.15"
 NCDatasets = "0.14.2"
 NVTX = "0.3, 1"
 NullBroadcasts = "0.1"
@@ -92,6 +99,7 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+Musica = "d3d182ee-e566-4962-9279-3a9916be1802"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
@@ -99,4 +107,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CairoMakie", "Distributions", "Downloads", "IntervalSets", "OrderedCollections", "Pkg", "PrettyTables", "SafeTestsets", "Test"]
+test = ["Aqua", "CairoMakie", "Distributions", "Downloads", "IntervalSets", "Musica", "OrderedCollections", "Pkg", "PrettyTables", "SafeTestsets", "Test"]

--- a/ext/ClimaAtmosMusica/ClimaAtmosMusica.jl
+++ b/ext/ClimaAtmosMusica/ClimaAtmosMusica.jl
@@ -1,0 +1,23 @@
+module ClimaAtmosMusica
+
+import ClimaAtmos
+import Musica
+
+"""
+    ClimaAtmos.chemistry_tendency!(Yₜ, Y, p, t, ::ClimaAtmos.GasPhaseChem)
+
+MUSICA-backed gas-phase chemistry tendency.
+Loaded automatically when `Musica` is imported alongside `ClimaAtmos`.
+"""
+function ClimaAtmos.chemistry_tendency!(
+    Yₜ,
+    Y,
+    p,
+    t,
+    ::ClimaAtmos.GasPhaseChem,
+)
+    @info "MUSICA version: $(Musica.get_version())"
+    return nothing
+end
+
+end # module ClimaAtmosMusica

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -50,6 +50,9 @@ include(joinpath("cache", "surface_albedo.jl"))
 # Microphysics module (SGS quadrature, cloud fraction, tendency limiters, wrappers)
 include(joinpath("parameterized_tendencies", "microphysics", "microphysics.jl"))
 
+# Chemistry module (gas-phase chemistry with a MUSICA backend)
+include(joinpath("parameterized_tendencies", "chemistry", "chemistry.jl"))
+
 include(joinpath("surface_conditions", "SurfaceConditions.jl"))
 include(joinpath("setups", "Setups.jl"))
 include(joinpath("utils", "refstate_thermodynamics.jl"))

--- a/src/parameterized_tendencies/chemistry/chemistry.jl
+++ b/src/parameterized_tendencies/chemistry/chemistry.jl
@@ -1,0 +1,13 @@
+# ============================================================================
+# Chemistry Module
+# ============================================================================
+# Gas-phase chemistry for ClimaAtmos.
+# The MUSICA backend is provided by the ClimaAtmosMusica extension;
+# this file defines only the no-op fallback for when no chemistry is loaded.
+
+"""
+    chemistry_tendency!(Yₜ, Y, p, t, ::Nothing)
+
+No-op: no chemistry model is active.
+"""
+chemistry_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -254,6 +254,9 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     radiation_tendency!(Yₜ, Y, p, t, p.atmos.radiation_mode)
     edmfx_tke_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
+    # Chemistry tendencies
+    chemistry_tendency!(Yₜ, Y, p, t, p.atmos.chemistry_model)
+
     # Unified microphysics tendencies (cloud condensation + precipitation)
     if p.atmos.microphysics_tendency_timestepping == Explicit()
         microphysics_tendency!(

--- a/src/types.jl
+++ b/src/types.jl
@@ -853,6 +853,19 @@ with single-column model setups. Most external users will not need these compone
     scm_coriolis::SC = nothing
 end
 
+
+abstract type AbstractChemistryModel end
+struct GasPhaseChem <: AbstractChemistryModel end
+
+"""
+    AtmosChem
+
+Groups chemistry models and types.
+"""
+@kwdef struct AtmosChem{CM}
+    chemistry_model::CM = nothing
+end
+
 """
     AtmosWater
 
@@ -934,7 +947,7 @@ Base.broadcastable(x::AtmosSurface) = tuple(x)
 # struct definition (later in this file) so the type is in scope when those
 # methods are parsed.
 
-struct AtmosModel{W, SCM, R, TC, PF, GW, VD, SP, SU, NU}
+struct AtmosModel{W, SCM, R, TC, PF, GW, VD, SP, SU, NU, CM}
     water::W
     scm_setup::SCM
     radiation::R
@@ -945,6 +958,7 @@ struct AtmosModel{W, SCM, R, TC, PF, GW, VD, SP, SU, NU}
     sponge::SP
     surface::SU
     numerics::NU
+    chemistry::CM
 
     """Whether to apply surface flux tendency (independent of surface conditions)"""
     disable_surface_flux_tendency::Bool
@@ -961,6 +975,7 @@ const ATMOS_MODEL_GROUPS = (
     (AtmosSurface, :surface),
     (AtmosNumerics, :numerics),
     (SCMSetup, :scm_setup),
+    (AtmosChem, :chemistry),
 )
 
 # Auto-generate map from property_name to group_field
@@ -1135,6 +1150,8 @@ function AtmosModel(; kwargs...)
         _create_grouped_struct(AtmosSurface, atmos_model_kwargs, group_kwargs)
     numerics =
         _create_grouped_struct(AtmosNumerics, atmos_model_kwargs, group_kwargs)
+    chemistry =
+        _create_grouped_struct(AtmosChem, atmos_model_kwargs, group_kwargs)
 
     vertical_diffusion = get(atmos_model_kwargs, :vertical_diffusion, nothing)
     disable_surface_flux_tendency =
@@ -1153,6 +1170,7 @@ function AtmosModel(; kwargs...)
         typeof(sponge),
         typeof(surface),
         typeof(numerics),
+        typeof(chemistry),
     }(
         water,
         scm_setup,
@@ -1164,6 +1182,7 @@ function AtmosModel(; kwargs...)
         sponge,
         surface,
         numerics,
+        chemistry,
         disable_surface_flux_tendency,
     )
 end

--- a/test/parameterized_tendencies/chemistry/chemistry_tendency.jl
+++ b/test/parameterized_tendencies/chemistry/chemistry_tendency.jl
@@ -1,0 +1,34 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+
+@testset "Chemistry Tendencies" begin
+
+    # ========================================================================
+    # Default: no chemistry model → no-op tendency
+    # ========================================================================
+    @testset "Default chemistry model is nothing" begin
+        model = CA.AtmosModel()
+        @test model.chemistry_model === nothing
+    end
+
+    @testset "chemistry_tendency! with nothing is a no-op" begin
+        result = CA.chemistry_tendency!(nothing, nothing, nothing, 0.0, nothing)
+        @test result === nothing
+    end
+
+    # ========================================================================
+    # With Musica loaded: GasPhaseChem prints the version string
+    # ========================================================================
+    @testset "GasPhaseChem prints MUSICA version" begin
+        import Musica
+        @test_logs (:info, r"MUSICA version: .+") CA.chemistry_tendency!(
+            nothing,
+            nothing,
+            nothing,
+            0.0,
+            CA.GasPhaseChem(),
+        )
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,9 @@ if TEST_GROUP in ("parameterizations", "all")
     @safetestset "BMT integration tests" begin @time include("parameterized_tendencies/microphysics/bmt_integration.jl") end
     @safetestset "Allocation tests" begin @time include("parameterized_tendencies/microphysics/allocations.jl") end
 
+    # Chemistry tests
+    @safetestset "Chemistry tendency tests" begin @time include("parameterized_tendencies/chemistry/chemistry_tendency.jl") end
+
     # NOTE: Gravity wave visualization scripts (test_nogw_3d.jl, test_nogw_mima.jl,
     # test_nogw_single_column.jl, test_ogw_3d.jl, test_ogw_baseflux.jl) are not included
     # in the test suite because they have no @test assertions - they only generate


### PR DESCRIPTION
Following from: https://github.com/CliMA/ClimaAtmos.jl/pull/4525

## Purpose 
This is an initial pull request for chemistry in ClimaAtmos. It currently prints the Musica.jl version every time the chemical tendencies are calculated.

## To-do
We might want to make chemistry optional and off by default, rather than always on. We also discussed Musica.jl as an optional dependency. The "hello world" version printing should also probably not happen every time a tendency is calculated.

## Content
Currently complete: printing Musica.jl version in the BOMEX single column model. I tested it as follows:

```
julia --project=.buildkite
import ClimaAtmos as CA
Base.pathof(CA) # making sure it is using the correct source code (the local changes)
simulation = CA.get_simulation(CA.AtmosConfig("config/model_configs/prognostic_edmfx_bomex_column.yml"))
sol_res = CA.solve_atmos!(simulation) # run the simulation
```

With the current code, this test succeeds if it prints `MUSICA version: 0.15.0` more times than anyone could ever possibly want