### PR TITLE
Initialize albedo as NaN for CouplerAlbedo

### DIFF
--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -120,6 +120,9 @@ end
     set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
 
 Tell the ClimaAtmos to skip setting the surface albedo, as it is handled by the coupler.
+The albedo is set to NaN here at the start of the simulation, so that it will be very
+obvious if it isn't overwritten by the coupler.
+
 To avoid NaNs in the first radiation call, the coupler retrieves the albedo initial
 conditions from the surface models, and provides these to the atmosphere model
 before stepping.
@@ -130,6 +133,9 @@ function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
         # set initial insolation initial conditions
         !(p.atmos.insolation isa IdealizedInsolation) &&
             set_insolation_variables!(Y, p, t, p.atmos.insolation)
+
+        p.radiation.rrtmgp_model.direct_sw_surface_albedo .= NaN
+        p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .= NaN
     else
         nothing
     end

--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -120,10 +120,9 @@ end
     set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
 
 Tell the ClimaAtmos to skip setting the surface albedo, as it is handled by the coupler.
-
-When running in a coupled simulation, set the surface albedo to 0.38 at the beginning of the simulation,
-so the initial callback initialization doesn't lead to NaNs in the radiation model.
-Subsequently, the surface albedo will be updated by the coupler.
+To avoid NaNs in the first radiation call, the coupler retrieves the albedo initial
+conditions from the surface models, and provides these to the atmosphere model
+before stepping.
 """
 function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
     FT = eltype(Y)
@@ -131,10 +130,6 @@ function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
         # set initial insolation initial conditions
         !(p.atmos.insolation isa IdealizedInsolation) &&
             set_insolation_variables!(Y, p, t, p.atmos.insolation)
-        # set surface albedo to 0.38
-        @warn "Setting surface albedo to 0.38 at the beginning of the simulation"
-        p.radiation.rrtmgp_model.direct_sw_surface_albedo .= FT(0.38)
-        p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .= FT(0.38)
     else
         nothing
     end

--- a/src/cache/surface_albedo.jl
+++ b/src/cache/surface_albedo.jl
@@ -120,12 +120,10 @@ end
     set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
 
 Tell the ClimaAtmos to skip setting the surface albedo, as it is handled by the coupler.
-The albedo is set to NaN here at the start of the simulation, so that it will be very
-obvious if it isn't overwritten by the coupler.
 
-To avoid NaNs in the first radiation call, the coupler retrieves the albedo initial
-conditions from the surface models, and provides these to the atmosphere model
-before stepping.
+To avoid NaNs or invalid values in the first radiation call, the coupler retrieves
+the albedo initial conditions from the surface models, and provides these to the
+atmosphere model before stepping.
 """
 function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
     FT = eltype(Y)
@@ -133,9 +131,6 @@ function set_surface_albedo!(Y, p, t, ::CouplerAlbedo)
         # set initial insolation initial conditions
         !(p.atmos.insolation isa IdealizedInsolation) &&
             set_insolation_variables!(Y, p, t, p.atmos.insolation)
-
-        p.radiation.rrtmgp_model.direct_sw_surface_albedo .= NaN
-        p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .= NaN
     else
         nothing
     end

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -46,15 +46,18 @@ Random.seed!(1234)
         simulation = ClimaAtmos.get_simulation(config)
         (; u, p) = simulation.integrator
 
-        # At t=0, should initialize to default (0.38)
-        ClimaAtmos.set_surface_albedo!(u, p, 0.0, p.atmos.surface_albedo)
-        @test all(p.radiation.rrtmgp_model.direct_sw_surface_albedo .== FT(0.38))
-        @test all(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .== FT(0.38))
+        direct_albedo_init = deepcopy(p.radiation.rrtmgp_model.direct_sw_surface_albedo)
+        diffuse_albedo_init = deepcopy(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo)
 
-        # At t>0, should remain unchanged (coupler controls updates)
+        # At t=0, albedo should remain unchanged
+        ClimaAtmos.set_surface_albedo!(u, p, 0.0, p.atmos.surface_albedo)
+        @test p.radiation.rrtmgp_model.direct_sw_surface_albedo == direct_albedo_init
+        @test p.radiation.rrtmgp_model.diffuse_sw_surface_albedo == diffuse_albedo_init
+
+        # At t>0, albedo should still remain unchanged
         ClimaAtmos.set_surface_albedo!(u, p, 1.0, p.atmos.surface_albedo)
-        @test all(p.radiation.rrtmgp_model.direct_sw_surface_albedo .== FT(0.38))
-        @test all(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo .== FT(0.38))
+        @test p.radiation.rrtmgp_model.direct_sw_surface_albedo == direct_albedo_init
+        @test p.radiation.rrtmgp_model.diffuse_sw_surface_albedo == diffuse_albedo_init
     end
 end
 

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -46,9 +46,6 @@ Random.seed!(1234)
         simulation = ClimaAtmos.get_simulation(config)
         (; u, p) = simulation.integrator
 
-        direct_albedo_init = deepcopy(p.radiation.rrtmgp_model.direct_sw_surface_albedo)
-        diffuse_albedo_init = deepcopy(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo)
-
         # At t=0, albedo should be set to NaN
         ClimaAtmos.set_surface_albedo!(u, p, 0.0, p.atmos.surface_albedo)
         @test all(isnan.(p.radiation.rrtmgp_model.direct_sw_surface_albedo))

--- a/test/surface_albedo.jl
+++ b/test/surface_albedo.jl
@@ -49,15 +49,15 @@ Random.seed!(1234)
         direct_albedo_init = deepcopy(p.radiation.rrtmgp_model.direct_sw_surface_albedo)
         diffuse_albedo_init = deepcopy(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo)
 
-        # At t=0, albedo should remain unchanged
+        # At t=0, albedo should be set to NaN
         ClimaAtmos.set_surface_albedo!(u, p, 0.0, p.atmos.surface_albedo)
-        @test p.radiation.rrtmgp_model.direct_sw_surface_albedo == direct_albedo_init
-        @test p.radiation.rrtmgp_model.diffuse_sw_surface_albedo == diffuse_albedo_init
+        @test all(isnan.(p.radiation.rrtmgp_model.direct_sw_surface_albedo))
+        @test all(isnan.(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo))
 
-        # At t>0, albedo should still remain unchanged
+        # At t>0, albedo should remain unchanged
         ClimaAtmos.set_surface_albedo!(u, p, 1.0, p.atmos.surface_albedo)
-        @test p.radiation.rrtmgp_model.direct_sw_surface_albedo == direct_albedo_init
-        @test p.radiation.rrtmgp_model.diffuse_sw_surface_albedo == diffuse_albedo_init
+        @test all(isnan.(p.radiation.rrtmgp_model.direct_sw_surface_albedo))
+        @test all(isnan.(p.radiation.rrtmgp_model.diffuse_sw_surface_albedo))
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
All surface models in coupled simulations provide albedo during initialization, before the first step. This means we don't need to set albedo in the radiation cache to a temporary dummy value anymore.

The albedos are already set to NaN at initialization, so we'll be able to easily identify and debug if albedos are not being set correctly by the coupler.

There are no downstream changes needed in ClimaCoupler, unless we want to explicitly check that the atmosphere albedos are not NaN after a CoupledSimulation is created. We don't do this for any other variables though so maybe it's odd to just do it for albedo.

## To Do
- [x] update albedo initial value
- [x] test from coupler - see https://github.com/CliMA/ClimaCoupler.jl/pull/1956 passes [here](https://buildkite.com/clima/climacoupler-ci/builds/9064)