### PR TITLE
Release patch v0.39.5, update .buildkite Manifest

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -150,9 +150,9 @@ version = "1.11.0"
 
 [[deps.AtmosphericProfilesLibrary]]
 deps = ["Interpolations", "LinearAlgebra"]
-git-tree-sha1 = "4f5654bb77c179b6021c21c25ad336fe886258f6"
+git-tree-sha1 = "4f22cccc46fc221f3fa36c31ea6f57098aef8632"
 uuid = "86bc3604-9858-485a-bdbe-831ec50de11d"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.Atomix]]
 deps = ["UnsafeAtomics"]
@@ -413,7 +413,7 @@ version = "0.5.22"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.39.4"
+version = "0.39.5"
 
     [deps.ClimaAtmos.extensions]
     ClimaAtmosMusica = "Musica"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+v0.39.5
+-------
+
+- [#4548](https://github.com/CliMA/ClimaAtmos.jl/pull/4548) ![][badge-✨feature/enhancement] Auto-discover SGS updraft tracers in prognostic EDMF tendency processes via `sgs_tracer_names(Y)`, so adding a passive SGS tracer no longer requires editing each tendency. New documentation in `docs/src/passive_tracers.md`.
+- [#4578](https://github.com/CliMA/ClimaAtmos.jl/pull/4578) ![][badge-🔥behavioralΔ] Add the Rayleigh sponge tendency for microphysics tracers.
+
 v0.39.4
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.39.4"
+version = "0.39.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
## Purpose

Cut patch release v0.39.5.

- Bump `Project.toml` version 0.39.4 → 0.39.5.
- Freeze the `main` section of `NEWS.md` as v0.39.5 ([#4548](https://github.com/CliMA/ClimaAtmos.jl/pull/4548) SGS tracer auto-discovery, [#4578](https://github.com/CliMA/ClimaAtmos.jl/pull/4578) microphysics Rayleigh sponge).
- `Pkg.update()` on the `.buildkite` environment (AtmosphericProfilesLibrary 0.1.7 → 0.1.8, ClimaAtmos dev version 0.39.5).

After merge, comment `@JuliaRegistrator register` on the merge commit to register; TagBot will create the `v0.39.5` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)