### PR TITLE
reduce ci duration for autodiff baroclinic wave

### DIFF
--- a/config/model_configs/baroclinic_wave_dense_autodiff.yml
+++ b/config/model_configs/baroclinic_wave_dense_autodiff.yml
@@ -1,8 +1,8 @@
-dt_save_state_to_disk: "2days"
+dt_save_state_to_disk: "1days"
 initial_condition: "DryBaroclinicWave"
 use_dense_jacobian: true
 update_jacobian_every: dt
-t_end: "6days"
+t_end: "2days"
 disable_surface_flux_tendency: true
 diagnostics:
   - short_name: [pfull, ua, wa, va, rv, ta, ke]

--- a/config/model_configs/baroclinic_wave_sparse_autodiff.yml
+++ b/config/model_configs/baroclinic_wave_sparse_autodiff.yml
@@ -1,9 +1,9 @@
-dt_save_state_to_disk: "2days"
+dt_save_state_to_disk: "1days"
 initial_condition: "DryBaroclinicWave"
 use_auto_jacobian: true
 update_jacobian_every: dt
 debug_jacobian: true
-t_end: "6days"
+t_end: "2days"
 disable_surface_flux_tendency: true
 diagnostics:
   - short_name: [pfull, ua, wa, va, rv, ta, ke]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
buildkite ci takes two hours because the baroclinic wave dense autodiff test times out after an hour, and then retries.

These tests are mainly used to test infrastructure, not numerics, so they do not need to be long.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
