### PR TITLE
Revert to use actual column geometry instead of box

### DIFF
--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -593,11 +593,12 @@ function make_plots(::ColumnPlots, output_paths::Vector{<:AbstractString})
     short_names = ["ta", "wa"]
     vars = map_comparison(simdirs, short_names) do simdir, short_name
         var = get(simdir; short_name)
-        # Column simulations use a minimal box, so slice x,y to get 1D profiles
-        if haskey(var.dims, "x")
+        # For vertical-only (FiniteDifferenceGrid) spaces, the data may have
+        # extra singleton dimensions. Check and squeeze if needed.
+        if haskey(var.dims, "x") && length(var.dims["x"]) == 1
             var = slice(var; x = var.dims["x"][1])
         end
-        if haskey(var.dims, "y")
+        if haskey(var.dims, "y") && length(var.dims["y"]) == 1
             var = slice(var; y = var.dims["y"][1])
         end
         return var
@@ -658,17 +659,6 @@ function make_plots(
         short_name in short_names
     ]
 
-    # Column simulations use a minimal box, so slice x,y to get 1D profiles
-    vars = map(vars) do var
-        if haskey(var.dims, "x")
-            var = slice(var; x = var.dims["x"][1])
-        end
-        if haskey(var.dims, "y")
-            var = slice(var; y = var.dims["y"][1])
-        end
-        return var
-    end
-
     # We first prepare the axes with all the nice labels with ClimaAnalysis, then we use
     # CairoMakie to add the additional lines.
     fig = CairoMakie.Figure(; size = figsize)
@@ -708,13 +698,6 @@ function make_plots(
 
     # surface_precipitation
     surface_precip = get(simdir; short_name = "pr", reduction = "inst", period = "10s")
-    # Column simulations use a minimal box, so slice x,y
-    if haskey(surface_precip.dims, "x")
-        surface_precip = slice(surface_precip; x = surface_precip.dims["x"][1])
-    end
-    if haskey(surface_precip.dims, "y")
-        surface_precip = slice(surface_precip; y = surface_precip.dims["y"][1])
-    end
     viz.line_plot1D!(
         fig,
         surface_precip;
@@ -1449,8 +1432,8 @@ function make_plots(
 )
     simdirs = SimDir.(output_paths)
 
-    # All EDMF simulations use a small box for column mode
-    is_box = true
+    # Determine if this is a box or column type
+    is_box = sim_type isa Union{EDMFBoxPlots, DiagEDMFBoxPlotsWithPrecip}
 
     # Determine precipitation names based on type
     if sim_type isa DiagEDMFBoxPlotsWithPrecip

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,5 +1,4 @@
-358
-
+359
 # **README**
 #
 # What is the ref_counter?
@@ -32,6 +31,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+359
+- Use 1D vertical column instead of minimal box for `config = column`
+
 358
 - Use the same scaling factor for diffusion and hyperdiffusion of condensate and precipitation
 

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -357,21 +357,7 @@ function get_grid(parsed_args, params, context)
             kwargs...,
         )
     elseif config == "column"
-        # Use a minimal BoxGrid for column simulations (x_elem=1, y_elem=1, nh_poly=1)
-        # This provides a 2x2 horizontal grid that behaves like a single column
-        BoxGrid(
-            FT;
-            context,
-            x_elem = 1,
-            x_max = FT(1e5),  # 100 km
-            y_elem = 1,
-            y_max = FT(1e5),
-            nh_poly = 1,
-            bubble = false,
-            periodic_x = true,
-            periodic_y = true,
-            kwargs...,
-        )
+        ColumnGrid(FT; context, kwargs...)
     elseif config == "box"
         BoxGrid(
             FT;

--- a/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/non_orographic_gravity_wave.jl
@@ -15,7 +15,7 @@ non_orographic_gravity_wave_cache(Y, atmos::AtmosModel) =
 non_orographic_gravity_wave_cache(Y, ::Nothing) = (;)
 
 function non_orographic_gravity_wave_cache(Y, gw::NonOrographicGravityWave)
-    if iscolumn_or_box(axes(Y.c))
+    if iscolumn(axes(Y.c))
         FT = Spaces.undertype(axes(Y.c))
         (; source_height, Bw, Bn, Bt_0, dc, cmax, c0, nk, cw, cn) = gw
 
@@ -181,7 +181,7 @@ function non_orographic_gravity_wave_compute_tendency!(
     ᶜu = Geometry.UVVector.(Y.c.uₕ).components.data.:1
     ᶜv = Geometry.UVVector.(Y.c.uₕ).components.data.:2
 
-    if iscolumn_or_box(axes(Y.c))
+    if iscolumn(axes(Y.c))
         # source level: the index of the level that is closest to the source height
         (; gw_source_height, source_ρ_z_u_v_level) =
             p.non_orographic_gravity_wave

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -630,14 +630,6 @@ function issphere(space)
            Domains.SphereDomain
 end
 
-function isbox(space)
-    h_space = Spaces.horizontal_space(space)
-    return Meshes.domain(Spaces.topology(h_space)) isa Domains.RectangleDomain
-end
-
-# Check if space is a single-column model (true column or minimal box used as column)
-iscolumn_or_box(space) = iscolumn(space) || isbox(space)
-
 """
     clima_to_era5_name_dict()
 


### PR DESCRIPTION
This changes the `config = column` option to use an actual 1D column grid. The ref counter will need to be bumped.