### PR TITLE
Auto-discovery of tracers for hyperdiff tendency

### DIFF
--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -46,23 +46,10 @@ function hyperdiffusion_cache(
 
     # Sub-grid scale quantities
     ᶜ∇²uʲs = turbconv_model isa PrognosticEDMFX ? similar(Y.c, NTuple{n, C123{FT}}) : (;)
-    moisture_sgs_quantities =
-        microphysics_model isa NonEquilibriumMicrophysics1M ?
-        (;
-            ᶜ∇²q_lclʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_iclʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_raiʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_snoʲs = similar(Y.c, NTuple{n, FT}),
-        ) :
-        microphysics_model isa NonEquilibriumMicrophysics2M ?
-        (;
-            ᶜ∇²q_lclʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_iclʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_raiʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²q_snoʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²n_lclʲs = similar(Y.c, NTuple{n, FT}),
-            ᶜ∇²n_raiʲs = similar(Y.c, NTuple{n, FT}),
-        ) : (;)
+    # Single reusable scratch field for auto-discovered SGS tracers
+    sgs_tracer_hyperdiff =
+        turbconv_model isa PrognosticEDMFX && !isempty(sgs_tracer_names(Y)) ?
+        (; ᶜ∇²sgs_tracerʲs = similar(Y.c, NTuple{n, FT})) : (;)
     sgs_quantities =
         turbconv_model isa PrognosticEDMFX ?
         (;
@@ -70,7 +57,7 @@ function hyperdiffusion_cache(
             ᶜ∇²uᵥʲs = similar(Y.c, NTuple{n, C3{FT}}),
             ᶜ∇²mseʲs = similar(Y.c, NTuple{n, FT}),
             ᶜ∇²q_totʲs = similar(Y.c, NTuple{n, FT}),
-            moisture_sgs_quantities...,
+            sgs_tracer_hyperdiff...,
         ) : (;)
     maybe_ᶜ∇²tke =
         use_prognostic_tke(turbconv_model) ? (; ᶜ∇²tke = similar(Y.c, FT)) : (;)
@@ -217,26 +204,7 @@ function dss_hyperdiffusion_tendency_pairs(p)
     tc_tracer_pairs =
         turbconv_model isa PrognosticEDMFX ?
         (p.hyperdiff.ᶜ∇²q_totʲs => buffer.ᶜ∇²q_totʲs,) : ()
-    tc_moisture_pairs =
-        turbconv_model isa PrognosticEDMFX &&
-        p.atmos.microphysics_model isa NonEquilibriumMicrophysics1M ?
-        (
-            p.hyperdiff.ᶜ∇²q_lclʲs => buffer.ᶜ∇²q_lclʲs,
-            p.hyperdiff.ᶜ∇²q_iclʲs => buffer.ᶜ∇²q_iclʲs,
-            p.hyperdiff.ᶜ∇²q_raiʲs => buffer.ᶜ∇²q_raiʲs,
-            p.hyperdiff.ᶜ∇²q_snoʲs => buffer.ᶜ∇²q_snoʲs,
-        ) :
-        turbconv_model isa PrognosticEDMFX &&
-        p.atmos.microphysics_model isa NonEquilibriumMicrophysics2M ?
-        (
-            p.hyperdiff.ᶜ∇²q_lclʲs => buffer.ᶜ∇²q_lclʲs,
-            p.hyperdiff.ᶜ∇²q_iclʲs => buffer.ᶜ∇²q_iclʲs,
-            p.hyperdiff.ᶜ∇²q_raiʲs => buffer.ᶜ∇²q_raiʲs,
-            p.hyperdiff.ᶜ∇²q_snoʲs => buffer.ᶜ∇²q_snoʲs,
-            p.hyperdiff.ᶜ∇²n_lclʲs => buffer.ᶜ∇²n_lclʲs,
-            p.hyperdiff.ᶜ∇²n_raiʲs => buffer.ᶜ∇²n_raiʲs,
-        ) : ()
-    tracer_pairs = (core_tracer_pairs..., tc_tracer_pairs..., tc_moisture_pairs...)
+    tracer_pairs = (core_tracer_pairs..., tc_tracer_pairs...)
     return (dynamics_pairs..., tracer_pairs...)
 end
 
@@ -260,28 +228,6 @@ NVTX.@annotate function prep_tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
         for j in 1:n
             # Note: It is more correct to have ρa inside and outside the divergence
             @. ᶜ∇²q_totʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_tot))
-        end
-        if microphysics_model isa NonEquilibriumMicrophysics1M
-            (; ᶜ∇²q_lclʲs, ᶜ∇²q_iclʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs) = p.hyperdiff
-            for j in 1:n
-                # Note: It is more correct to have ρa inside and outside the divergence
-                @. ᶜ∇²q_lclʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_lcl))
-                @. ᶜ∇²q_iclʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_icl))
-                @. ᶜ∇²q_raiʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_rai))
-                @. ᶜ∇²q_snoʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_sno))
-            end
-        elseif microphysics_model isa NonEquilibriumMicrophysics2M
-            (; ᶜ∇²q_lclʲs, ᶜ∇²q_iclʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs, ᶜ∇²n_lclʲs, ᶜ∇²n_raiʲs) =
-                p.hyperdiff
-            for j in 1:n
-                # Note: It is more correct to have ρa inside and outside the divergence
-                @. ᶜ∇²q_lclʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_lcl))
-                @. ᶜ∇²q_iclʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_icl))
-                @. ᶜ∇²q_raiʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_rai))
-                @. ᶜ∇²q_snoʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_sno))
-                @. ᶜ∇²n_lclʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).n_lcl))
-                @. ᶜ∇²n_raiʲs.:($$j) = wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).n_rai))
-            end
         end
     end
     return nothing
@@ -325,34 +271,35 @@ NVTX.@annotate function apply_tracer_hyperdiffusion_tendency!(Yₜ, Y, p, t)
                 ν₄_scalar * Y.c.sgsʲs.:($$j).ρa / (1 - Y.c.sgsʲs.:($$j).q_tot) *
                 wdivₕ(gradₕ(ᶜ∇²q_totʲs.:($$j)))
         end
-        if microphysics_model isa NonEquilibriumMicrophysics1M
-            (; ᶜ∇²q_lclʲs, ᶜ∇²q_iclʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs) = p.hyperdiff
-            for j in 1:n
-                @. Yₜ.c.sgsʲs.:($$j).q_lcl -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_lclʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_icl -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_iclʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_rai -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_raiʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_sno -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_snoʲs.:($$j)))
-            end
-        elseif microphysics_model isa NonEquilibriumMicrophysics2M
-            (; ᶜ∇²q_lclʲs, ᶜ∇²q_iclʲs, ᶜ∇²q_raiʲs, ᶜ∇²q_snoʲs, ᶜ∇²n_lclʲs, ᶜ∇²n_raiʲs) =
-                p.hyperdiff
-            for j in 1:n
-                @. Yₜ.c.sgsʲs.:($$j).q_lcl -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_lclʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_icl -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_iclʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).n_lcl -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²n_lclʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_rai -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_raiʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).q_sno -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²q_snoʲs.:($$j)))
-                @. Yₜ.c.sgsʲs.:($$j).n_rai -=
-                    ν₄_scalar_microphysics * wdivₕ(gradₕ(ᶜ∇²n_raiʲs.:($$j)))
+        # Auto-discovered SGS tracers: prep → DSS → apply per tracer,
+        # reusing a single scratch field.
+        if !isempty(sgs_tracer_names(Y))
+            _microphysics_names = (
+                @name(q_lcl), @name(q_icl), @name(q_rai),
+                @name(q_sno), @name(n_lcl), @name(n_rai),
+            )
+            (; ᶜ∇²sgs_tracerʲs) = p.hyperdiff
+            for χ_name in sgs_tracer_names(Y)
+                for j in 1:n
+                    # Prep: compute ∇²χ
+                    ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:($j), χ_name)
+                    # Note: It is more correct to have ρa inside and outside the divergence
+                    @. ᶜ∇²sgs_tracerʲs.:($$j) = wdivₕ(gradₕ(ᶜχʲ))
+                end
+                # DSS
+                if do_dss(axes(Y.c))
+                    Spaces.weighted_dss!(
+                        ᶜ∇²sgs_tracerʲs =>
+                            p.hyperdiff.hyperdiffusion_ghost_buffer.ᶜ∇²sgs_tracerʲs,
+                    )
+                end
+                # Apply: ∇⁴χ tendency
+                ν = χ_name in _microphysics_names ?
+                    ν₄_scalar_microphysics : ν₄_scalar
+                for j in 1:n
+                    ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:($j), χ_name)
+                    @. ᶜχʲₜ -= ν * wdivₕ(gradₕ(ᶜ∇²sgs_tracerʲs.:($$j)))
+                end
             end
         end
     end


### PR DESCRIPTION
Adds a generic loop over `sgs_tracer_names(Y)` in hyperdiffusion. Any scalar added to `sgsʲs` that isn't `ρa`, `mse`, or `q_tot` now automatically receives hyperdiffusion.

Changes in `hyperdiffusion.jl`:
- **Cache**: Replaced 6 per-species scratch fields (`ᶜ∇²q_lclʲs`, `ᶜ∇²q_iclʲs`, ...) with a single reusable `ᶜ∇²sgs_tracerʲs` field.
- **Prep**: Removed per-species `∇²` computation blocks (now done inline).
- **DSS pairs**: Removed per-species DSS buffer pairs (now done per-tracer).
- **Apply**: Replaced per-species tendency blocks with a fused prep → DSS → apply loop over `sgs_tracer_names(Y)`.

`q_tot` and `mse` remain hardcoded because they receive special treatment (`q_tot` couples to `ρa`; `mse` is in the non-tracer hyperdiffusion path).

## Tradeoff: batched vs per-tracer DSS

Previously, `∇²` values for all microphysics species were computed in `prep_tracer_hyperdiffusion_tendency!`, then **batch-DSSed** in a single `weighted_dss2!` call alongside all other hyperdiffusion quantities, then applied in `apply_tracer_hyperdiffusion_tendency!`.

The new code uses a **fused loop**: for each tracer, it computes `∇²`, DSSes it individually, then applies the `∇⁴` tendency before moving to the next tracer. This reuses one scratch field but issues one `weighted_dss2!` call per tracer instead of one batched call for all.

| | Old (batched) | New (per-tracer) |
|---|---|---|
| **Scratch memory** | 4–6 fields (one per species) | 1 field (reused) |
| **DSS calls** | 1 batched call | N calls (one per tracer) |
| **Extensibility** | Requires new code per species | Automatic |
| **Code size** | ~60 lines of per-species boilerplate | ~25 lines of generic loop |

For the current tracer count (4–6 microphysics + 0–1 passive), the per-tracer DSS overhead is negligible. If this becomes a bottleneck with many tracers, the batched approach can be restored by allocating a NamedTuple of scratch fields keyed by tracer name.

