### PR TITLE
Auto-discover SGS updraft tracers in prognostic EDMF

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -68,6 +68,7 @@ makedocs(;
             "Grids" => "grids.md",
             "Setups" => "setups.md",
             "Surface Conditions" => "surface_conditions.md",
+            "Passive Tracers" => "passive_tracers.md",
             "Trace Gases (Radiation)" => "tracers.md",
             "Available Diagnostics" => "available_diagnostics.md",
             "Bibliography" => "references.md",

--- a/docs/src/passive_tracers.md
+++ b/docs/src/passive_tracers.md
@@ -1,0 +1,166 @@
+# Tracers
+
+ClimaAtmos provides automatic treatment of conserved scalar tracers at two
+levels: **grid-scale** (resolved) and **sub-grid scale** (SGS, inside
+prognostic EDMF updrafts). Both levels use an auto-discovery mechanism: any
+field that follows the naming convention is automatically picked up for
+transport, diffusion, and other generic operations — no
+additional code changes are required.
+
+## Grid-Scale Tracers
+
+Grid-scale tracers are density-weighted scalars ``\rho \chi`` stored at cell
+centers in the prognostic state `Y.c`.
+
+### Naming convention
+
+A grid-scale tracer is identified by a name that starts with `ρ` followed
+by the scalar name, e.g. `ρq_tot`, `ρq_lcl`, `ρn_rai`. The utility function
+`gs_tracer_names(Y)` discovers all such tracers automatically by inspecting
+`Y.c` and excluding non-tracer fields (`ρ`, `ρe_tot`, `uₕ`, `ρtke`,
+`sgsʲs`).
+
+### Automatically handled operations
+
+| Operation | Description |
+|---|---|
+| Horizontal advection | Flux-form divergence of ``\rho \chi \boldsymbol{u}_h`` |
+| Vertical advection | Upwinded vertical transport |
+| Vertical diffusion | Eddy-diffusivity-based mixing |
+| Hyperdiffusion | 4th-order ``\nabla^4`` stabilization with DSS |
+
+The iteration utility `foreach_gs_tracer(f, Y...)` applies a function `f` to
+each discovered tracer.
+
+## SGS Tracers (Prognostic EDMF)
+
+When prognostic EDMF is enabled, each updraft carries its own set of scalar
+fields inside `Y.c.sgsʲs.:(j)`. The utility function `sgs_tracer_names(Y)`
+discovers all scalars in the first updraft (`Y.c.sgsʲs.:(1)`) and excludes
+the core EDMF variables `ρa`, `mse`, and `q_tot`, which receive
+physics-specific treatment.
+
+### Naming convention
+
+An SGS tracer `χ` in `Y.c.sgsʲs.:(j)` maps to a grid-scale
+density-weighted counterpart `ρχ` in `Y.c`. For example:
+
+| SGS field (in `sgsʲs.:(j)`) | Grid-scale field (in `Y.c`) |
+|---|---|
+| `q_lcl` | `ρq_lcl` |
+| `q_rai` | `ρq_rai` |
+| `n_rai` | `ρn_rai` |
+| `A` (user-defined) | `ρA` |
+
+This pairing is enforced by `get_ρχ_name(χ_name)` which constructs
+`ρχ` from `χ`.
+
+### Automatically handled operations
+
+The following operations are auto-discovered for all SGS tracers. No code
+changes are needed when adding a new tracer:
+
+| Operation | File | Pattern |
+|---|---|---|
+| Horizontal advection | `advection.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| Vertical advection (advective form) | `advection.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| Entrainment/detrainment mixing | `edmfx_entr_detr.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| SGS mass flux (draft + environment → grid mean) | `edmfx_sgs_flux.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| SGS diffusive flux (grid mean) | `edmfx_sgs_flux.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| Updraft vertical diffusion | `mass_flux_closures.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| Updraft constraint enforcement | `mass_flux_closures.jl` | `for χ_name in sgs_tracer_names(Y)` |
+| Rayleigh sponge damping | `remaining_tendency.jl` | `for χ_name in sgs_tracer_names(Y)` |
+
+All SGS tracers (cloud species and precipitation alike) receive the same
+reduced vertical diffusion coefficient (`α_vert_diff_microphysics`).
+
+## Adding a New Passive Tracer
+
+To add a new passive tracer `A` that is transported through the full
+grid-scale + SGS system, the only changes needed are:
+
+### Step 1: Add `ρA` to the grid-scale prognostic state
+
+In `prognostic_variables.jl`, add `ρA` to the center variables:
+
+```julia
+ρA = ρ * physical_state.A
+```
+
+This gives automatic grid-scale advection, diffusion, hyperdiffusion,
+and surface flux — all handled by `foreach_gs_tracer`.
+
+### Step 2: Add `A` to the SGS updraft state
+
+In `prognostic_variables.jl`, add `A` to the SGS struct:
+
+```julia
+sgsʲs = uniform_subdomains((; ρa, mse, q_tot, A = physical_state.A), turbconv_model)
+```
+
+This gives automatic SGS entrainment, mass flux, diffusive flux,
+vertical diffusion, updraft constraints, advection, and sponge damping —
+all handled by `sgs_tracer_names`.
+
+### Step 3: Initial condition
+
+Set the initial value of `A` in the setup file (e.g. `Bomex.jl`):
+
+```julia
+A = FT(1.0)  # constant initial concentration
+```
+
+That's it — no tendency code changes needed.
+
+### Step 4 (if using implicit solver): Update the Jacobian
+
+The implicit solver's Jacobian (`manual_sparse_jacobian.jl`) uses hardcoded
+tracer lists for performance reasons (`unrolled_foreach` with compile-time
+tuples). Adding a new tracer to the Jacobian requires manually editing
+several locations in `jacobian_cache` (sparsity pattern) and
+`update_jacobian!` (numeric updates). Search for existing microphysics
+tracer names (e.g. `q_lcl`, `q_rai`) to find each block and add the new
+tracer alongside them.
+
+Key locations to update:
+
+| Location | What to add |
+|---|---|
+| `condensate_names` / `condensate_mass_names` in `jacobian_cache` | `@name(c.ρA)` |
+| `sgs_condensate_names` / `sgs_condensate_mass_names` in `jacobian_cache` | `@name(c.sgsʲs.:(1).A)` |
+| SGS vertical diffusion block | Append to `sgs_microphysics_tracers` tuple |
+| SGS entrainment block | Append to `sgs_microphysics_tracers` tuple |
+| Grid-mean + SGS mass flux block | Append to `microphysics_tracers` tuple |
+
+For **moisture species** that affect pressure, buoyancy, or have a
+sedimentation velocity, additional blocks need updating (pressure
+gradient, sedimentation, SGS pressure/buoyancy). Search for existing
+species like `q_rai` to locate each block.
+
+!!! note
+    A passive tracer that doesn't affect thermodynamics and has no
+    sedimentation can often run without Jacobian entries. The implicit
+    solver will still converge, just more slowly for that variable.
+
+### Operations that remain manual
+
+| Operation | Reason |
+|---|---|
+| Initial / boundary conditions | Problem-specific |
+| Source / sink terms | Physics-specific |
+| Jacobian blocks (implicit solver) | See Step 4 above |
+| Diagnostics output | User must define short names |
+
+## Implementation details
+
+The auto-discovery relies on two key patterns:
+
+1. **Field-name predicates** — `_is_sgs_tracer_name` and
+   `is_ρ_weighted_name` filter the top-level field names at the type
+   level, enabling `unrolled_filter` to resolve the tracer list with
+   zero runtime cost.
+
+2. **`MatrixFields.get_field` + `FieldName`** — tracer fields are
+   accessed via `MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)` using
+   the discovered `FieldName`. This is equivalent to direct property
+   access (e.g. `Y.c.sgsʲs.:(1).q_lcl`) and compiles to the same code.

--- a/docs/src/tracers.md
+++ b/docs/src/tracers.md
@@ -1,5 +1,3 @@
-# Aerosols
-
 # Trace Gases
 `ClimaAtmos` implements two modes for each ozone and carbon dioxide: one time varying and one time invariant. These are only relevant for the radiation transfer, and only when RRTMGP is used. All other atmospheric gases are held fixed with default values from RRTMPG that can be changed in the toml file.
 

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -135,30 +135,14 @@ NVTX.@annotate function horizontal_tracer_advection_tendency!(Yₜ, Y, p, t)
             @. Yₜ.c.sgsʲs.:($$j).q_tot -=
                 split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).q_tot) -
                 Y.c.sgsʲs.:($$j).q_tot * split_divₕ(ᶜuʲs.:($$j), 1)
-            if p.atmos.microphysics_model isa Union{
-                NonEquilibriumMicrophysics1M,
-                NonEquilibriumMicrophysics2M,
-            }
-                @. Yₜ.c.sgsʲs.:($$j).q_lcl -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).q_lcl) -
-                    Y.c.sgsʲs.:($$j).q_lcl * split_divₕ(ᶜuʲs.:($$j), 1)
-                @. Yₜ.c.sgsʲs.:($$j).q_icl -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).q_icl) -
-                    Y.c.sgsʲs.:($$j).q_icl * split_divₕ(ᶜuʲs.:($$j), 1)
-                @. Yₜ.c.sgsʲs.:($$j).q_rai -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).q_rai) -
-                    Y.c.sgsʲs.:($$j).q_rai * split_divₕ(ᶜuʲs.:($$j), 1)
-                @. Yₜ.c.sgsʲs.:($$j).q_sno -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).q_sno) -
-                    Y.c.sgsʲs.:($$j).q_sno * split_divₕ(ᶜuʲs.:($$j), 1)
-            end
-            if p.atmos.microphysics_model isa NonEquilibriumMicrophysics2M
-                @. Yₜ.c.sgsʲs.:($$j).n_lcl -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).n_lcl) -
-                    Y.c.sgsʲs.:($$j).n_lcl * split_divₕ(ᶜuʲs.:($$j), 1)
-                @. Yₜ.c.sgsʲs.:($$j).n_rai -=
-                    split_divₕ(ᶜuʲs.:($$j), Y.c.sgsʲs.:($$j).n_rai) -
-                    Y.c.sgsʲs.:($$j).n_rai * split_divₕ(ᶜuʲs.:($$j), 1)
+            # Auto-discovered SGS tracers (microphysics species and any
+            # user-defined passive tracers)
+            for χ_name in sgs_tracer_names(Y)
+                ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
+                ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:(1), χ_name)
+                @. ᶜχʲₜ -=
+                    split_divₕ(ᶜuʲs.:($$j), ᶜχʲ) -
+                    ᶜχʲ * split_divₕ(ᶜuʲs.:($$j), 1)
             end
         end
     end
@@ -395,6 +379,20 @@ function edmfx_sgs_vertical_advection_tendency!(
         )
         @. Yₜ.c.sgsʲs.:($$j).q_tot += va
 
+        # Advective form advection of auto-discovered SGS tracers
+        # (microphysics species and any user-defined passive tracers)
+        # with the updraft velocity
+        for χ_name in sgs_tracer_names(Y)
+            ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:($j), χ_name)
+            ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:($j), χ_name)
+            va = vertical_advection(
+                ᶠu³ʲs.:($j),
+                ᶜχʲ,
+                edmfx_tracer_upwinding,
+            )
+            @. ᶜχʲₜ += va
+        end
+
         if p.atmos.microphysics_model isa
            Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
             # TODO - add precipitation and cloud sedimentation in implicit solver/tendency with if/else
@@ -427,14 +425,6 @@ function edmfx_sgs_vertical_advection_tendency!(
                 ᶜqʲ = MatrixFields.get_field(Y, qʲ_name)
                 ᶜqʲₜ = MatrixFields.get_field(Yₜ, qʲ_name)
                 ᶜwʲ = MatrixFields.get_field(p.precomputed, wʲ_name)
-
-                # Advective form advection of tracers with updraft velocity
-                va = vertical_advection(
-                    ᶠu³ʲs.:($j),
-                    ᶜqʲ,
-                    edmfx_tracer_upwinding,
-                )
-                @. ᶜqʲₜ += va
 
                 # Flux form sedimentation of tracers
                 vtt = p.scratch.ᶜtemp_scalar_4
@@ -476,14 +466,6 @@ function edmfx_sgs_vertical_advection_tendency!(
                 ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
                 ᶜχʲₜ = MatrixFields.get_field(Yₜ, χʲ_name)
                 ᶜwʲ = MatrixFields.get_field(p.precomputed, wʲ_name)
-
-                # Advective form advection of tracers with updraft velocity
-                va = vertical_advection(
-                    ᶠu³ʲs.:($j),
-                    ᶜχʲ,
-                    edmfx_tracer_upwinding,
-                )
-                @. ᶜχʲₜ += va
 
                 # Flux form sedimentation of tracers
                 vtt = p.scratch.ᶜtemp_scalar_4

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -485,15 +485,6 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
     ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
     ᶜlg = Fields.local_geometry_field(Y.c)
 
-    microphysics_tracers = (
-        (@name(c.sgsʲs.:(1).q_lcl), @name(q_lcl)),
-        (@name(c.sgsʲs.:(1).q_icl), @name(q_icl)),
-        (@name(c.sgsʲs.:(1).q_rai), @name(q_rai)),
-        (@name(c.sgsʲs.:(1).q_sno), @name(q_sno)),
-        (@name(c.sgsʲs.:(1).n_lcl), @name(n_lcl)),
-        (@name(c.sgsʲs.:(1).n_rai), @name(n_rai)),
-    )
-
     for j in 1:n
         ᶜentrʲ = @. lazy(
             compute_entrainment(
@@ -511,11 +502,12 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
         @. Yₜ.c.sgsʲs.:($$j).q_tot +=
             (ᶜentrʲ .+ ᶜturb_entrʲ) * (ᶜq_tot⁰ - ᶜq_totʲ)
 
-        MatrixFields.unrolled_foreach(microphysics_tracers) do (χʲ_name, χ_name)
-            MatrixFields.has_field(Y, χʲ_name) || return
+        # Auto-discovered SGS tracers (microphysics species and any
+        # user-defined passive tracers)
+        for χ_name in sgs_tracer_names(Y)
             ᶜχ⁰ = ᶜspecific_env_value(χ_name, Y, p)
-            ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
-            ᶜχʲₜ = MatrixFields.get_field(Yₜ, χʲ_name)
+            ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
+            ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:(1), χ_name)
             @. ᶜχʲₜ += (ᶜentrʲ .+ ᶜturb_entrʲ) * (ᶜχ⁰ - ᶜχʲ)
         end
     end

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -126,57 +126,41 @@ function edmfx_sgs_mass_flux_tendency!(
             @. Yₜ.c.ρq_tot += vtt
         end
 
-        # Microphysics tracers fluxes
-        if p.atmos.microphysics_model isa
-           Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
-            microphysics_tracers = (
-                (@name(c.ρq_lcl), @name(c.sgsʲs.:(1).q_lcl), @name(q_lcl)),
-                (@name(c.ρq_icl), @name(c.sgsʲs.:(1).q_icl), @name(q_icl)),
-                (@name(c.ρq_rai), @name(c.sgsʲs.:(1).q_rai), @name(q_rai)),
-                (@name(c.ρq_sno), @name(c.sgsʲs.:(1).q_sno), @name(q_sno)),
-                (@name(c.ρn_lcl), @name(c.sgsʲs.:(1).n_lcl), @name(n_lcl)),
-                (@name(c.ρn_rai), @name(c.sgsʲs.:(1).n_rai), @name(n_rai)),
-            )
-            # TODO using unrolled_foreach here allocates! (breaks the flame tests
-            # even though they use 0M microphysics)
-            # MatrixFields.unrolled_foreach(
-            #     microphysics_tracers,
-            # ) do (ρχ_name, χʲ_name, _)
-            for (ρχ_name, χʲ_name, _) in microphysics_tracers
-                MatrixFields.has_field(Y, ρχ_name) || continue
-
-                ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
+        # Auto-discovered SGS tracer fluxes (microphysics species and any
+        # user-defined passive tracers)
+        # Draft fluxes
+        for χ_name in sgs_tracer_names(Y)
+            ρχ_name = get_ρχ_name(χ_name)
+            for j in 1:n
+                ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:($j), χ_name)
                 @. ᶜa_scalar =
                     ᶜχʲ *
-                    draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1))
+                    draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))
                 vtt = vertical_transport(
-                    ᶜρʲs.:(1),
-                    ᶠu³ʲs.:(1),
+                    ᶜρʲs.:($j),
+                    ᶠu³ʲs.:($j),
                     ᶜa_scalar,
                     dt,
                     edmfx_tracer_upwinding,
                 )
-                ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
+                ᶜρχₜ = MatrixFields.get_field(Yₜ.c, ρχ_name)
                 @. ᶜρχₜ += vtt
             end
-            # MatrixFields.unrolled_foreach(
-            #     microphysics_tracers,
-            # ) do (ρχ_name, _, χ_name)
-            for (ρχ_name, _, χ_name) in microphysics_tracers
-                MatrixFields.has_field(Y, ρχ_name) || continue
-
-                ᶜχ⁰ = ᶜspecific_env_value(χ_name, Y, p)
-                @. ᶜa_scalar = ᶜχ⁰ * draft_area(ᶜρa⁰, ᶜρ⁰)
-                vtt = vertical_transport(
-                    ᶜρ⁰,
-                    ᶠu³⁰,
-                    ᶜa_scalar,
-                    dt,
-                    edmfx_tracer_upwinding,
-                )
-                ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
-                @. ᶜρχₜ += vtt
-            end
+        end
+        # Environment fluxes
+        for χ_name in sgs_tracer_names(Y)
+            ρχ_name = get_ρχ_name(χ_name)
+            ᶜχ⁰ = ᶜspecific_env_value(χ_name, Y, p)
+            @. ᶜa_scalar = ᶜχ⁰ * draft_area(ᶜρa⁰, ᶜρ⁰)
+            vtt = vertical_transport(
+                ᶜρ⁰,
+                ᶠu³⁰,
+                ᶜa_scalar,
+                dt,
+                edmfx_tracer_upwinding,
+            )
+            ᶜρχₜ = MatrixFields.get_field(Yₜ.c, ρχ_name)
+            @. ᶜρχₜ += vtt
         end
     end
     # TODO - add vertical momentum fluxes
@@ -459,16 +443,15 @@ function edmfx_sgs_diffusive_flux_tendency!(
             top = Operators.SetValue(C3(FT(0))),
             bottom = Operators.SetValue(C3(FT(0))),
         )
-        microphysics_tracers = (
-            @name(c.ρq_lcl), @name(c.ρq_icl), @name(c.ρq_rai), @name(c.ρq_sno),
-            @name(c.ρn_lcl), @name(c.ρn_rai),
-        )
-        MatrixFields.unrolled_foreach(microphysics_tracers) do ρχ_name
-            MatrixFields.has_field(Y, ρχ_name) || return
-            ᶜρχ = MatrixFields.get_field(Y, ρχ_name)
+        # Auto-discovered grid-scale tracers (microphysics species and any
+        # user-defined passive tracers)
+        for χ_name in sgs_tracer_names(Y)
+            ρχ_name = get_ρχ_name(χ_name)
+            MatrixFields.has_field(Y.c, ρχ_name) || continue
+            ᶜρχ = MatrixFields.get_field(Y.c, ρχ_name)
+            ᶜρχₜ = MatrixFields.get_field(Yₜ.c, ρχ_name)
             ᶜχ = (@. lazy(specific(ᶜρχ, Y.c.ρ)))
             @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρq(-(ᶠρaK_h * α_vert_diff_microphysics * ᶠgradᵥ(ᶜχ)))
-            ᶜρχₜ = MatrixFields.get_field(Yₜ, ρχ_name)
             @. ᶜρχₜ -= ᶜρχₜ_diffusion
         end
 

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -159,30 +159,16 @@ function edmfx_vertical_diffusion_tendency!(
                 ᶜdivᵥ_q_tot(-(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜq_totʲ))) / ᶜρʲ
         end
 
-        if p.atmos.microphysics_model isa
-           Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
+        if !isempty(sgs_tracer_names(Y))
             α_vert_diff_microphysics = CAP.α_vert_diff_tracer(params)
             ᶜρʲ = ᶜρʲs.:(1)
             ᶜdivᵥ_q = Operators.DivergenceF2C(
                 top = Operators.SetValue(C3(FT(0))),
                 bottom = Operators.SetValue(C3(FT(0))),
             )
-
-            microphysics_tracers = (
-                @name(c.sgsʲs.:(1).q_lcl), @name(c.sgsʲs.:(1).q_icl),
-                @name(c.sgsʲs.:(1).q_rai), @name(c.sgsʲs.:(1).q_sno),
-                @name(c.sgsʲs.:(1).n_lcl), @name(c.sgsʲs.:(1).n_rai),
-            )
-
-            # TODO: using unrolled_foreach here allocates! (breaks the flame tests
-            # even though they use 0M microphysics)
-            # MatrixFields.unrolled_foreach(cloud_tracers) do χʲ_name
-            for χʲ_name in microphysics_tracers
-                MatrixFields.has_field(Y, χʲ_name) || continue
-
-                ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
-                ᶜχʲₜ = MatrixFields.get_field(Yₜ, χʲ_name)
-
+            for χ_name in sgs_tracer_names(Y)
+                ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
+                ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:(1), χ_name)
                 @. ᶜχʲₜ -=
                     ᶜdivᵥ_q(
                         -(
@@ -253,14 +239,6 @@ function enforce_edmf_updraft_constraints!(Y, p, t, turbconv_model)
     n = n_prognostic_mass_flux_subdomains(turbconv_model)
     n == 0 && return nothing
     (; ᶜh_tot, ᶜK, ᶜρʲs) = p.precomputed
-    microphysics_tracers = (
-        (@name(c.sgsʲs.:(1).q_lcl), @name(c.ρq_lcl)),
-        (@name(c.sgsʲs.:(1).q_icl), @name(c.ρq_icl)),
-        (@name(c.sgsʲs.:(1).q_rai), @name(c.ρq_rai)),
-        (@name(c.sgsʲs.:(1).q_sno), @name(c.ρq_sno)),
-        (@name(c.sgsʲs.:(1).n_lcl), @name(c.ρn_lcl)),
-        (@name(c.sgsʲs.:(1).n_rai), @name(c.ρn_rai)),
-    )
     for j in 1:n
         # clip updraft area fraction and vertical velocity to non-negative values
         @. Y.c.sgsʲs.:($$j).ρa = max(0, min(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)))
@@ -290,13 +268,13 @@ function enforce_edmf_updraft_constraints!(Y, p, t, turbconv_model)
             ),
         )
 
-        # relax updraft microphysics tracers toward the grid mean when ρa is
+        # Auto-discovered SGS tracers: relax toward grid mean when ρa is
         # negligible; enforce mass conservation bound ρaχʲ < ρχ.
-        # has_field returns false for 0M configs, making this block a no-op.
-        MatrixFields.unrolled_foreach(microphysics_tracers) do (χʲ_name, ρχ_name)
-            MatrixFields.has_field(Y, χʲ_name) || return
-            ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
-            ᶜρχ = MatrixFields.get_field(Y, ρχ_name)
+        for χ_name in sgs_tracer_names(Y)
+            ρχ_name = get_ρχ_name(χ_name)
+            MatrixFields.has_field(Y.c, ρχ_name) || continue
+            ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
+            ᶜρχ = MatrixFields.get_field(Y.c, ρχ_name)
             @. ᶜχʲ = ifelse(
                 Y.c.sgsʲs.:($$j).ρa < ϵ_numerics(FT),
                 specific(ᶜρχ, Y.c.ρ),

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -178,21 +178,17 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
             )
             @. Yₜ.c.sgsʲs.:($$j).q_tot += rst_sgs_q_tot
         end
-        if microphysics_model isa NonEquilibriumMicrophysics1M
-            # TODO: This doesn't work for multiple updrafts
-            moisture_species = (
-                (@name(c.sgsʲs.:(1).q_lcl), @name(c.ρq_lcl)),
-                (@name(c.sgsʲs.:(1).q_icl), @name(c.ρq_icl)),
-                (@name(c.sgsʲs.:(1).q_rai), @name(c.ρq_rai)),
-                (@name(c.sgsʲs.:(1).q_sno), @name(c.ρq_sno)),
-            )
-            MatrixFields.unrolled_foreach(moisture_species) do (sgs_q_name, ρq_name)
-                ᶜρq = MatrixFields.get_field(Y, ρq_name)
-                ᶜq = @. lazy(specific(ᶜρq, Y.c.ρ))
-                ᶜsgs_q = MatrixFields.get_field(Y, sgs_q_name)
-                ᶜsgs_qₜ = MatrixFields.get_field(Yₜ, sgs_q_name)
-                rst_sgs_q = rayleigh_sponge_tendency_sgs_tracer(ᶜsgs_q, ᶜq, rayleigh_sponge)
-                @. ᶜsgs_qₜ += rst_sgs_q
+        # Auto-discovered SGS tracers (microphysics species and any
+        # user-defined passive tracers)
+        for χ_name in sgs_tracer_names(Y)
+            ρχ_name = get_ρχ_name(χ_name)
+            ᶜρχ = MatrixFields.get_field(Y.c, ρχ_name)
+            ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+            for j in 1:n
+                ᶜsgs_χ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
+                ᶜsgs_χₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:(1), χ_name)
+                rst_sgs_χ = rayleigh_sponge_tendency_sgs_tracer(ᶜsgs_χ, ᶜχ, rayleigh_sponge)
+                @. ᶜsgs_χₜ += rst_sgs_χ
             end
         end
     end

--- a/src/utils/variable_manipulations.jl
+++ b/src/utils/variable_manipulations.jl
@@ -182,6 +182,30 @@ foreach_gs_tracer(f::F, Y_or_similar_values...) where {F} =
 
 
 """
+    sgs_tracer_names(Y)
+
+Return a `Tuple` of `FieldName`s for all SGS (sub-grid scale) tracers
+present in the first updraft of `Y`. Returns `()` when prognostic EDMF
+is not active (i.e. when `Y.c` has no `sgsʲs` field).
+
+"Tracer" here means any scalar in `Y.c.sgsʲs.:(1)` that is **not** one
+of the core EDMF variables `ρa`, `mse`, or `q_tot` (which receive
+physics-specific treatment).
+"""
+_is_sgs_tracer_name(::MatrixFields.FieldName{name_chain}) where {name_chain} =
+    !(last(name_chain) in (:ρa, :mse, :q_tot))
+
+sgs_tracer_names(Y) =
+    _sgs_tracer_names(Val(hasproperty(Y.c, :sgsʲs)), Y)
+_sgs_tracer_names(::Val{false}, Y) = ()
+_sgs_tracer_names(::Val{true}, Y) =
+    unrolled_filter(
+        _is_sgs_tracer_name,
+        MatrixFields.top_level_names(Y.c.sgsʲs.:(1)),
+    )
+
+
+"""
     sgs_weight_function(a, a_half)
 
 Computes a smooth, monotonic weight function `w(a)` that ranges from 0 to 1.


### PR DESCRIPTION
This PR introduces `sgs_tracer_names(Y)` (analogous to the existing `gs_tracer_names`/`foreach_gs_tracer` for grid-scale tracers) that auto-discovers specific tracers inside `Y.c.sgsʲs.:(j)`. This replaces ~10 locations where microphysics tracer names (`q_lcl`, `q_icl`, `q_rai`, `q_sno`, `n_lcl`, `n_rai`) were hardcoded in explicit tuples.

After this refactor, adding a new passive tracer to prognostic EDMF tendencies requires only adding it to the initial state + `sgsʲs` NamedTuple + grid-scale `ρχ`. All tendency operations listed below are picked up automatically.

### Naming convention

Any scalar field added to `Y.c.sgsʲs.:(j)` is automatically discovered as a passive SGS tracer **unless** it is in the exclusion set `{ρa, mse, q_tot}`. The corresponding grid-scale density-weighted variable must follow the existing `ρ`-prefix convention: a tracer named `χ` in `sgsʲs` maps to `ρχ` in `Y.c` (e.g., `q_lcl` → `ρq_lcl`, `A` → `ρA`).

### What's auto-discovered (tendency code)

| Process | File |
|---|---|
| Horizontal advection | `advection.jl` |
| Vertical advection (advective form) | `advection.jl` |
| Entrainment/detrainment mixing | `edmfx_entr_detr.jl` |
| SGS mass flux (draft + environment → grid mean) | `edmfx_sgs_flux.jl` |
| SGS diffusive flux (grid mean) | `edmfx_sgs_flux.jl` |
| Updraft vertical diffusion | `mass_flux_closures.jl` |
| Rayleigh sponge | `remaining_tendency.jl` |
| Filter/physical constraints | `mass_flux_closures.jl` |

All SGS tracers (cloud species and precipitation alike) receive the same reduced diffusion coefficient (`α_vert_diff_microphysics`).

### What remains manually wired

| Process | Why |
|---|---|
| Jacobian blocks (`manual_sparse_jacobian.jl`) | `unrolled_foreach` with closures inside `@.` broadcasts allocates; hardcoded blocks avoid this. Search for existing tracer names (e.g. `q_lcl`, `q_rai`) to find each block. See `docs/src/passive_tracers.md` Step 4. |
| SGS hyperdiffusion (`hyperdiffusion.jl`) | 3-phase pipeline (prep → DSS → apply) requires per-tracer scratch fields in the cache. |
| `mse` / `q_tot` transport | Couple to enthalpy, buoyancy, kinetic energy, `ρa` density |
| `ρa`–`q_tot` coupling in hyperdiffusion | Physics-specific density correction |
| Sedimentation (flux-form + terminal velocities) | Per-species terminal velocity fields, `q_tot` feedback |
| Microphysics source/sink tendencies | Physics-specific |

### Documentation

New `docs/src/passive_tracers.md` added with:
- Auto-discovery mechanism for grid-scale and SGS tracers
- 3-step guide for adding a new passive tracer
- Step 4: Jacobian update guide (search for existing tracer names)
- Note that passive tracers without thermodynamic impact can often skip Jacobian entries

### TODO (follow-up PRs)

- [ ] **SGS hyperdiffusion auto-discovery**: Replace per-tracer scratch fields (`ᶜ∇²q_lclʲs`, etc.) with a single reusable `ᶜ∇²sgs_tracerʲs` and process sequentially.
- [ ] **Jacobian auto-discovery**: Figure out what to do
