### PR TITLE
ci: Add PR preview links as PR comment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,3 +33,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
         run: julia --project=docs/ docs/make.jl
+
+  comment:
+    needs: docbuild
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post or update preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const url = `https://${owner.toLowerCase()}.github.io/${repo}/previews/PR${pr}/`;
+            const marker = '<!-- docs-preview-comment -->';
+            const body = `${marker}\n📖 Docs preview for this PR: ${url}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }


### PR DESCRIPTION
Add a comment step to post preview links for pull requests. This is intended to be a more visible and easier to find alternative to scrolling through the (rather long) list of checks at the bottom of the PR.
