### PR TITLE
Bugfix: enforce mp constraints

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-361
+362
 # **README**
 #
 # What is the ref_counter?
@@ -31,6 +31,12 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+362
+- Use ϵ_numerics(FT) (not eps(FT)) as the threshold in enforce_grid_mean_microphysics_constraints!
+  and fall back to ratio = 0 (not 1) below it, so noise-level condensate is zeroed rather than 
+  left untouched. eps(FT) is too large for comparing agains q values close to the domain height
+  where density is small (ρq / ρ can get larger than eps)
+
 361
 - SGS cloud-fraction: bugfix + smooth non-equilibrium floor. Floor `σ_S`
   at `ϵ_numerics(FT)` instead of `sqrt(ϵ_numerics(FT))` (old floor was

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -217,9 +217,9 @@ function enforce_grid_mean_microphysics_constraints!(Y, p, t)
 
     @. ρq_cond = Y.c.ρq_lcl + Y.c.ρq_icl + Y.c.ρq_rai + Y.c.ρq_sno
     @. ratio = ifelse(
-        ρq_cond > eps(FT),
-        min(FT(1), max(FT(0), Y.c.ρq_tot) / ρq_cond),
-        FT(1),
+        (ρq_cond > ϵ_numerics(FT)) & (Y.c.ρq_tot > ϵ_numerics(FT)),
+        min(FT(1), Y.c.ρq_tot / ρq_cond),
+        FT(0),
     )
     @. Y.c.ρq_lcl *= ratio
     @. Y.c.ρq_icl *= ratio


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Use `ϵ_numerics(FT)` (not `eps(FT)`) as the threshold in `enforce_grid_mean_microphysics_constraints!`; `eps` is too large for comparing agains q values close to the domain height where density is small (`\rho q / \rho` can get larger than `eps`)
- and fall back to ratio = 0 (not 1) below it, so noise-level condensate is zeroed rather than left untouched.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
