### PR TITLE
Non-dimensionalize variance floor parameter in CF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- ![][badge-🔥behavioralΔ] Non-dimensionalize the variance floor parameter in the truncated-Gaussian cloud-fraction closure. The hardcoded `σ_S_fix = 1e-6` is replaced with a scale-aware floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that tracks local saturation humidity. Additionally, an Edgeworth skewness correction using the third central moment (`mu_3`) is added to account for asymmetric SGS moisture distributions.
+
 v0.39.5
 -------
 
@@ -41,6 +43,7 @@ v0.39.1
 
 v0.39.0
 -------
+
 - [#4486](https://github.com/CliMA/ClimaAtmos.jl/pull/4486) [badge-💥breaking]
   Updated YAML config schema:
   - `vert_diff: true` → `"VerticalDiffusion"`; `false` → `~`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
-- ![][badge-🔥behavioralΔ] Non-dimensionalize the variance floor parameter in the truncated-Gaussian cloud-fraction closure. The hardcoded `σ_S_fix = 1e-6` is replaced with a scale-aware floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that tracks local saturation humidity. Additionally, an Edgeworth skewness correction using the third central moment (`mu_3`) is added to account for asymmetric SGS moisture distributions.
+- ![][badge-🔥behavioralΔ] Non-dimensionalize the variance floor parameter in the truncated-Gaussian cloud-fraction closure. The hardcoded `σ_S_floor = 1e-6` is replaced with a scale-aware floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that tracks local saturation humidity.
 
 v0.39.5
 -------

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -32,12 +32,10 @@
 
 #=
 363
-- SGS cloud-fraction: non-dimensionalize variance floor and add Edgeworth
-  skewness correction. Replace hardcoded `σ_S_fix = 1e-6` with a
-  scale-aware floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that
-  tracks local saturation humidity. Add third-moment (`mu_3`) Edgeworth
-  correction `(γ₁/6)(z² − 1)φ(z)` to the truncated-Gaussian cloud-fraction
-  closure, accounting for asymmetric SGS moisture distributions.
+- SGS cloud-fraction: non-dimensionalize variance floor.
+  Replace hardcoded `σ_S_floor = 1e-6` with a scale-aware
+  floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that
+  tracks local saturation humidity.
 
 362
 - Use ϵ_numerics(FT) (not eps(FT)) as the threshold in enforce_grid_mean_microphysics_constraints!

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-362
+363
 # **README**
 #
 # What is the ref_counter?
@@ -31,9 +31,17 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+363
+- SGS cloud-fraction: non-dimensionalize variance floor and add Edgeworth
+  skewness correction. Replace hardcoded `σ_S_fix = 1e-6` with a
+  scale-aware floor `σ_S_floor = sqrt((ε_rel · q_sat)² + σ_abs²)` that
+  tracks local saturation humidity. Add third-moment (`mu_3`) Edgeworth
+  correction `(γ₁/6)(z² − 1)φ(z)` to the truncated-Gaussian cloud-fraction
+  closure, accounting for asymmetric SGS moisture distributions.
+
 362
 - Use ϵ_numerics(FT) (not eps(FT)) as the threshold in enforce_grid_mean_microphysics_constraints!
-  and fall back to ratio = 0 (not 1) below it, so noise-level condensate is zeroed rather than 
+  and fall back to ratio = 0 (not 1) below it, so noise-level condensate is zeroed rather than
   left untouched. eps(FT) is too large for comparing agains q values close to the domain height
   where density is small (ρq / ρ can get larger than eps)
 

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -158,14 +158,21 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange)` — the SGS mean
-    # saturation variable, the standard deviation, and the
-    # Lagrange multiplier used by `Microphysics1MEvaluator`. Allocated only
-    # for 1M/2M microphysics schemes.
+    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange, mu_3, q_sat)` — the SGS
+    # mean saturation variable, the standard deviation, the Lagrange multiplier
+    # used by `Microphysics1MEvaluator`, the third central moment (Edgeworth
+    # cloud-fraction correction), and the mean saturation specific humidity
+    # (q_sat-scaled cloud-fraction floor). Allocated only for 1M/2M schemes.
     uses_microphysics_quadrature_moments =
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
-    SGSMomentsNT = @NamedTuple{mu_S::FT, sigma_S::FT, λ_lagrange::FT}
+    SGSMomentsNT = @NamedTuple{
+        mu_S::FT,
+        sigma_S::FT,
+        λ_lagrange::FT,
+        mu_3::FT,
+        q_sat::FT,
+    }
     covariance_quantities = if uses_sgs_quadrature
         base = (;
             ᶜT′T′ = zeros(axes(Y.c)),

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -158,10 +158,9 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange, mu_3, q_sat)` — the SGS
-    # mean saturation variable, the standard deviation, the Lagrange multiplier
-    # used by `Microphysics1MEvaluator`, the third central moment (Edgeworth
-    # cloud-fraction correction), and the mean saturation specific humidity
+    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange, q_sat)` — the SGS mean
+    # saturation variable, the standard deviation, the Lagrange multiplier used
+    # by `Microphysics1MEvaluator`, and the mean saturation specific humidity
     # (q_sat-scaled cloud-fraction floor). Allocated only for 1M/2M schemes.
     uses_microphysics_quadrature_moments =
         atmos.microphysics_model isa
@@ -170,7 +169,6 @@ function precomputed_quantities(Y, atmos)
         mu_S::FT,
         sigma_S::FT,
         λ_lagrange::FT,
-        mu_3::FT,
         q_sat::FT,
     }
     covariance_quantities = if uses_sgs_quadrature

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -158,10 +158,9 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange, q_sat)` — the SGS mean
-    # saturation variable, the standard deviation, the Lagrange multiplier used
-    # by `Microphysics1MEvaluator`, and the mean saturation specific humidity
-    # (q_sat-scaled cloud-fraction floor). Allocated only for 1M/2M schemes.
+    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange)` — the SGS mean
+    # saturation variable, the standard deviation, and the Lagrange multiplier
+    # used by `Microphysics1MEvaluator`. Allocated only for 1M/2M schemes.
     uses_microphysics_quadrature_moments =
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
@@ -169,7 +168,6 @@ function precomputed_quantities(Y, atmos)
         mu_S::FT,
         sigma_S::FT,
         λ_lagrange::FT,
-        q_sat::FT,
     }
     covariance_quantities = if uses_sgs_quadrature
         base = (;

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -346,7 +346,7 @@ end
 # where Φ is the standard normal CDF and φ is its PDF.
 #
 # For the *cloud fraction* we use an augmented variance with a fixed
-# non-equilibrium floor `σ_S_floor` (hardcoded inside
+# non-equilibrium floor `σ_S_floor` (defined inside
 # `_compute_cloud_fraction`):
 #
 #     σ_aug = α · sqrt(σ_S² + σ_S_floor²),

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -575,8 +575,6 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     # with a value consistent with the final SGS moments, so EDMF weighting
     # must be re-applied here even though `set_cloud_fraction!` already
     # applied it during Picard.
-    # q_sat is computed inline here (not cached) — it's cheap and avoids
-    # adding a field to the ᶜsgs_moments named tuple.
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
         p.precomputed.ᶜsgs_moments.sigma_S,

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -287,7 +287,7 @@ end
 @inline function (eval::SGSMomentsEvaluator)(T_hat, q_tot_hat)
     q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
     s = q_tot_hat - q_sat_hat
-    return (mu_S = s, s_sq = s * s)
+    return (mu_S = s, s_sq = s * s, s_cube = s^3)
 end
 
 
@@ -302,7 +302,11 @@ The variance is guarded against negative values from quadrature cancellation
 (clipped at zero) and the standard deviation is floored at `ϵ_numerics(FT)`
 so the normalised closure (`C = q_c / (α·σ_S)`) is well-conditioned.
 
-Returns `(; mu_S, sigma_S)`.
+Also returns the third central moment `mu_3 = E[(S − μ_S)³]` (for the Edgeworth
+skewness correction in the cloud fraction) and the mean saturation specific
+humidity `q_sat` (for the `q_sat`-scaled non-equilibrium floor `σ_S_floor`).
+
+Returns `(; mu_S, sigma_S, mu_3, q_sat)`.
 """
 @inline function _sgs_saturation_moments(
     thp, ρ, T_mean, q_tot_mean,
@@ -315,9 +319,13 @@ Returns `(; mu_S, sigma_S)`.
         evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
     )
     sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, zero(FT))
+    # Third central moment: E[(S−μ_S)³] = E[S³] − 3 μ_S E[S²] + 2 μ_S³.
+    mu_3 = raw.s_cube - 3 * raw.mu_S * raw.s_sq + 2 * raw.mu_S^3
     return (;
         mu_S = raw.mu_S,
         sigma_S = max(sqrt(sigma_S_sq), ϵ_numerics(FT)),
+        mu_3 = mu_3,
+        q_sat = TD.q_vap_saturation(thp, T_mean, ρ),
     )
 end
 
@@ -346,10 +354,10 @@ end
 # where Φ is the standard normal CDF and φ is its PDF.
 #
 # For the *cloud fraction* we use an augmented variance with a fixed
-# non-equilibrium floor `σ_S_fix` (hardcoded inside
+# non-equilibrium floor `σ_S_floor` (hardcoded inside
 # `_compute_cloud_fraction`):
 #
-#     σ_aug = α · sqrt(σ_S² + σ_S_fix²),
+#     σ_aug = α · sqrt(σ_S² + σ_S_floor²),
 #
 # which keeps CF well-behaved in the singular limit (q_c, σ_S²) → 0.  CF is
 # always computed by solving the truncated-Gaussian closure with `σ_aug`,
@@ -432,33 +440,62 @@ dependent logic.
 end
 
 """
-    _compute_cloud_fraction(q_c, sigma_S, α)
+    _compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)
 
-Cloud fraction `CF = Φ(z)` where `z` solves the truncated-Gaussian condensate
-relation `q_c/σ_aug = z·Φ(z) + φ(z)` (see [`_compute_z`](@ref)) with the
-augmented standard deviation `σ_aug = α · sqrt(σ_S² + σ_S_fix²)`.
+Cloud fraction `CF = Φ(z) + (γ₁/6)(z²−1)φ(z)` (clipped to `[0,1]`), where `z`
+solves the truncated-Gaussian condensate relation `q_c/σ_aug = z·Φ(z) + φ(z)`
+(see [`_compute_z`](@ref)) with the augmented standard deviation
+`σ_aug = α · σ_eff`, `σ_eff = sqrt(σ_S² + σ_S_floor²)`.
 
-Physical motivation: we assume the local condensate `q_c` fluctuates partly
-through the equilibrium variations of (T, q_tot) captured by the quadrature
-(`σ_S` from `_sgs_saturation_moments`), and partly through additional
-non-equilibrium variations not captured by the equilibrium SGS PDF.
-`σ_S_fix` models that always-present non-equilibrium contribution. We
-include it *only* in the CF computation so that CF stays small when both
-`q_c` and the quadrature `σ_S` are small (the singular limit where the
-unmodified truncated-Gaussian gives the mathematically correct but
-physically unhelpful `CF → 1`). The Lagrange multiplier `λ` and the
-`_compute_z` call inside `_compute_sgs_moments` use only the equilibrium
-`σ_S` so that mass conservation `E[max(0, λ + α·S′)] = q_c` is exactly
-preserved for the microphysics tendencies.
+Scale-aware non-equilibrium floor. We assume the local condensate `q_c`
+fluctuates partly through the equilibrium variations of (T, q_tot) captured by
+the quadrature (`σ_S`), and partly through non-equilibrium variations not
+captured by the equilibrium SGS PDF. `σ_S_floor` models the latter and is scaled
+with the saturation specific humidity,
+
+    σ_S_floor² = (ε_rel · q_sat)² + σ_abs².
+
+The q_sat-scaling implies saturation-excess fluctuations scale with q_sat.
+The parameter `ε_rel` is a condensate-patchiness scale: it indicates the
+condensate-to-q_sat ratio at which a subdomain saturates over its full area
+(`q_c ≫ ε_rel·q_sat ⇒ CF→1`; `q_c ≪ ε_rel·q_sat ⇒` patchy, `CF→0`).
+This is loosely the critical-relative-humidity idea (subgrid humidity
+variance ∝ q_sat, `ε_rel ~ 1 − RH_crit`; Quaas, 2012,
+doi:10.1029/2012JD017495). However, this is an inexact analogy because
+the PDF here is Gaussian (rather than a bounded top-hat as in Quaas 2012),
+so there is no sharp onset, and `ε_rel` is the *intra*-subdomain width
+only; the inter-subdomain (convective) spread is carried explicitly by the
+drafts. The parameter `ε_rel` is a q_sat-scaling whose magnitude grows
+with grid spacing (RH_crit ≈ 0.6–0.85, ε_rel ≈ 0.15–0.4 at 50–200 km).
+`σ_abs` keeps `σ_eff > 0` where `q_sat → 0` (upper stratosphere).
+
+The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
+`_compute_sgs_moments`) uses the equilibrium `σ_S`, so mass conservation
+`E[max(0, λ + α·S′)] = q_c` is exactly preserved for the microphysics tendencies.
+
+Edgeworth skewness correction. Cumulus/cirrus saturation-excess distributions
+are positively skewed, where a Gaussian CDF biases CF low. The leading
+Edgeworth term adds `(γ₁/6)(z²−1)φ(z)` with `γ₁ = mu_3 / σ_eff³` clamped to
+`[−1, 1]`; it vanishes in the singular limit (`mu_3 → 0`) and recovers the
+Gaussian CF for symmetric distributions.
 """
-@inline function _compute_cloud_fraction(q_c, sigma_S, α)
+@inline function _compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)
     FT = typeof(sigma_S)
-    # TODO: promote `σ_S_fix` to a calibrated parameter once values are clear.
-    σ_S_fix = FT(1e-6)
-    σ_aug = α * sqrt(sigma_S * sigma_S + σ_S_fix * σ_S_fix)
+    # TODO: promote ε_rel, σ_abs to calibrated parameters once values are clear. 
+    # ε_rel should increase with resolution
+    ε_rel = FT(0.15)   # residual fractional saturation variability (~ 1 − RH_crit)
+    σ_abs = FT(1e-7)   # absolute floor for numerical robustness as q_sat → 0
+    σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs * σ_abs
+    σ_eff = sqrt(sigma_S * sigma_S + σ_S_floor_sq)
+    σ_aug = α * σ_eff
     C = q_c / σ_aug
     z = _compute_z(C)
-    return normal_cdf(z)
+    # Leading Edgeworth (skewness) correction; clamp γ₁ for the validity of the
+    # expansion and clip CF to [0, 1].
+    γ₁ = clamp(mu_3 / (σ_eff * σ_eff * σ_eff), -one(FT), one(FT))
+    φz = exp(-z * z / 2) / sqrt(FT(2) * FT(π))
+    cf = normal_cdf(z) + (γ₁ / 6) * (z * z - one(FT)) * φz
+    return clamp(cf, zero(FT), one(FT))
 end
 
 """
@@ -489,19 +526,23 @@ materialized to a Field.
     moments = _sgs_saturation_moments(
         thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq,
     )
-    return _compute_cloud_fraction(q_liq + q_ice, moments.sigma_S, α)
+    return _compute_cloud_fraction(
+        q_liq + q_ice, moments.sigma_S, moments.mu_3, moments.q_sat, α,
+    )
 end
 
 """
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
-Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
+Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, mu_3, q_sat)`:
 
   - `mu_S       = E[S]`: SGS mean saturation variable.
   - `sigma_S    = sqrt(Var[S])`: SGS standard deviation, clipped at
     `ϵ_numerics(FT)` (see [`_sgs_saturation_moments`](@ref)).
   - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
     `E[max(0, λ + α·S′)] = q_c`.
+  - `mu_3       = E[(S−μ_S)³]`: third central moment (Edgeworth CF correction).
+  - `q_sat`: mean saturation specific humidity (q_sat-scaled CF floor).
 """
 @inline function _compute_sgs_moments(
     thp, ρ, T, q_tot, q_c,
@@ -513,7 +554,13 @@ Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
     C = q_c / σ_S_eff
     z = _compute_z(C)
     λ_lagrange = z * σ_S_eff
-    return (; moments.mu_S, moments.sigma_S, λ_lagrange)
+    return (;
+        moments.mu_S,
+        moments.sigma_S,
+        λ_lagrange,
+        moments.mu_3,
+        moments.q_sat,
+    )
 end
 
 """
@@ -541,7 +588,7 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     α = sgs_variance_fidelity(CAP.cloud_fraction_steepness_scale(p.params))
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
 
-    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange).
+    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange, mu_3, q_sat).
     @. p.precomputed.ᶜsgs_moments = _compute_sgs_moments(
         thermo_params, ᶜρ_env, ᶜT_mean, ᶜq_mean, ᶜq_lcl + ᶜq_icl,
         $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq, FT(α),
@@ -556,6 +603,8 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
         p.precomputed.ᶜsgs_moments.sigma_S,
+        p.precomputed.ᶜsgs_moments.mu_3,
+        p.precomputed.ᶜsgs_moments.q_sat,
         FT(α),
     )
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -504,7 +504,7 @@ materialized to a Field.
     moments = _sgs_saturation_moments(
         thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq,
     )
-    q_sat = TD.q_vap_saturation(thermo_params, T, ρ)
+    q_sat = TD.q_vap_saturation(thermo_params, T, ρ, q_liq, q_ice)
     return _compute_cloud_fraction(
         q_liq + q_ice, moments.sigma_S, q_sat, α,
     )
@@ -578,7 +578,7 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
         p.precomputed.ᶜsgs_moments.sigma_S,
-        TD.q_vap_saturation(thermo_params, ᶜT_mean, ᶜρ_env),
+        TD.q_vap_saturation(thermo_params, ᶜT_mean, ᶜρ_env, ᶜq_lcl, ᶜq_icl),
         FT(α),
     )
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -302,10 +302,7 @@ The variance is guarded against negative values from quadrature cancellation
 (clipped at zero) and the standard deviation is floored at `ϵ_numerics(FT)`
 so the normalised closure (`C = q_c / (α·σ_S)`) is well-conditioned.
 
-Also returns the mean saturation specific humidity `q_sat` (for the
-`q_sat`-scaled non-equilibrium floor `σ_S_floor`).
-
-Returns `(; mu_S, sigma_S, q_sat)`.
+Returns `(; mu_S, sigma_S)`.
 """
 @inline function _sgs_saturation_moments(
     thp, ρ, T_mean, q_tot_mean,
@@ -321,7 +318,6 @@ Returns `(; mu_S, sigma_S, q_sat)`.
     return (;
         mu_S = raw.mu_S,
         sigma_S = max(sqrt(sigma_S_sq), ϵ_numerics(FT)),
-        q_sat = TD.q_vap_saturation(thp, T_mean, ρ),
     )
 end
 
@@ -460,9 +456,8 @@ doi:10.1029/2012JD017495). However, this is an inexact analogy because
 the PDF here is Gaussian (rather than a bounded top-hat as in Quaas 2012),
 so there is no sharp onset, and `ε_rel` is the *intra*-subdomain width
 only; the inter-subdomain (convective) spread is carried explicitly by the
-drafts. The parameter `ε_rel` is a q_sat-scaling whose magnitude grows
-with grid spacing (RH_crit ≈ 0.6–0.85, ε_rel ≈ 0.15–0.4 at 50–200 km).
-`σ_abs` keeps `σ_eff > 0` where `q_sat → 0` (upper stratosphere).
+drafts. The parameter `ε_rel` is a q_sat-scaling whose magnitude should grow
+with grid spacing.
 
 The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
 `_compute_sgs_moments`) uses the equilibrium `σ_S`, so mass conservation
@@ -472,10 +467,10 @@ The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
     FT = typeof(sigma_S)
     # TODO: promote ε_rel, σ_abs to calibrated parameters once values are clear.
     # ε_rel should increase with resolution
-    ε_rel = FT(0.15)   # residual fractional saturation variability (~ 1 − RH_crit)
+    ε_rel = FT(0.02)   # residual fractional saturation variability (~ 1 − RH_crit)
     σ_abs = FT(1e-7)   # absolute floor for numerical robustness as q_sat → 0
-    σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs * σ_abs
-    σ_aug = α * sqrt(sigma_S * sigma_S + σ_S_floor_sq)
+    σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs^2
+    σ_aug = α * sqrt(sigma_S^2 + σ_S_floor_sq)
     C = q_c / σ_aug
     z = _compute_z(C)
     return normal_cdf(z)
@@ -509,22 +504,22 @@ materialized to a Field.
     moments = _sgs_saturation_moments(
         thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq,
     )
+    q_sat = TD.q_vap_saturation(thermo_params, T, ρ)
     return _compute_cloud_fraction(
-        q_liq + q_ice, moments.sigma_S, moments.q_sat, α,
+        q_liq + q_ice, moments.sigma_S, q_sat, α,
     )
 end
 
 """
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
-Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, q_sat)`:
+Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
 
   - `mu_S       = E[S]`: SGS mean saturation variable.
   - `sigma_S    = sqrt(Var[S])`: SGS standard deviation, clipped at
     `ϵ_numerics(FT)` (see [`_sgs_saturation_moments`](@ref)).
   - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
     `E[max(0, λ + α·S′)] = q_c`.
-  - `q_sat`: mean saturation specific humidity (q_sat-scaled CF floor).
 """
 @inline function _compute_sgs_moments(
     thp, ρ, T, q_tot, q_c,
@@ -540,7 +535,6 @@ Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, q_sat)`:
         moments.mu_S,
         moments.sigma_S,
         λ_lagrange,
-        moments.q_sat,
     )
 end
 
@@ -569,7 +563,7 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     α = sgs_variance_fidelity(CAP.cloud_fraction_steepness_scale(p.params))
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
 
-    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange, q_sat).
+    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange).
     @. p.precomputed.ᶜsgs_moments = _compute_sgs_moments(
         thermo_params, ᶜρ_env, ᶜT_mean, ᶜq_mean, ᶜq_lcl + ᶜq_icl,
         $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq, FT(α),
@@ -581,10 +575,12 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     # with a value consistent with the final SGS moments, so EDMF weighting
     # must be re-applied here even though `set_cloud_fraction!` already
     # applied it during Picard.
+    # q_sat is computed inline here (not cached) — it's cheap and avoids
+    # adding a field to the ᶜsgs_moments named tuple.
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
         p.precomputed.ᶜsgs_moments.sigma_S,
-        p.precomputed.ᶜsgs_moments.q_sat,
+        TD.q_vap_saturation(thermo_params, ᶜT_mean, ᶜρ_env),
         FT(α),
     )
     _apply_edmf_cloud_weighting!(Y, p, turbconv_model, thermo_params)

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -287,7 +287,7 @@ end
 @inline function (eval::SGSMomentsEvaluator)(T_hat, q_tot_hat)
     q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
     s = q_tot_hat - q_sat_hat
-    return (mu_S = s, s_sq = s * s, s_cube = s^3)
+    return (mu_S = s, s_sq = s^2)
 end
 
 
@@ -302,11 +302,10 @@ The variance is guarded against negative values from quadrature cancellation
 (clipped at zero) and the standard deviation is floored at `ϵ_numerics(FT)`
 so the normalised closure (`C = q_c / (α·σ_S)`) is well-conditioned.
 
-Also returns the third central moment `mu_3 = E[(S − μ_S)³]` (for the Edgeworth
-skewness correction in the cloud fraction) and the mean saturation specific
-humidity `q_sat` (for the `q_sat`-scaled non-equilibrium floor `σ_S_floor`).
+Also returns the mean saturation specific humidity `q_sat` (for the
+`q_sat`-scaled non-equilibrium floor `σ_S_floor`).
 
-Returns `(; mu_S, sigma_S, mu_3, q_sat)`.
+Returns `(; mu_S, sigma_S, q_sat)`.
 """
 @inline function _sgs_saturation_moments(
     thp, ρ, T_mean, q_tot_mean,
@@ -319,12 +318,9 @@ Returns `(; mu_S, sigma_S, mu_3, q_sat)`.
         evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
     )
     sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, zero(FT))
-    # Third central moment: E[(S−μ_S)³] = E[S³] − 3 μ_S E[S²] + 2 μ_S³.
-    mu_3 = raw.s_cube - 3 * raw.mu_S * raw.s_sq + 2 * raw.mu_S^3
     return (;
         mu_S = raw.mu_S,
         sigma_S = max(sqrt(sigma_S_sq), ϵ_numerics(FT)),
-        mu_3 = mu_3,
         q_sat = TD.q_vap_saturation(thp, T_mean, ρ),
     )
 end
@@ -440,12 +436,11 @@ dependent logic.
 end
 
 """
-    _compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)
+    _compute_cloud_fraction(q_c, sigma_S, q_sat, α)
 
-Cloud fraction `CF = Φ(z) + (γ₁/6)(z²−1)φ(z)` (clipped to `[0,1]`), where `z`
-solves the truncated-Gaussian condensate relation `q_c/σ_aug = z·Φ(z) + φ(z)`
-(see [`_compute_z`](@ref)) with the augmented standard deviation
-`σ_aug = α · σ_eff`, `σ_eff = sqrt(σ_S² + σ_S_floor²)`.
+Cloud fraction `CF = Φ(z)`, where `z` solves the truncated-Gaussian condensate
+relation `q_c/σ_aug = z·Φ(z) + φ(z)` (see [`_compute_z`](@ref)) with the
+augmented standard deviation `σ_aug = α · sqrt(σ_S² + σ_S_floor²)`.
 
 Scale-aware non-equilibrium floor. We assume the local condensate `q_c`
 fluctuates partly through the equilibrium variations of (T, q_tot) captured by
@@ -472,30 +467,18 @@ with grid spacing (RH_crit ≈ 0.6–0.85, ε_rel ≈ 0.15–0.4 at 50–200 km)
 The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
 `_compute_sgs_moments`) uses the equilibrium `σ_S`, so mass conservation
 `E[max(0, λ + α·S′)] = q_c` is exactly preserved for the microphysics tendencies.
-
-Edgeworth skewness correction. Cumulus/cirrus saturation-excess distributions
-are positively skewed, where a Gaussian CDF biases CF low. The leading
-Edgeworth term adds `(γ₁/6)(z²−1)φ(z)` with `γ₁ = mu_3 / σ_eff³` clamped to
-`[−1, 1]`; it vanishes in the singular limit (`mu_3 → 0`) and recovers the
-Gaussian CF for symmetric distributions.
 """
-@inline function _compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)
+@inline function _compute_cloud_fraction(q_c, sigma_S, q_sat, α)
     FT = typeof(sigma_S)
-    # TODO: promote ε_rel, σ_abs to calibrated parameters once values are clear. 
+    # TODO: promote ε_rel, σ_abs to calibrated parameters once values are clear.
     # ε_rel should increase with resolution
     ε_rel = FT(0.15)   # residual fractional saturation variability (~ 1 − RH_crit)
     σ_abs = FT(1e-7)   # absolute floor for numerical robustness as q_sat → 0
     σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs * σ_abs
-    σ_eff = sqrt(sigma_S * sigma_S + σ_S_floor_sq)
-    σ_aug = α * σ_eff
+    σ_aug = α * sqrt(sigma_S * sigma_S + σ_S_floor_sq)
     C = q_c / σ_aug
     z = _compute_z(C)
-    # Leading Edgeworth (skewness) correction; clamp γ₁ for the validity of the
-    # expansion and clip CF to [0, 1].
-    γ₁ = clamp(mu_3 / (σ_eff * σ_eff * σ_eff), -one(FT), one(FT))
-    φz = exp(-z * z / 2) / sqrt(FT(2) * FT(π))
-    cf = normal_cdf(z) + (γ₁ / 6) * (z * z - one(FT)) * φz
-    return clamp(cf, zero(FT), one(FT))
+    return normal_cdf(z)
 end
 
 """
@@ -527,21 +510,20 @@ materialized to a Field.
         thermo_params, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq,
     )
     return _compute_cloud_fraction(
-        q_liq + q_ice, moments.sigma_S, moments.mu_3, moments.q_sat, α,
+        q_liq + q_ice, moments.sigma_S, moments.q_sat, α,
     )
 end
 
 """
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
-Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, mu_3, q_sat)`:
+Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, q_sat)`:
 
   - `mu_S       = E[S]`: SGS mean saturation variable.
   - `sigma_S    = sqrt(Var[S])`: SGS standard deviation, clipped at
     `ϵ_numerics(FT)` (see [`_sgs_saturation_moments`](@ref)).
   - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
     `E[max(0, λ + α·S′)] = q_c`.
-  - `mu_3       = E[(S−μ_S)³]`: third central moment (Edgeworth CF correction).
   - `q_sat`: mean saturation specific humidity (q_sat-scaled CF floor).
 """
 @inline function _compute_sgs_moments(
@@ -558,7 +540,6 @@ Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange, mu_3, q_sat)`:
         moments.mu_S,
         moments.sigma_S,
         λ_lagrange,
-        moments.mu_3,
         moments.q_sat,
     )
 end
@@ -588,7 +569,7 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     α = sgs_variance_fidelity(CAP.cloud_fraction_steepness_scale(p.params))
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
 
-    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange, mu_3, q_sat).
+    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange, q_sat).
     @. p.precomputed.ᶜsgs_moments = _compute_sgs_moments(
         thermo_params, ᶜρ_env, ᶜT_mean, ᶜq_mean, ᶜq_lcl + ᶜq_icl,
         $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq, FT(α),
@@ -603,7 +584,6 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
         p.precomputed.ᶜsgs_moments.sigma_S,
-        p.precomputed.ᶜsgs_moments.mu_3,
         p.precomputed.ᶜsgs_moments.q_sat,
         FT(α),
     )

--- a/test/parameterized_tendencies/microphysics/allocations.jl
+++ b/test/parameterized_tendencies/microphysics/allocations.jl
@@ -86,8 +86,14 @@ end
 
 function _allocs_cloud_fraction_simple()
     FT = Float64
-    CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(1))
-    return @allocated CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(1))
+    CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(0), FT(5e-5), FT(1))
+    return @allocated CA._compute_cloud_fraction(
+        FT(1e-3),
+        FT(3.16e-4),
+        FT(0),
+        FT(5e-5),
+        FT(1),
+    )
 end
 
 function _allocs_cloud_fraction_fused(thp, sgs_quad)

--- a/test/parameterized_tendencies/microphysics/allocations.jl
+++ b/test/parameterized_tendencies/microphysics/allocations.jl
@@ -86,11 +86,10 @@ end
 
 function _allocs_cloud_fraction_simple()
     FT = Float64
-    CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(0), FT(5e-5), FT(1))
+    CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), FT(5e-5), FT(1))
     return @allocated CA._compute_cloud_fraction(
         FT(1e-3),
         FT(3.16e-4),
-        FT(0),
         FT(5e-5),
         FT(1),
     )

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -2,7 +2,7 @@
 Unit tests for cloud_fraction.jl
 
 Tests cover:
-1. `_compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)` - truncated-Gaussian CF closure
+1. `_compute_cloud_fraction(q_c, sigma_S, q_sat, α)` - truncated-Gaussian CF closure
    with the smooth non-equilibrium floor (`σ_S_floor`) hardcoded inside.
 =#
 
@@ -18,7 +18,7 @@ import ClimaAtmos as CA
                 α = FT(1)
 
                 @testset "No condensate → zero cloud fraction" begin
-                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-4), FT(0), FT(5e-5), α)
+                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-4), FT(5e-5), α)
                     @test cf < eps(FT)
                 end
 
@@ -26,7 +26,6 @@ import ClimaAtmos as CA
                     cf = CA._compute_cloud_fraction(
                         FT(1e-3),
                         FT(3.16e-4),
-                        FT(0),
                         FT(5e-5),
                         α,
                     )
@@ -34,13 +33,14 @@ import ClimaAtmos as CA
                 end
 
                 @testset "Zero sigma, large condensate → cf ≈ 1" begin
-                    # σ_S = 0 ⇒ σ_aug = σ_S_floor (1e-6); C = 1e-3/1e-6 → CF ≈ 1.
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(0), FT(0), FT(5e-5), α)
+                    # σ_S = 0 ⇒ σ_aug = σ_S_floor = √((ε_rel·q_sat)² + σ_abs²)
+                    # ≈ 0.15·5e-5 = 7.5e-6; C = 1e-3/7.5e-6 ≫ 1 → CF ≈ 1.
+                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(0), FT(5e-5), α)
                     @test cf > FT(0.99)
                 end
 
                 @testset "Large condensate, small sigma → cf ≈ 1" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-5), FT(0), FT(5e-5), α)
+                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-5), FT(5e-5), α)
                     @test cf > FT(0.99)
                 end
 
@@ -48,7 +48,6 @@ import ClimaAtmos as CA
                     cf = CA._compute_cloud_fraction(
                         FT(1e-3),
                         FT(3.16e-4),
-                        FT(0),
                         FT(5e-5),
                         α,
                     )
@@ -57,7 +56,7 @@ import ClimaAtmos as CA
 
                 @testset "CF monotone in σ_S at fixed q_c" begin
                     cfs = [
-                        CA._compute_cloud_fraction(FT(1e-3), σ, FT(0), FT(5e-5), α) for
+                        CA._compute_cloud_fraction(FT(1e-3), σ, FT(5e-5), α) for
                         σ in FT[1e-4, 3.16e-4, 1e-3, 3.16e-3]
                     ]
                     for i in 2:length(cfs)
@@ -69,7 +68,6 @@ import ClimaAtmos as CA
                     cf = CA._compute_cloud_fraction(
                         FT(1e-6),
                         FT(3.16e-2),
-                        FT(0),
                         FT(5e-5),
                         α,
                     )
@@ -77,8 +75,8 @@ import ClimaAtmos as CA
                 end
 
                 @testset "Tiny q_c with tiny σ_S → cf stays bounded (smooth floor)" begin
-                    # σ_aug ≈ σ_S_floor = 1e-6; C = q_c/1e-6 small ⇒ CF small.
-                    cf = CA._compute_cloud_fraction(FT(1e-9), FT(1e-12), FT(0), FT(5e-5), α)
+                    # σ_aug ≈ σ_S_floor ≈ 7.5e-6; C = q_c/σ_aug small ⇒ CF small.
+                    cf = CA._compute_cloud_fraction(FT(1e-9), FT(1e-12), FT(5e-5), α)
                     @test cf < FT(0.51)
                 end
             end

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -2,8 +2,8 @@
 Unit tests for cloud_fraction.jl
 
 Tests cover:
-1. `_compute_cloud_fraction(q_c, sigma_S, α)` - truncated-Gaussian CF closure
-   with the smooth non-equilibrium floor (`σ_S_fix`) hardcoded inside.
+1. `_compute_cloud_fraction(q_c, sigma_S, mu_3, q_sat, α)` - truncated-Gaussian CF closure
+   with the smooth non-equilibrium floor (`σ_S_floor`) hardcoded inside.
 =#
 
 using Test
@@ -18,34 +18,46 @@ import ClimaAtmos as CA
                 α = FT(1)
 
                 @testset "No condensate → zero cloud fraction" begin
-                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-4), α)
+                    cf = CA._compute_cloud_fraction(FT(0), FT(1e-4), FT(0), FT(5e-5), α)
                     @test cf < eps(FT)
                 end
 
                 @testset "Condensate present, nonzero sigma → cf > 0" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), α)
+                    cf = CA._compute_cloud_fraction(
+                        FT(1e-3),
+                        FT(3.16e-4),
+                        FT(0),
+                        FT(5e-5),
+                        α,
+                    )
                     @test FT(0) < cf <= FT(1)
                 end
 
                 @testset "Zero sigma, large condensate → cf ≈ 1" begin
-                    # σ_S = 0 ⇒ σ_aug = σ_S_fix (1e-6); C = 1e-3/1e-6 → CF ≈ 1.
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(0), α)
+                    # σ_S = 0 ⇒ σ_aug = σ_S_floor (1e-6); C = 1e-3/1e-6 → CF ≈ 1.
+                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(0), FT(0), FT(5e-5), α)
                     @test cf > FT(0.99)
                 end
 
                 @testset "Large condensate, small sigma → cf ≈ 1" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-5), α)
+                    cf = CA._compute_cloud_fraction(FT(1e-2), FT(1e-5), FT(0), FT(5e-5), α)
                     @test cf > FT(0.99)
                 end
 
                 @testset "Type stability" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-3), FT(3.16e-4), α)
+                    cf = CA._compute_cloud_fraction(
+                        FT(1e-3),
+                        FT(3.16e-4),
+                        FT(0),
+                        FT(5e-5),
+                        α,
+                    )
                     @test cf isa FT
                 end
 
                 @testset "CF monotone in σ_S at fixed q_c" begin
                     cfs = [
-                        CA._compute_cloud_fraction(FT(1e-3), σ, α) for
+                        CA._compute_cloud_fraction(FT(1e-3), σ, FT(0), FT(5e-5), α) for
                         σ in FT[1e-4, 3.16e-4, 1e-3, 3.16e-3]
                     ]
                     for i in 2:length(cfs)
@@ -54,13 +66,19 @@ import ClimaAtmos as CA
                 end
 
                 @testset "Large σ_S, small q_c → cf approaching 0" begin
-                    cf = CA._compute_cloud_fraction(FT(1e-6), FT(3.16e-2), α)
+                    cf = CA._compute_cloud_fraction(
+                        FT(1e-6),
+                        FT(3.16e-2),
+                        FT(0),
+                        FT(5e-5),
+                        α,
+                    )
                     @test cf < FT(0.01)
                 end
 
                 @testset "Tiny q_c with tiny σ_S → cf stays bounded (smooth floor)" begin
-                    # σ_aug ≈ σ_S_fix = 1e-6; C = q_c/1e-6 small ⇒ CF small.
-                    cf = CA._compute_cloud_fraction(FT(1e-9), FT(1e-12), α)
+                    # σ_aug ≈ σ_S_floor = 1e-6; C = q_c/1e-6 small ⇒ CF small.
+                    cf = CA._compute_cloud_fraction(FT(1e-9), FT(1e-12), FT(0), FT(5e-5), α)
                     @test cf < FT(0.51)
                 end
             end


### PR DESCRIPTION
## Purpose 
Replace the hardcoded `σ_S_fix = 1e-6` in the truncated-Gaussian cloud-fraction closure with a scale-aware floor `σ_S_fix = sqrt((ε_rel · q_sat)² + σ_abs²)`, proportional to local saturation humidity. This prevents the absolute threshold from over-suppressing cirrus where `q_sat` is small.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
