### PR TITLE
Fix callbacks order

### DIFF
--- a/src/callbacks/get_callbacks.jl
+++ b/src/callbacks/get_callbacks.jl
@@ -425,19 +425,21 @@ Creates the tuple of model callbacks for any AtmosModel by calling
 """
 function default_model_callbacks(model::AtmosModel; kwargs...)
     callbacks = ()
+    # Physical constraints callback is registered here rather than at the component
+    # level because the decision depends on both the microphysics model AND the
+    # turbconv model simultaneously — registering from each component independently
+    # would cause double-registration for EDMF + 1M/2M configurations.
+    # Placed before the component callbacks so it fires before any other component
+    # callback that reads cache fields (e.g. radiation)
+    if needs_enforce_physical_constraints(model)
+        callbacks = (callbacks..., enforce_physical_constraints_callback(kwargs[:dt]))
+    end
     model_component_names =
         filter(x -> x !== :disable_surface_flux_tendency, propertynames(model))
     for property in model_component_names
         component_callbacks =
             default_model_callbacks(getproperty(model, property); kwargs...)
         callbacks = (callbacks..., component_callbacks...)
-    end
-    # Physical constraints callback is registered here rather than at the component
-    # level because the decision depends on both the microphysics model AND the
-    # turbconv model simultaneously — registering from each component independently
-    # would cause double-registration for EDMF + 1M/2M configurations.
-    if needs_enforce_physical_constraints(model)
-        callbacks = (callbacks..., enforce_physical_constraints_callback(kwargs[:dt]))
     end
     return callbacks
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Run `enforce_physical_constraints` before other callbacks so they use constraint-cleaned cache. Fixes restart reproducibility (when liq and ice are present).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
