### PR TITLE
Remove unused artifact: DYAMOND_SUMMER_ICS_p14deg

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -75,9 +75,6 @@ lazy = true
     sha256 = "9a5efd20d68d9b954af2fd7803bccdda3fc7ef4ff60421ed13d18f768312d2e3"
     url = "https://caltech.box.com/shared/static/whn01xr83v0s4p8tc59ds3nvfsfe6ebs.gz"
 
-[DYAMOND_SUMMER_ICS_p14deg]
-git-tree-sha1 = "789c8dd160b022a6c714a102c1495530c7a9d20c"
-
 [era5_inst_model_levels]
 git-tree-sha1 = "8aae2d7330f90a029a4891be658a691e4e3362dc"
 

--- a/reproducibility_tests/test_reproducibility.jl
+++ b/reproducibility_tests/test_reproducibility.jl
@@ -27,7 +27,12 @@ if isempty(computed_rms_files)
     if isempty(dirs) # no comparable references
         bins = compute_bins()
         if isempty(bins)
-            @warn "No reproducibility data found"
+            # Finding no reference data here usually means it has not finished
+            # being generated/moved into place (or the staging step failed).
+            # Fail loudly rather than silently skipping the reproducibility
+            # check. Outside CI there is legitimately no data, so only warn.
+            msg = "No reproducibility data found"
+            debug_reproducibility() ? error(msg) : @warn msg
         else
             # Verify the ref counter was incremented
             newest_saved_dir =


### PR DESCRIPTION
This artifact isn't used anywhere. We can still keep it on central, but if it is unused there is no need to keep it listed as a dependency.