### PR TITLE
improve downgrade tests

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -33,4 +33,27 @@ jobs:
           skip: Artifacts, Dates, Downloads, LazyArtifacts, LinearAlgebra, Logging, Printf, Test, Statistics, Random, Pkg, Glib_jll, Musica
 
       - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - name: Run infrastructure tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: infrastructure
+      - name: Run diagnostics tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: diagnostics
+      - name: Run dynamics tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: dynamics
+      - name: Run parameterizations tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: parameterizations
+      - name: Run restarts tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: restarts
+      - name: Run era5 tests
+        uses: julia-actions/julia-runtest@latest
+        env:
+          TEST_GROUP: era5

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -182,7 +182,7 @@ function parse_frequency_to_schedule(
 
     return CAD.EveryCalendarDtSchedule(
         period_dates;
-        reference_date = start_date,
+        start_date,
         date_last = date_last,
     )
 end
@@ -271,7 +271,7 @@ function checkpoint_callback(
     if checkpoint_frequency != Inf
         schedule = CAD.EveryCalendarDtSchedule(
             checkpoint_frequency;
-            reference_date = start_date,
+            start_date,
             date_last = t_start isa ITime ?
                         ClimaUtilities.TimeManager.date(t_start) :
                         start_date + Dates.Second(t_start),

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -101,7 +101,7 @@ function common_diagnostics(
                     date_last),
                 output_schedule_func = EveryCalendarDtSchedule(
                     period;
-                    reference_date = start_date,
+                    start_date,
                     date_last = date_last,
                 ),
                 reduction_time_func = reduction,
@@ -147,7 +147,7 @@ function make_compute_schedule(variable, period, start_date, date_last)
     compute_every = short_name in HOURLY_DIAGS ? Dates.Hour(1) : Dates.Hour(6)
     return EveryCalendarDtSchedule(
         compute_every;
-        reference_date = start_date,
+        start_date,
         date_last = date_last,
     )
 end

--- a/src/utils/AtmosArtifacts.jl
+++ b/src/utils/AtmosArtifacts.jl
@@ -37,7 +37,8 @@ function res_file_path(name; context = nothing)
     if _artifact_exists(name)
         full_name = name
     else
-        @warn "Higher resolution $name is not available. Using low-res version. Consult ClimaArtifacts to acquire the higher resolution version."
+        @warn "Higher resolution $name is not available. Using low-res version. Consult ClimaArtifacts to acquire the higher resolution version." _id =
+            Symbol(name) maxlog = 1
         full_name = "$(name)_lowres"
     end
     return joinpath(@clima_artifact(full_name, context), "$(full_name).nc")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Make the downgrade tests less likely to fail

## Content

I think the downgrade tests have been failing because they are running out of memory. The GitHub actions runners for ubuntu have [16GB](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) of memory. I ran the tests locally and monitored the memory usage. It grows to >16GB, even when explicitly calling the garbage collector. I'm not sure what causes this, but a few guesses are:
- maybe some files are not closing as expected
- the generated code and cached type inference builds up to a large size, particularly with tests that create a whole simulation.  I don't think this is cleared by the garbage collector, and small changes to configs can cause more type inference.  The anonymous functions used for diagnostics can also result in repeated inference, even if the config does not change.

When the memory of the Julia process got close to or over the amount of physical memory of my laptop, I noticed that simple tests took much longer than expected.

This PR makes the dowgrade action start and end a Julia process for each test group, which should reduce peak memory usage.

Unrelated to the downgrade tests:
Also updates the call to `EveryCalendarDtSchedule`. This was throwing a lot of warnings in the tests.
Also limits the number of warnings about using low resolution artifacts


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
