### PR TITLE
Improve YAML parsing, other small fixes

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -348,6 +348,9 @@ toml:
 strict_params:
   help: "Raise an error if any overridden parameters are unused."
   value: true
+strict_config:
+  help: "If true, raise an error (instead of a warning) when the configuration contains keys that are not part of the default configuration. [`true`, `false` (default)]"
+  value: false
 prognostic_tke:
   help: "A flag for prognostic TKE [`false` (default), `true`]"
   value: false

--- a/docs/src/config_no_table.md
+++ b/docs/src/config_no_table.md
@@ -60,6 +60,21 @@ The `help` field is optional if you don't plan on making a permanent change to t
 
 See below for the full list of configuration arguments.
 
+# Environment variables
+
+A few behaviors are controlled by environment variables rather than the
+configuration file:
+
+- **`CI`**: when set (as it is on our continuous-integration tests), the
+  default output directory is `<job_id>` instead of `output/<job_id>`. Set by
+  the CI system; you normally do not need to set it yourself. (See
+  `setup_output_dir` in `src/simulation/restart.jl`.)
+
+- **`CLIMAATMOS_GC_NSTEPS`**: number of steps between manual garbage-collection
+  calls for distributed (MPI) runs. Defaults to `1000`. Only has an effect when
+  running with more than one process. (See `gc_callback` in
+  `src/callbacks/get_callbacks.jl`.)
+
 # Common Configurations
 
 ClimaAtmos provides a set of common numerical configurations that can be used as building blocks for different types of simulations. These configurations are located in `config/common_configs/` and contain standardized settings for grid resolution, time stepping, numerical schemes, and diagnostics.

--- a/docs/src/itime.md
+++ b/docs/src/itime.md
@@ -66,9 +66,10 @@ x / y
 In this section, we address how to use `ITime` instead of floating point for
 time in a ClimaAtmos simulation and how to write code with `ITime` in mind.
 
-If you are running a simulation from a YAML file, you can simply set `use_itime`
-to `true` to enable `ITime`. If you do not want to use `ITime`, then set
-`use_itime` to `false` to not use `ITime` which will use floating point instead.
+ClimaAtmos always uses `ITime` for simulation time: the time step, start time,
+and end time are converted to `ITime` when the simulation is built, regardless of
+whether they are provided as strings (e.g. `"30secs"`) or numbers. Floating-point
+simulation time is no longer supported.
 
 !!! note "Different results from rounding using `ITime`"
     If `a` is a floating point number and `t` is an `ITime`, then we round

--- a/docs/src/itime.md
+++ b/docs/src/itime.md
@@ -68,8 +68,7 @@ time in a ClimaAtmos simulation and how to write code with `ITime` in mind.
 
 ClimaAtmos always uses `ITime` for simulation time: the time step, start time,
 and end time are converted to `ITime` when the simulation is built, regardless of
-whether they are provided as strings (e.g. `"30secs"`) or numbers. Floating-point
-simulation time is no longer supported.
+whether they are provided as strings (e.g. `"30secs"`) or numbers.
 
 !!! note "Different results from rounding using `ITime`"
     If `a` is a floating point number and `t` is an `ITime`, then we round

--- a/src/callbacks/callback_helpers.jl
+++ b/src/callbacks/callback_helpers.jl
@@ -141,7 +141,7 @@ function n_steps_per_cycle_per_cb(cbs, dt)
     return map(atmos_callbacks(cbs)) do cb
         cbf = callback_frequency(cb)
         if cbf isa EveryΔt
-            cbf.Δt isa ITime ? cbf.Δt / dt : Int(ceil(cbf.Δt / dt))
+            cbf.Δt / dt
         elseif cbf isa EveryNSteps
             cbf.n
         else

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -202,15 +202,13 @@ function set_insolation_variables!(Y, p, t, ::IdealizedInsolation)
     @. rrtmgp_model.cos_zenith = (1 + FT(0.3) * (1 - 3 * sind(latitude)^2)) * FT(0.5)
 end
 
-function set_insolation_variables!(Y, p, t, tvi::TimeVaryingInsolation)
+function set_insolation_variables!(Y, p, t, ::TimeVaryingInsolation)
     FT = Spaces.undertype(axes(Y.c))
     params = p.params
     insolation_params = CAP.insolation_params(params)
     (; insolation_tuple, rrtmgp_model) = p.radiation
 
-    current_datetime =
-        t isa ITime ? ClimaUtilities.TimeManager.date(t) :
-        tvi.start_date + Dates.Second(round(Int, t)) # current time
+    current_datetime = ClimaUtilities.TimeManager.date(t)
 
     bottom_coords = Fields.coordinate_field(Spaces.level(Y.c, 1))
     cos_zenith =

--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -152,10 +152,7 @@ function parse_frequency_to_schedule(
         return CAD.DivisorSchedule(steps)
     end
 
-    date_last =
-        t_start isa ITime ?
-        ClimaUtilities.TimeManager.date(t_start) :
-        start_date + Dates.Second(t_start)
+    date_last = ClimaUtilities.TimeManager.date(t_start)
 
     if occursin("months", frequency_str)
         months = match(r"^(\d+)months$", frequency_str)
@@ -272,9 +269,7 @@ function checkpoint_callback(
         schedule = CAD.EveryCalendarDtSchedule(
             checkpoint_frequency;
             start_date,
-            date_last = t_start isa ITime ?
-                        ClimaUtilities.TimeManager.date(t_start) :
-                        start_date + Dates.Second(t_start),
+            date_last = ClimaUtilities.TimeManager.date(t_start),
         )
         cond = (u, t, integrator) -> schedule(integrator)
         affect! = (integrator) -> save_state_to_disk_func(integrator, output_dir)
@@ -329,15 +324,12 @@ function scheduled_callback(
     t_end,
     checkpoint_frequency = nothing,
 )
-    FT = typeof(dt) <: ITime ? Float64 : (dt isa AbstractFloat ? typeof(dt) : Float64)
     dt_seconds_float = time_to_seconds(dt_str)
-    dt_seconds_val = FT(dt_seconds_float)
-    dt_seconds =
-        dt isa ITime ? ITime(dt_seconds_float) : dt_seconds_val
+    dt_seconds = ITime(dt_seconds_float)
     dt_seconds, _, _, _ = promote(dt_seconds, t_start, dt, t_end)
 
     if !isnothing(checkpoint_frequency) && checkpoint_frequency != Inf
-        dt_s = Dates.Second(round(Int, dt_seconds_val))
+        dt_s = Dates.Second(round(Int, dt_seconds_float))
         if !isdivisible(checkpoint_frequency, dt_s)
             @warn "$(nameof(affect!)) period ($dt_s) is not an even divisor of the checkpoint frequency ($checkpoint_frequency). This simulation will not be reproducible when restarted."
         end

--- a/src/config/atmos_config.jl
+++ b/src/config/atmos_config.jl
@@ -7,16 +7,17 @@ A fully resolved ClimaAtmos configuration, used to build an `AtmosModel` and
 `AtmosSimulation`.
 
 # Fields
-- `toml_dict`: the merged ClimaParams TOML parameter dictionary (built by
-  `ClimaParams.create_toml_dict` from the files listed under the `toml` config
-  key). It holds the physical parameter values (with units and defaults) that
-  the model reads, as opposed to `parsed_args`, which holds the run/model
-  configuration options. `eltype(toml_dict)` determines the float type `FT`.
-- `parsed_args`: the run configuration as a `key => value` dictionary, obtained
-  by overriding `default_config.yml` with the user-supplied configuration.
-- `comms_ctx`: the `ClimaComms` context (device and MPI information).
-- `config_files`: the configuration files that were merged to build this config.
-- `job_id`: a unique identifier for the run, used e.g. for the output directory.
+
+  - `toml_dict`: the merged ClimaParams TOML parameter dictionary (built by
+    `ClimaParams.create_toml_dict` from the files listed under the `toml` config
+    key). It holds the physical parameter values (with units and defaults) that
+    the model reads, as opposed to `parsed_args`, which holds the run/model
+    configuration options. `eltype(toml_dict)` determines the float type `FT`.
+  - `parsed_args`: the run configuration as a `key => value` dictionary, obtained
+    by overriding `default_config.yml` with the user-supplied configuration.
+  - `comms_ctx`: the `ClimaComms` context (device and MPI information).
+  - `config_files`: the configuration files that were merged to build this config.
+  - `job_id`: a unique identifier for the run, used e.g. for the output directory.
 """
 struct AtmosConfig{FT, TD, PA, C, CF}
     toml_dict::TD

--- a/src/config/atmos_config.jl
+++ b/src/config/atmos_config.jl
@@ -1,5 +1,23 @@
 import ClimaParams as CP
 
+"""
+    AtmosConfig{FT, TD, PA, C, CF}
+
+A fully resolved ClimaAtmos configuration, used to build an `AtmosModel` and
+`AtmosSimulation`.
+
+# Fields
+- `toml_dict`: the merged ClimaParams TOML parameter dictionary (built by
+  `ClimaParams.create_toml_dict` from the files listed under the `toml` config
+  key). It holds the physical parameter values (with units and defaults) that
+  the model reads, as opposed to `parsed_args`, which holds the run/model
+  configuration options. `eltype(toml_dict)` determines the float type `FT`.
+- `parsed_args`: the run configuration as a `key => value` dictionary, obtained
+  by overriding `default_config.yml` with the user-supplied configuration.
+- `comms_ctx`: the `ClimaComms` context (device and MPI information).
+- `config_files`: the configuration files that were merged to build this config.
+- `job_id`: a unique identifier for the run, used e.g. for the output directory.
+"""
 struct AtmosConfig{FT, TD, PA, C, CF}
     toml_dict::TD
     parsed_args::PA
@@ -33,27 +51,30 @@ end
 """
     AtmosConfig(
         config_file::String = default_config_file;
-        job_id = job_id_from_config_file(config_file),
+        job_id = nothing,
         comms_ctx = nothing,
     )
     AtmosConfig(
         config_files::Union{NTuple{<:Any, String} ,Vector{String}};
-        job_id = job_id_from_config_files(config_files),
+        job_id = nothing,
         comms_ctx = nothing,
     )
 
 Helper function for the AtmosConfig constructor. Reads a YAML file into a Dict
 and passes it to the AtmosConfig constructor.
+
+When `job_id` is not passed explicitly, it is taken from the `job_id` key in the
+configuration (if present), and otherwise derived from the config file names.
 """
 AtmosConfig(
     config_file::String = default_config_file;
-    job_id = job_id_from_config_file(config_file),
+    job_id = nothing,
     comms_ctx = nothing,
 ) = AtmosConfig((config_file,); job_id, comms_ctx)
 
 function AtmosConfig(
     config_files::TupleOrVector(String);
-    job_id = job_id_from_config_files(config_files),
+    job_id = nothing,
     comms_ctx = nothing,
 )
 
@@ -62,6 +83,12 @@ function AtmosConfig(
     configs = map(all_config_files) do config_file
         strip_help_messages(load_yaml_file(config_file))
     end
+    # Resolve `job_id` here to derive it from the user-provided `config_files`.
+    job_id = @something(
+        job_id,
+        get(merge(configs...), "job_id", nothing),
+        job_id_from_config_files(config_files),
+    )
     return AtmosConfig(
         configs;
         comms_ctx,
@@ -87,7 +114,7 @@ function AtmosConfig(
     configs::TupleOrVector(AbstractDict);
     comms_ctx = nothing,
     config_files = [default_config_file],
-    job_id = "",
+    job_id = nothing,
 )
     config_files = map(x -> normrelpath(x), config_files)
 
@@ -95,6 +122,12 @@ function AtmosConfig(
     # relies on the fact that override_default_config uses
     # default_config_file.
     config = merge(configs...)
+    # Resolve `job_id` (before `override_default_config` drops non-schema keys)
+    job_id = @something(
+        job_id,
+        get(config, "job_id", nothing),
+        job_id_from_config_files(config_files),
+    )
     comms_ctx = isnothing(comms_ctx) ? get_comms_context(config) : comms_ctx
     config = override_default_config(config)
 

--- a/src/config/cli_options.jl
+++ b/src/config/cli_options.jl
@@ -10,7 +10,7 @@ function argparse_settings()
         arg_type = String
         default = [default_config_file]
         "--job_id"
-        help = "A unique job identifier, among all possible (parallel) running jobs."
+        help = "A unique job identifier, among all possible (parallel) running jobs. If omitted, it is taken from the `job_id` key in the configuration, or derived from the config file names."
         arg_type = String
         default = job_id_from_config_file(default_config_file)
         #! format: on

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -655,6 +655,25 @@ function check_case_consistency(parsed_args)
     turbconv = parsed_args["turbconv"]
     topography = parsed_args["topography"]
     prescribed_flow = parsed_args["prescribed_flow"]
+    config = parsed_args["config"]
+
+    # --- Geometry consistency (always checked, independent of the case-specific
+    # checks below) ---
+    valid_configs = ("sphere", "column", "box", "plane")
+    @assert(
+        config in valid_configs,
+        "Unknown `config = $(repr(config))`. Valid options are: $(join(valid_configs, ", "))."
+    )
+    # Columns use a FiniteDifference grid with no horizontal spectral-element
+    # space, so topography and the bubble correction do not apply.
+    @assert(
+        config != "column" || topography == "NoWarp",
+        "`config: column` does not support topography (got `topography: $topography`)."
+    )
+    @assert(
+        config != "column" || !parsed_args["bubble"],
+        "`config: column` does not support the bubble correction; set `bubble: false`."
+    )
 
     # ISDAC consistency: when initial_condition is ISDAC, surface/rad/external
     # forcing must all be set to the matching ISDAC variants. Subsidence,

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -654,22 +654,12 @@ function check_case_consistency(parsed_args)
     prescribed_flow = parsed_args["prescribed_flow"]
     config = parsed_args["config"]
 
-    # --- Geometry consistency (always checked, independent of the case-specific
-    # checks below) ---
+    # Geometry consistency (always checked, independent of the case-specific
+    # checks below)
     valid_configs = ("sphere", "column", "box", "plane")
     @assert(
         config in valid_configs,
         "Unknown `config = $(repr(config))`. Valid options are: $(join(valid_configs, ", "))."
-    )
-    # Columns use a FiniteDifference grid with no horizontal spectral-element
-    # space, so topography and the bubble correction do not apply.
-    @assert(
-        config != "column" || topography == "NoWarp",
-        "`config: column` does not support topography (got `topography: $topography`)."
-    )
-    @assert(
-        config != "column" || !parsed_args["bubble"],
-        "`config: column` does not support the bubble correction; set `bubble: false`."
     )
 
     # ISDAC consistency: when initial_condition is ISDAC, surface/rad/external

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -189,10 +189,7 @@ function get_insolation_form(parsed_args; setup_type = nothing)
     return if insolation == "idealized"
         IdealizedInsolation()
     elseif insolation == "timevarying"
-        # TODO: Remove this argument once we have support for integer time and
-        # we can easily convert from time to date
-        start_date = parse_date(parsed_args["start_date"])
-        TimeVaryingInsolation(start_date)
+        TimeVaryingInsolation()
     elseif insolation == "rcemipii"
         RCEMIPIIInsolation()
     elseif insolation == "gcmdriven"

--- a/src/config/yaml_helper.jl
+++ b/src/config/yaml_helper.jl
@@ -141,7 +141,8 @@ function override_default_config(config_dict::AbstractDict;)
         keys(config_dict),
     )
     if !isempty(unused_keys)
-        @warn "The configuration passed to ClimaAtmos contains unused keys: $(join(unused_keys, ", "))"
+        msg = "The configuration passed to ClimaAtmos contains unused keys: $(join(unused_keys, ", "))"
+        config["strict_config"] ? error(msg) : @warn msg
     end
 
     config == default_config && @info "Using default configuration"

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -291,10 +291,9 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
         vtt = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, dt, energy_q_tot_upwinding)
         vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, dt, Val(:none))
         @. Yₜ.c.ρq_tot += vtt - vtt_central
-        if prescribed_flow isa PrescribedFlow
-            vtt_bc = ᶜρq_tot_vertical_transport_bc(prescribed_flow, thermo_params, t, ᶠu³)
-            @. Yₜ.c.ρq_tot += vtt_bc
-        end
+        vtt_bc =
+            ᶜρq_tot_vertical_transport_bc(prescribed_flow, thermo_params, t, ᶠu³)
+        @. Yₜ.c.ρq_tot += vtt_bc
     end
 
     if isnothing(ᶠf¹²)

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -128,10 +128,9 @@ end
 Convert dt, t_start, and t_end to ITime.
 """
 function convert_time_args(dt, t_start, t_end, start_date)
-    to_seconds(t) = t isa AbstractString ? time_to_seconds(t) : Float64(t)
-    dt = ITime(to_seconds(dt))
-    t_start = ITime(to_seconds(t_start), epoch = start_date)
-    t_end = ITime(to_seconds(t_end), epoch = start_date)
+    dt = ITime(time_to_seconds(dt))
+    t_start = ITime(time_to_seconds(t_start), epoch = start_date)
+    t_end = ITime(time_to_seconds(t_end), epoch = start_date)
     # ITime(0) is added for backward compatibility (since t_start used to always be 0)
     (dt, t_start, t_end, _) = promote(dt, t_start, t_end, ITime(0))
     return (dt, t_start, t_end)
@@ -281,9 +280,8 @@ function AtmosSimulation{FT}(;
             restart_file, t_start, start_date, model, context,
         )
         # t_start is already converted from restart file, but we still need to convert dt and t_end
-        to_seconds(t) = t isa AbstractString ? time_to_seconds(t) : Float64(t)
-        dt = ITime(to_seconds(dt))
-        t_end = ITime(to_seconds(t_end), epoch = start_date)
+        dt = ITime(time_to_seconds(dt))
+        t_end = ITime(time_to_seconds(t_end), epoch = start_date)
         # Promote with t_start to ensure all have compatible types
         (dt, t_start, t_end, _) = promote(dt, t_start, t_end, ITime(0))
     else

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -57,7 +57,7 @@ function setup_diagnostics_and_writers(
 
     # Add default diagnostics if enabled
     if default
-        sim_duration = t_end isa ITime ? t_end - dt : t_end
+        sim_duration = t_end - dt
         default_diag_list = CAD.default_diagnostics(
             model,
             sim_duration,

--- a/src/simulation/restart.jl
+++ b/src/simulation/restart.jl
@@ -139,7 +139,9 @@ function setup_output_dir(
     restart_file,
     comms_ctx,
 )
-    # Set up base output directory
+    # Set up base output directory.
+    # The `CI` environment variable (set by our continuous-integration system)
+    # switches the default output location from `output/<job_id>` to `<job_id>`.
     default_output = haskey(ENV, "CI") ? job_id : joinpath("output", job_id)
     base_output_dir = isnothing(output_dir) ? default_output : output_dir
 

--- a/src/simulation/restart.jl
+++ b/src/simulation/restart.jl
@@ -50,9 +50,7 @@ function handle_restart(
     context,
 )
     # Validate t_start before restart (matches get_simulation behavior)
-    t_start_seconds =
-        t_start_original isa AbstractString ?
-        time_to_seconds(t_start_original) : Float64(t_start_original)
+    t_start_seconds = time_to_seconds(t_start_original)
     if t_start_seconds != 0
         @warn "Non zero `t_start` passed with a restarting simulation. The provided `t_start` will be ignored."
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -154,10 +154,7 @@ end
 
 abstract type AbstractInsolation end
 struct IdealizedInsolation <: AbstractInsolation end
-struct TimeVaryingInsolation <: AbstractInsolation
-    # TODO: Remove when we can easily go from time to date
-    start_date::Dates.DateTime
-end
+struct TimeVaryingInsolation <: AbstractInsolation end
 struct RCEMIPIIInsolation <: AbstractInsolation end
 struct GCMDrivenInsolation <: AbstractInsolation end
 struct ExternalTVInsolation <: AbstractInsolation end

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -332,10 +332,11 @@ Normalize a time specification to a number of seconds (`Float64`).
 
 This is the single entry point for the three time representations that flow in
 through the script and YAML interfaces:
-- `Number`: already in seconds, returned as a `Float64` (handles `Inf`).
-- `ITime`: converted to seconds.
-- `String`: parsed. Supported units: seconds, minutes, hours, days, weeks as
-`s`, `secs`, `m`, `mins`, `h`, `hours`, `d`, `days`, `weeks`.
+
+  - `Number`: already in seconds, returned as a `Float64` (handles `Inf`).
+  - `ITime`: converted to seconds.
+  - `String`: parsed. Supported units: seconds, minutes, hours, days, weeks as
+    `s`, `secs`, `m`, `mins`, `h`, `hours`, `d`, `days`, `weeks`.
 """
 time_to_seconds(t::Number) = Float64(t)
 time_to_seconds(t::ITime) = float(t)

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -3,6 +3,7 @@
 #####
 import ClimaComms
 import ClimaCore: Spaces, Topologies, Fields, Geometry, Quadratures, Grids
+import ClimaUtilities.TimeManager: ITime
 import LinearAlgebra: norm_sqr
 using Dates: DateTime, @dateformat_str
 import StaticArrays: SMatrix
@@ -324,15 +325,20 @@ onto the vertical axis.
 """
 get_physical_w(u, local_geometry) = Geometry.WVector(u, local_geometry)[1]
 
-time_to_seconds(t::Number) =
-    t == Inf ? t : error("Uncaught case in computing time from given string.")
-
 """
-    time_to_seconds(s::String)
+    time_to_seconds(t)
 
-Convert a string representing a time to seconds. Supported units: seconds, minutes, hours, days, weeks as
+Normalize a time specification to a number of seconds (`Float64`).
+
+This is the single entry point for the three time representations that flow in
+through the script and YAML interfaces:
+- `Number`: already in seconds, returned as a `Float64` (handles `Inf`).
+- `ITime`: converted to seconds.
+- `String`: parsed. Supported units: seconds, minutes, hours, days, weeks as
 `s`, `secs`, `m`, `mins`, `h`, `hours`, `d`, `days`, `weeks`.
 """
+time_to_seconds(t::Number) = Float64(t)
+time_to_seconds(t::ITime) = float(t)
 function time_to_seconds(s::String)
     s == "Inf" && return Inf
     # match a number followed by one of the supported units of time

--- a/test/restart_AtmosSimulation.jl
+++ b/test/restart_AtmosSimulation.jl
@@ -15,7 +15,6 @@ include("restart_utils.jl")
 
 function amip_target(context, output_dir)
     FT = Float32
-    start_date = DateTime(2010, 1, 1)
 
     param_dict =
         ClimaParams.create_toml_dict(
@@ -63,7 +62,7 @@ function amip_target(context, output_dir)
         deep_atmosphere,
     )
 
-    insolation = CA.TimeVaryingInsolation(start_date)
+    insolation = CA.TimeVaryingInsolation()
 
     n_updrafts = 1
     prognostic_tke = true


### PR DESCRIPTION
This PR closes #4395, addresses part of #3024

Content:
- Remove remaining support for float time. This was already disabled as an option, so this just cleans up remaining float-related code.
- Centralize time parsing with `time_to_seconds` function that uniformly converts strings, numbers, and itime.
- Don't check `isa PrescribedFlow` before running  `ᶜρq_tot_vertical_transport_bc`, it is already a no-op if `isnothing(flow)`
- Document environment variables CI and CLIMAATMOS_GC_NSTEPS and AtmosConfig struct
- Add `strict_config` option that throws an error if any unused keys are passed to a config.
- Improve `check_case_consistency` with a few more geometry checks
- Allow `job_id` to be specified in the YAML config