### PR TITLE
Area fraction IMEX stage equation analytic solve

### DIFF
--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -20,7 +20,7 @@ z_max: 1500
 z_stretch: false
 perturb_initstate: false
 dt: 120secs
-t_end: 6hours
+t_end: 24hours
 dt_save_state_to_disk: 10mins
 toml: [toml/prognostic_edmfx_1M.toml]
 netcdf_interpolation_num_points: [8, 8, 30]

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-356
+357
 
 # **README**
 #
@@ -32,6 +32,10 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+357
+- Solve the updraft area-fraction (ρa) equation analytically at the IMEX implicit
+  stage. Refactor entrainment/detrainment.
+
 356
 - Changed the default microphysics options
   - include cloud ice melt

--- a/src/cache/diagnostic_edmf_precomputed_quantities.jl
+++ b/src/cache/diagnostic_edmf_precomputed_quantities.jl
@@ -740,10 +740,9 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
             )
             @. entrʲ_prev_level = compute_entrainment(
                 entr_vel_scale_prev_level,
-                nonvelocity_entrainment(
+                area_bounding_entr_detr(
                     turbconv_params,
                     draft_area(ρaʲ_prev_level, ρʲ_prev_level),
-                    p.atmos.edmfx_model.entr_model,
                 ),
                 get_physical_w(u³ʲ_prev_halflevel, local_geometry_prev_halflevel) -
                 get_physical_w(u³_prev_halflevel, local_geometry_prev_halflevel),
@@ -880,12 +879,21 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                 turbconv_params,
                 draft_area(ρaʲ_prev_level, ρʲ_prev_level),
                 ρaʲ_prev_level,
-                get_physical_w(u³ʲ_prev_halflevel, local_geometry_prev_halflevel),
-                vertical_buoyancy_acceleration(
-                    ρ_prev_level,
-                    ρʲ_prev_level,
-                    ᶜgradᵥ_ᶠΦ_prev_level,
-                    local_geometry_prev_halflevel,
+                # Diagnostic EDMF integrates level-by-level on field-value
+                # slices, so the inverse buoyancy time scale is evaluated
+                # at cell centers (no face/interp pattern available here).
+                detr_buoy_inv_time_scale(
+                    get_physical_w(
+                        u³ʲ_prev_halflevel,
+                        local_geometry_prev_halflevel,
+                    ),
+                    vertical_buoyancy_acceleration(
+                        ρ_prev_level,
+                        ρʲ_prev_level,
+                        ᶜgradᵥ_ᶠΦ_prev_level,
+                        local_geometry_prev_halflevel,
+                    ),
+                    CAP.detr_buoy_inv_tau_max(turbconv_params),
                 ),
                 # Approximate the updraft mass-flux divergence as
                 #   div(ρa u³) ≈ ρa · div(ρu³) / ρ,
@@ -893,11 +901,9 @@ NVTX.@annotate function set_diagnostic_edmf_precomputed_quantities_do_integral!(
                 # vary with height at this level (constant-area approximation).
                 # `vert_div_level` holds div(ρu³) / ρ, so we multiply by ρa here.
                 ρaʲ_prev_level * vert_div_level,
-                entrʲ_prev_level,
-                nonvelocity_detrainment(
+                area_bounding_entr_detr(
                     turbconv_params,
                     draft_area(ρaʲ_prev_level, ρʲ_prev_level),
-                    p.atmos.edmfx_model.detr_model,
                 ),
                 p.atmos.edmfx_model.detr_model,
             )

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -287,14 +287,12 @@ function precomputed_quantities(Y, atmos)
         atmos.turbconv_model isa PrognosticEDMFX ?
         (;
             ρtke_flux = similar(Fields.level(Y.f, half), C3{FT}),
-            ᶜentrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜentr_vel_scaleʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜentr_nonvelʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜdetrʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜdetr_nonvelʲs = similar(Y.c, NTuple{n, FT}),
             ᶜturb_entrʲs = similar(Y.c, NTuple{n, FT}),
+            ᶜarea_bounding_entr_detrʲs = similar(Y.c, NTuple{n, FT}),
             ᶜρ_diffʲs = similar(Y.c, NTuple{n, FT}),
             ᶠu₃_tendencyʲs = similar(Y.f, NTuple{n, C3{FT}}),
+            ᶜρa_tendencyʲs = similar(Y.c, NTuple{n, FT}),
             precipitation_sgs_quantities...,
         ) : (;)
 

--- a/src/cache/prognostic_edmf_precomputed_quantities.jl
+++ b/src/cache/prognostic_edmf_precomputed_quantities.jl
@@ -87,77 +87,6 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_environment!(
 end
 
 """
-    update_prognostic_edmfx_entr_detr!(Y, p)
-
-Compute and store total entrainment/detrainment rates for all updrafts using the
-current values of the velocity-dependent coefficient (`ᶜentr_vel_scaleʲs`) and
-velocity-independent rates (`ᶜentr_nonvelʲs`, `ᶜdetr_nonvelʲs`), which must
-already have been populated (by `set_prognostic_edmf_precomputed_quantities_explicit_closures!`
-or equivalent).
-
-Called from both the explicit closures (to initialise the rates before the first
-implicit solve) and the implicit draft (to refresh them with the post-solve velocity).
-"""
-function update_prognostic_edmfx_entr_detr!(Y, p)
-    turbconv_params = CAP.turbconv_params(p.params)
-    (; ᶜgradᵥ_ᶠΦ) = p.core
-    (;
-        ᶜuʲs,
-        ᶠu³ʲs,
-        ᶜρʲs,
-        ᶜρ_diffʲs,
-        ᶜentrʲs,
-        ᶜentr_vel_scaleʲs,
-        ᶜentr_nonvelʲs,
-        ᶜdetrʲs,
-        ᶜdetr_nonvelʲs,
-    ) = p.precomputed
-    ᶜlg = Fields.local_geometry_field(Y.c)
-    ᶜmassflux_vert_div = p.scratch.ᶜtemp_scalar_2
-    n = n_mass_flux_subdomains(p.atmos.turbconv_model)
-    buoyancy_flux_val =
-        Fields.field_values(p.precomputed.sfc_conditions.buoyancy_flux)
-
-    for j in 1:n
-        @. ᶜentrʲs.:($$j) = compute_entrainment(
-            ᶜentr_vel_scaleʲs.:($$j),
-            ᶜentr_nonvelʲs.:($$j),
-            get_physical_w(ᶜuʲs.:($$j), ᶜlg),
-        )
-        # ρa is not necessarily equal to its final implicit solution here; the
-        # detrainment will be recomputed in the implicit draft after ρa converges.
-        @. ᶜmassflux_vert_div =
-            ᶜdivᵥ(ᶠinterp(Y.c.sgsʲs.:($$j).ρa) * ᶠu³ʲs.:($$j))
-        @. ᶜdetrʲs.:($$j) = compute_detrainment(
-            turbconv_params,
-            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-            Y.c.sgsʲs.:($$j).ρa,
-            get_physical_w(ᶜuʲs.:($$j), ᶜlg),
-            vertical_buoyancy_acceleration(ᶜρ_diffʲs.:($$j), ᶜgradᵥ_ᶠΦ, ᶜlg),
-            ᶜmassflux_vert_div,
-            ᶜentrʲs.:($$j),
-            ᶜdetr_nonvelʲs.:($$j),
-            p.atmos.edmfx_model.detr_model,
-        )
-        detr_int_val = Fields.field_values(Fields.level(ᶜdetrʲs.:($j), 1))
-        detr_nonvel_int_val =
-            Fields.field_values(Fields.level(ᶜdetr_nonvelʲs.:($j), 1))
-        @. detr_int_val = ifelse(
-            buoyancy_flux_val < 0,
-            detr_int_val,
-            detr_nonvel_int_val,
-        )
-        @. ᶜdetrʲs.:($$j) = limit_detrainment(
-            ᶜdetrʲs.:($$j),
-            ᶜentrʲs.:($$j),
-            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-            p.dt,
-        )
-    end
-    return nothing
-end
-
-"""
     set_prognostic_edmf_precomputed_quantities_draft!(Y, p, ᶠuₕ³, t)
 
 Updates velocity and thermodynamics quantities in each SGS draft.
@@ -254,7 +183,6 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_draft!(
                 ᶜq_iceʲ,
             )
     end
-    update_prognostic_edmfx_entr_detr!(Y, p)
 
     return nothing
 end
@@ -292,13 +220,11 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
         ᶜq_iceʲs,
         ᶜρʲs,
         ᶜentr_vel_scaleʲs,
-        ᶜentr_nonvelʲs,
-        ᶜdetr_nonvelʲs,
+        ᶜarea_bounding_entr_detrʲs,
         ᶜturb_entrʲs,
         ᶜρ_diffʲs,
     ) = p.precomputed
     (; ustar) = p.precomputed.sfc_conditions
-    ᶜaʲ_int_val = p.scratch.temp_data_level
 
     ᶜz = Fields.coordinate_field(Y.c).z
     ᶜdz = Fields.Δz_field(axes(Y.c))
@@ -307,13 +233,14 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
     ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
 
     for j in 1:n
-        # Compute the entrainment velocity scale and the velocity-independent entrainment.
+        # Compute the entrainment velocity scale and the signed area-bounding rate.
         # The environment velocity is passed as w⁰ = 0 to the coefficient model;
         # using the true (ᶜwʲ - ᶜw⁰) difference would introduce residual forcing
         # when ᶜwʲ ≈ 0, which can spuriously grow the area fraction and destabilize
-        # otherwise trivial updrafts. The total entrainment rate is assembled later
-        # in `set_prognostic_edmf_precomputed_quantities_draft!` via `compute_entrainment`
-        # using the (then-updated) updraft velocity |wʲ|.
+        # otherwise trivial updrafts. The total entrainment rate is then assembled
+        # at every tendency call site (`edmfx_entr_detr_tendency!`,
+        # `edmfx_first_interior_entr_tendency!`, and the implicit ρa solve) via
+        # `compute_entrainment` using the (then-updated) updraft velocity |wʲ|.
         @. ᶜentr_vel_scaleʲs.:($$j) = entrainment_velocity_scale(
             thermo_params,
             turbconv_params,
@@ -345,29 +272,20 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
             max(ᶜtke, 0),
             p.atmos.edmfx_model.entr_model,
         )
-        @. ᶜentr_nonvelʲs.:($$j) = nonvelocity_entrainment(
-            turbconv_params,
-            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-            p.atmos.edmfx_model.entr_model,
-        )
-        @. ᶜdetr_nonvelʲs.:($$j) = nonvelocity_detrainment(
-            turbconv_params,
-            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
-            p.atmos.edmfx_model.detr_model,
-        )
-
         @. ᶜturb_entrʲs.:($$j) = turbulent_entrainment(
             turbconv_params,
             draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
         )
 
+        @. ᶜarea_bounding_entr_detrʲs.:($$j) = area_bounding_entr_detr(
+            turbconv_params,
+            draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+        )
         set_first_cell_entr_detr_bc!(
             Fields.field_values(Fields.level(Y.c.sgsʲs.:($j).ρa, 1)),
             Fields.field_values(Fields.level(ᶜρʲs.:($j), 1)),
-            Fields.field_values(Fields.level(ᶜentr_nonvelʲs.:($j), 1)),
+            Fields.field_values(Fields.level(ᶜarea_bounding_entr_detrʲs.:($j), 1)),
             Fields.field_values(Fields.level(ᶜentr_vel_scaleʲs.:($j), 1)),
-            Fields.field_values(Fields.level(ᶜdetr_nonvelʲs.:($j), 1)),
-            ᶜaʲ_int_val,
             Fields.field_values(p.precomputed.sfc_conditions.buoyancy_flux),
             Fields.field_values(Fields.level(ᶜdz, 1)),
             turbconv_params.surface_area,
@@ -377,10 +295,6 @@ NVTX.@annotate function set_prognostic_edmf_precomputed_quantities_explicit_clos
 
         @. ᶜρ_diffʲs.:($$j) = (ᶜρʲs.:($$j) - Y.c.ρ) / ᶜρʲs.:($$j)
     end
-    # Compute total rates using the current (pre-implicit) velocity so that
-    # ᶜentrʲs / ᶜdetrʲs are finite on the first call from build_cache,
-    # before the implicit draft has run for the first time.
-    update_prognostic_edmfx_entr_detr!(Y, p)
 
     # TODO: Make strain_rate_norm calculation a function in eddy_diffusion_closures
     # TODO: Currently the shear production only includes vertical gradients

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -56,6 +56,11 @@ import ..SurfaceConditions: SlabOceanTemperature
 
 # functions used to calculate diagnostics
 import ..draft_area
+import ..compute_entrainment
+import ..compute_detrainment
+import ..detr_buoy_inv_time_scale
+import ..vertical_buoyancy_acceleration
+import ..get_physical_w
 import ..compute_gm_mixing_length
 
 import ..horizontal_integral_at_boundary

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -327,8 +327,19 @@ compute_entr(state, cache, time) =
     compute_entr(state, cache, time, cache.atmos.turbconv_model)
 compute_entr(_, _, _, turbconv_model) = error_diagnostic_variable("entr", turbconv_model)
 
-compute_entr(_, cache, _, ::Union{PrognosticEDMFX, DiagnosticEDMFX}) =
-    cache.precomputed.ᶜentrʲs.:1
+function compute_entr(state, cache, _, ::PrognosticEDMFX)
+    (; ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs, ᶜuʲs) = cache.precomputed
+    ᶜlg = Fields.local_geometry_field(state.c)
+    return @. lazy(
+        compute_entrainment(
+            ᶜentr_vel_scaleʲs.:1,
+            ᶜarea_bounding_entr_detrʲs.:1,
+            get_physical_w(ᶜuʲs.:1, ᶜlg),
+        ),
+    )
+end
+
+compute_entr(_, cache, _, ::DiagnosticEDMFX) = cache.precomputed.ᶜentrʲs.:1
 
 add_diagnostic_variable!(short_name = "entr", units = "s^-1",
     long_name = "Entrainment rate",
@@ -357,8 +368,45 @@ compute_detr(state, cache, time) =
     compute_detr(state, cache, time, cache.atmos.turbconv_model)
 compute_detr(_, _, _, turbconv_model) = error_diagnostic_variable("detr", turbconv_model)
 
-compute_detr(_, cache, _, ::Union{PrognosticEDMFX, DiagnosticEDMFX}) =
-    cache.precomputed.ᶜdetrʲs.:1
+function compute_detr(state, cache, _, ::PrognosticEDMFX)
+    (; ᶜρ_diffʲs, ᶜρʲs, ᶜarea_bounding_entr_detrʲs) = cache.precomputed
+    (; ᶠgradᵥ_ᶜΦ) = cache.core
+    turbconv_params = CAP.turbconv_params(cache.params)
+    detr_buoy_inv_tau_max = CAP.detr_buoy_inv_tau_max(turbconv_params)
+    detr_model = cache.atmos.edmfx_model.detr_model
+    ᶠlg = Fields.local_geometry_field(state.f)
+    ᶠdz = Fields.Δz_field(axes(state.f))
+    ρaʲ = state.c.sgsʲs.:(1).ρa
+    u₃ʲ = state.f.sgsʲs.:(1).u₃
+    # Evaluate the buoyancy inverse time scale at faces (where w and grad_Φ are
+    # naturally defined) and interpolate to centers for smoother behaviour.
+    ᶜbuoy_inv_time_scale = @. lazy(
+        ᶜinterp(
+            detr_buoy_inv_time_scale(
+                u₃ʲ.components.data.:1 / ᶠdz,
+                vertical_buoyancy_acceleration(
+                    ᶠinterp(ᶜρ_diffʲs.:1),
+                    ᶠgradᵥ_ᶜΦ,
+                    ᶠlg,
+                ),
+                detr_buoy_inv_tau_max,
+            ),
+        ),
+    )
+    return @. lazy(
+        compute_detrainment(
+            turbconv_params,
+            draft_area(ρaʲ, ᶜρʲs.:1),
+            ρaʲ,
+            ᶜbuoy_inv_time_scale,
+            ᶜdivᵥ(ᶠleft_bias(ρaʲ) * u₃ʲ),
+            ᶜarea_bounding_entr_detrʲs.:1,
+            detr_model,
+        ),
+    )
+end
+
+compute_detr(_, cache, _, ::DiagnosticEDMFX) = cache.precomputed.ᶜdetrʲs.:1
 
 add_diagnostic_variable!(short_name = "detr", units = "s^-1",
     long_name = "Detrainment rate",

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -365,7 +365,6 @@ function edmfx_sgs_vertical_advection_tendency!(
     turbconv_model::PrognosticEDMFX,
 )
     n = n_prognostic_mass_flux_subdomains(turbconv_model)
-    (; dt) = p
     (; edmfx_mse_q_tot_upwinding, edmfx_tracer_upwinding) = p.atmos.numerics
     (; ᶠu³ʲs, ᶜρʲs, ᶜρ_diffʲs) = p.precomputed
     (; ᶜgradᵥ_ᶠΦ) = p.core
@@ -374,16 +373,12 @@ function edmfx_sgs_vertical_advection_tendency!(
     ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
 
     for j in 1:n
+        ᶜa = (@. lazy(draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))))
+
         # buoyancy term in mse equation
         @. Yₜ.c.sgsʲs.:($$j).mse +=
             adjoint(CT3(ᶜinterp(Y.f.sgsʲs.:($$j).u₃))) *
             ᶜρ_diffʲs.:($$j) * ᶜgradᵥ_ᶠΦ
-
-        ᶜa = (@. lazy(draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j))))
-        # Flux form vertical advection of area fraction with the updraft velocity
-        vtt =
-            vertical_transport(ᶜρʲs.:($j), ᶠu³ʲs.:($j), ᶜa, dt, edmfx_mse_q_tot_upwinding)
-        @. Yₜ.c.sgsʲs.:($$j).ρa += vtt
 
         # Advective form advection of mse and q_tot with the updraft velocity
         # Note: This allocates because the function is too long

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -63,78 +63,101 @@ function calculate_pi_groups(
 end
 
 """
-    detr_area_limiter_factor(entr::FT, detr, a, turbconv_params) where {FT}
+    entr_upper_area_limiter_factor(a, turbconv_params)
 
-Return a multiplicative limiter for the net area tendency based on the current
-subdomain area `a`.
+Return a multiplicative limiter for the entrainment rate based on the
+current subdraft area `a`.
 
-If `entr > detr`, the net tendency would increase area, so the limiter damps
-growth as `a` approaches the upper bound `a_max`. In that case the returned
-factor is
+The factor smoothly damps entrainment as the area approaches the upper
+bound `a_max` (preventing the area from being driven above `a_max`):
 
-    max(0, 1 - a / a_max)^max_area_limiter_power.
+    (max(0, 1 - a / a_max))^max_area_limiter_power
 
-If `entr < detr`, the net tendency would decrease area, so the limiter damps
-shrinkage as `a` approaches the lower bound `a_min`. In that case the returned
-factor is
+The upper bound `a_max` is obtained from `turbconv_params` through
+`CAP.max_area`, and `max_area_limiter_power` from `CAP.max_area_limiter_power`.
 
-    max(0, 1 - a_min / a)^min_area_limiter_power.
-
-Thus the limiter is close to one away from the active bound and smoothly
-approaches zero at the corresponding bound. The lower and upper bounds are
-obtained from `turbconv_params` through `CAP.min_area` and `CAP.max_area`.
+This is the entrainment counterpart of [`detr_lower_area_limiter_factor`](@ref),
+which damps detrainment near the lower bound `a_min`. Together they keep
+`a ∈ [a_min, a_max]` without requiring a comparison between `entr` and `detr`.
 """
-@inline function detr_area_limiter_factor(entr::FT, detr, a, turbconv_params) where {FT}
-    a_min = CAP.min_area(turbconv_params)
+@inline function entr_upper_area_limiter_factor(a::FT, turbconv_params) where {FT}
     a_max = CAP.max_area(turbconv_params)
-    min_area_limiter_power = CAP.min_area_limiter_power(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
     a_safe = max(eps(FT), a)
-    return ifelse(
-        entr > detr,
-        (max(0, (1 - a_safe / a_max)))^max_area_limiter_power,
-        (max(0, (1 - a_min / a_safe)))^min_area_limiter_power,
+    return (max(0, (1 - a_safe / a_max)))^max_area_limiter_power
+end
+
+"""
+    detr_lower_area_limiter_factor(a, turbconv_params)
+
+Return a multiplicative limiter for the detrainment rate based on the current
+subdraft area `a`.
+
+The factor smoothly damps detrainment as the area approaches the lower bound
+`a_min` (preventing the area from being driven below `a_min`):
+
+    (max(0, 1 - a_min / a))^min_area_limiter_power
+
+The lower bound `a_min` is obtained from `turbconv_params` through
+`CAP.min_area`, and `min_area_limiter_power` from `CAP.min_area_limiter_power`.
+
+This is the detrainment counterpart of [`entr_upper_area_limiter_factor`](@ref),
+which damps entrainment near the upper bound `a_max`. Together they keep
+`a ∈ [a_min, a_max]` without requiring a comparison between `entr` and `detr`.
+"""
+@inline function detr_lower_area_limiter_factor(a::FT, turbconv_params) where {FT}
+    a_min = CAP.min_area(turbconv_params)
+    min_area_limiter_power = CAP.min_area_limiter_power(turbconv_params)
+    a_safe = max(eps(FT), a)
+    return (max(0, (1 - a_min / a_safe)))^min_area_limiter_power
+end
+
+"""
+    detr_buoy_inv_time_scale(Δwʲ, Δbuoyʲ, detr_buoy_inv_tau_max)
+
+Clipped inverse buoyancy time-scale [1/s] used by the buoyancy-driven
+detrainment branch:
+
+    τ⁻¹_buoy = min(detr_buoy_inv_tau_max,
+                   |min(Δbuoyʲ, 0)| / max(eps, |Δwʲ|))
+
+Only negative buoyancy contributes (positive buoyancy doesn't detrain), and
+the rate is capped at `detr_buoy_inv_tau_max` so a vanishing `Δwʲ` doesn't
+produce an unbounded rate.
+
+Extracted as a helper so it can be reused by `detrainment_rate` (the
+explicit detrainment closure) and the implicit ρa solve (where the same
+buoyancy-detrainment piece appears in the `(ε − δ)` denominator).
+"""
+@inline function detr_buoy_inv_time_scale(Δwʲ, Δbuoyʲ, detr_buoy_inv_tau_max)
+    FT = typeof(Δwʲ)
+    return min(
+        detr_buoy_inv_tau_max,
+        abs(min(Δbuoyʲ, FT(0))) / max(eps(FT), abs(Δwʲ)),
     )
 end
 
 """
-    compute_entrainment(ᶜentr_vel_scale, ᶜentr_nonvel, ᶜwʲ)
+    compute_entrainment(ᶜentr_vel_scale, ᶜarea_bounding_entr_detr, ᶜwʲ)
 
 Total entrainment rate [1/s] as the sum of a velocity-proportional term
-and a background (time-scale) term:
+and the positive part of the signed area-bounding rate:
 
-    entr = entr_vel_scale * |wʲ| + entr_nonvel
+    entr = entr_vel_scale * |wʲ| + max(0, area_bounding_entr_detr)
 
-`entr_vel_scale` [1/m] and `entr_nonvel` [1/s] are precomputed by
-`entrainment_velocity_scale` and `nonvelocity_entrainment` respectively.
-`ᶜwʲ` is the physical updraft vertical velocity [m/s] (not a difference
-from the environment); the environment velocity is approximated as zero
-when computing the scale (see `set_prognostic_edmf_precomputed_quantities_explicit_closures!`).
+`entr_vel_scale` [1/m] is precomputed by `entrainment_velocity_scale`, and
+`area_bounding_entr_detr` [1/s] is the signed rate produced by
+[`area_bounding_entr_detr`](@ref) (positive ⇒ this entrainment branch,
+negative ⇒ the detrainment branch in `compute_detrainment`).
+`ᶜwʲ` is the physical updraft vertical velocity [m/s].
 """
 compute_entrainment(
     ᶜentr_vel_scale,
-    ᶜentr_nonvel,
+    ᶜarea_bounding_entr_detr,
     ᶜwʲ,
-) = ᶜentr_vel_scale * abs(ᶜwʲ) + ᶜentr_nonvel
-
-"""
-    entr_area_limiter_factor(ᶜaʲ, turbconv_params)
-
-Return a multiplicative limiter for the entrainment rate based on the
-current subdraft area `ᶜaʲ`.
-
-The factor smoothly damps entrainment as the area approaches 1 (fully
-occupied):
-
-    (1 - clamp(ᶜaʲ, 0, 1))^entr_mult_limiter_coeff
-
-where `entr_mult_limiter_coeff` is obtained from `turbconv_params`.
-"""
-@inline function entr_area_limiter_factor(ᶜaʲ, turbconv_params)
-    FT = eltype(ᶜaʲ)
-    entr_mult_limiter_coeff = CAP.entr_mult_limiter_coeff(turbconv_params)
-    return (FT(1) - min(max(ᶜaʲ, FT(0)), FT(1)))^entr_mult_limiter_coeff
-end
+) =
+    ᶜentr_vel_scale * abs(ᶜwʲ) +
+    max(zero(ᶜarea_bounding_entr_detr), ᶜarea_bounding_entr_detr)
 
 """
     entrainment_velocity_scale(
@@ -143,36 +166,16 @@ end
         model_option::AbstractEntrainmentModel,
     )
 
-    and
+Velocity-scaling prefactor [1/m] for the model-specific entrainment rate.
+The total entrainment rate [1/s] is assembled by `compute_entrainment` as
 
-    nonvelocity_entrainment(
-        turbconv_params, ᶜaʲ,
-        model_option::AbstractEntrainmentModel,
-    )
+    entr = entr_vel_scale * abs(wʲ) + max(0, area_bounding_entr_detr)
 
-These two functions together decompose the total entrainment rate into
-a velocity-dependent part and a background (time-scale) part:
+where the second term comes from [`area_bounding_entr_detr`](@ref) (its
+positive branch). `model_option` dispatches to different entrainment models,
+such as `NoEntrainment`, `PiGroupsEntrainment`, or `InvZEntrainment`.
 
-    entr = entr_vel_scale * abs(wʲ) + entr_nonvel
-
-where `entr` has units of [1/s], `entr_vel_scale` has units of [1/m],
-and `entr_nonvel` has units of [1/s]. `entrainment_velocity_scale` computes
-the velocity-scaling prefactor [1/m] and `nonvelocity_entrainment` computes
-the velocity-independent rate [1/s], both according to the model specified
-by `model_option`. The total entrainment rate [1/s] is assembled by
-`compute_entrainment`.
-
-The specific formulation depends on the concrete type passed as
-`model_option`. This argument dispatches to different entrainment models,
-such as `NoEntrainment` (which returns zero entrainment),
-`PiGroupsEntrainment` (which computes an entrainment scale based on
-a linear combination of scaled non-dimensional Pi-groups together with a
-constant background entrainment term), or `InvZEntrainment`
-(a physically inspired formulation with a scale proportional to `1/z`).
-Each model implements a distinct physical or empirical representation
-of entrainment in updrafts.
-
-Arguments for `entrainment_velocity_scale` (all cell-centered):
+Arguments (all cell-centered):
 
   - `thermo_params`: Thermodynamic parameters.
   - `turbconv_params`: Turbulence convection parameters.
@@ -188,26 +191,9 @@ Arguments for `entrainment_velocity_scale` (all cell-centered):
   - `ᶜRH⁰`: Environment relative humidity [-].
   - `ᶜbuoy⁰`: Environment buoyancy [m/s²].
   - `ᶜtke`: Turbulent kinetic energy [m²/s²].
-  - `model_option`: Object specifying the entrainment model
-    (e.g., `NoEntrainment`, `PiGroupsEntrainment`,
-    or `InvZEntrainment`).
-
-Arguments for `nonvelocity_entrainment`:
-
-  - `turbconv_params`: Turbulence convection parameters.
-  - `ᶜaʲ`: Updraft area fraction [-].
   - `model_option`: Object specifying the entrainment model.
 
-Returns (for each function):
-
-  - `entrainment_velocity_scale`: Velocity-scaling prefactor [1/m].
-  - `nonvelocity_entrainment`: Background (velocity-independent) entrainment rate [1/s].
-
-These quantities are combined by `compute_entrainment` as
-
-    entr = entr_vel_scale * abs(w⁰ - wʲ) + entr_nonvel
-
-to obtain the total entrainment rate [1/s].
+Returns the velocity-scaling prefactor [1/m].
 """
 function entrainment_velocity_scale(
     thermo_params,
@@ -280,7 +266,7 @@ function entrainment_velocity_scale(
         entr_param_vec[5] * abs(Π₅) +
         entr_param_vec[6]
 
-    area_limiter_factor = entr_area_limiter_factor(ᶜaʲ, turbconv_params)
+    area_limiter_factor = entr_upper_area_limiter_factor(ᶜaʲ, turbconv_params)
     entr_vel_scale = area_limiter_factor * max(0, pi_sum) / elev_above_sfc
     return max(0, entr_vel_scale)
 end
@@ -312,70 +298,79 @@ function entrainment_velocity_scale(
         return 0
     end
 
-    area_limiter_factor = entr_area_limiter_factor(ᶜaʲ, turbconv_params)
+    area_limiter_factor = entr_upper_area_limiter_factor(ᶜaʲ, turbconv_params)
     entr_vel_scale = area_limiter_factor * entr_vel_scale_param / elev_above_sfc
     return max(0, entr_vel_scale)
 end
 
-function nonvelocity_entrainment(
-    turbconv_params,
-    ᶜaʲ,
-    ::NoEntrainment,
-)
-    return zero(eltype(ᶜaʲ))
-end
+"""
+    area_bounding_entr_detr(turbconv_params, a)
 
-function nonvelocity_entrainment(
-    turbconv_params,
-    ᶜaʲ,
-    ::PiGroupsEntrainment,
-)
-    entr_inv_tau = CAP.entr_inv_tau(turbconv_params)
-    area_limiter_factor = entr_area_limiter_factor(ᶜaʲ, turbconv_params)
-    entr_nonvel = area_limiter_factor * entr_inv_tau
-    return max(0, entr_nonvel)
-end
+Signed velocity-independent rate [1/s] that smoothly relaxes the updraft
+area `a` back into `[a_min, a_max]`, applied unconditionally (no
+dispatch on the entrainment/detrainment model). The sign convention is
 
-function nonvelocity_entrainment(
-    turbconv_params,
-    ᶜaʲ,
-    ::InvZEntrainment,
-)
-    entr_inv_tau = CAP.entr_inv_tau(turbconv_params)
-    min_area_limiter_scale = CAP.min_area_limiter_scale(turbconv_params)
-    min_area_limiter_power = CAP.min_area_limiter_power(turbconv_params)
+    > 0  ⇒  acts as additional entrainment (drives the area up; a < a_min)
+    < 0  ⇒  acts as additional detrainment (drives the area down; a > a_max)
+    = 0  ⇒  inactive (a_min ≤ a ≤ a_max)
+
+The result is
+
+    +min_area_limiter_scale · (max(0, a_min − a)/a_min)^min_area_limiter_power
+    −max_area_limiter_scale · (max(0, a − a_max)/(1 − a_max))^max_area_limiter_power.
+
+The two ranges (`a < a_min` and `a > a_max`) are mutually exclusive, so
+exactly one term is non-zero outside `[a_min, a_max]` and both are zero
+inside it.
+
+The positive part is consumed by [`compute_entrainment`](@ref) via
+`max(0, area_bounding_entr_detr)`; the negative part is consumed by
+[`compute_detrainment`](@ref) via `max(0, -area_bounding_entr_detr)`.
+"""
+@inline function area_bounding_entr_detr(turbconv_params, a)
+    FT = typeof(a)
     a_min = CAP.min_area(turbconv_params)
+    a_max = CAP.max_area(turbconv_params)
+    min_scale = CAP.min_area_limiter_scale(turbconv_params)
+    min_power = CAP.min_area_limiter_power(turbconv_params)
+    max_scale = CAP.max_area_limiter_scale(turbconv_params)
+    max_power = CAP.max_area_limiter_power(turbconv_params)
 
-    # Extra entrainment for a < a_min that smoothly relaxes the area
-    # toward a_min (0 at a_min, min_area_limiter_scale at a = 0).
-    min_area_limiter =
-        min_area_limiter_scale * (max(0, a_min - ᶜaʲ) / a_min)^min_area_limiter_power
+    # Extra entrainment for a < a_min (0 at a_min, min_scale at a = 0).
+    min_relax = min_scale * (max(FT(0), a_min - a) / a_min)^min_power
+    # Extra detrainment for a > a_max (0 at a_max, max_scale at a = 1).
+    max_relax = max_scale * (max(FT(0), a - a_max) / (1 - a_max))^max_power
 
-    area_limiter_factor = entr_area_limiter_factor(ᶜaʲ, turbconv_params)
-    entr_nonvel = area_limiter_factor * (entr_inv_tau + min_area_limiter)
-    return max(0, entr_nonvel)
+    return min_relax - max_relax
 end
 
 """
-    compute_detrainment(turbconv_params, aʲ, ρaʲ, Δwʲ, Δbuoyʲ,
-                        massflux_vert_div, entr, detr_nonvel, detr_model)
+    compute_detrainment(turbconv_params, aʲ, ρaʲ, buoy_inv_time_scale,
+                        massflux_vert_div, area_bounding_entr_detr, detr_model)
 
-Total detrainment rate [1/s].
+Total detrainment rate [1/s] as the sum of the model-specific rate from
+`detrainment_rate` (which internally applies
+[`detr_lower_area_limiter_factor`](@ref) so that detrainment is damped as
+`a → a_min`) with the negative part of the signed area-bounding rate:
 
-Calls `detrainment_rate` for the model-specific rate, adds `detr_nonvel`
-(e.g., background detrainment), then applies an area limiter so that near
-`a_min`/`a_max` the net area tendency `(entr - detr)` smoothly approaches zero.
+    detr = detrainment_rate(...) + max(0, -area_bounding_entr_detr)
+
+`area_bounding_entr_detr` is produced by [`area_bounding_entr_detr`](@ref);
+its positive branch feeds [`compute_entrainment`](@ref) while the
+negative branch (the only one that contributes here) drives the area back
+below `a_max`.
 
 Arguments:
 
   - `turbconv_params`: Turbulence convection parameters.
   - `aʲ`: Updraft area fraction [-].
   - `ρaʲ`: Updraft density-area product [kg/m³].
-  - `Δwʲ`: Updraft physical vertical velocity [m/s].
-  - `Δbuoyʲ`: Updraft buoyancy (vertical acceleration) [m/s²].
+  - `buoy_inv_time_scale`: Clipped inverse buoyancy time scale [1/s] from
+    [`detr_buoy_inv_time_scale`](@ref). The caller chooses where to evaluate
+    it (centers, or faces with subsequent `ᶜinterp`) to control smoothness.
   - `massflux_vert_div`: Vertical divergence of the updraft mass flux [kg/(m³ s)].
-  - `entr`: Total entrainment rate [1/s].
-  - `detr_nonvel`: Additional (e.g., background) detrainment rate [1/s].
+  - `area_bounding_entr_detr`: Signed area-bounding rate [1/s] from
+    [`area_bounding_entr_detr`](@ref).
   - `detr_model`: Object specifying the detrainment model.
 
 Returns the total detrainment rate [1/s].
@@ -384,33 +379,27 @@ function compute_detrainment(
     turbconv_params,
     aʲ,
     ρaʲ,
-    Δwʲ,
-    Δbuoyʲ,
+    buoy_inv_time_scale,
     massflux_vert_div,
-    entr,
-    detr_nonvel,
+    area_bounding_entr_detr,
     detr_model,
 )
 
-    detr =
-        detrainment_rate(
-            turbconv_params,
-            ρaʲ,
-            Δwʲ,
-            Δbuoyʲ,
-            massflux_vert_div,
-            detr_model,
-        ) + detr_nonvel
+    detr = detrainment_rate(
+        turbconv_params,
+        aʲ,
+        ρaʲ,
+        buoy_inv_time_scale,
+        massflux_vert_div,
+        detr_model,
+    )
 
-    # Adjust detrainment so that near the area bounds it approaches entrainment,
-    # causing the net area tendency (entr - detr) to smoothly go to zero.
-    factor = detr_area_limiter_factor(entr, detr, aʲ, turbconv_params)
-    return factor * detr + (1 - factor) * entr
+    return detr + max(zero(area_bounding_entr_detr), -area_bounding_entr_detr)
 end
 
 """
-    detrainment_rate(turbconv_params, ᶜρaʲ, ᶜΔwʲ, ᶜΔbuoyʲ, ᶜmassflux_vert_div,
-                     detr_model::AbstractDetrainmentModel)
+    detrainment_rate(turbconv_params, ᶜaʲ, ᶜρaʲ, ᶜbuoy_inv_time_scale,
+                     ᶜmassflux_vert_div, detr_model::AbstractDetrainmentModel)
 
 Model-specific detrainment rate [1/s] for a given detrainment model.
 
@@ -421,9 +410,10 @@ non-trivial rate.
 Arguments:
 
   - `turbconv_params`: Turbulence convection parameters.
+  - `ᶜaʲ`: Updraft area fraction [-].
   - `ᶜρaʲ`: Updraft density-area product [kg/m³].
-  - `ᶜΔwʲ`: Updraft physical vertical velocity [m/s].
-  - `ᶜΔbuoyʲ`: Updraft buoyancy (vertical acceleration) [m/s²].
+  - `ᶜbuoy_inv_time_scale`: Clipped inverse buoyancy time scale [1/s] from
+    [`detr_buoy_inv_time_scale`](@ref).
   - `ᶜmassflux_vert_div`: Vertical divergence of the updraft mass flux [kg/(m³ s)].
   - `detr_model`: Detrainment model dispatch tag.
 
@@ -431,69 +421,35 @@ Returns the model-specific detrainment rate [1/s] (zero for the abstract fallbac
 """
 function detrainment_rate(
     turbconv_params,
+    ᶜaʲ,
     ᶜρaʲ,
-    ᶜΔwʲ,
-    ᶜΔbuoyʲ,
+    ᶜbuoy_inv_time_scale,
     ᶜmassflux_vert_div,
     ::AbstractDetrainmentModel,
 )
     return zero(eltype(ᶜρaʲ))
 end
-function nonvelocity_detrainment(
-    turbconv_params,
-    ᶜaʲ,
-    ::AbstractDetrainmentModel,
-)
-    return zero(eltype(ᶜaʲ))
-end
 
 function detrainment_rate(
     turbconv_params,
+    ᶜaʲ,
     ᶜρaʲ,
-    ᶜΔwʲ,
-    ᶜΔbuoyʲ,
+    ᶜbuoy_inv_time_scale,
     ᶜmassflux_vert_div,
     ::BuoyancyVelocityDetrainment,
 )
     FT = eltype(ᶜρaʲ)
     detr_buoy_coeff = CAP.detr_buoy_coeff(turbconv_params)
-    detr_buoy_inv_tau_max = CAP.detr_buoy_inv_tau_max(turbconv_params)
     detr_massflux_vertdiv_coeff =
         CAP.detr_massflux_vertdiv_coeff(turbconv_params)
 
-    # Clip buoyancy time scale to `buoy_inv_time_scale` to avoid too fast detrainment
-    # when velocity is small
-    buoy_inv_time_scale =
-        min(
-            detr_buoy_inv_tau_max,
-            abs(min(ᶜΔbuoyʲ, 0)) / max(eps(FT), abs(ᶜΔwʲ)),
+    area_limiter_factor = detr_lower_area_limiter_factor(ᶜaʲ, turbconv_params)
+    detr =
+        area_limiter_factor *
+        (
+            detr_buoy_coeff * ᶜbuoy_inv_time_scale -
+            detr_massflux_vertdiv_coeff * min(ᶜmassflux_vert_div, 0) / max(eps(FT), ᶜρaʲ)
         )
-
-    detr =
-        detr_buoy_coeff * buoy_inv_time_scale -
-        detr_massflux_vertdiv_coeff * min(ᶜmassflux_vert_div, 0) / max(eps(FT), ᶜρaʲ)
-
-    return max(0, detr)
-end
-
-function nonvelocity_detrainment(
-    turbconv_params,
-    ᶜaʲ,
-    ::BuoyancyVelocityDetrainment,
-)
-    detr_inv_tau = CAP.detr_inv_tau(turbconv_params)
-    max_area_limiter_scale = CAP.max_area_limiter_scale(turbconv_params)
-    max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
-    a_max = CAP.max_area(turbconv_params)
-
-    # Extra detrainment for a > a_max that smoothly relaxes the area back
-    # toward a_max (0 at a_max, max_area_limiter_scale at a = 1).
-    max_area_limiter =
-        max_area_limiter_scale * (max(0, ᶜaʲ - a_max) / (1 - a_max))^max_area_limiter_power
-
-    detr =
-        detr_inv_tau +
-        max_area_limiter
 
     return max(0, detr)
 end
@@ -503,15 +459,31 @@ function turbulent_entrainment(turbconv_params, ᶜaʲ)
     return max(turb_entr_param_vec[1] * exp(-turb_entr_param_vec[2] * ᶜaʲ), 0)
 end
 
+"""
+    edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model)
+
+Add the entrainment contribution to the EDMF scalar tendencies (`mse`,
+`q_tot`, and the microphysics tracers carried by the updraft).
+
+Detrainment is **not** applied here because it is absorbed into the
+analytic implicit ρa solve (see
+[`solve_sgs_ρa_implicit_stage_analytic!`](@ref)); scalars are detrained
+implicitly through the area divergence of the mass flux.
+
+The entrainment rate is assembled lazily from the precomputed
+`ᶜentr_vel_scaleʲs`, `ᶜarea_bounding_entr_detrʲs`, and the updraft physical
+velocity via [`compute_entrainment`](@ref).
+"""
 edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model) = nothing
 
 function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMFX)
 
     n = n_mass_flux_subdomains(turbconv_model)
-    (; ᶜturb_entrʲs, ᶜentrʲs, ᶜdetrʲs) = p.precomputed
+    (; ᶜturb_entrʲs, ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs, ᶜuʲs) = p.precomputed
 
     ᶜmse⁰ = ᶜspecific_env_mse(Y, p)
     ᶜq_tot⁰ = ᶜspecific_env_value(@name(q_tot), Y, p)
+    ᶜlg = Fields.local_geometry_field(Y.c)
 
     microphysics_tracers = (
         (@name(c.sgsʲs.:(1).q_lcl), @name(q_lcl)),
@@ -523,13 +495,16 @@ function edmfx_entr_detr_tendency!(Yₜ, Y, p, t, turbconv_model::PrognosticEDMF
     )
 
     for j in 1:n
-        ᶜentrʲ = ᶜentrʲs.:($j)
-        ᶜdetrʲ = ᶜdetrʲs.:($j)
+        ᶜentrʲ = @. lazy(
+            compute_entrainment(
+                ᶜentr_vel_scaleʲs.:($$j),
+                ᶜarea_bounding_entr_detrʲs.:($$j),
+                get_physical_w(ᶜuʲs.:($$j), ᶜlg),
+            ),
+        )
         ᶜturb_entrʲ = ᶜturb_entrʲs.:($j)
         ᶜmseʲ = Y.c.sgsʲs.:($j).mse
         ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
-
-        @. Yₜ.c.sgsʲs.:($$j).ρa += Y.c.sgsʲs.:($$j).ρa * (ᶜentrʲ - ᶜdetrʲ)
 
         @. Yₜ.c.sgsʲs.:($$j).mse += (ᶜentrʲ .+ ᶜturb_entrʲ) * (ᶜmse⁰ - ᶜmseʲ)
 
@@ -565,13 +540,14 @@ function edmfx_first_interior_entr_tendency!(
     turbconv_model::PrognosticEDMFX,
 )
 
-    (; params, dt) = p
-    (; ᶜK, ᶜρʲs, ᶜentrʲs) = p.precomputed
+    (; params) = p
+    (; ᶜK, ᶜρʲs, ᶜturb_entrʲs, ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs, ᶜuʲs) =
+        p.precomputed
 
     FT = eltype(params)
     n = n_mass_flux_subdomains(p.atmos.turbconv_model)
-    thermo_params = CAP.thermodynamics_params(params)
     turbconv_params = CAP.turbconv_params(params)
+    ᶜlg = Fields.local_geometry_field(Y.c)
     ᶜaʲ_int_val = p.scratch.temp_data_level
     ᶜmse_buoyant_air_int_val = p.scratch.temp_data_level_2
     ᶜq_tot_buoyant_air_int_val = p.scratch.temp_data_level_3
@@ -614,21 +590,27 @@ function edmfx_first_interior_entr_tendency!(
     env_q_tot_int_val = Fields.field_values(Fields.level(ᶜq_tot⁰, 1))
 
     for j in 1:n
-
         # Apply entrainment tendencies in the first model cell for moist static energy (mse)
         # and total humidity (q_tot). The entrained fluid is assumed to have a scalar value
         # given by `sgs_scalar_first_interior_bc` (mean + SGS perturbation). Since
         # `edmfx_entr_detr_tendency!` computes entrainment based on the environment–updraft
         # contrast, we supply the high-value (entrained) tracer minus the environment value
         # here to form the correct tendency.
-        entr_int_val = Fields.field_values(Fields.level(ᶜentrʲs.:($j), 1))
+        ᶜentrʲ = @. lazy(
+            compute_entrainment(
+                ᶜentr_vel_scaleʲs.:($$j),
+                ᶜarea_bounding_entr_detrʲs.:($$j),
+                get_physical_w(ᶜuʲs.:($$j), ᶜlg),
+            ),
+        )
+        entr_int_val = Fields.field_values(Fields.level(ᶜentrʲ, 1))
+        turb_entr_int_val = Fields.field_values(Fields.level(ᶜturb_entrʲs.:($j), 1))
         sgsʲs_ρ_int_val = Fields.field_values(Fields.level(ᶜρʲs.:($j), 1))
         sgsʲs_ρa_int_val = Fields.field_values(Fields.level(Y.c.sgsʲs.:($j).ρa, 1))
         @. ᶜaʲ_int_val = max(
             FT(turbconv_params.surface_area),
             draft_area(sgsʲs_ρa_int_val, sgsʲs_ρ_int_val),
         )
-
         sgsʲs_mseₜ_int_val =
             Fields.field_values(Fields.level(Yₜ.c.sgsʲs.:($j).mse, 1))
         @. ᶜmse_buoyant_air_int_val = sgs_scalar_first_interior_bc(
@@ -642,7 +624,9 @@ function edmfx_first_interior_entr_tendency!(
             obukhov_length_val,
             sfc_local_geometry_val,
         )
-        @. sgsʲs_mseₜ_int_val += entr_int_val * (ᶜmse_buoyant_air_int_val - env_mse_int_val)
+        @. sgsʲs_mseₜ_int_val +=
+            (entr_int_val + turb_entr_int_val) *
+            (ᶜmse_buoyant_air_int_val - env_mse_int_val)
 
         sgsʲs_q_totₜ_int_val =
             Fields.field_values(Fields.level(Yₜ.c.sgsʲs.:($j).q_tot, 1))
@@ -658,64 +642,57 @@ function edmfx_first_interior_entr_tendency!(
             sfc_local_geometry_val,
         )
         @. sgsʲs_q_totₜ_int_val +=
-            entr_int_val * (ᶜq_tot_buoyant_air_int_val - env_q_tot_int_val)
+            (entr_int_val + turb_entr_int_val) *
+            (ᶜq_tot_buoyant_air_int_val - env_q_tot_int_val)
 
     end
 end
 
 """
     set_first_cell_entr_detr_bc!(
-        ρaʲ_int, ρʲ_int, entr_nonvel_int, entr_vel_scale_int, detr_nonvel_int,
+        ρaʲ_int, ρʲ_int, area_bounding_entr_detr_int, entr_vel_scale_int,
         buoyancy_flux, dz_int, surface_area, dt, FT,
     )
 
-Apply surface boundary conditions for entrainment and detrainment at the first
-model cell for a single EDMF updraft.
+Apply surface boundary conditions for the area-bounding rate and the
+entrainment velocity scale at the first model cell for a single EDMF
+updraft.
 
-When `buoyancy_flux < 0` (convectively stable): the background entrainment and
-entrainment velocity scale are left unchanged; `detr_nonvel` is floored at
-`entr_nonvel` to prevent net area growth from the lower boundary.
+When `buoyancy_flux < 0` (convectively stable): the area-bounding rate is
+clipped to ≤ 0 so the lower boundary cannot drive net area growth.
 
-When `buoyancy_flux ≥ 0` (convectively unstable): the updraft area is nudged
-toward `surface_area`:
+When `buoyancy_flux ≥ 0` (convectively unstable): the updraft area is
+nudged toward `surface_area` by overwriting the area-bounding rate with
+the signed first-order step
 
-  - `ρaʲ` is seeded so a zero-area plume can start growing.
-  - If `a < surface_area`: `entr_nonvel` is set to `(surface_area/a − 1)/dt` and
-    `entr_vel_scale` is set to `2/dz` (the kinematic one-sided estimate of
-    `∂(ρaw)/∂z` at the surface), so entrainment grows the area.
-  - If `a ≥ surface_area`: `detr_nonvel` is set to drive area back down;
-    `entr_vel_scale` is still `2/dz`.
+    area_bounding_entr_detr = (1 − a / surface_area) / dt,
 
-!!! note "Two-place first-cell treatment"
-
-    The first-cell boundary condition is applied in two stages:
-
-     1. This function sets the input coefficients (bg_entr, entr_coeff, detr_nonvel).
-     2. `update_prognostic_edmfx_entr_detr!` overrides the total detrainment at
-        level 1 to strip the area limiter added by `compute_detrainment`.
-        These two stages should be kept in sync.
+which is positive (entrainment) when `a < surface_area` and negative
+(detrainment) when `a > surface_area`. The form `(1 − a/surface_area)/dt`
+is linear in `a`, finite at `a = 0`, and compatible with the implicit
+update inside the ρa solve. The entrainment velocity scale is also
+replaced with the kinematic estimate `2/dz` so the total entrainment
+includes the one-sided advective area flux `∂(ρaw)/∂z` at the surface.
+Finally, `ρaʲ` is seeded with a tiny positive value so an initially
+zero-area plume can start growing.
 
 Arguments (all level-1 field-value slices unless noted):
 
-  - `ρaʲ_int`             — updraft `ρa` [kg/m³] (read/write; seeded first)
-  - `ρʲ_int`              — updraft density [kg/m³] (read-only)
-  - `entr_nonvel_int`         — background entrainment [1/s] (read/write)
-  - `entr_vel_scale_int`  — entrainment velocity scale [1/m] (read/write)
-  - `detr_nonvel_int`     — additional detrainment [1/s] (read/write)
-  - `aʲ_int`              — scratch for draft area [-] (write-only; pre-allocated by caller)
-  - `buoyancy_flux`       — surface buoyancy flux [m²/s³] (read-only scalar field values)
-  - `dz_int`              — first-cell height [m] (read-only)
-  - `surface_area`        — target updraft area fraction [-] (scalar)
-  - `dt`                  — timestep [s] (scalar)
-  - `FT`                  — float type
+  - `ρaʲ_int`                 — updraft `ρa` [kg/m³] (read/write; seeded first)
+  - `ρʲ_int`                  — updraft density [kg/m³] (read-only)
+  - `area_bounding_entr_detr_int` — signed area-bounding rate [1/s] (read/write)
+  - `entr_vel_scale_int`      — entrainment velocity scale [1/m] (read/write)
+  - `buoyancy_flux`           — surface buoyancy flux [m²/s³] (read-only scalar field values)
+  - `dz_int`                  — first-cell height [m] (read-only)
+  - `surface_area`            — target updraft area fraction [-] (scalar)
+  - `dt`                      — timestep [s] (scalar)
+  - `FT`                      — float type
 """
 function set_first_cell_entr_detr_bc!(
     ρaʲ_int,
     ρʲ_int,
-    entr_nonvel_int,
+    area_bounding_entr_detr_int,
     entr_vel_scale_int,
-    detr_nonvel_int,
-    aʲ_int,
     buoyancy_flux,
     dz_int,
     surface_area,
@@ -728,12 +705,14 @@ function set_first_cell_entr_detr_bc!(
         FT(0),
         max(FT(0), ρʲ_int * eps(FT) - ρaʲ_int),
     )
-    @. aʲ_int = draft_area(ρaʲ_int, ρʲ_int)
 
-    @. entr_nonvel_int = ifelse(
-        buoyancy_flux < 0 || aʲ_int >= FT(surface_area),
-        entr_nonvel_int,
-        (FT(surface_area) / aʲ_int - 1) / FT(dt),
+    # Signed surface-BC area-bounding rate. When buoyancy_flux ≥ 0, drive
+    # `a` toward `surface_area` via a first-order step; otherwise clip to
+    # ≤ 0 so the lower boundary cannot grow the area further.
+    @. area_bounding_entr_detr_int = ifelse(
+        buoyancy_flux < 0,
+        min(area_bounding_entr_detr_int, FT(0)),
+        (FT(1) - draft_area(ρaʲ_int, ρʲ_int) / FT(surface_area)) / FT(dt),
     )
     # Replace entrainment coefficient with the kinematic estimate 2/dz when
     # buoyancy flux is positive so the total entrainment includes the advective
@@ -743,20 +722,11 @@ function set_first_cell_entr_detr_bc!(
         entr_vel_scale_int,
         FT(2) / dz_int,
     )
-    @. detr_nonvel_int = ifelse(
-        buoyancy_flux < 0,
-        max(detr_nonvel_int, entr_nonvel_int),
-        ifelse(
-            aʲ_int < FT(surface_area),
-            FT(0),
-            entr_nonvel_int - (FT(surface_area) / aʲ_int - 1) / FT(dt),
-        ),
-    )
     return nothing
 end
 
-# limit entrainment and detrainment rates for prognostic EDMFX
-# limit rates approximately below the inverse timescale 1/dt
+# limit entrainment and detrainment rates for diagnostic EDMF
+# limit rates approximately below the inverse timescale w/dz
 limit_entrainment(entr::FT, a, dt) where {FT} = max(
     min(
         entr,
@@ -765,20 +735,11 @@ limit_entrainment(entr::FT, a, dt) where {FT} = max(
     ),
     0,
 )
-limit_detrainment(detr::FT, a, dt) where {FT} =
-    max(min(detr, FT(0.9) * 1 / dt), 0)
-limit_detrainment(detr::FT, entr::FT, a, dt) where {FT} =
-    max(detr, entr - FT(0.9) * 1 / dt)
-
-function limit_turb_entrainment(dyn_entr::FT, turb_entr, dt) where {FT}
-    return max(min((FT(0.9) * 1 / dt) - dyn_entr, turb_entr), 0)
-end
-
-# limit entrainment and detrainment rates for diagnostic EDMF
-# limit rates approximately below the inverse timescale w/dz
 limit_entrainment(entr::FT, a, w, dz) where {FT} =
     max(min(entr, FT(0.9) * w / dz), 0)
 
+limit_detrainment(detr::FT, a, dt) where {FT} =
+    max(min(detr, FT(0.9) * 1 / dt), 0)
 limit_detrainment(detr::FT, a, w, dz, dt) where {FT} =
     limit_detrainment(max(min(detr, FT(0.9) * w / dz), 0), a, dt)
 

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -61,6 +61,7 @@ NVTX.@annotate function implicit_tendency!(Yₜ, Y, p, t)
     pressure_work_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
     sgs_u₃_implicit_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
+    sgs_ρa_implicit_tendency!(Yₜ, Y, p, t, p.atmos.turbconv_model)
 
     # NOTE: This will zero out all momentum tendencies in the edmfx advection test
     # DO NOT add additional velocity tendencies after this function

--- a/src/prognostic_equations/implicit/initialize_implicit_problem.jl
+++ b/src/prognostic_equations/implicit/initialize_implicit_problem.jl
@@ -25,20 +25,24 @@ function initialize_implicit_stage_problem!(Y, p, dtγ)
 
     if p.atmos.turbconv_model isa PrognosticEDMFX
 
-        (; ᶠu₃_tendencyʲs) = p.precomputed
+        (; ᶠu₃_tendencyʲs, ᶜρa_tendencyʲs) = p.precomputed
         n = n_mass_flux_subdomains(p.atmos.turbconv_model)
 
-        # store -u₃_old / dtγ
+        # store -u₃_old / dtγ and -ρa_old / dtγ
         for j in 1:n
             @. ᶠu₃_tendencyʲs.:($$j) = -Y.f.sgsʲs.:($$j).u₃ / dtγ
+            @. ᶜρa_tendencyʲs.:($$j) = -Y.c.sgsʲs.:($$j).ρa / dtγ
         end
 
-        # analytic stage solve (overwrites Y)
+        # analytic stage solves (overwrite Y)
         solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
+        solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
 
         # add +u₃_stage / dtγ → (u₃_stage - u₃_old) / dtγ
+        # add +ρa_stage / dtγ → (ρa_stage - ρa_old) / dtγ
         for j in 1:n
             @. ᶠu₃_tendencyʲs.:($$j) += Y.f.sgsʲs.:($$j).u₃ / dtγ
+            @. ᶜρa_tendencyʲs.:($$j) += Y.c.sgsʲs.:($$j).ρa / dtγ
         end
     end
 end
@@ -125,7 +129,7 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
     (; turbconv_model, rayleigh_sponge) = p.atmos
     (; ᶜρ_diffʲs, ᶜρʲs) = p.precomputed
     (; ᶠgradᵥ_ᶜΦ) = p.core
-    (; ᶜturb_entrʲs, ᶜentr_vel_scaleʲs, ᶜentr_nonvelʲs) = p.precomputed
+    (; ᶜturb_entrʲs, ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs) = p.precomputed
     FT = eltype(p.params)
 
     turbconv_params = CAP.turbconv_params(params)
@@ -158,9 +162,14 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
         # Implicit entrainment: the velocity-dependent coefficient contributes a
         # quadratic sink (∝ w²) and the background/turbulent entrainment contributes
         # a linear sink (∝ w), after applying the approximation w₀ - w ≈ -(ρ/ρa⁰) w.
+        # The positive part of `area_bounding_entr_detr` is the entrainment branch
+        # of the signed area-bounding rate (see `area_bounding_entr_detr`).
         @. ᶠa += ᶠinterp(ᶜentr_vel_scaleʲs.:($$j) * ᶜρ_over_ρa⁰ * ᶜρ_over_ρa⁰) / ᶠdz
         @. ᶠb +=
-            ᶠinterp((ᶜentr_nonvelʲs.:($$j) + ᶜturb_entrʲs.:($$j)) * ᶜρ_over_ρa⁰)
+            ᶠinterp(
+                (max(FT(0), ᶜarea_bounding_entr_detrʲs.:($$j)) + ᶜturb_entrʲs.:($$j)) *
+                ᶜρ_over_ρa⁰,
+            )
 
         # Implicit NH pressure drag contributes a quadratic sink in w².
         if p.atmos.edmfx_model.nh_pressure isa Val{true}
@@ -207,4 +216,204 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
         end
     end
 
+end
+
+"""
+    sgs_ρa_implicit_tendency!(Yₜ, Y, p, t, turbconv_model)
+
+Set the cached updraft area tendency for the implicit stage.
+
+For `PrognosticEDMFX`, the implicit-stage value of `ρa` is computed
+analytically in `initialize_implicit_stage_problem!` and written directly
+into `Y`. This routine supplies the corresponding cached tendency,
+
+    (ρa_stage - ρa_old) / dtγ,
+
+to the implicit ODE solve so that the analytically computed `ρa` value is
+preserved.
+"""
+sgs_ρa_implicit_tendency!(Yₜ, Y, p, t, _) = nothing
+
+function sgs_ρa_implicit_tendency!(
+    Yₜ,
+    Y,
+    p,
+    t,
+    turbconv_model::PrognosticEDMFX,
+)
+    (; ᶜρa_tendencyʲs) = p.precomputed
+    n = n_mass_flux_subdomains(turbconv_model)
+    for j in 1:n
+        @. Yₜ.c.sgsʲs.:($$j).ρa = ᶜρa_tendencyʲs.:($$j)
+    end
+end
+
+"""
+    solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
+
+Compute and set the IMEX/ARK implicit-stage solution for the updraft
+area-weighted density `ρa` in each EDMFX mass-flux subdomain.
+
+The implicit stage equation for ρaʲ in flux form is
+
+    ∂ρa/∂t + ∂(ρa · w) / ∂z = (ε − δ) · ρa,
+
+With first-order upwinding for upward ᶠu₃ʲ, the stage equation reduces to
+the forward recurrence
+
+    ρa_new[i] = (ρa_old[i]/dtγ + α_bot · ρa_new[i−1]) / denominator[i],
+
+with
+
+    denominator[i] = 1/dtγ + α_top − (ε − δ)[i],
+    α_face         = (ρʲ_face · w_face) / (ρʲ_upwind · Δz[i])
+                   = (ᶠinterp(ρʲ·J)/ᶠJ · ᶠu₃ʲ/Δz_face) / (ρʲ_upwind · Δz[i]),
+
+evaluated at the top (i + ½) and bottom (i − ½) faces. The upwind density
+`ρʲ_upwind` is taken from the cell below each face for upward flow: ρʲ[i]
+at the top face and ρʲ[i−1] at the bottom face.
+
+The `(ε − δ)` piece of the recurrence is assembled inline from
+`ᶜarea_bounding_entr_detrʲs`, `ᶜentr_vel_scaleʲs`, and the buoyancy
+detrainment expression (see [`detr_buoy_inv_time_scale`](@ref)) using the
+freshly solved `u₃` from the preceding analytic solve; the
+mass-flux-divergence component of detrainment is folded into a
+multiplicative prefactor on the implicit advection term (so it is treated
+implicitly together with the flux divergence) rather than added to
+`(ε − δ)`.
+
+Surface boundary: at face ½, `u₃ = 0` (no-penetration), so the physical
+mass flux into cell 1 vanishes. To avoid NaN from `ᶠleft_bias(ᶜρʲ)`
+hitting the undefined ghost cell below the domain, `α_bot[1]` is explicitly
+overwritten to zero. The recurrence then reduces at cell 1 to
+`ρa_new[1] = ρa_old[1]/dtγ / denominator[1]`, i.e. the first cell evolves
+purely from its own forcing and from local entrainment/detrainment, with
+zero inflow from below.
+
+`denominator` is floored at `0.1/dtγ`, which is equivalent to bounding
+`(ε − δ) ≤ 0.9/dtγ` and has a similar effect as the protection previously
+provided by `limit_detrainment`. This caps the per-step growth at ≈ 10×.
+
+The sweep uses `Operators.column_accumulate!` for performance.
+"""
+function solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
+
+    p.atmos.turbconv_model isa PrognosticEDMFX || return
+
+    (; turbconv_model) = p.atmos
+    (; ᶜρ_diffʲs, ᶜρʲs) = p.precomputed
+    (; ᶠgradᵥ_ᶜΦ) = p.core
+    (; ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs) = p.precomputed
+    FT = eltype(p.params)
+
+    turbconv_params = CAP.turbconv_params(p.params)
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    ᶠJ = Fields.local_geometry_field(Y.f).J
+    ᶜdz = Fields.Δz_field(axes(Y.c))
+    ᶠdz = Fields.Δz_field(axes(Y.f))
+    ᶠlg = Fields.local_geometry_field(Y.f)
+    detr_buoy_coeff = CAP.detr_buoy_coeff(turbconv_params)
+    detr_buoy_inv_tau_max = CAP.detr_buoy_inv_tau_max(turbconv_params)
+    detr_massflux_vertdiv_coeff =
+        CAP.detr_massflux_vertdiv_coeff(turbconv_params)
+
+    # Cell-centred coefficients of the recurrence:
+    #   ᶜnumerator            = ρa_old[i] / dtγ
+    #   ᶜdenominator          = 1/dtγ + α_top · (1 − implicit_detr_prefactor) − (ε − δ)
+    #   ᶜmass_flux_factor_bot = α_bot · (1 − implicit_detr_prefactor)
+    # where α_face = (ᶠinterp(ρʲ·J)/ᶠJ · ᶠu₃ʲ/Δz_face) / (ρʲ_upwind · Δz).
+    # For upward flow the upwind density at the bottom face is ρʲ[i−1], which we
+    # extract via `ᶠleft_bias(ᶜρʲs)`. The mass-flux-divergence component of the
+    # detrainment is folded into `ᶜone_minus_implicit_detr_prefactor` (a
+    # multiplicative correction on the implicit advection term), leaving the
+    # `(ε − δ)` term to carry only the area-bounding, velocity-scale
+    # entrainment, and buoyancy-based detrainment pieces.
+    # `ᶠleft_bias`/`ᶠright_bias` (C2F) and `ᶜleft_bias`/`ᶜright_bias` (F2C) come
+    # from `abbreviations.jl`.
+    ᶜnumerator = p.scratch.ᶜtemp_scalar
+    ᶜdenominator = p.scratch.ᶜtemp_scalar_2
+    ᶜmass_flux_factor_bot = p.scratch.ᶜtemp_scalar_3
+    ᶜexplicit_entr_minus_detr = p.scratch.ᶜtemp_scalar_4
+    ᶠw = p.scratch.ᶠtemp_scalar
+
+    n = n_mass_flux_subdomains(turbconv_model)
+    for j in 1:n
+        @. ᶠw = Y.f.sgsʲs.:($$j).u₃.components.data.:1 / ᶠdz
+
+        # entr and detr
+        ᶜarea_limiter_factor = @. lazy(
+            detr_lower_area_limiter_factor(
+                draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+                turbconv_params,
+            ),
+        )
+        ᶜone_minus_implicit_detr_prefactor = @. lazy(
+            ifelse(
+                ᶜdivᵥ(ᶠleft_bias(Y.c.sgsʲs.:($$j).ρa) * Y.f.sgsʲs.:($$j).u₃) < 0,
+                FT(1) - ᶜarea_limiter_factor * detr_massflux_vertdiv_coeff,
+                FT(1),
+            ),
+        )
+        # Evaluate the inverse buoyancy time scale at faces (where w
+        # lives naturally) and interpolate to centers for smoother
+        # behaviour in the (ε − δ) term.
+        ᶜbuoy_inv_time_scale = @. lazy(
+            ᶜinterp(
+                detr_buoy_inv_time_scale(
+                    ᶠw,
+                    vertical_buoyancy_acceleration(
+                        ᶠinterp(ᶜρ_diffʲs.:($$j)),
+                        ᶠgradᵥ_ᶜΦ,
+                        ᶠlg,
+                    ),
+                    detr_buoy_inv_tau_max,
+                ),
+            ),
+        )
+        @. ᶜexplicit_entr_minus_detr =
+            ᶜarea_bounding_entr_detrʲs.:($$j) +
+            ᶜentr_vel_scaleʲs.:($$j) * ᶜinterp(ᶠw) -
+            ᶜarea_limiter_factor * detr_buoy_coeff * ᶜbuoy_inv_time_scale
+
+        @. ᶜnumerator = Y.c.sgsʲs.:($$j).ρa / dtγ
+        # Floor at 0.1 / dtγ so (ε − δ) is effectively bounded by 0.9/dtγ,
+        # mirroring the protection that the previous `limit_detrainment` call
+        # provided.
+        @. ᶜdenominator =
+            max(
+                FT(0.1) / dtγ,
+                1 / dtγ - ᶜexplicit_entr_minus_detr +
+                ᶜone_minus_implicit_detr_prefactor * ᶜright_bias(
+                    ᶠinterp(ᶜρʲs.:($$j) * ᶜJ) / ᶠJ * ᶠw,
+                ) / ᶜρʲs.:($$j) / ᶜdz,
+            )
+        @. ᶜmass_flux_factor_bot =
+            ᶜone_minus_implicit_detr_prefactor * ᶜleft_bias(
+                ᶠinterp(ᶜρʲs.:($$j) * ᶜJ) / ᶠJ * ᶠw / ᶠleft_bias(ᶜρʲs.:($$j)),
+            ) / ᶜdz
+        # At cell 1, `ᶠleft_bias(ᶜρʲ)` evaluates at the surface face where
+        # the cell below the domain is undefined → NaN. Physically the mass
+        # flux is zero there (u₃ = 0 at the surface), so we overwrite
+        # α_bot[1] with FT(0) to keep the recurrence well-defined.
+        ᶜmass_flux_factor_bot_first =
+            Fields.field_values(Fields.level(ᶜmass_flux_factor_bot, 1))
+        @. ᶜmass_flux_factor_bot_first = FT(0)
+
+        input = @. lazy(tuple(
+            ᶜnumerator,
+            ᶜdenominator,
+            ᶜmass_flux_factor_bot,
+        ))
+
+        # Bottom-to-top sweep. The zero-flux boundary at the surface is
+        # imposed by `init = FT(0)` (zero ρa below the column), so the first
+        # cell sees no inflow from below and is free to evolve.
+        Operators.column_accumulate!(
+            Y.c.sgsʲs.:($j).ρa,
+            input;
+            init = FT(0),
+        ) do ρa_prev, (num, den, mf_bot)
+            return (num + mf_bot * ρa_prev) / den
+        end
+    end
 end

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -111,7 +111,6 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
             sgs_condensate_names...,
             @name(c.sgsʲs.:(1).q_tot),
             @name(c.sgsʲs.:(1).mse),
-            @name(c.sgsʲs.:(1).ρa)
         )
     available_sgs_scalar_names =
         filter(is_in_Y, sgs_scalar_names)
@@ -226,15 +225,7 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                         similar(Y.c, TridiagonalRow),
                 available_sgs_condensate_mass_names,
             )...,
-            map(
-                name ->
-                    (@name(c.sgsʲs.:(1).ρa), name) => similar(Y.c, TridiagonalRow),
-                available_sgs_condensate_mass_names,
-            )...,
-            (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).q_tot)) =>
-                similar(Y.c, TridiagonalRow),
-            (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).mse)) =>
-                similar(Y.c, TridiagonalRow),
+            (@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).ρa)) => FT(-1) * I,
             (@name(f.sgsʲs.:(1).u₃), @name(f.sgsʲs.:(1).u₃)) => FT(-1) * I,
         )
     else
@@ -253,19 +244,11 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                 )...,
                 map(
                     name ->
-                        (name, @name(c.sgsʲs.:(1).ρa)) =>
-                            similar(Y.c, TridiagonalRow),
-                    available_tracer_names,
-                )...,
-                map(
-                    name ->
                         (name, @name(f.u₃)) =>
                             similar(Y.c, BidiagonalRow_ACT3),
                     available_condensate_names,
                 )...,
                 (@name(c.ρe_tot), @name(c.sgsʲs.:(1).mse)) =>
-                    similar(Y.c, TridiagonalRow),
-                (@name(c.ρe_tot), @name(c.sgsʲs.:(1).ρa)) =>
                     similar(Y.c, TridiagonalRow),
                 # (ρe_tot, ρ) and (ρq_tot, ρ) are needed for the mass flux Jacobian.
                 # When diffusion is implicit they already appear in diffusion_blocks;
@@ -291,12 +274,15 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     )
 
     mass_and_surface_names = (@name(c.ρ), sfc_if_available...)
+    sgs_ρa_if_available =
+        is_in_Y(@name(c.sgsʲs.:(1).ρa)) ? (@name(c.sgsʲs.:(1).ρa),) : ()
     available_scalar_names = (
         mass_and_surface_names...,
         available_tracer_names...,
         @name(c.ρe_tot),
         ρtke_if_available...,
         available_sgs_scalar_names...,
+        sgs_ρa_if_available...,
     )
 
     velocity_alg = MatrixFields.BlockLowerTriangularSolve(
@@ -321,14 +307,9 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
                     MatrixFields.BlockLowerTriangularSolve(
                         available_sgs_condensate_names...;
                         alg₂ = MatrixFields.BlockLowerTriangularSolve(
-                            @name(c.sgsʲs.:(1).q_tot);
-                            alg₂ = MatrixFields.BlockLowerTriangularSolve(
-                                @name(c.sgsʲs.:(1).mse);
-                                alg₂ = MatrixFields.BlockLowerTriangularSolve(
-                                    @name(c.sgsʲs.:(1).ρa);
-                                    alg₂ = gs_scalar_subalg,
-                                ),
-                            ),
+                            @name(c.sgsʲs.:(1).q_tot),
+                            @name(c.sgsʲs.:(1).mse);
+                            alg₂ = gs_scalar_subalg,
                         ),
                     )
                 else
@@ -818,89 +799,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                     ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1)))
                 ) - (I,)
 
-            ∂ᶜρaʲ_err_∂ᶜρaʲ =
-                matrix[@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).ρa)]
-            @. ᶜadvection_matrix =
-                -(ᶜadvdivᵥ_matrix()) ⋅
-                DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ)
-            @. ∂ᶜρaʲ_err_∂ᶜρaʲ =
-                dtγ * ᶜadvection_matrix ⋅
-                ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅
-                DiagonalMatrixRow(1 / ᶜρʲs.:(1)) - (I,)
-
-            # contribution of ρʲ variations in vertical transport of ρa and updraft buoyancy eq
-            ∂ᶜρaʲ_err_∂ᶜmseʲ =
-                matrix[@name(c.sgsʲs.:(1).ρa), @name(c.sgsʲs.:(1).mse)]
-            @. ᶠbidiagonal_matrix_ct3 =
-                DiagonalMatrixRow(
-                    ᶠset_upwind_bcs(
-                        ᶠupwind(
-                            ᶠu³ʲs.:(1),
-                            draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)),
-                        ),
-                    ) / ᶠJ,
-                ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
-                    ᶜJ * ᶜkappa_mʲ * (ᶜρʲs.:(1))^2 / ((ᶜkappa_mʲ + 1) * ᶜp),
-                )
-            @. ᶠbidiagonal_matrix_ct3_2 =
-                DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ) ⋅
-                ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅
-                DiagonalMatrixRow(
-                    Y.c.sgsʲs.:(1).ρa * ᶜkappa_mʲ / ((ᶜkappa_mʲ + 1) * ᶜp),
-                )
-            @. ∂ᶜρaʲ_err_∂ᶜmseʲ =
-                dtγ * ᶜadvdivᵥ_matrix() ⋅
-                (ᶠbidiagonal_matrix_ct3 - ᶠbidiagonal_matrix_ct3_2)
-
-            turbconv_params = CAP.turbconv_params(params)
-            α_b = CAP.pressure_normalmode_buoy_coeff1(turbconv_params)
-            ᶜ∂RmT∂qʲ = p.scratch.ᶜtemp_scalar_2
-            sgs_microphysics_tracers =
-                p.atmos.microphysics_model isa Union{
-                    NonEquilibriumMicrophysics1M,
-                    NonEquilibriumMicrophysics2M,
-                } ?
-                (
-                    (@name(c.sgsʲs.:(1).q_tot), -LH_v0, Δcp_v, ΔR_v),
-                    (@name(c.sgsʲs.:(1).q_lcl), LH_v0, Δcp_l, -R_v),
-                    (@name(c.sgsʲs.:(1).q_icl), LH_s0, Δcp_i, -R_v),
-                    (@name(c.sgsʲs.:(1).q_rai), LH_v0, Δcp_l, -R_v),
-                    (@name(c.sgsʲs.:(1).q_sno), LH_s0, Δcp_i, -R_v),
-                ) : (
-                    (@name(c.sgsʲs.:(1).q_tot), -LH_v0, Δcp_v, ΔR_v),
-                )
-
-            for (qʲ_name, LH, ∂cp∂q, ∂Rm∂q) in sgs_microphysics_tracers
-                MatrixFields.has_field(Y, qʲ_name) || continue
-
-                @. ᶜ∂RmT∂qʲ =
-                    ᶜkappa_mʲ / (ᶜkappa_mʲ + 1) * (LH - ∂cp∂q * (ᶜTʲs.:(1) - T_0)) +
-                    ∂Rm∂q * ᶜTʲs.:(1)
-
-                # ∂ᶜρaʲ_err_∂ᶜqʲ through ρʲ variations in vertical transport of ρa
-                ∂ᶜρaʲ_err_∂ᶜqʲ = matrix[@name(c.sgsʲs.:(1).ρa), qʲ_name]
-                @. ᶠbidiagonal_matrix_ct3 =
-                    DiagonalMatrixRow(
-                        ᶠset_upwind_bcs(
-                            ᶠupwind(
-                                ᶠu³ʲs.:(1),
-                                draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)),
-                            ),
-                        ) / ᶠJ,
-                    ) ⋅ ᶠinterp_matrix() ⋅ DiagonalMatrixRow(
-                        ᶜJ * (ᶜρʲs.:(1))^2 / ᶜp * ᶜ∂RmT∂qʲ,
-                    )
-                @. ᶠbidiagonal_matrix_ct3_2 =
-                    DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ) ⋅
-                    ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1))) ⋅
-                    DiagonalMatrixRow(
-                        Y.c.sgsʲs.:(1).ρa / ᶜp * ᶜ∂RmT∂qʲ,
-                    )
-                @. ∂ᶜρaʲ_err_∂ᶜqʲ =
-                    dtγ * ᶜadvdivᵥ_matrix() ⋅
-                    (ᶠbidiagonal_matrix_ct3 - ᶠbidiagonal_matrix_ct3_2)
-            end
-
             # advection and sedimentation of microphysics tracers
             if p.atmos.microphysics_model isa Union{
                 NonEquilibriumMicrophysics1M,
@@ -1013,13 +911,20 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
             end
             # entrainment and detrainment (rates are treated explicitly)
             begin # sgs_entr_detr always implicit
-                (; ᶜentrʲs, ᶜdetrʲs, ᶜturb_entrʲs) = p.precomputed
+                (; ᶜturb_entrʲs, ᶜentr_vel_scaleʲs, ᶜarea_bounding_entr_detrʲs, ᶜuʲs) =
+                    p.precomputed
+                ᶜlg = Fields.local_geometry_field(Y.c)
+                ᶜentrʲ = @. lazy(
+                    compute_entrainment(
+                        ᶜentr_vel_scaleʲs.:(1),
+                        ᶜarea_bounding_entr_detrʲs.:(1),
+                        get_physical_w(ᶜuʲs.:(1), ᶜlg),
+                    ),
+                )
                 @. ∂ᶜq_totʲ_err_∂ᶜq_totʲ -=
-                    dtγ * DiagonalMatrixRow(ᶜentrʲs.:(1) + ᶜturb_entrʲs.:(1))
+                    dtγ * DiagonalMatrixRow(ᶜentrʲ + ᶜturb_entrʲs.:(1))
                 @. ∂ᶜmseʲ_err_∂ᶜmseʲ -=
-                    dtγ * DiagonalMatrixRow(ᶜentrʲs.:(1) + ᶜturb_entrʲs.:(1))
-                @. ∂ᶜρaʲ_err_∂ᶜρaʲ +=
-                    dtγ * DiagonalMatrixRow(ᶜentrʲs.:(1) - ᶜdetrʲs.:(1))
+                    dtγ * DiagonalMatrixRow(ᶜentrʲ + ᶜturb_entrʲs.:(1))
                 if p.atmos.microphysics_model isa Union{
                     NonEquilibriumMicrophysics1M,
                     NonEquilibriumMicrophysics2M,
@@ -1037,7 +942,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
 
                         ∂ᶜqʲ_err_∂ᶜqʲ = matrix[qʲ_name, qʲ_name]
                         @. ∂ᶜqʲ_err_∂ᶜqʲ -=
-                            dtγ * DiagonalMatrixRow(ᶜentrʲs.:(1) + ᶜturb_entrʲs.:(1))
+                            dtγ * DiagonalMatrixRow(ᶜentrʲ + ᶜturb_entrʲs.:(1))
                     end
                 end
             end
@@ -1151,25 +1056,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                         ) / ᶠJ * (g³³(ᶠgⁱʲ)),
                     )
 
-                # grid-mean ∂/∂(rho*a)
-                ∂ᶜρe_tot_err_∂ᶜρa =
-                    matrix[@name(c.ρe_tot), @name(c.sgsʲs.:(1).ρa)]
-                @. ∂ᶜρe_tot_err_∂ᶜρa =
-                    dtγ * -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
-                        (ᶠu³ʲs.:(1) - ᶠu³) *
-                        ᶠinterp((Y.c.sgsʲs.:(1).mse + ᶜKʲs.:(1) - ᶜh_tot)) / ᶠJ,
-                    ) ⋅ ᶠinterp_matrix() ⋅
-                    DiagonalMatrixRow(ᶜJ)
-
-                ∂ᶜρq_tot_err_∂ᶜρa =
-                    matrix[@name(c.ρq_tot), @name(c.sgsʲs.:(1).ρa)]
-                @. ∂ᶜρq_tot_err_∂ᶜρa =
-                    dtγ * -(ᶜadvdivᵥ_matrix()) ⋅ DiagonalMatrixRow(
-                        (ᶠu³ʲs.:(1) - ᶠu³) *
-                        ᶠinterp((Y.c.sgsʲs.:(1).q_tot - ᶜq_tot)) / ᶠJ,
-                    ) ⋅ ᶠinterp_matrix() ⋅
-                    DiagonalMatrixRow(ᶜJ)
-
                 # grid-mean tracers
                 if p.atmos.microphysics_model isa Union{
                     NonEquilibriumMicrophysics1M,
@@ -1199,7 +1085,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                         microphysics_tracers,
                     ) do (ρχ_name, χʲ_name, χ_name)
                         MatrixFields.has_field(Y, ρχ_name) || return
-                        ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
 
                         ∂ᶜρχ_err_∂ᶜχʲ =
                             matrix[ρχ_name, χʲ_name]
@@ -1207,13 +1092,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                             dtγ *
                             ᶜtridiagonal_matrix ⋅
                             DiagonalMatrixRow(draft_area(Y.c.sgsʲs.:(1).ρa, ᶜρʲs.:(1)))
-
-                        ∂ᶜρχ_err_∂ᶜρa =
-                            matrix[ρχ_name, @name(c.sgsʲs.:(1).ρa)]
-                        @. ∂ᶜρχ_err_∂ᶜρa =
-                            dtγ *
-                            ᶜtridiagonal_matrix ⋅
-                            DiagonalMatrixRow(ᶜχʲ / ᶜρʲs.:(1))
 
                     end
 
@@ -1247,7 +1125,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                         microphysics_tracers,
                     ) do (ρχ_name, χʲ_name, χ_name)
                         MatrixFields.has_field(Y, ρχ_name) || return
-                        ᶜχʲ = MatrixFields.get_field(Y, χʲ_name)
                         ᶜχ⁰ = ᶜspecific_env_value(χ_name, Y, p)
 
                         ∂ᶜρχ_err_∂ᶜχʲ =
@@ -1256,25 +1133,6 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                             dtγ *
                             ᶜtridiagonal_matrix ⋅
                             DiagonalMatrixRow(-1 * Y.c.sgsʲs.:(1).ρa / ᶜρ⁰)
-
-                        ∂ᶜρχ_err_∂ᶜρa =
-                            matrix[ρχ_name, @name(c.sgsʲs.:(1).ρa)]
-                        # pull out and store for kernel performance
-                        @. ᶠbidiagonal_matrix_ct3_2 =
-                            ᶠset_tracer_upwind_matrix_bcs(
-                                ᶠtracer_upwind_matrix(CT3(sign(ᶠu³⁰_data))),
-                            ) ⋅ DiagonalMatrixRow(ᶜχ⁰ * draft_area(ᶜρa⁰, ᶜρ⁰))
-                        @. ∂ᶜρχ_err_∂ᶜρa +=
-                            dtγ *
-                            ᶜtracer_advection_matrix ⋅
-                            DiagonalMatrixRow(
-                                (ᶠu³⁰_data - ᶠu³ʲ_data) / ᶠinterp(ᶜρa⁰),
-                            ) ⋅ ᶠbidiagonal_matrix_ct3_2
-
-                        @. ∂ᶜρχ_err_∂ᶜρa +=
-                            dtγ *
-                            ᶜtridiagonal_matrix ⋅
-                            DiagonalMatrixRow(-1 * ᶜχʲ / ᶜρ⁰)
 
                         ∂ᶜρχ_err_∂ᶜρχ =
                             matrix[ρχ_name, ρχ_name]

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -46,6 +46,7 @@ const ᶜsubdivᵥ = Operators.DivergenceF2C(
 # Precipitation has no flux at the top, but it has free outflow at the bottom.
 const ᶜprecipdivᵥ = Operators.DivergenceF2C(top = Operators.SetValue(CT3(0)))
 
+const ᶠleft_bias = Operators.LeftBiasedC2F()
 const ᶠright_bias = Operators.RightBiasedC2F() # for free outflow in ᶜprecipdivᵥ
 const ᶜleft_bias = Operators.LeftBiasedF2C()
 const ᶜright_bias = Operators.RightBiasedF2C()

--- a/test/restart.jl
+++ b/test/restart.jl
@@ -109,8 +109,9 @@ function test_restart(test_dict; job_id, comms_ctx, more_ignore = Symbol[])
             # Covariance fields depend on scratch state
             :ᶜT′T′,
             :ᶜq′q′,
-            # Scratch field for prognostic EDMF (uninitialized until tendencies run)
+            # Scratch fields for prognostic EDMF (uninitialized until tendencies run)
             :ᶠu₃_tendencyʲs,
+            :ᶜρa_tendencyʲs,
             # RRTMGP internal arrays may differ due to RNG state
             rrtmgp_clear_fix...,
             # Config-specific

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -13,8 +13,8 @@ value = 1.0e-5
 [EDMF_max_area]
 value = 0.7
 
-[entr_inv_tau]
-value = 0.0001
+[turb_entr_param_vec]
+value = [0.0001, 50.0, 0.0]
 
 [entr_coeff]
 value = 0.1
@@ -25,17 +25,8 @@ value = 0.0001
 [min_area_limiter_power]
 value = 1
 
-[detr_inv_tau]
-value = 0.0001
-
-[detr_coeff]
-value = 0
-
 [detr_buoy_coeff]
 value = 1
-
-[detr_vertdiv_coeff]
-value = 0
 
 [detr_massflux_vertdiv_coeff]
 value = 1


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Refactor EDMFX entrainment/detrainment closures and solve the updraft ρa equation analytically at the IMEX implicit stage.

## Changes
  
### Implicit-stage ρa solve
  - Added solve_sgs_ρan_implicit_stage_analytic!: column forward-sweep solve via Operators.column_accumulate!, mirroring the existing analytic u₃ solve.
  - Mass-flux-divergence detrainment treated implicitly via a multiplicative prefactor on the advection term. 
  - Denominator floored at 0.1/dtγ (replaces limit_detrainment).
  - Removed explicit Yₜ.ρa += vertical_transport(...); updated manual_sparse_jacobian.jl (dropped ρa from scalar names, added trivial (ρa, ρa) => -I, removed from block-lower-triangular solve).

### Unified signed area-relaxation rate
  - Replaced ᶜentr_nonvelʲs / ᶜdetr_nonvelʲs with a single signed field ᶜarea_relax_entr_detrʲs (> 0 ⇒ entrainment, < 0 ⇒ detrainment).
  - New model-agnostic helper area_relaxing_entr_detr(turbconv_params, a), applied unconditionally.
  - compute_entrainment / compute_detrainment consume the positive / negative parts.

### Surface boundary condition
  - Rewrote set_first_cell_entr_detr_bc! with the linear form (1 − a/surface_area)/dt.
  - Dropped the a_int argument; writes a single signed value into ᶜarea_relax_entr_detrʲs.
  - Replaced entr_vel_scale with 2/dz when buoyancy flux ≥ 0.
  - Set α_bot[1] = 0 explicitly to avoid NaN at the surface ghost cell.
  
### Cleanups
  - Removed update_prognostic_edmfx_entr_detr!, the level-1 detrainment override, and the post-hoc limit_detrainment call.
  - New GPU-friendly helper detr_buoy_inv_time_scale(Δwʲ, Δbuoyʲ, detr_buoy_inv_tau_max), shared by detrainment_rate and the implicit ρa solve.
  - Added ᶠleft_bias = Operators.LeftBiasedC2F() to abbreviations.jl.
  - Split diagnostic dispatch (compute_entr / compute_detr) per turbconv model.

### Parameter / reproducibility
  - toml/prognostic_edmfx_1M.toml: entr_inv_tau → turb_entr_param_vec = [0.0001, 50.0, 0.0].
  - Bumped ref_counter.jl 354 → 355.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
