### PR TITLE
Clean up accumulation of available configs

### DIFF
--- a/docs/src/repl_scripts.jl
+++ b/docs/src/repl_scripts.jl
@@ -22,10 +22,10 @@ function print_repl_script(config)
     println(ib)
 end
 
-configs = configs_per_config_id()
+configs = load_all_configs()
 @assert length(configs) > 0
 
-for (job_id, (; config, config_file)) in configs
+for (job_id, config) in configs
     println("### Buildkite job `$job_id`")
     print_repl_script(config)
     println()

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -1,13 +1,4 @@
 redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
-import YAML
-
-"""
-    TargetJobConfig(target_job)
-
-Creates a full model configuration from the given target job.
-"""
-TargetJobConfig(target_job) =
-    CA.AtmosConfig(CA.config_from_target_job(target_job))
 
 import ClimaTimeSteppers as CTS
 get_W(i::CTS.DistributedODEIntegrator) =

--- a/perf/tabulate_perf_summary.jl
+++ b/perf/tabulate_perf_summary.jl
@@ -26,14 +26,8 @@ all metrics can be found in `get_summary`.
 
 ca_dir = joinpath(dirname(@__DIR__))
 
-get_config_ids(buildkite_path; filter_name = nothing) =
-    keys(configs_per_config_id(buildkite_path, filter_name))
-
 function combine_PRs_performance_benchmarks(path)
-    job_ids = get_config_ids(
-        joinpath(ca_dir, "config");
-        filter_name = ("perf_summary" => true),
-    )
+    job_ids = keys(load_all_configs("perf_summary" => true))
     # Combine summaries into one dict
     summaries = OrderedCollections.OrderedDict()
     for job_id in job_ids

--- a/src/config/atmos_config.jl
+++ b/src/config/atmos_config.jl
@@ -33,12 +33,12 @@ end
 """
     AtmosConfig(
         config_file::String = default_config_file;
-        job_id = config_id_from_config_file(config_file),
+        job_id = job_id_from_config_file(config_file),
         comms_ctx = nothing,
     )
     AtmosConfig(
         config_files::Union{NTuple{<:Any, String} ,Vector{String}};
-        job_id = config_id_from_config_files(config_files),
+        job_id = job_id_from_config_files(config_files),
         comms_ctx = nothing,
     )
 
@@ -47,13 +47,13 @@ and passes it to the AtmosConfig constructor.
 """
 AtmosConfig(
     config_file::String = default_config_file;
-    job_id = config_id_from_config_file(config_file),
+    job_id = job_id_from_config_file(config_file),
     comms_ctx = nothing,
 ) = AtmosConfig((config_file,); job_id, comms_ctx)
 
 function AtmosConfig(
     config_files::TupleOrVector(String);
-    job_id = config_id_from_config_files(config_files),
+    job_id = job_id_from_config_files(config_files),
     comms_ctx = nothing,
 )
 

--- a/src/config/cli_options.jl
+++ b/src/config/cli_options.jl
@@ -11,7 +11,7 @@ function argparse_settings()
         "--job_id"
         help = "A unique job identifier, among all possible (parallel) running jobs."
         arg_type = String
-        default = config_id_from_config_file(default_config_file)
+        default = job_id_from_config_file(default_config_file)
     end
     return s
 end

--- a/src/config/yaml_helper.jl
+++ b/src/config/yaml_helper.jl
@@ -28,19 +28,6 @@ function default_config_dict(config_file = default_config_file)
     return strip_help_messages(config)
 end
 
-"""
-    config_from_target_job(target_job)
-
-Given a job id string, returns the configuration for that job.
-Does not include the default configuration dictionary.
-"""
-function config_from_target_job(target_job)
-    # get(configs_per_config_id(), target_job, error("")) doesn't work for some reason
-    for (job_id, config_tuple) in configs_per_config_id()
-        job_id == target_job && return config_tuple.config
-    end
-end
-
 ContainerType(T) = Union{Tuple{<:T, Vararg{T}}, Vector{<:T}}
 
 """
@@ -177,35 +164,27 @@ function non_default_config_entries(config, defaults = default_config_dict())
 end
 
 """
-    configs_per_config_id(directory)
+    load_all_configs([with_pair])
 
-Walks a directory and reads all of the yaml files that are used to configure the driver,
-then parses them into a vector of dictionaries. Does not include the default configuration.
-To filter only configurations with a certain key/value pair,
-use the `filter_name` keyword argument with a Pair.
+Loads all available configs, excluding the default config, and stores them in a
+Dict that maps each one to a unique string. A key/value pair can also be used to
+filter out all configs which do not associate that key with the specified value.
 """
-function configs_per_config_id(
-    directory::AbstractString = config_path,
-    filter_name = nothing,
-)
-    cmds = Dict()
-    for (root, _, files) in walkdir(directory)
+function load_all_configs(with_pair = nothing)
+    configs = Dict()
+    for (root, _, files) in walkdir(config_path)
         for f in files
             file = joinpath(root, f)
-            !endswith(file, ".yml") && continue
-            occursin("default_configs", file) && continue
+            (endswith(file, ".yml") && file != default_config_file) || continue
             config = load_yaml_file(file)
-            name = config_id_from_config_file(file)
-            cmds[name] = (; config, config_file = file)
+            if !isnothing(with_pair)
+                (key, value) = with_pair
+                (haskey(config, key) && config[key] == value) || continue
+            end
+            configs[job_id_from_config_file(file)] = config
         end
     end
-    if !isnothing(filter_name)
-        (key, value) = filter_name
-        filter!(cmds) do (config_id, nt)
-            get(nt.config, key, "") == value
-        end
-    end
-    return cmds
+    return configs
 end
 
 function is_unique_basename(file, bname = first(splitext(basename(file))))
@@ -221,7 +200,7 @@ function is_unique_basename(file, bname = first(splitext(basename(file))))
     return is_unique
 end
 
-function config_id_from_config_file(config_file::String)
+function job_id_from_config_file(config_file::String)
     @assert isfile(config_file)
     bname = first(splitext(basename(config_file)))
     if is_unique_basename(config_file, bname)
@@ -231,9 +210,9 @@ function config_id_from_config_file(config_file::String)
     end
 end
 
-# Can we do better?
-config_id_from_config_files(config_files::Union{Tuple, Vector}) =
-    join(map(x -> config_id_from_config_file(x), config_files), "_")
+job_id_from_config_files(config_files::Union{Tuple, Vector}) =
+    join(map(x -> job_id_from_config_file(x), config_files), "_")
+
 """
     maybe_resolve_and_acquire_artifacts(input_str::AbstractString, context)
 

--- a/test/config.jl
+++ b/test/config.jl
@@ -3,46 +3,16 @@ import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaAtmos as CA
 
-include(joinpath(pkgdir(CA), "perf", "common.jl"))
-
-@testset "TargetJobConfig" begin
-    dry_barowave_file =
-        joinpath(pkgdir(CA), "config", "model_configs", "baroclinic_wave.yml")
-    target_job_config = TargetJobConfig("baroclinic_wave")
-    file_config = CA.AtmosConfig(dry_barowave_file)
-    @test file_config.parsed_args == target_job_config.parsed_args
-    @test file_config.toml_dict.data == target_job_config.toml_dict.data
-    @test file_config.comms_ctx == target_job_config.comms_ctx
-end
-
-function extract_job_ids(folder_path)
-    job_id_dict = Dict()
-    for (root, _, files) in walkdir(folder_path)
-        for file in files
-            filepath = joinpath(root, file)
-            data = CA.load_yaml_file(filepath)
-            if haskey(data, "job_id")
-                job_id_dict[filepath] = data["job_id"]
-            end
-        end
-    end
-    return job_id_dict
-end
-
-file_to_job_id = extract_job_ids(joinpath(pkgdir(CA), "config"))
-# Check that all jobs have a unique job_id
-value_to_keys = Dict()
-for (key, value) in file_to_job_id
-    if haskey(value_to_keys, value)
-        push!(value_to_keys[value], key)
-    else
-        value_to_keys[value] = [key]
+@testset "Check that every available config file has a unique `job_id`" begin
+    all_job_ids = String[]
+    for (root, _, files) in walkdir(CA.config_path), f in files
+        file = joinpath(root, f)
+        endswith(file, ".yml") || continue
+        job_id = CA.job_id_from_config_file(file)
+        @test !(job_id in all_job_ids)
+        push!(all_job_ids, job_id)
     end
 end
-# Filter the keys that have more than one associated key
-repeated_job_ids = filter(kv -> length(kv[2]) > 1, value_to_keys)
-
-@test isempty(repeated_job_ids)
 
 file, io = mktemp()
 config_err = ErrorException("File $(CA.normrelpath(file)) is empty or missing.")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR simplifies how we accumulate all available configs, and also eliminates the `config_from_target_job` function. That function was only used in one unit test, which is currently failing the Julia 1.10 downgrade test (the failure first happened [here](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/26974927751/job/79599400933), but has since been replicated in other PRs, like [here](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/26982779992/job/79625683999)).

## Content
- Remove `config_from_target_job` and `TargetJobConfig`, along with the associated unit test
- Rename `configs_per_config_id` to `load_all_configs`, and simplify its docstring and implementation
- Simplify the `repeated_job_ids` test, so that it mirrors the implementation of `load_all_configs`
- Rename `config_id_from_config_file` to `job_id_from_config_file`, since it's called `job_id` everywhere else

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
