### PR TITLE
 Add microphysics process tendency diagnostics

### DIFF
--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -36,4 +36,38 @@ diagnostics:
     period: 10mins
   - short_name: [husra, hussn]
     period: 10mins
+  - short_name: [
+      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
+      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
+      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
+      mp1m_S_accr_melt_lcl_sno,
+      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
+      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
+      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
+      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
+      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
+      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
+      mp1mup_S_accr_melt_lcl_sno,
+      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
+      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
+      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
+      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
+      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
+      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
+      mp1men_S_accr_melt_lcl_sno,
+      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
+      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
+      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
+      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
+    ]
+    period: 10mins
 ode_algo: "ARS222"
+

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -34,4 +34,38 @@ diagnostics:
     period: 10mins
   - short_name: [husra, hussn]
     period: 10mins
+  - short_name: [
+      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
+      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
+      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
+      mp1m_S_accr_melt_lcl_sno,
+      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
+      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
+      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
+      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
+      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
+      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
+      mp1mup_S_accr_melt_lcl_sno,
+      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
+      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
+      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
+      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
+      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
+      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
+      mp1men_S_accr_melt_lcl_sno,
+      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
+      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
+      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
+      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
+    ]
+    period: 10mins
 ode_algo: "ARS222"
+

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -34,4 +34,38 @@ diagnostics:
     period: 10mins
   - short_name: [husra, hussn, husraup, hussnup, husraen, hussnen]
     period: 10mins
+  - short_name: [
+      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
+      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
+      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
+      mp1m_S_accr_melt_lcl_sno,
+      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
+      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
+      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
+      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
+      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
+      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
+      mp1mup_S_accr_melt_lcl_sno,
+      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
+      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
+      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
+      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
+      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
+      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
+      mp1men_S_accr_melt_lcl_sno,
+      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
+      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
+      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
+      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
+    ]
+    period: 10mins
 ode_algo: "ARS222"
+

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -190,6 +190,7 @@ function make_plots_generic(
     summary_files = String[],
     MAX_NUM_COLS = 1,
     MAX_NUM_ROWS = min(4, length(vars)),
+    fig_size = nothing,
     save_jpeg_copy = false,
     kwargs...,
 )
@@ -223,7 +224,7 @@ function make_plots_generic(
 
     # Define fig, grid, and grid_pos, used below. (Needed for scope)
     function makefig()
-        fig = CairoMakie.Figure(; size = (900, 300 * MAX_NUM_ROWS))
+        fig = CairoMakie.Figure(; size = something(fig_size, (900, 300 * MAX_NUM_ROWS)))
         if is_comparison
             for (col, path) in enumerate(output_path)
                 # CairoMakie seems to use this Label to determine the width of the figure.
@@ -1354,6 +1355,40 @@ end
 
 
 """
+    plot_mp1m_row!(grid_loc, row_vars)
+
+Plot a row of 3 mp1m time-height contour panels (grid-mean, updraft,
+environment) with shared symmetric colorbar and divergent RdBu colormap.
+
+`row_vars` is a tuple/vector of 3 OutputVar objects.
+"""
+function plot_mp1m_row!(grid_loc, row_vars)
+    # Compute shared symmetric color range across the row
+    maxabs = maximum(
+        maximum(abs.(v.data)) for v in row_vars;
+        init = eps(Float64),
+    )
+    crange = (-maxabs, maxabs)
+
+    for (col, var) in enumerate(row_vars)
+        gl = grid_loc[1, col] = CairoMakie.GridLayout()
+        viz.plot!(
+            gl,
+            var;
+            more_kwargs = Dict(
+                :axis => ca_kwargs(
+                    title = parse_var_attributes(var),
+                ),
+                :plot => ca_kwargs(
+                    colormap = Makie.Reverse(:RdBu),
+                    colorrange = crange,
+                ),
+            ),
+        )
+    end
+end
+
+"""
     plot_parsed_attribute_title!(grid_loc, var)
 
 Helper function for `make_plots_generic`. Plots an OutputVar `var`,
@@ -1477,11 +1512,101 @@ function make_plots(
         MAX_NUM_ROWS = 4,
     )
 
+    summary_files = [tmp_file]
+
+    # Microphysics 1M process tendency plots (grid-mean, updraft, environment)
+    mp1m_vars_zt = []  # time-z fields for contour plots
+    if sim_type isa EDMFColumnPlotsWithPrecip &&
+       !(sim_type isa Val{:prognostic_edmfx_rico_column_2M})
+        mp1m_source_names = [
+            "S_phase_change_vap_lcl", "S_phase_change_vap_icl",
+            "S_acnv_lcl_rai", "S_acnv_icl_sno",
+            "S_accr_lcl_rai", "S_accr_lcl_sno_cold", "S_accr_lcl_sno_warm",
+            "S_accr_melt_lcl_sno",
+            "S_accr_icl_rai", "S_accr_freeze_icl_rai", "S_accr_icl_sno",
+            "S_accr_rai_sno_cold", "S_accr_rai_sno_warm", "S_accr_melt_rai_sno",
+            "S_phase_change_vap_rai", "S_phase_change_vap_sno",
+            "S_melt_icl_lcl", "S_melt_sno_rai",
+        ]
+
+        # Use only the current simulation (not main branch comparison)
+        # since mp1m diagnostics are new and won't exist in older runs.
+        mp1m_simdirs = simdirs[1:1]
+        mp1m_output_paths = output_paths[1:1]
+
+        # Interleave as (grid-mean, updraft, environment) per source term
+        # so each row in the contour plot shows one process across domains
+        mp1m_all_names = vec(
+            ["mp1m_", "mp1mup_", "mp1men_"] .*
+            permutedims(mp1m_source_names),
+        )
+
+        # Load the time-z fields for all mp1m variables
+        mp1m_vars_zt =
+            map_comparison(mp1m_simdirs, mp1m_all_names) do simdir, sn
+                var = get(simdir; short_name = sn, reduction, period)
+                if is_box
+                    var = slice(var, x = 0.0, y = 0.0)
+                end
+                return var
+            end
+
+        # Group as (grid-mean, updraft, environment) triplets for profile plots
+        mp1m_tuples = [
+            ("mp1m_$(s)", "mp1mup_$(s)", "mp1men_$(s)")
+            for s in mp1m_source_names
+        ]
+
+        mp1m_profile_groups =
+            map_comparison(mp1m_simdirs, mp1m_tuples) do simdir, name_tuple
+                vars = map(name_tuple) do sn
+                    var = get(simdir; short_name = sn, reduction, period)
+                    if is_box
+                        var = slice(var, x = 0.0, y = 0.0)
+                    end
+                    return slice(var, time = LAST_SNAP)
+                end
+                return vars
+            end
+
+        mp1m_file = make_plots_generic(
+            mp1m_output_paths,
+            mp1m_profile_groups;
+            output_name = "mp1m_tendencies",
+            plot_fn = plot_edmf_vert_profile!,
+            MAX_NUM_COLS = 2,
+            MAX_NUM_ROWS = 4,
+        )
+        push!(summary_files, mp1m_file)
+
+        # Time-height contour plots for mp1m: 3 columns (gm, up, en) per row
+        # with shared symmetric colorbar per row and divergent colormap.
+        # Group the flat vars into (gm, up, en) triplets per source term.
+        mp1m_row_groups = [
+            (
+                mp1m_vars_zt[(i - 1) * 3 + 1],
+                mp1m_vars_zt[(i - 1) * 3 + 2],
+                mp1m_vars_zt[(i - 1) * 3 + 3],
+            ) for i in 1:length(mp1m_source_names)
+        ]
+        mp1m_zt_file = make_plots_generic(
+            mp1m_output_paths,
+            mp1m_row_groups;
+            output_name = "mp1m_timeseries",
+            plot_fn = plot_mp1m_row!,
+            MAX_NUM_COLS = 1,
+            MAX_NUM_ROWS = 3,
+            fig_size = (1500, 900),
+        )
+        push!(summary_files, mp1m_zt_file)
+    end
+
+    # Time-height contour plots: existing EDMF variables
     make_plots_generic(
         output_paths,
         collect(Iterators.flatten(var_groups_zt)),
         plot_fn = plot_parsed_attribute_title!,
-        summary_files = [tmp_file],
+        summary_files = summary_files,
         MAX_NUM_COLS = 2,
         MAX_NUM_ROWS = 4,
     )

--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -100,6 +100,7 @@ include("tracer_diagnostics.jl")
 include("gravitywave_diagnostics.jl")
 include("conservation_diagnostics.jl")
 include("negative_scalars_diagnostics.jl")
+include("microphysics_diagnostics.jl")
 
 # Default diagnostics and higher level interfaces
 include("default_diagnostics.jl")

--- a/src/diagnostics/microphysics_diagnostics.jl
+++ b/src/diagnostics/microphysics_diagnostics.jl
@@ -1,0 +1,188 @@
+#=
+This file is included in Diagnostics.jl
+
+Microphysics 1-moment process tendency diagnostics.
+
+Outputs individual source terms from CloudMicrophysics
+`bulk_microphysics_tendencies(InstantaneousVerbose(), ...)` for:
+  - Grid-mean state (prefix: mp1m_)
+  - Updraft state for PrognosticEDMFX (prefix: mp1mup_)
+  - Environment state for PrognosticEDMFX (prefix: mp1men_)
+
+Each diagnostic calls InstantaneousVerbose and extracts a single scalar field
+inside the broadcast, so the result is a proper `Field{FT}` with zero
+intermediate allocations.
+=#
+
+import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
+
+# ---------------------------------------------------------------------------
+# Helper: call InstantaneousVerbose and extract one field by name.
+# Because everything is @inline, the compiler can dead-code-eliminate unused
+# source terms inside the broadcast.
+# ---------------------------------------------------------------------------
+@inline function _mp1m_source_term(
+    ::Val{F}, mp, tps, ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
+) where {F}
+    src = BMT.bulk_microphysics_tendencies(
+        BMT.InstantaneousVerbose(), BMT.Microphysics1Moment(),
+        mp, tps, ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
+    )
+    return getfield(src, F)
+end
+
+# ---------------------------------------------------------------------------
+# The 18 source terms produced by _microphysics_source_terms.
+# Each entry: (field_symbol, human-readable description)
+# ---------------------------------------------------------------------------
+const MP1M_SOURCE_TERMS = [
+    (:S_phase_change_vap_lcl, "Vapor ↔ cloud liquid phase change"),
+    (:S_phase_change_vap_icl, "Vapor ↔ cloud ice phase change"),
+    (:S_acnv_lcl_rai, "Cloud liquid → rain autoconversion"),
+    (:S_acnv_icl_sno, "Cloud ice → snow autoconversion"),
+    (:S_accr_lcl_rai, "Cloud liquid + rain accretion"),
+    (:S_accr_lcl_sno_cold, "Cloud liquid + snow accretion (cold)"),
+    (:S_accr_lcl_sno_warm, "Cloud liquid + snow accretion (warm)"),
+    (:S_accr_melt_lcl_sno, "Thermal melt of snow by warm cloud liquid"),
+    (:S_accr_icl_rai, "Cloud ice + rain accretion"),
+    (:S_accr_freeze_icl_rai, "Rain frozen in ice-rain collision"),
+    (:S_accr_icl_sno, "Cloud ice + snow accretion"),
+    (:S_accr_rai_sno_cold, "Rain-snow accretion (cold, rain → snow)"),
+    (:S_accr_rai_sno_warm, "Rain-snow accretion (warm, snow → rain)"),
+    (:S_accr_melt_rai_sno, "Thermal melt of snow by warm rain"),
+    (:S_phase_change_vap_rai, "Rain condensation/evaporation"),
+    (:S_phase_change_vap_sno, "Snow deposition/sublimation"),
+    (:S_melt_icl_lcl, "Cloud ice melt → cloud liquid"),
+    (:S_melt_sno_rai, "Snow melt → rain"),
+]
+
+# ---------------------------------------------------------------------------
+# Grid-mean compute function
+# ---------------------------------------------------------------------------
+function compute_mp1m_source(state, cache, ::Val{F}) where {F}
+    cmp = CAP.microphysics_1m_params(cache.params)
+    thp = CAP.thermodynamics_params(cache.params)
+    ᶜρ = state.c.ρ
+    ᶜT = cache.precomputed.ᶜT
+    ᶜq_tot = @. lazy(specific(state.c.ρq_tot, ᶜρ))
+    ᶜq_lcl = @. lazy(specific(state.c.ρq_lcl, ᶜρ))
+    ᶜq_icl = @. lazy(specific(state.c.ρq_icl, ᶜρ))
+    ᶜq_rai = @. lazy(specific(state.c.ρq_rai, ᶜρ))
+    ᶜq_sno = @. lazy(specific(state.c.ρq_sno, ᶜρ))
+    return @. lazy(
+        _mp1m_source_term(
+            Val(F), cmp, thp, ᶜρ, ᶜT, ᶜq_tot, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
+        ),
+    )
+end
+
+# Dispatch: only defined for 1M microphysics
+compute_mp1m_source(state, cache, time, F) =
+    compute_mp1m_source(state, cache, time, F, cache.atmos.microphysics_model)
+compute_mp1m_source(_, _, _, F, model) =
+    error_diagnostic_variable("mp1m_$(F)", model)
+compute_mp1m_source(state, cache, _, F, ::NonEquilibriumMicrophysics1M) =
+    compute_mp1m_source(state, cache, F)
+
+# ---------------------------------------------------------------------------
+# Updraft compute function (PrognosticEDMFX, first subdomain)
+# ---------------------------------------------------------------------------
+function compute_mp1m_source_updraft(state, cache, ::Val{F}) where {F}
+    cmp = CAP.microphysics_1m_params(cache.params)
+    thp = CAP.thermodynamics_params(cache.params)
+    ᶜρʲ = cache.precomputed.ᶜρʲs.:1
+    ᶜTʲ = cache.precomputed.ᶜTʲs.:1
+    ᶜq_totʲ = cache.precomputed.ᶜq_tot_nonnegʲs.:1
+    ᶜq_lclʲ = (state.c.sgsʲs.:1).q_lcl
+    ᶜq_iclʲ = (state.c.sgsʲs.:1).q_icl
+    ᶜq_raiʲ = (state.c.sgsʲs.:1).q_rai
+    ᶜq_snoʲ = (state.c.sgsʲs.:1).q_sno
+    return @. lazy(
+        _mp1m_source_term(
+            Val(F), cmp, thp,
+            ᶜρʲ, ᶜTʲ, ᶜq_totʲ, ᶜq_lclʲ, ᶜq_iclʲ, ᶜq_raiʲ, ᶜq_snoʲ,
+        ),
+    )
+end
+
+# Dispatch: only for 1M + PrognosticEDMFX
+compute_mp1m_source_updraft(state, cache, time, F) =
+    compute_mp1m_source_updraft(
+        state, cache, time, F,
+        cache.atmos.microphysics_model, cache.atmos.turbconv_model,
+    )
+compute_mp1m_source_updraft(_, _, _, F, mp_model, tc_model) =
+    error_diagnostic_variable("mp1mup_$(F)", (mp_model, tc_model))
+compute_mp1m_source_updraft(
+    state, cache, _, F,
+    ::NonEquilibriumMicrophysics1M, ::PrognosticEDMFX,
+) = compute_mp1m_source_updraft(state, cache, F)
+
+# ---------------------------------------------------------------------------
+# Environment compute function (PrognosticEDMFX)
+# ---------------------------------------------------------------------------
+function compute_mp1m_source_env(state, cache, ::Val{F}) where {F}
+    cmp = CAP.microphysics_1m_params(cache.params)
+    thp = CAP.thermodynamics_params(cache.params)
+    (; ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = cache.precomputed
+    ᶜρ⁰ = @. lazy(
+        TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰),
+    )
+    ᶜq_lcl⁰ = ᶜspecific_env_value(@name(q_lcl), state, cache)
+    ᶜq_icl⁰ = ᶜspecific_env_value(@name(q_icl), state, cache)
+    ᶜq_rai⁰ = ᶜspecific_env_value(@name(q_rai), state, cache)
+    ᶜq_sno⁰ = ᶜspecific_env_value(@name(q_sno), state, cache)
+    return @. lazy(
+        _mp1m_source_term(
+            Val(F), cmp, thp,
+            ᶜρ⁰, ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
+        ),
+    )
+end
+
+# Dispatch: only for 1M + PrognosticEDMFX
+compute_mp1m_source_env(state, cache, time, F) =
+    compute_mp1m_source_env(
+        state, cache, time, F,
+        cache.atmos.microphysics_model, cache.atmos.turbconv_model,
+    )
+compute_mp1m_source_env(_, _, _, F, mp_model, tc_model) =
+    error_diagnostic_variable("mp1men_$(F)", (mp_model, tc_model))
+compute_mp1m_source_env(
+    state, cache, _, F,
+    ::NonEquilibriumMicrophysics1M, ::PrognosticEDMFX,
+) = compute_mp1m_source_env(state, cache, F)
+
+# ---------------------------------------------------------------------------
+# Register all diagnostics via loops
+# ---------------------------------------------------------------------------
+
+for (prefix, label, location, compute_fn) in (
+    ("mp1m", "", "grid-mean state", compute_mp1m_source),
+    (
+        "mp1mup",
+        " Updraft",
+        "updraft state (first subdomain)",
+        compute_mp1m_source_updraft,
+    ),
+    (
+        "mp1men",
+        " Environment",
+        "environment state",
+        compute_mp1m_source_env,
+    ),
+)
+    for (field, description) in MP1M_SOURCE_TERMS
+        add_diagnostic_variable!(;
+            short_name = "$(prefix)_$(field)",
+            long_name = "1M Microphysics$(label): $(description)",
+            units = "kg kg^-1 s^-1",
+            comments = "Instantaneous source term $(field) from " *
+                       "bulk_microphysics_tendencies(InstantaneousVerbose()). " *
+                       "Evaluated at $(location).",
+            compute = let F = Val(field), f = compute_fn
+                (state, cache, time) -> f(state, cache, time, F)
+            end,
+        )
+    end
+end

--- a/test/diagnostics/unit_diagnostics.jl
+++ b/test/diagnostics/unit_diagnostics.jl
@@ -375,6 +375,14 @@ VALID_CASES = [
     cases(("cdncup", "cdncen", "ncraup", "ncraen"), :m2_pedmfx)...,
     # VerticalDiffusion, DecayWithHeightDiffusion, EDMF
     cases(("edt", "evu"), (:vd, :dwh, :m0_pedmfx))...,
+
+    # ---------------------------------------------------------------------------
+    # microphysics_diagnostics.jl
+    # Grid-mean (mp1m_) needs 1M; updraft/environment need 1M + PrognosticEDMFX
+    # ---------------------------------------------------------------------------
+    cases(vec("mp1m_" .* string.(first.(CA.Diagnostics.MP1M_SOURCE_TERMS))), :m1)...,
+    cases(vec("mp1mup_" .* string.(first.(CA.Diagnostics.MP1M_SOURCE_TERMS))), :m1_pedmfx)...,
+    cases(vec("mp1men_" .* string.(first.(CA.Diagnostics.MP1M_SOURCE_TERMS))), :m1_pedmfx)...,
 ]
 #! format: on
 #


### PR DESCRIPTION
This PR adds the ability to output individual 1-moment microphysics process tendencies (e.g., condensation, autoconversion, accretion, melting) as diagnostic variables. All 18 source terms from `CloudMicrophysics.BulkMicrophysicsTendencies` are supported, with three variants each:

- **Grid-mean** (`mp1m_S_*`) — available for any 1M microphysics configuration
- **Updraft** (`mp1mup_S_*`) — available with prognostic EDMF
- **Environment** (`mp1men_S_*`) — available with prognostic EDMF

The 54 diagnostics are registered via a loop over source term names, avoiding boilerplate repetition.

### Design choice between recomputing vs caching

**Caching approach (rejected):**
- Call `bulk_microphysics_tendencies(InstantaneousVerbose(), ...)` once per diagnostic period
- Store the full `MicrophysicsSourceTerms` struct in a pre-allocated cache field
- Pro: single evaluation
- Con: requires allocating and managing a new cache field with 18 arrays; broadcasting the verbose function over the column returns a struct-of-arrays that must be unpacked; invasive changes to the cache infrastructure

**Recompute approach (chosen):**
- Each diagnostic independently calls `bulk_microphysics_tendencies(InstantaneousVerbose(Val(:field_name)), ...)` which returns a single scalar per grid point
- The microphysics evaluations are fast (simple arithmetic), so recomputing is cheap
- Pro: zero cache allocations, no changes to the model's cache structure, each diagnostic is self-contained
- Con: redundant computation if many tendencies are requested simultaneously

The recompute approach was chosen because it requires no changes to the model's state or cache and avoids allocation concerns. Hopefully the microphysics tendency functions are lightweight enough that recomputing them is negligible compared to I/O costs.

> [!NOTE]
> These are *instantaneous* diagnostic tendencies, not the actual linearized tendencies seen by the ODE solver. They are useful for understanding which microphysics processes are active and where, but may differ from the solver's view.

### CI integration

The three prognostic EDMF single-column cases (DYCOMS-RF02, RICO, TRMM) now output all 54 microphysics tendency diagnostics. CI plots include:
- **Vertical profile plots** — grid-mean, updraft, and environment overlaid per source term
- **Time-height contour plots** — 3-column layout (grid-mean | updraft | environment) per row

Both are saved as PDF artifacts in Buildkite CI output.