### PR TITLE
Cloud fraction fix: bugfix sigma_S floor and smooth non-equilibrium floor

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-360
+361
 # **README**
 #
 # What is the ref_counter?
@@ -31,6 +31,14 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+361
+- SGS cloud-fraction: bugfix + smooth non-equilibrium floor. Floor `σ_S`
+  at `ϵ_numerics(FT)` instead of `sqrt(ϵ_numerics(FT))` (old floor was
+  ~1e-7 in Float32 and incorrectly clipped small `q_c`). Cloud fraction
+  now uses an augmented `σ_aug = α · sqrt(σ_S² + σ_S_fix²)` with
+  hardcoded `σ_S_fix = 1e-6` to prevent CF → 1 when both `q_c` and
+  `σ_S` are tiny. `λ_lagrange` still uses `α · σ_S` for mass conservation.
+
 360
 - Changed the default snow autoconversion to NoSupersaturation
 

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -158,13 +158,14 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    # `ᶜsgs_moments` caches `(mu_S, sigma_S_sq, λ_lagrange)` — the SGS mean saturation
-    # variable, variance, and Lagrange multiplier used by `Microphysics1MEvaluator`.
-    # Allocated only for 1M/2M microphysics schemes.
+    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange)` — the SGS mean
+    # saturation variable, the standard deviation, and the
+    # Lagrange multiplier used by `Microphysics1MEvaluator`. Allocated only
+    # for 1M/2M microphysics schemes.
     uses_microphysics_quadrature_moments =
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
-    SGSMomentsNT = @NamedTuple{mu_S::FT, sigma_S_sq::FT, λ_lagrange::FT}
+    SGSMomentsNT = @NamedTuple{mu_S::FT, sigma_S::FT, λ_lagrange::FT}
     covariance_quantities = if uses_sgs_quadrature
         base = (;
             ᶜT′T′ = zeros(axes(Y.c)),

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -255,7 +255,7 @@ end
 # SGS Moments — pre-pass quadrature
 # ============================================================================
 #
-# A Gauss-Hermite pass over the SGS PDF computes σ_S² via `_sgs_saturation_moments`,
+# A Gauss-Hermite pass over the SGS PDF computes σ_S via `_sgs_saturation_moments`,
 # which drives the truncated-Gaussian cloud-fraction and λ_lagrange closures.
 #
 # The saturation variable is ALWAYS defined as the linear excess
@@ -292,15 +292,17 @@ end
 
 
 """
-    _sgs_saturation_moments(thp, ρ, T_mean, q_tot_mean, sgs_quad, T′T′, q′q′, corr_Tq)
+    _sgs_saturation_moments(thp, ρ, T_mean, q_tot_mean,
+                            sgs_quad, T′T′, q′q′, corr_Tq)
 
-Compute μ_S = E[S] and σ_S² = Var[S] of the linear saturation excess
+Compute μ_S = E[S] and σ_S = sqrt(Var[S]) of the linear saturation excess
 S = q_tot − q_sat via a single Gauss-Hermite quadrature pass over the SGS PDF.
 
-The SGS distribution type controls how quadrature points are sampled but S is
-always the linear excess (see block comment above).
+The variance is guarded against negative values from quadrature cancellation
+(clipped at zero) and the standard deviation is floored at `ϵ_numerics(FT)`
+so the normalised closure (`C = q_c / (α·σ_S)`) is well-conditioned.
 
-Returns `(; mu_S, sigma_S_sq)`.
+Returns `(; mu_S, sigma_S)`.
 """
 @inline function _sgs_saturation_moments(
     thp, ρ, T_mean, q_tot_mean,
@@ -312,9 +314,10 @@ Returns `(; mu_S, sigma_S_sq)`.
     raw = integrate_over_sgs(
         evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
     )
+    sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, zero(FT))
     return (;
         mu_S = raw.mu_S,
-        sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, ϵ_numerics(FT)),
+        sigma_S = max(sqrt(sigma_S_sq), ϵ_numerics(FT)),
     )
 end
 
@@ -330,17 +333,32 @@ end
 #     E[max(0, λ + α·S′)] = q_c,                                     (*)
 #
 # where α = `sgs_variance_fidelity` controls how much of the SGS variance is
-# propagated into the local condensate (currently α = 1).
+# propagated into the local condensate (currently α = 1). The effective
+# scale `σ_S_eff = α · σ_S` uses the standard deviation returned by
+# `_sgs_saturation_moments` (already floored at `ϵ_numerics(FT)` to keep
+# the normalised problem well-conditioned for tiny variances).
 #
-# Introducing  z = λ / (α·σ_S)  and  C = q_c / (α·σ_S),
+# Introducing  z = λ / σ_S_eff  and  C = q_c / σ_S_eff,
 # the truncated-Gaussian expectation in (*) evaluates to:
 #
 #     C = z·Φ(z) + φ(z),
 #
-# where Φ is the standard normal CDF and φ is its PDF.  The cloud fraction
-# (fraction of the α·S′ PDF above −λ, i.e. fraction with positive shifted excess) is:
+# where Φ is the standard normal CDF and φ is its PDF.
 #
-#     CF = P(α·S′ > −λ) = Φ(λ/(α·σ_S)) = Φ(z).
+# For the *cloud fraction* we use an augmented variance with a fixed
+# non-equilibrium floor `σ_S_fix` (hardcoded inside
+# `_compute_cloud_fraction`):
+#
+#     σ_aug = α · sqrt(σ_S² + σ_S_fix²),
+#
+# which keeps CF well-behaved in the singular limit (q_c, σ_S²) → 0.  CF is
+# always computed by solving the truncated-Gaussian closure with `σ_aug`,
+# i.e. `C_aug = q_c / σ_aug`, `z_aug = _compute_z(C_aug)`, `CF = Φ(z_aug)`.
+# `λ_lagrange` is *not* used to recover CF (the natural shortcut
+# `Φ(λ/σ_aug)` would be inconsistent because `λ` is computed with the
+# equilibrium `σ_S_eff`, not `σ_aug`).  `λ_lagrange` is computed from the
+# raw `σ_S_eff` so the mass-conservation constraint (*) is preserved for
+# the microphysics tendencies.
 #
 # Inverting C = z·Φ(z)+φ(z) for z uses Newton iteration on
 # F(z) = z·Φ(z)+φ(z)−C with F′(z) = Φ(z):
@@ -348,11 +366,11 @@ end
 #     z_{n+1} = (C − φ(z_n)) / Φ(z_n).
 #
 # **Algorithm** (one Newton step with a fitted initial guess):
-# 1. Initial guess:  CF₀ = tanh(1.35·C)  [least-squares fit to exact solution],
-#                    z₀  = Φ⁻¹(CF₀)  via `normal_cdf_inv` (A&S 26.2.22).
-#    The A&S inverse correctly scales as −√(−2 ln CF₀) in the tail, avoiding
+# 1. Initial guess:  Φ(z₀) = tanh(1.35·C)  [least-squares fit to exact solution],
+#                    z₀    = Φ⁻¹(Φ(z₀))  via `normal_cdf_inv` (A&S 26.2.22).
+#    The A&S inverse correctly scales as −√(−2 ln Φ(z₀)) in the tail, avoiding
 #    the extreme underestimate of the tanh-based inverse that causes divergence.
-# 2. One Newton step:  z₁ = (C − φ(z₀)) / CF₀  (using Φ(z₀) = CF₀).
+# 2. One Newton step:  z₁ = (C − φ(z₀)) / Φ(z₀).
 # 3. CF = Φ(z₁) via `normal_cdf` (A&S 26.2.17, max error ≈ 7.5×10⁻⁸).
 
 """
@@ -366,8 +384,10 @@ condensate computation:
 
     E[max(0, λ + α·S′)] = q_c,
 
-where `S′ = S − μ_S ~ N(0, σ_S²)`.  The effective standard deviation is
-`α·σ_S`, so `C = q_c / (α·σ_S)` and `λ = z·α·σ_S`.
+where `S′ = S − μ_S ~ N(0, σ_S²)`.  The effective standard deviation used by
+the Lagrange-multiplier closure is `σ_S_eff = α · σ_S` (with `σ_S` clipped at
+`ϵ_numerics(FT)` inside [`_sgs_saturation_moments`](@ref)), so `C = q_c / σ_S_eff`
+and `λ = z · σ_S_eff`.
 
 With the default `cf_steepness_coeff = 1` this gives `α = 1` (full variance
 propagation). Increasing the steepness coefficient sharpens the CF transition
@@ -383,66 +403,62 @@ and reduces `α`.
 sgs_variance_fidelity(cf_steepness_coeff::FT) where {FT} = one(FT) / cf_steepness_coeff
 
 """
-    _compute_z(q_c, sigma_S_sq, α)
+    _compute_z(C)
 
-Compute the normalised threshold `z = λ/(α·σ_S)` that satisfies the
-truncated-Gaussian condensate relation `C = z·Φ(z) + φ(z)`, where
-`C = q_c / (α·σ_S)`, via one Newton step seeded with an analytic initial guess.
-`α` is the variance fidelity parameter from `sgs_variance_fidelity`.
+Compute the normalised threshold `z` that satisfies the truncated-Gaussian
+condensate relation `C = z·Φ(z) + φ(z)` via one Newton step seeded with an
+analytic initial guess.
 
-Does not guard against `q_c = 0`. When `q_c = 0`, `C = 0` and the initial
-guess is clamped to `ϵ_numerics(FT)`, causing `z` to become a large negative
-number (not `-Inf`, but sufficiently negative that `Φ(z)` rounds to zero at
-floating-point precision). Use `_compute_cloud_fraction` if an exact hard zero
-is required.
+`C = q_c / σ_eff` is the normalised condensate; the caller is responsible
+for computing it (typically with `σ_eff = α · σ_S` or `σ_eff = σ_aug` for
+the smooth-floored CF formula) so this helper stays free of parameter-
+dependent logic.
 """
-@inline function _compute_z(q_c, sigma_S_sq, α)
-    FT = typeof(sigma_S_sq)
-    σ_S = α * sqrt(max(sigma_S_sq, ϵ_numerics(FT)))
-    C = q_c / σ_S
+@inline function _compute_z(C)
+    FT = typeof(C)
 
-    # 1. Initial guess: CF₀ = tanh(1.35 · C)
-    cf0 = tanh(FT(1.35) * C)
-    # Upper bound must be representably less than 1: ϵ_numerics(FT) = cbrt(floatmin(FT))
-    # is so small that 1 - ϵ_numerics rounds to exactly 1.0 in floating-point, causing
-    # normal_cdf_inv(1) → log(0) → NaN. eps(FT) is the unit-roundoff at 1, so
-    # 1 - eps(FT) is always the largest Float strictly below 1.
-    cf0_safe = clamp(cf0, ϵ_numerics(FT), one(FT) - eps(FT))
+    # 1. Initial guess: Φ(z₀) = tanh(1.35 · C).
+    Φz0 = tanh(FT(1.35) * C)
+    # Upper bound must be representably less than 1: 1 - eps(FT) is the
+    # largest Float strictly below 1, avoiding normal_cdf_inv(1) → log(0) → NaN.
+    Φz0_safe = clamp(Φz0, ϵ_numerics(FT), one(FT) - eps(FT))
 
-    # z₀ = Φ⁻¹(CF₀) via A&S 26.2.22
-    z0 = normal_cdf_inv(cf0_safe)
+    # z₀ = Φ⁻¹(Φz0) via A&S 26.2.22
+    z0 = normal_cdf_inv(Φz0_safe)
 
     # 2. One Newton step: z₁ = (C − φ(z₀)) / Φ(z₀)
-    phi_z0 = exp(-z0 * z0 / 2) / sqrt(FT(2) * FT(π))
-    return (C - phi_z0) / cf0_safe
+    φz0 = exp(-z0 * z0 / 2) / sqrt(FT(2) * FT(π))
+    return (C - φz0) / Φz0_safe
 end
 
 """
-    _compute_cloud_fraction(q_c, sigma_S_sq, α)
+    _compute_cloud_fraction(q_c, sigma_S, α)
 
 Cloud fraction `CF = Φ(z)` where `z` solves the truncated-Gaussian condensate
-relation `q_c/(α·σ_S) = z·Φ(z) + φ(z)`.  Returns exactly `0` when `q_c = 0`.
-`α` is the variance fidelity parameter from `sgs_variance_fidelity`.
-"""
-@inline function _compute_cloud_fraction(q_c, sigma_S_sq, α)
-    FT = typeof(sigma_S_sq)
-    # No condensate → no cloud.
-    q_c > zero(FT) || return zero(FT)
-    return normal_cdf(_compute_z(q_c, sigma_S_sq, α))
-end
+relation `q_c/σ_aug = z·Φ(z) + φ(z)` (see [`_compute_z`](@ref)) with the
+augmented standard deviation `σ_aug = α · sqrt(σ_S² + σ_S_fix²)`.
 
+Physical motivation: we assume the local condensate `q_c` fluctuates partly
+through the equilibrium variations of (T, q_tot) captured by the quadrature
+(`σ_S` from `_sgs_saturation_moments`), and partly through additional
+non-equilibrium variations not captured by the equilibrium SGS PDF.
+`σ_S_fix` models that always-present non-equilibrium contribution. We
+include it *only* in the CF computation so that CF stays small when both
+`q_c` and the quadrature `σ_S` are small (the singular limit where the
+unmodified truncated-Gaussian gives the mathematically correct but
+physically unhelpful `CF → 1`). The Lagrange multiplier `λ` and the
+`_compute_z` call inside `_compute_sgs_moments` use only the equilibrium
+`σ_S` so that mass conservation `E[max(0, λ + α·S′)] = q_c` is exactly
+preserved for the microphysics tendencies.
 """
-    _cloud_fraction_from_lambda(λ_lagrange, sigma_S_sq, α)
-
-Recover the cloud fraction `CF = Φ(z)` from the stored Lagrange multiplier
-`λ_lagrange = z·α·σ_S` and the SGS variance `sigma_S_sq`, without re-running
-the Newton iteration.  Since `z = λ_lagrange / (α·σ_S)`, this is simply
-`normal_cdf(λ_lagrange / (α·σ_S))`.
-"""
-@inline function _cloud_fraction_from_lambda(λ_lagrange, sigma_S_sq, α)
-    FT = typeof(λ_lagrange)
-    σ_S = α * sqrt(max(sigma_S_sq, ϵ_numerics(FT)))
-    return normal_cdf(λ_lagrange / σ_S)
+@inline function _compute_cloud_fraction(q_c, sigma_S, α)
+    FT = typeof(sigma_S)
+    # TODO: promote `σ_S_fix` to a calibrated parameter once values are clear.
+    σ_S_fix = FT(1e-6)
+    σ_aug = α * sqrt(sigma_S * sigma_S + σ_S_fix * σ_S_fix)
+    C = q_c / σ_aug
+    z = _compute_z(C)
+    return normal_cdf(z)
 end
 
 """
@@ -473,31 +489,31 @@ materialized to a Field.
     moments = _sgs_saturation_moments(
         thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq,
     )
-    return _compute_cloud_fraction(q_liq + q_ice, moments.sigma_S_sq, α)
+    return _compute_cloud_fraction(q_liq + q_ice, moments.sigma_S, α)
 end
 
 """
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
-Single quadrature pass returning `(mu_S, sigma_S_sq, λ_lagrange)`:
+Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
 
   - `mu_S       = E[S]`: SGS mean saturation variable.
-  - `sigma_S_sq = Var[S]`: SGS saturation variance (used to compute CF cheaply).
-  - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying `E[max(0, λ + α·S′)] = q_c`.
-
-When `q_c = 0`, `_compute_z` gives a large-negative `z`, so `λ_lagrange` is
-a large-negative multiple of `α·σ_S`, driving the shifted excess to zero.
+  - `sigma_S    = sqrt(Var[S])`: SGS standard deviation, clipped at
+    `ϵ_numerics(FT)` (see [`_sgs_saturation_moments`](@ref)).
+  - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
+    `E[max(0, λ + α·S′)] = q_c`.
 """
 @inline function _compute_sgs_moments(
     thp, ρ, T, q_tot, q_c,
     sgs_quad, T′T′, q′q′, corr_Tq, α,
 )
-    FT = typeof(ρ)
     moments =
         _sgs_saturation_moments(thp, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq)
-    z = _compute_z(q_c, moments.sigma_S_sq, α)
-    λ_lagrange = z * α * sqrt(max(moments.sigma_S_sq, ϵ_numerics(FT)))
-    return (; moments.mu_S, moments.sigma_S_sq, λ_lagrange)
+    σ_S_eff = α * moments.sigma_S
+    C = q_c / σ_S_eff
+    z = _compute_z(C)
+    λ_lagrange = z * σ_S_eff
+    return (; moments.mu_S, moments.sigma_S, λ_lagrange)
 end
 
 """
@@ -506,9 +522,9 @@ end
 Final post-Aitken update. No-op when `ᶜsgs_moments` is not allocated (dry / 0M).
 
 Uses ONE quadrature pass via `_compute_sgs_moments` to fill
-`ᶜsgs_moments = (mu_S, sigma_S_sq, λ_lagrange)`, then recovers
-`ᶜcloud_fraction = Φ(λ/(α·σ_S))` cheaply via `_cloud_fraction_from_lambda`
-and applies EDMF updraft weighting.
+`ᶜsgs_moments = (mu_S, sigma_S, λ_lagrange)`, then computes
+`ᶜcloud_fraction` consistently with the augmented `σ_aug` closure (see
+[`_compute_cloud_fraction`](@ref)) and applies EDMF updraft weighting.
 """
 NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     hasproperty(p.precomputed, :ᶜsgs_moments) || return nothing
@@ -525,18 +541,21 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     α = sgs_variance_fidelity(CAP.cloud_fraction_steepness_scale(p.params))
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
 
-    # ONE quadrature pass → (mu_S, sigma_S_sq, λ_lagrange).
+    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange).
     @. p.precomputed.ᶜsgs_moments = _compute_sgs_moments(
         thermo_params, ᶜρ_env, ᶜT_mean, ᶜq_mean, ᶜq_lcl + ᶜq_icl,
         $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq, FT(α),
     )
-    # Cheap: recover CF from stored λ and α·σ_S — no Newton iteration.
-    # This overwrites the Picard iterate with a value consistent with the
-    # final SGS moments, so EDMF weighting must be re-applied here even
-    # though set_cloud_fraction! already applied it during Picard.
-    @. p.precomputed.ᶜcloud_fraction = _cloud_fraction_from_lambda(
-        p.precomputed.ᶜsgs_moments.λ_lagrange,
-        p.precomputed.ᶜsgs_moments.sigma_S_sq,
+    # Recompute CF from q_c and σ_S using the augmented-σ closure. We cannot
+    # use `Φ(λ/σ_aug)` because λ was computed with the equilibrium σ_S_eff,
+    # not σ_aug — `Φ(λ/σ_aug)` would not match the truncated-Gaussian
+    # closure for the augmented variance. This overwrites the Picard iterate
+    # with a value consistent with the final SGS moments, so EDMF weighting
+    # must be re-applied here even though `set_cloud_fraction!` already
+    # applied it during Picard.
+    @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
+        ᶜq_lcl + ᶜq_icl,
+        p.precomputed.ᶜsgs_moments.sigma_S,
         FT(α),
     )
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)

--- a/test/parameterized_tendencies/microphysics/allocations.jl
+++ b/test/parameterized_tendencies/microphysics/allocations.jl
@@ -86,8 +86,8 @@ end
 
 function _allocs_cloud_fraction_simple()
     FT = Float64
-    CA._compute_cloud_fraction(FT(1e-3), FT(1e-7), FT(1))
-    return @allocated CA._compute_cloud_fraction(FT(1e-3), FT(1e-7), FT(1))
+    CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(1))
+    return @allocated CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(1))
 end
 
 function _allocs_cloud_fraction_fused(thp, sgs_quad)

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -2,7 +2,8 @@
 Unit tests for cloud_fraction.jl
 
 Tests cover:
-1. `_compute_cloud_fraction(q_c, sigma_S_sq, α)` - truncated-Gaussian CF closure
+1. `_compute_cloud_fraction(q_c, sigma_S, α)` - truncated-Gaussian CF closure
+   with the smooth non-equilibrium floor (`σ_S_fix`) hardcoded inside.
 =#
 
 using Test
@@ -17,50 +18,50 @@ import ClimaAtmos as CA
                 α = FT(1)
 
                 @testset "No condensate → zero cloud fraction" begin
-                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-8), α)
-                    @test cf == FT(0)
+                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-4), α)
+                    @test cf < eps(FT)
                 end
 
                 @testset "Condensate present, nonzero sigma → cf > 0" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(1e-7), α)
+                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), α)
                     @test FT(0) < cf <= FT(1)
                 end
 
-                @testset "Zero variance, condensate present → cf ≈ 1" begin
+                @testset "Zero sigma, large condensate → cf ≈ 1" begin
+                    # σ_S = 0 ⇒ σ_aug = σ_S_fix (1e-6); C = 1e-3/1e-6 → CF ≈ 1.
                     cf = CA._compute_cloud_fraction(FT(1e-3), FT(0), α)
                     @test cf > FT(0.99)
                 end
 
-                @testset "Large condensate, small variance → cf ≈ 1" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-10), α)
+                @testset "Large condensate, small sigma → cf ≈ 1" begin
+                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-5), α)
                     @test cf > FT(0.99)
                 end
 
                 @testset "Type stability" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(1e-7), α)
+                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), α)
                     @test cf isa FT
                 end
 
-                @testset "CF monotone in σ_S² at fixed q_c" begin
-                    # Broader PDF → more unsaturated points → CF decreases toward 0.5.
+                @testset "CF monotone in σ_S at fixed q_c" begin
                     cfs = [
-                        CA._compute_cloud_fraction(FT(1e-3), σ², α) for
-                        σ² in FT[1e-9, 1e-8, 1e-7, 1e-6]
+                        CA._compute_cloud_fraction(FT(1e-3), σ, α) for
+                        σ in FT[1e-4, 3.16e-4, 1e-3, 3.16e-3]
                     ]
                     for i in 2:length(cfs)
                         @test cfs[i] <= cfs[i - 1] + FT(1e-6)
                     end
                 end
 
-                @testset "Large σ_S², small q_c → cf approaching 0" begin
-                    # C = q_c/(α·σ_S) → 0 ⟹ z → −∞ ⟹ CF = Φ(z) → 0.
-                    cf = CA._compute_cloud_fraction(FT(1e-6), FT(1e-3), α)
+                @testset "Large σ_S, small q_c → cf approaching 0" begin
+                    cf = CA._compute_cloud_fraction(FT(1e-6), FT(3.16e-2), α)
                     @test cf < FT(0.01)
                 end
 
-                @testset "σ_S² → 0 limit → cf ≈ 1 when q_c > 0" begin
-                    cf = CA._compute_cloud_fraction(FT(2e-3), FT(1e-12), α)
-                    @test cf > FT(0.99)
+                @testset "Tiny q_c with tiny σ_S → cf stays bounded (smooth floor)" begin
+                    # σ_aug ≈ σ_S_fix = 1e-6; C = q_c/1e-6 small ⇒ CF small.
+                    cf = CA._compute_cloud_fraction(FT(1e-9), FT(1e-12), α)
+                    @test cf < FT(0.51)
                 end
             end
         end

--- a/test/parameterized_tendencies/microphysics/sgs_moments.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_moments.jl
@@ -3,8 +3,8 @@ Unit tests for the SGS quadrature infrastructure.
 
 Tests `SGSMomentsEvaluator` and `_sgs_saturation_moments`, verifying:
   - S = q_tot − q_sat always, regardless of SGS distribution type
-  - σ_S² ≥ 0 and → 0 in the zero-variance limit (T′T′ = q′q′ = 0)
-  - σ_S² is monotonically increasing with σ_q
+  - σ_S ≥ ϵ_numerics in the zero-variance limit (T′T′ = q′q′ = 0)
+  - σ_S is monotonically increasing with σ_q
   - grid-mean fallback: nothing and GridMeanSGS give the same result
 =#
 
@@ -40,7 +40,7 @@ const CA = ClimaAtmos
         end
     end
 
-    @testset "_sgs_saturation_moments: zero-variance limit (σ_S² → 0)" begin
+    @testset "_sgs_saturation_moments: zero-variance limit (σ_S → ϵ_numerics)" begin
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
                 toml_dict = CP.create_toml_dict(FT)
@@ -65,14 +65,14 @@ const CA = ClimaAtmos
                     mom = CA._sgs_saturation_moments(
                         thp, ρ, T_mean, q_tot_mean, quad, FT(0), FT(0), FT(0),
                     )
-                    @test mom.sigma_S_sq ≥ 0
-                    @test mom.sigma_S_sq < FT(1e-10)
+                    @test mom.sigma_S ≥ 0
+                    @test mom.sigma_S < FT(1e-10)
                 end
             end
         end
     end
 
-    @testset "_sgs_saturation_moments: σ_S² increases monotonically with σ_q" begin
+    @testset "_sgs_saturation_moments: σ_S increases monotonically with σ_q" begin
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
                 toml_dict = CP.create_toml_dict(FT)
@@ -92,10 +92,10 @@ const CA = ClimaAtmos
                     mom = CA._sgs_saturation_moments(
                         thp, ρ, T_mean, q_tot_mean, quad, FT(0), σ_q^2, FT(0),
                     )
-                    @test mom.sigma_S_sq ≥ 0
-                    @test isfinite(mom.sigma_S_sq)
-                    @test mom.sigma_S_sq > prev
-                    prev = mom.sigma_S_sq
+                    @test mom.sigma_S ≥ 0
+                    @test isfinite(mom.sigma_S)
+                    @test mom.sigma_S > prev
+                    prev = mom.sigma_S
                 end
             end
         end
@@ -116,9 +116,9 @@ const CA = ClimaAtmos
                 m2 = CA._sgs_saturation_moments(thp, ρ, T_mean, q_tot_mean,
                     CA.GridMeanSGS(), FT(1), FT(1e-6), FT(0))
 
-                @test isfinite(m1.sigma_S_sq)
-                @test m1.sigma_S_sq ≥ 0
-                @test m2.sigma_S_sq ≈ m1.sigma_S_sq rtol = FT(1e-6)
+                @test isfinite(m1.sigma_S)
+                @test m1.sigma_S ≥ 0
+                @test m2.sigma_S ≈ m1.sigma_S rtol = FT(1e-6)
             end
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Refactor SGS cloud-fraction closure: 
 - bug fix: clip `σ_S` at `eps_numerics` instead of `sqrt(eps_numerics)`: for small `q_c` values this would result in no microphysics tendencies;
 - Use the augmented `σ_aug = α · sqrt(σ_S² + σ_S_fix²)` with hardcoded `σ_S_fix = 1e-6` to prevent CF → 1 when both `q_c` and `σ_S` are tiny.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
