### PR TITLE
add common diagnostic and modify edmf plots

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,6 +158,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_0M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_gabls_box.yml
           --job_id diagnostic_edmfx_gabls_box
         artifact_paths: "diagnostic_edmfx_gabls_box/output_active/*"
@@ -168,6 +169,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_0M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_bomex_box.yml
           --job_id diagnostic_edmfx_bomex_box
         artifact_paths: "diagnostic_edmfx_bomex_box/output_active/*"
@@ -178,6 +180,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_0M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf01_box.yml
           --job_id diagnostic_edmfx_dycoms_rf01_box
         artifact_paths: "diagnostic_edmfx_dycoms_rf01_box/output_active/*"
@@ -188,6 +191,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_1M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_dycoms_rf02_box.yml
           --job_id diagnostic_edmfx_dycoms_rf02_box
         artifact_paths: "diagnostic_edmfx_dycoms_rf02_box/output_active/*"
@@ -198,6 +202,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_1M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_rico_box.yml
           --job_id diagnostic_edmfx_rico_box
         artifact_paths: "diagnostic_edmfx_rico_box/output_active/*"
@@ -208,6 +213,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_1M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_box.yml
           --job_id diagnostic_edmfx_trmm_box
         artifact_paths: "diagnostic_edmfx_trmm_box/output_active/*"
@@ -218,6 +224,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_0M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_stretched_box.yml
           --job_id diagnostic_edmfx_trmm_stretched_box
         artifact_paths: "diagnostic_edmfx_trmm_stretched_box/output_active/*"
@@ -228,6 +235,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_diagedmf_0M.yml
           --config_file $CONFIG_PATH/diagnostic_edmfx_trmm_box_0M.yml
           --job_id diagnostic_edmfx_trmm_box_0M
         artifact_paths: "diagnostic_edmfx_trmm_box_0M/output_active/*"
@@ -250,6 +258,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_simpleplume_column.yml
           --job_id prognostic_edmfx_simpleplume_column
         artifact_paths: "prognostic_edmfx_simpleplume_column/output_active/*"
@@ -260,6 +269,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_soares_column.yml
           --job_id prognostic_edmfx_soares_column
         artifact_paths: "prognostic_edmfx_soares_column/output_active/*"
@@ -270,6 +280,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_gabls_column.yml
           --job_id prognostic_edmfx_gabls_column
         artifact_paths: "prognostic_edmfx_gabls_column/output_active/*"
@@ -280,6 +291,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_fixtke_column.yml
           --job_id prognostic_edmfx_bomex_fixtke_column
         artifact_paths: "prognostic_edmfx_bomex_fixtke_column/output_active/*"
@@ -290,6 +302,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_column.yml
           --job_id prognostic_edmfx_bomex_column
         artifact_paths: "prognostic_edmfx_bomex_column/output_active/*"
@@ -300,6 +313,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_bomex_implicit_column.yml
           --job_id prognostic_edmfx_bomex_implicit_column
         artifact_paths: "prognostic_edmfx_bomex_implicit_column/output_active/*"
@@ -310,6 +324,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_dycoms_rf01_column.yml
           --job_id prognostic_edmfx_dycoms_rf01_column
         artifact_paths: "prognostic_edmfx_dycoms_rf01_column/output_active/*"
@@ -320,6 +335,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_1M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_dycoms_rf02_column.yml
           --job_id prognostic_edmfx_dycoms_rf02_column
 
@@ -335,6 +351,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_1M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_rico_column.yml
           --job_id prognostic_edmfx_rico_column
 
@@ -360,6 +377,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_1M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column.yml
           --job_id prognostic_edmfx_trmm_column
 
@@ -375,6 +393,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_trmm_column_0M.yml
           --job_id prognostic_edmfx_trmm_column_0M
         artifact_paths: "prognostic_edmfx_trmm_column_0M/output_active/*"
@@ -385,6 +404,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_gcmdriven_column.yml
           --job_id prognostic_edmfx_gcmdriven_column
         artifact_paths: "prognostic_edmfx_gcmdriven_column/output_active/*"
@@ -395,6 +415,7 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $COMMON_CONFIG_PATH/diagnostics_column_progedmf_0M.yml
           --config_file $CONFIG_PATH/prognostic_edmfx_tv_era5driven_column.yml
           --job_id prognostic_edmfx_tv_era5driven_column
         artifact_paths: "prognostic_edmfx_tv_era5driven_column/output_active/*"

--- a/config/common_configs/diagnostics_column_diagedmf_0M.yml
+++ b/config/common_configs/diagnostics_column_diagedmf_0M.yml
@@ -1,0 +1,9 @@
+diagnostics:
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10mins
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+    period: 10mins
+  - short_name: [entr, detr, turbentr, bgrad, strain, edt, evu]
+    period: 10mins

--- a/config/common_configs/diagnostics_column_diagedmf_1M.yml
+++ b/config/common_configs/diagnostics_column_diagedmf_1M.yml
@@ -1,0 +1,14 @@
+diagnostics:
+  - short_name: [ta, thetaa, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, husra, hussn]
+    period: 10mins
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, husup, hurup, clwup, cliup, husraup, hussnup]
+    period: 10mins
+  - short_name: [husraup, hussnup]
+    period: 1hours
+    reduction_time: average
+  - short_name: [waen, tke, lmix]
+    period: 10mins
+  - short_name: [entr, detr, turbentr, bgrad, strain, edt, evu]
+    period: 10mins

--- a/config/common_configs/diagnostics_column_progedmf_0M.yml
+++ b/config/common_configs/diagnostics_column_progedmf_0M.yml
@@ -1,0 +1,9 @@
+diagnostics:
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10mins
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
+    period: 10mins
+  - short_name: [entr, detr, turbentr, bgrad, strain, edt, evu]
+    period: 10mins

--- a/config/common_configs/diagnostics_column_progedmf_1M.yml
+++ b/config/common_configs/diagnostics_column_progedmf_1M.yml
@@ -1,0 +1,47 @@
+diagnostics:
+  - short_name: [ta, thetaa, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, husra, hussn]
+    period: 10mins
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, husup, hurup, clwup, cliup, husraup, hussnup]
+    period: 10mins
+  - short_name: [husraup, hussnup]
+    period: 1hours
+    reduction_time: average
+  - short_name: [waen, taen, thetaaen, husen, huren, clwen, clien, husraen, hussnen, tke, lmix]
+    period: 10mins
+  - short_name: [entr, detr, turbentr, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [
+      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
+      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
+      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
+      mp1m_S_accr_melt_lcl_sno,
+      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
+      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
+      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
+      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
+      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
+      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
+      mp1mup_S_accr_melt_lcl_sno,
+      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
+      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
+      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
+      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
+      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
+      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
+      mp1men_S_accr_melt_lcl_sno,
+      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
+      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
+      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
+      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
+    ]
+    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_bomex_box.yml
+++ b/config/model_configs/diagnostic_edmfx_bomex_box.yml
@@ -22,8 +22,3 @@ t_end: "6hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/diagnostic_edmfx.toml]
 netcdf_interpolation_num_points: [8, 8, 60]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf01_box.yml
@@ -22,8 +22,3 @@ t_end: 4hours
 dt_save_state_to_disk: 10mins
 toml: [toml/diagnostic_edmfx.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
+++ b/config/model_configs/diagnostic_edmfx_dycoms_rf02_box.yml
@@ -23,12 +23,3 @@ t_end: 6hours
 dt_save_state_to_disk: 10mins
 toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_gabls_box.yml
+++ b/config/model_configs/diagnostic_edmfx_gabls_box.yml
@@ -22,8 +22,3 @@ t_end: 9hours
 dt_save_state_to_disk: 10mins
 toml: [toml/diagnostic_edmfx.toml]
 netcdf_interpolation_num_points: [8, 8, 8]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_rico_box.yml
+++ b/config/model_configs/diagnostic_edmfx_rico_box.yml
@@ -23,12 +23,3 @@ t_end: 8hours
 dt_save_state_to_disk: 10mins
 toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 100]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_test_box.yml
+++ b/config/model_configs/diagnostic_edmfx_test_box.yml
@@ -13,7 +13,19 @@ microphysics_model: "0M"
 toml: [toml/diagnostic_edmfx.toml]
 netcdf_interpolation_num_points: [8, 8, 45]
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10secs
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10secs
+    reduction_time: average
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi]
+    period: 10secs
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins
+    period: 10secs
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
+    period: 10secs
+    reduction_time: average
+  - short_name: [entr, detr, bgrad, strain, edt, evu]
+    period: 10secs
+
+  

--- a/config/model_configs/diagnostic_edmfx_trmm_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box.yml
@@ -24,12 +24,3 @@ dt_save_state_to_disk: 10mins
 FLOAT_TYPE: "Float64"
 toml: [toml/diagnostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 82]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_box_0M.yml
@@ -24,8 +24,3 @@ FLOAT_TYPE: "Float64"
 toml: [toml/diagnostic_edmfx_0M.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [8, 8, 82]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins

--- a/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
+++ b/config/model_configs/diagnostic_edmfx_trmm_stretched_box.yml
@@ -24,8 +24,3 @@ dt_save_state_to_disk: 10mins
 FLOAT_TYPE: "Float64"
 toml: [toml/diagnostic_edmfx_0M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, tke, lmix]
-    period: 10mins

--- a/config/model_configs/prognostic_edmfx_adv_test_column.yml
+++ b/config/model_configs/prognostic_edmfx_adv_test_column.yml
@@ -14,9 +14,19 @@ dt_save_state_to_disk: "100secs"
 FLOAT_TYPE: "Float64"
 toml: [toml/prognostic_edmfx_advection.toml]
 netcdf_interpolation_num_points: [2, 2, 63]
+ode_algo: "ARS222"
 diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10mins
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
+    period: 10mins
+    reduction_time: average
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
     period: 10mins
-ode_algo: "ARS222"
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
+    period: 10mins
+    reduction_time: average
+  - short_name: [entr, detr, bgrad, strain, edt, evu]
+    period: 10mins

--- a/config/model_configs/prognostic_edmfx_bomex_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column.yml
@@ -22,11 +22,4 @@ t_end: "6hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, lmixw, lmixtke, lmixb, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_column_sparse_autodiff.yml
@@ -26,10 +26,3 @@ t_end: "3hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, lmixw, lmixtke, lmixb, bgrad, strain, edt, evu]
-    period: 10mins

--- a/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_fixtke_column.yml
@@ -21,11 +21,4 @@ t_end: "6hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_implicit_column.yml
@@ -22,11 +22,4 @@ t_end: "6hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_bomex.toml]
 netcdf_interpolation_num_points: [2, 2, 60]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, lmixw, lmixtke, lmixb, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf01_column.yml
@@ -23,11 +23,4 @@ t_end: 6hours
 dt_save_state_to_disk: 10mins
 toml: [toml/prognostic_edmfx.toml]
 netcdf_interpolation_num_points: [2, 2, 30]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -25,49 +25,4 @@ t_end: 6hours
 dt_save_state_to_disk: 10mins
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup]
-    period: 10mins
-  - short_name: [waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
-    period: 10mins
-  - short_name: [
-      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
-      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
-      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
-      mp1m_S_accr_melt_lcl_sno,
-      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
-      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
-      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
-      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
-      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
-      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
-      mp1mup_S_accr_melt_lcl_sno,
-      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
-      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
-      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
-      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
-      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
-      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
-      mp1men_S_accr_melt_lcl_sno,
-      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
-      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
-      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
-      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
-    ]
-    period: 10mins
 ode_algo: "ARS222"
-

--- a/config/model_configs/prognostic_edmfx_gabls_column.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column.yml
@@ -24,11 +24,4 @@ dt_save_state_to_disk: "30mins"
 perturb_initstate: false
 toml: [toml/prognostic_edmfx.toml]
 netcdf_interpolation_num_points: [2, 2, 8]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
+++ b/config/model_configs/prognostic_edmfx_gabls_column_sparse_autodiff.yml
@@ -28,10 +28,3 @@ dt_save_state_to_disk: "30mins"
 perturb_initstate: false
 toml: [toml/prognostic_edmfx.toml]
 netcdf_interpolation_num_points: [2, 2, 8]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins

--- a/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
+++ b/config/model_configs/prognostic_edmfx_gcmdriven_column.yml
@@ -27,18 +27,5 @@ dt_save_state_to_disk: "6hours"
 toml: [toml/prognostic_edmfx_gcmdriven.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
-output_default_diagnostics: false
 rad: allskywithclear
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [rlut, rlutcs, rsut, rsutcs, clwvi, lwp, clivi, dsevi, clvi, prw, hurvi, husv]
-    period: 10mins
-  - reduction_time: max
-    short_name: tke
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -25,47 +25,5 @@ t_end: "24hours"
 dt_save_state_to_disk: "60mins"
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 100]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn]
-    period: 10mins
-  - short_name: [
-      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
-      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
-      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
-      mp1m_S_accr_melt_lcl_sno,
-      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
-      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
-      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
-      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
-      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
-      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
-      mp1mup_S_accr_melt_lcl_sno,
-      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
-      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
-      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
-      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
-      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
-      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
-      mp1men_S_accr_melt_lcl_sno,
-      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
-      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
-      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
-      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
-    ]
-    period: 10mins
 ode_algo: "ARS222"
 

--- a/config/model_configs/prognostic_edmfx_simpleplume_column.yml
+++ b/config/model_configs/prognostic_edmfx_simpleplume_column.yml
@@ -22,11 +22,4 @@ t_end: "12hours"
 dt_save_state_to_disk: "10mins"
 toml: [toml/prognostic_edmfx_simpleplume.toml]
 netcdf_interpolation_num_points: [2, 2, 80]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_soares_column.yml
+++ b/config/model_configs/prognostic_edmfx_soares_column.yml
@@ -22,11 +22,4 @@ dt: "5secs"
 t_end: "8hours"
 toml: [toml/prognostic_edmfx.toml]
 netcdf_interpolation_num_points: [2, 2, 100]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_trmm_column.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column.yml
@@ -25,47 +25,4 @@ t_end: 12hours
 dt_save_state_to_disk: 60mins
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [2, 2, 82]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-  - short_name: [husra, hussn, husraup, hussnup, husraen, hussnen]
-    period: 10mins
-  - short_name: [
-      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
-      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
-      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
-      mp1m_S_accr_melt_lcl_sno,
-      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
-      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
-      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
-      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
-      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
-      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
-      mp1mup_S_accr_melt_lcl_sno,
-      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
-      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
-      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
-      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
-      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
-      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
-      mp1men_S_accr_melt_lcl_sno,
-      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
-      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
-      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
-      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
-    ]
-    period: 10mins
 ode_algo: "ARS222"
-

--- a/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
+++ b/config/model_configs/prognostic_edmfx_trmm_column_0M.yml
@@ -23,11 +23,4 @@ dt: 150secs
 t_end: 12hours
 toml: [toml/prognostic_edmfx_implicit_scm_calibrated_5_cases_shallow_deep_v1.toml]
 netcdf_interpolation_num_points: [8, 8, 82]
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr, cape]
-    period: 10mins
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 10mins
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
 ode_algo: "ARS222"

--- a/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
+++ b/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml
@@ -29,15 +29,5 @@ t_end: "30hours"
 toml: [toml/prognostic_edmfx_calibrated.toml]
 netcdf_output_at_levels: true
 netcdf_interpolation_num_points: [2, 2, 60]
-output_default_diagnostics: false
 rad: allskywithclear
-diagnostics:
-  - short_name: [ts, ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, hussfc, evspsbl, pr]
-    period: 6hours
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke]
-    period: 6hours
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 6hours
-  - short_name: [rlut, rlutcs, rsut, rsutcs, clwvi, lwp, clivi, dsevi, clvi, prw, hurvi, husv]
-    period: 6hours
 ode_algo: "ARS222"

--- a/docs/src/config_no_table.md
+++ b/docs/src/config_no_table.md
@@ -62,7 +62,7 @@ See below for the full list of configuration arguments.
 
 # Common Configurations
 
-ClimaAtmos provides a set of common numerical configurations that can be used as building blocks for different types of simulations. These configurations are located in `config/common_configs/` and contain standardized settings for grid resolution, time stepping, and numerical schemes.
+ClimaAtmos provides a set of common numerical configurations that can be used as building blocks for different types of simulations. These configurations are located in `config/common_configs/` and contain standardized settings for grid resolution, time stepping, numerical schemes, and diagnostics.
 
 ## Available Common Configurations
 
@@ -80,6 +80,14 @@ ClimaAtmos provides a set of common numerical configurations that can be used as
 
 - **`numerics_sphere_he30ze63.yml`**: Spherical configuration with 30 horizontal elements (110km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 
+### Diagnostics Configurations for Prognostic EDMF Columns
+
+Common diagnostics sets for prognostic EDMF single-column runs. Each file defines a `diagnostics:` block mostly at 10-minute output frequency; individual model configs can add case-specific diagnostics on top.
+
+- **`diagnostics_column_progedmf_0M.yml`**: Standard diagnostics for prognostic EDMF columns with 0-moment microphysics (`microphysics_model: "0M"`). Includes atmospheric state, surface fluxes and precipitation, updraft/environment profiles, and entrainment/detrainment variables.
+
+- **`diagnostics_column_progedmf_1M.yml`**: Standard diagnostics for prognostic EDMF columns with 1-moment microphysics (`microphysics_model: "1M"`). Extends the 0M set with rain/snow specific humidities, updraft/environment precipitation variables, and the full suite of 1M bulk microphysics process rates for the environment, updraft, and environment (`mp1m_*`, `mp1mup_*`, `mp1men_*`).
+
 ## Using Common Configurations
 
 Common configurations are designed to be used in combination with model-specific configurations. In the CI pipeline and when running simulations, you can specify multiple configuration files:
@@ -90,4 +98,13 @@ julia --project=.buildkite .buildkite/ci_driver.jl \
   --config_file config/model_configs/your_model_config.yml
 ```
 
-The common configuration provides the numerical setup (grid, time stepping, etc.), while the model configuration provides the physical setup (physics schemes, initial conditions, etc.). The model configuration will override any conflicting settings from the common configuration. Please modify them only if you are certain of the implications.
+For EDMF single-column runs, a diagnostics common config is prepended before the model config:
+
+```bash
+julia --project=.buildkite .buildkite/ci_driver.jl \
+  --config_file config/common_configs/diagnostics_column_progedmf_0M.yml \
+  --config_file config/model_configs/prognostic_edmfx_bomex_column.yml \
+  --job_id prognostic_edmfx_bomex_column
+```
+
+The common configuration provides the numerical setup (grid, time stepping, etc.), or common diagnostics, while the model configuration provides the physical setup (physics schemes, initial conditions, etc.). The model configuration will override any conflicting settings from the common configuration. Please modify them only if you are certain of the implications.

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1458,12 +1458,11 @@ function make_plots(
     elseif sim_type isa EDMFColumnPlotsWithPrecip
         if sim_type isa Val{:prognostic_edmfx_rico_column_2M}
             precip_names = (
-                "husra", "hussn", "husraup", "hussnup", "husraen", "hussnen",
-                "cdnc", "ncra", "cdncup", "ncraup", "cdncen", "ncraen",
+                "husra", "hussn", "husraup", "hussnup",
+                "cdnc", "ncra", "cdncup", "ncraup",
             )
         else
-            precip_names =
-                ("husra", "hussn", "husraup", "hussnup", "husraen", "hussnen")
+            precip_names = ("husra", "hussn", "husraup", "hussnup")
         end
     else
         precip_names = ()
@@ -1471,26 +1470,61 @@ function make_plots(
 
     short_names = [
         "wa", "waup", "ta", "taup", "hus", "husup", "arup", "tke", "ua",
-        "thetaa", "thetaaup", "ha", "haup", "hur", "hurup", "lmix",
+        "thetaa", "thetaaup", "hur", "hurup", "lmix",
         "cl", "clw", "clwup", "cli", "cliup",
         precip_names...,
     ]
-    reduction = "inst"
+    reduction_avg = "average"
+    reduction_inst = "inst"
 
-    available_periods = ClimaAnalysis.available_periods(
-        simdirs[1];
-        short_name = short_names[1],
-        reduction,
+    available_periods_avg = collect(
+        ClimaAnalysis.available_periods(
+            simdirs[1];
+            short_name = short_names[1],
+            reduction = reduction_avg,
+        ),
     )
-    # choose the shortest available period
-    available_periods = collect(available_periods) # ensure vector for indexing
-    period = available_periods[argmin(CA.time_to_seconds.(available_periods))]
+    period_avg =
+        available_periods_avg[argmin(CA.time_to_seconds.(available_periods_avg))]
+
+    available_periods_inst = collect(
+        ClimaAnalysis.available_periods(
+            simdirs[1];
+            short_name = short_names[1],
+            reduction = reduction_inst,
+        ),
+    )
+    period_inst =
+        available_periods_inst[argmin(CA.time_to_seconds.(available_periods_inst))]
 
     short_name_tuples = pair_edmf_names(short_names)
     var_groups_zt =
         map_comparison(simdirs, short_name_tuples) do simdir, name_tuple
-            vars = map(short_name -> get(simdir; short_name, reduction, period), name_tuple)
+            vars = map(
+                short_name ->
+                    get(
+                        simdir;
+                        short_name,
+                        reduction = reduction_inst,
+                        period = period_inst,
+                    ),
+                name_tuple,
+            )
             # For box types, slice to a point (x=0, y=0)
+            if is_box
+                return map(var -> slice(var, x = 0.0, y = 0.0), vars)
+            else
+                return vars
+            end
+        end
+
+    var_groups_z_avg =
+        map_comparison(simdirs, short_name_tuples) do simdir, name_tuple
+            vars = map(
+                short_name ->
+                    get(simdir; short_name, reduction = reduction_avg, period = period_avg),
+                name_tuple,
+            )
             if is_box
                 return map(var -> slice(var, x = 0.0, y = 0.0), vars)
             else
@@ -1500,7 +1534,7 @@ function make_plots(
 
     var_groups_z = [
         ([slice(v, time = LAST_SNAP) for v in group]...,) for
-        group in var_groups_zt
+        group in var_groups_z_avg
     ]
 
     tmp_file = make_plots_generic(
@@ -1513,6 +1547,17 @@ function make_plots(
     )
 
     summary_files = [tmp_file]
+
+    # Time-height contour plots: existing EDMF variables (intermediate)
+    zt_file = make_plots_generic(
+        output_paths,
+        collect(Iterators.flatten(var_groups_zt));
+        output_name = "zt_contour",
+        plot_fn = plot_parsed_attribute_title!,
+        MAX_NUM_COLS = 2,
+        MAX_NUM_ROWS = 4,
+    )
+    push!(summary_files, zt_file)
 
     # Microphysics 1M process tendency plots (grid-mean, updraft, environment)
     mp1m_vars_zt = []  # time-z fields for contour plots
@@ -1544,40 +1589,17 @@ function make_plots(
         # Load the time-z fields for all mp1m variables
         mp1m_vars_zt =
             map_comparison(mp1m_simdirs, mp1m_all_names) do simdir, sn
-                var = get(simdir; short_name = sn, reduction, period)
+                var = get(
+                    simdir;
+                    short_name = sn,
+                    reduction = reduction_inst,
+                    period = period_inst,
+                )
                 if is_box
                     var = slice(var, x = 0.0, y = 0.0)
                 end
                 return var
             end
-
-        # Group as (grid-mean, updraft, environment) triplets for profile plots
-        mp1m_tuples = [
-            ("mp1m_$(s)", "mp1mup_$(s)", "mp1men_$(s)")
-            for s in mp1m_source_names
-        ]
-
-        mp1m_profile_groups =
-            map_comparison(mp1m_simdirs, mp1m_tuples) do simdir, name_tuple
-                vars = map(name_tuple) do sn
-                    var = get(simdir; short_name = sn, reduction, period)
-                    if is_box
-                        var = slice(var, x = 0.0, y = 0.0)
-                    end
-                    return slice(var, time = LAST_SNAP)
-                end
-                return vars
-            end
-
-        mp1m_file = make_plots_generic(
-            mp1m_output_paths,
-            mp1m_profile_groups;
-            output_name = "mp1m_tendencies",
-            plot_fn = plot_edmf_vert_profile!,
-            MAX_NUM_COLS = 2,
-            MAX_NUM_ROWS = 4,
-        )
-        push!(summary_files, mp1m_file)
 
         # Time-height contour plots for mp1m: 3 columns (gm, up, en) per row
         # with shared symmetric colorbar per row and divergent colormap.
@@ -1601,11 +1623,28 @@ function make_plots(
         push!(summary_files, mp1m_zt_file)
     end
 
-    # Time-height contour plots: existing EDMF variables
+    # Timeseries line plots for column-integrated variables (no z dimension)
+    # This is the final assembling call — merges all summary_files into summary.pdf
+    timeseries_names = ["lwp", "clivi", "rwp", "swp", "pr"]
+    timeseries_names_avail =
+        timeseries_names ∩ collect(keys(simdirs[1].vars))
+    vars_timeseries =
+        map_comparison(simdirs, timeseries_names_avail) do simdir, short_name
+            var = get(
+                simdir;
+                short_name,
+                reduction = reduction_inst,
+                period = period_inst,
+            )
+            if is_box
+                var = slice(var, x = 0.0, y = 0.0)
+            end
+            return var
+        end
     make_plots_generic(
         output_paths,
-        collect(Iterators.flatten(var_groups_zt)),
-        plot_fn = plot_parsed_attribute_title!,
+        vars_timeseries;
+        output_name = "summary",
         summary_files = summary_files,
         MAX_NUM_COLS = 2,
         MAX_NUM_ROWS = 4,

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-354
+355
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+355
+- Add plots of some new diagnostics for prognostic EDMF test cases. There is no change in model behavior.
+
 354
 - Update to ClimaCore 0.14.54
 

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -516,8 +516,8 @@ compute_husen(state, cache, time) = compute_husen(state, cache, time,
     cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_husen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft specific humidity \
-                               with a moist model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment specific humidity \
+                               with a moist model and with PrognosticEDMFX")
 
 compute_husen(_, cache, _, ::MoistMicrophysics, ::PrognosticEDMFX) =
     cache.precomputed.ᶜq_tot_nonneg⁰
@@ -534,8 +534,8 @@ compute_huren(state, cache, time) = compute_huren(state, cache, time,
     cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_huren(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft relative humidity \
-                               with a moist model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment relative humidity \
+                               with a moist model and with PrognosticEDMFX")
 
 function compute_huren(_, cache, _, ::MoistMicrophysics, ::PrognosticEDMFX)
     thermo_params = CAP.thermodynamics_params(cache.params)
@@ -559,8 +559,10 @@ compute_clwen(state, cache, time) = compute_clwen(state, cache, time,
     cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_clwen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft liquid water specific humidity \
-                               with a moist model and with EDMFX")
+    error_diagnostic_variable(
+        "Can only compute environment liquid water specific humidity \
+         with a moist model and with PrognosticEDMFX",
+    )
 
 compute_clwen(_, cache, _, ::EquilibriumMicrophysics0M, ::PrognosticEDMFX) =
     cache.precomputed.ᶜq_liq⁰
@@ -581,8 +583,10 @@ compute_cdncen(state, cache, time) = compute_cdncen(state, cache, time,
     cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_cdncen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft cloud liquid water \
-                               number mixing ratio with a 2M model and with EDMFX")
+    error_diagnostic_variable(
+        "Can only compute environment cloud liquid water \
+         number mixing ratio with a 2M model and with PrognosticEDMFX",
+    )
 
 compute_cdncen(state, cache, _, ::NonEquilibriumMicrophysics2M, ::PrognosticEDMFX) =
     ᶜspecific_env_value(@name(n_lcl), state, cache)
@@ -603,8 +607,8 @@ compute_clien(state, cache, time) = compute_clien(
     state, cache, time, cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_clien(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft ice water specific humidity \
-                               with a moist model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment ice water specific humidity \
+                               with a moist model and with PrognosticEDMFX")
 
 compute_clien(_, cache, _, ::EquilibriumMicrophysics0M, ::PrognosticEDMFX) =
     cache.precomputed.ᶜq_ice⁰
@@ -628,8 +632,8 @@ compute_husraen(state, cache, time) = compute_husraen(
     state, cache, time, cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_husraen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft rain specific humidity \
-                               with a 1M or 2M model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment rain specific humidity \
+                               with a 1M or 2M model and with PrognosticEDMFX")
 
 compute_husraen(state, cache, _,
     ::Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}, ::PrognosticEDMFX,
@@ -648,8 +652,8 @@ compute_ncraen(state, cache, time) = compute_ncraen(
     state, cache, time, cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_ncraen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft rain number mixing ratio \
-                               with a 2M model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment rain number mixing ratio \
+                               with a 2M model and with PrognosticEDMFX")
 
 compute_ncraen(state, cache, _, ::NonEquilibriumMicrophysics2M, ::PrognosticEDMFX) =
     ᶜspecific_env_value(@name(n_rai), state, cache)
@@ -670,8 +674,8 @@ compute_hussnen(state, cache, time) = compute_hussnen(
     state, cache, time, cache.atmos.microphysics_model, cache.atmos.turbconv_model,
 )
 compute_hussnen(_, _, _, _, _) =
-    error_diagnostic_variable("Can only compute updraft snow specific humidity \
-                               with a 1M or 2M model and with EDMFX")
+    error_diagnostic_variable("Can only compute environment snow specific humidity \
+                               with a 1M or 2M model and with PrognosticEDMFX")
 
 compute_hussnen(state, cache, _,
     ::Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}, ::PrognosticEDMFX,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Make EDMF ci plots more helpful. Now they contain:

- Profiles of grid-mean and edmf variables averaged over the last hour
- height-time contours of grid-mean and edmf variables
- height-time contours of microphysics tendencies
- Timeseries of column integrated quantities (e.g. lwp)

Also adds some common diagnostics configs for single column EDMF, so the configs are shorter:)

The ref counter is bumped because new plots are added. There is no actual behavior change.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
