### PR TITLE
Add "explicit" Bomex with passive tracer A

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,6 +208,16 @@ steps:
         artifact_paths: "prognostic_edmfx_bomex_column/output_active/*"
         agents:
           slurm_mem: 20GB
+
+      - label: ":genie: Prognostic EDMF: BOMEX with passive tracer A (1M, short dt)"
+        retry: *retry_policy
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $CONFIG_PATH/prognostic_edmfx_bomex_tracerA_column.yml
+          --job_id prognostic_edmfx_bomex_tracerA_column
+        artifact_paths: "prognostic_edmfx_bomex_tracerA_column/output_active/*"
+        agents:
+          slurm_mem: 20GB
       
       - label: ":genie: Prognostic EDMF: Trade wind Cu shallow convection (BOMEX), ML cloud"
         retry: *retry_policy

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -405,6 +405,9 @@ prescribed_aerosols:
 time_varying_trace_gases:
   help: "Trace gases that vary in time, e.g. [\"CO2\", \"O3\"]. Currently, only \"CO2\" and \"O3\" are supported. All other trace gases set fixed to default values from ClimaParams."
   value: []
+chemistry_model:
+  help: "Chemistry model [`~` (default, no passive tracers), `passive` (enables passive tracer A)]"
+  value: ~
 
 # EDMF configuration
 turbconv:

--- a/config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml
@@ -1,0 +1,73 @@
+initial_condition: "Bomex"
+turbconv: "prognostic_edmfx"
+implicit_diffusion: true
+approximate_linear_solve_iters: 2
+edmfx_entr_model: "Generalized"
+edmfx_detr_model: "Generalized"
+edmfx_sgs_mass_flux: true
+edmfx_sgs_diffusive_flux: true
+edmfx_nh_pressure: true
+edmfx_vertical_diffusion: true
+edmfx_filter: true
+prognostic_tke: true
+microphysics_model: "1M"
+cloud_model: "MLCloud"
+config: "column"
+z_max: 3e3
+z_elem: 60
+z_stretch: false
+perturb_initstate: false
+dt: "1secs"
+t_end: "6hours"
+dt_save_state_to_disk: "10mins"
+toml: [toml/prognostic_edmfx_bomex.toml]
+netcdf_interpolation_num_points: [2, 2, 60]
+ode_algo: "ARS222"
+chemistry_model: "passive"
+diagnostics:
+  - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, husra, hussn]
+    period: 10mins
+  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+    period: 10mins
+  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
+    period: 10mins
+  - short_name: [entr, detr, turbentr, bgrad, strain, edt, evu]
+    period: 10mins
+  - short_name: [q_gas_A, q_gas_Aup]
+    period: 10mins
+  - short_name: [husraup, hussnup, q_gas_A, q_gas_Aup]
+    period: 1hours
+    reduction_time: average
+  - short_name: [
+      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
+      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
+      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
+      mp1m_S_accr_melt_lcl_sno,
+      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
+      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
+      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
+      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
+      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
+      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
+      mp1mup_S_accr_melt_lcl_sno,
+      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
+      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
+      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
+      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
+    ]
+    period: 10mins
+  - short_name: [
+      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
+      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
+      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
+      mp1men_S_accr_melt_lcl_sno,
+      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
+      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
+      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
+      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
+    ]
+    period: 10mins

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1292,6 +1292,7 @@ EDMFColumnPlotsWithPrecip = Union{
     Val{:prognostic_edmfx_rico_column},
     Val{:prognostic_edmfx_rico_column_2M},
     Val{:prognostic_edmfx_trmm_column},
+    Val{:prognostic_edmfx_bomex_tracerA_column},
 }
 
 """
@@ -1429,8 +1430,13 @@ function make_plots(
         "wa", "waup", "ta", "taup", "hus", "husup", "arup", "tke", "ua",
         "thetaa", "thetaaup", "hur", "hurup", "lmix",
         "cl", "clw", "clwup", "cli", "cliup",
+        "q_gas_A", "q_gas_Aup",
         precip_names...,
     ]
+    short_names = filter(
+        n -> n in ClimaAnalysis.available_vars(simdirs[1]),
+        short_names,
+    )
     reduction_avg = "average"
     reduction_inst = "inst"
 

--- a/src/cache/temporary_quantities.jl
+++ b/src/cache/temporary_quantities.jl
@@ -16,9 +16,11 @@ function implicit_temporary_quantities(Y, atmos)
     return (;
         ᶠtemp_scalar = Fields.Field(FT, face_space), # ᶠρaK_h
         ᶠtemp_scalar_2 = Fields.Field(FT, face_space), # ᶠρaK_u
+        ᶠtemp_scalar_3 = Fields.Field(FT, face_space), # ᶠwaχ in advection
         ᶜtemp_scalar = Fields.Field(FT, center_space), # ᶜρχₜ_diffusion, ᶜa_scalar
         ᶜtemp_scalar_2 = Fields.Field(FT, center_space), # ᶜKᵥʲ
         ᶜtemp_scalar_3 = Fields.Field(FT, center_space), # ᶜK_h_scaled
+        ᶜtemp_scalar_4 = Fields.Field(FT, center_space), # ᶜq_icl (in surface conditions)
         ᶜtemp_C3 = Fields.Field(C3{FT}, center_space), # ᶜu₃ʲ
         ᶠtemp_CT3 = Fields.Field(CT3{FT}, face_space), # ᶠuₕ³, ᶠu³_diff
         ᶠtemp_UVWxUVW = Fields.Field(typeof(uvw_vec * uvw_vec'), face_space), # ᶠstrain_rate

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -867,3 +867,17 @@ function AtmosSurface(
         flux_scheme, temperature, boundary_overrides, surface_albedo,
     )
 end
+
+function AtmosChem(config::AtmosConfig)
+    chem = config.parsed_args["chemistry_model"]
+    chemistry_model = if isnothing(chem)
+        nothing
+    elseif chem == "passive"
+        GasPhaseChem()
+    else
+        error(
+            """Unknown chemistry_model `$chem`. Expected: ~ | "passive".""",
+        )
+    end
+    return AtmosChem(; chemistry_model)
+end

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -52,6 +52,7 @@ function get_atmos(config::AtmosConfig, params; setup_type = nothing)
         sponge = AtmosSponge(config, params),
         surface = AtmosSurface(config, params, FT; setup_type),
         numerics = AtmosNumerics(config, FT),
+        chemistry = AtmosChem(config),
         vertical_diffusion,
         disable_surface_flux_tendency = pa["disable_surface_flux_tendency"],
     )

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -49,6 +49,9 @@ import ..PrognosticEDMFX
 import ..NonOrographicGravityWave
 import ..OrographicGravityWave
 
+# chemistry_model
+import ..GasPhaseChem
+
 # surface temperature
 import ..SurfaceConditions
 import ..SurfaceConditions: SlabOceanTemperature

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -1123,3 +1123,22 @@ add_diagnostic_variable!(
     units = "1",
     compute = compute_env_q_tot_temperature_correlation,
 )
+
+###
+# Passive gas tracer A (3d)
+###
+compute_q_gas_A(state, cache, time) =
+    compute_q_gas_A(state, cache, time, cache.atmos.chemistry_model)
+compute_q_gas_A(_, _, _, chemistry_model) =
+    error_diagnostic_variable("q_gas_A", chemistry_model)
+
+compute_q_gas_A(state, _, _, ::GasPhaseChem) =
+    @. lazy(specific(state.c.ρq_gas_A, state.c.ρ))
+
+add_diagnostic_variable!(
+    short_name = "q_gas_A",
+    units = "kg kg^-1",
+    long_name = "Passive Gas Tracer A Concentration",
+    comments = "Grid-mean specific concentration of passive gas tracer A",
+    compute = compute_q_gas_A,
+)

--- a/src/diagnostics/edmfx_diagnostics.jl
+++ b/src/diagnostics/edmfx_diagnostics.jl
@@ -850,3 +850,25 @@ add_diagnostic_variable!(short_name = "evu", units = "m^2 s^-1",
     comments = "Vertical diffusion coefficient for momentum due to parameterized eddies",
     compute = compute_evu,
 )
+
+###
+# Updraft passive gas tracer A (3d)
+###
+compute_q_gas_Aup(state, cache, time) =
+    compute_q_gas_Aup(
+        state, cache, time,
+        cache.atmos.turbconv_model, cache.atmos.chemistry_model,
+    )
+compute_q_gas_Aup(_, _, _, turbconv_model, chemistry_model) =
+    error_diagnostic_variable("q_gas_Aup", (turbconv_model, chemistry_model))
+
+compute_q_gas_Aup(state, _, _, ::PrognosticEDMFX, ::GasPhaseChem) =
+    (state.c.sgsʲs.:1).q_gas_A
+
+add_diagnostic_variable!(
+    short_name = "q_gas_Aup",
+    units = "kg kg^-1",
+    long_name = "Updraft Passive Gas Tracer A Concentration",
+    comments = "Concentration of passive gas tracer A in the first updraft",
+    compute = compute_q_gas_Aup,
+)

--- a/src/parameterized_tendencies/chemistry/chemistry.jl
+++ b/src/parameterized_tendencies/chemistry/chemistry.jl
@@ -1,13 +1,21 @@
-# ============================================================================
-# Chemistry Module
-# ============================================================================
+###
+### Chemistry Module
+###
+
 # Gas-phase chemistry for ClimaAtmos.
 # The MUSICA backend is provided by the ClimaAtmosMusica extension;
-# this file defines only the no-op fallback for when no chemistry is loaded.
+# this file defines only the fallback for when no chemistry is loaded.
 
 """
     chemistry_tendency!(Yₜ, Y, p, t, ::Nothing)
 
-No-op: no chemistry model is active.
+No chemistry model is active.
 """
 chemistry_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing
+
+"""
+    chemistry_tendency!(Yₜ, Y, p, t, ::GasPhaseChem)
+
+Source terms are provided by Musica extension.
+"""
+chemistry_tendency!(Yₜ, Y, p, t, ::GasPhaseChem) = nothing

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -69,6 +69,9 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     ρtke_if_available =
         is_in_Y(@name(c.ρtke)) ? (@name(c.ρtke),) : ()
     sfc_if_available = is_in_Y(@name(sfc)) ? (@name(sfc),) : ()
+    ρq_gas_A_if_available = is_in_Y(@name(c.ρq_gas_A)) ? (@name(c.ρq_gas_A),) : ()
+    sgs_q_gas_A_if_available =
+        is_in_Y(@name(c.sgsʲs.:(1).q_gas_A)) ? (@name(c.sgsʲs.:(1).q_gas_A),) : ()
 
     condensate_mass_names = (
         @name(c.ρq_lcl),
@@ -111,6 +114,7 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
             sgs_condensate_names...,
             @name(c.sgsʲs.:(1).q_tot),
             @name(c.sgsʲs.:(1).mse),
+            sgs_q_gas_A_if_available...,
         )
     available_sgs_scalar_names =
         filter(is_in_Y, sgs_scalar_names)
@@ -122,7 +126,7 @@ function jacobian_cache(alg::ManualSparseJacobian, Y, atmos)
     # which means that multiplying inv(-1) by a Float32 will yield a Float64.
     identity_blocks = map(
         name -> (name, name) => FT(-1) * I,
-        (@name(c.ρ), sfc_if_available...),
+        (@name(c.ρ), sfc_if_available..., ρq_gas_A_if_available...),
     )
 
     active_scalar_names = (@name(c.ρ), @name(c.ρe_tot), ρq_tot_if_available...)
@@ -800,6 +804,20 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                     ᶠset_upwind_matrix_bcs(ᶠupwind_matrix(ᶠu³ʲs.:(1)))
                 ) - (I,)
 
+            # advection of passive chemistry tracers (no sedimentation)
+            if MatrixFields.has_field(Y, @name(c.sgsʲs.:(1).q_gas_A))
+                ∂ᶜq_gas_Aʲ_err_∂ᶜq_gas_Aʲ =
+                    matrix[@name(c.sgsʲs.:(1).q_gas_A), @name(c.sgsʲs.:(1).q_gas_A)]
+                @. ∂ᶜq_gas_Aʲ_err_∂ᶜq_gas_Aʲ =
+                    dtγ * (
+                        DiagonalMatrixRow(ᶜadvdivᵥ(ᶠu³ʲs.:(1))) -
+                        ᶜadvdivᵥ_matrix() ⋅
+                        ᶠset_tracer_upwind_matrix_bcs(
+                            ᶠtracer_upwind_matrix(ᶠu³ʲs.:(1)),
+                        )
+                    ) - (I,)
+            end
+
             # advection and sedimentation of microphysics tracers
             if p.atmos.microphysics_model isa Union{
                 NonEquilibriumMicrophysics1M,
@@ -943,6 +961,11 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                         @. ∂ᶜqʲ_err_∂ᶜqʲ -=
                             dtγ * DiagonalMatrixRow(ᶜentrʲ + ᶜturb_entrʲs.:(1))
                     end
+                end
+                # passive chemistry tracers
+                if MatrixFields.has_field(Y, @name(c.sgsʲs.:(1).q_gas_A))
+                    @. ∂ᶜq_gas_Aʲ_err_∂ᶜq_gas_Aʲ -=
+                        dtγ * DiagonalMatrixRow(ᶜentrʲ + ᶜturb_entrʲs.:(1))
                 end
             end
 

--- a/src/setups/Bomex.jl
+++ b/src/setups/Bomex.jl
@@ -63,7 +63,7 @@ function center_initial_condition(setup::Bomex, local_geometry, params)
 
     tke = prognostic_tke ? FT(0) : profiles.tke(z)
 
-    return physical_state(; T, p, q_tot, u = profiles.u(z), tke)
+    return physical_state(; T, p, q_tot, u = profiles.u(z), tke, q_gas_A = FT(1))
 end
 
 function surface_condition(::Bomex, params)

--- a/src/setups/Setups.jl
+++ b/src/setups/Setups.jl
@@ -36,6 +36,7 @@ import ..MoistMicrophysics
 import ..PrognosticEDMFX
 import ..EDOnlyEDMFX
 import ..n_mass_flux_subdomains
+import ..AbstractChemistryModel
 import ..Parameters.ClimaAtmosParameters
 import Thermodynamics.Parameters.ThermodynamicsParameters
 

--- a/src/setups/common/physical_state.jl
+++ b/src/setups/common/physical_state.jl
@@ -27,6 +27,7 @@ prognostic variables.
   - `q_rai`, `q_sno`: Precipitation specific humidities
   - `n_liq`, `n_rai`: Number densities (2-moment microphysics)
   - `n_ice`, `q_rim`, `b_rim`: P3 microphysics fields
+  - `q_gas_A`: Passive gas tracer concentration (default 0)
 """
 function physical_state(;
     T,
@@ -49,6 +50,7 @@ function physical_state(;
     n_ice = zero(T),
     q_rim = zero(T),
     b_rim = zero(T),
+    q_gas_A = zero(T),
 )
     # Validate only for real states (T is finite). Placeholder states with
     # T = NaN (e.g. WeatherModel, AMIPFromERA5) skip validation because their
@@ -57,7 +59,7 @@ function physical_state(;
         error("physical_state requires at least one of `p` or `ρ`")
     return (;
         T, p, ρ, u, v, q_tot, q_liq, q_ice, tke, draft_area,
-        q_rai, q_sno, n_liq, n_rai, n_ice, q_rim, b_rim,
+        q_rai, q_sno, n_liq, n_rai, n_ice, q_rim, b_rim, q_gas_A,
     )
 end
 

--- a/src/setups/common/prognostic_variables.jl
+++ b/src/setups/common/prognostic_variables.jl
@@ -22,6 +22,7 @@ function center_prognostic_variables(physical_state, local_geometry, params, atm
     sgs = turbconv_center_variables(
         physical_state, local_geometry, params,
         atmos_model.turbconv_model, atmos_model.microphysics_model,
+        atmos_model.chemistry_model,
     )
     return (; gs..., sgs...)
 end
@@ -48,6 +49,7 @@ function grid_scale_center_variables(physical_state, local_geometry, params, atm
         ρe_tot,
         moisture_variables(ρ, physical_state, atmos_model.microphysics_model)...,
         precip_variables(ρ, physical_state, atmos_model.microphysics_model)...,
+        chemistry_variables(ρ, physical_state, atmos_model.chemistry_model)...,
     )
 end
 
@@ -96,6 +98,24 @@ function precip_variables(ρ, physical_state, ::NonEquilibriumMicrophysics2MP3)
 end
 
 # ============================================================================
+# Chemistry dispatch
+# ============================================================================
+
+"""
+Grid-scale chemistry tracers, gated on chemistry model.
+"""
+chemistry_variables(ρ, physical_state, ::Nothing) = (;)
+chemistry_variables(ρ, physical_state, ::AbstractChemistryModel) =
+    (; ρq_gas_A = ρ * physical_state.q_gas_A)
+
+"""
+SGS chemistry tracers to include in the updraft NamedTuple.
+"""
+chemistry_sgs_variables(physical_state, ::Nothing) = (;)
+chemistry_sgs_variables(physical_state, ::AbstractChemistryModel) =
+    (; q_gas_A = physical_state.q_gas_A)
+
+# ============================================================================
 # Turbconv center dispatch
 # ============================================================================
 
@@ -108,7 +128,7 @@ mass-flux subdomains in `turbconv_model`.
 uniform_subdomains(nt, turbconv_model) =
     ntuple(Returns(nt), Val(n_mass_flux_subdomains(turbconv_model)))
 
-turbconv_center_variables(physical_state, local_geometry, params, ::Nothing, _) = (;)
+turbconv_center_variables(physical_state, local_geometry, params, ::Nothing, _, _) = (;)
 
 function turbconv_center_variables(
     physical_state,
@@ -116,6 +136,7 @@ function turbconv_center_variables(
     params,
     turbconv_model::PrognosticEDMFX,
     microphysics_model,
+    chemistry_model,
 )
     ρ = air_density(physical_state, params)
     (; tke, draft_area, T, q_tot, q_liq, q_ice) = physical_state
@@ -125,7 +146,10 @@ function turbconv_center_variables(
     thermo_params = CAP.thermodynamics_params(params)
     e_pot = geopotential(CAP.grav(params), local_geometry.coordinates.z)
     mse = TD.moist_static_energy(thermo_params, T, e_pot, q_tot, q_liq, q_ice)
-    sgsʲs = uniform_subdomains((; ρa, mse, q_tot), turbconv_model)
+    sgsʲs = uniform_subdomains(
+        (; ρa, mse, q_tot, chemistry_sgs_variables(physical_state, chemistry_model)...),
+        turbconv_model,
+    )
     return (; ρtke, sgsʲs)
 end
 
@@ -135,6 +159,7 @@ function turbconv_center_variables(
     params,
     turbconv_model::PrognosticEDMFX,
     microphysics_model::NonEquilibriumMicrophysics,
+    chemistry_model,
 )
     (; T, q_tot, q_liq, q_ice, q_rai, q_sno, n_liq, n_rai, tke, draft_area) = physical_state
     ρ = air_density(physical_state, params)
@@ -144,9 +169,11 @@ function turbconv_center_variables(
     thermo_params = CAP.thermodynamics_params(params)
     e_pot = geopotential(CAP.grav(params), local_geometry.coordinates.z)
     mse = TD.moist_static_energy(thermo_params, T, e_pot, q_tot, q_liq, q_ice)
+    chem_sgs = chemistry_sgs_variables(physical_state, chemistry_model)
     if microphysics_model isa NonEquilibriumMicrophysics1M
         sgsʲs = uniform_subdomains(
-            (; ρa, mse, q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno),
+            (; ρa, mse, q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno,
+                chem_sgs...),
             turbconv_model,
         )
     else  # NonEquilibriumMicrophysics2M
@@ -154,6 +181,7 @@ function turbconv_center_variables(
             (; ρa, mse, q_tot,
                 q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno,
                 n_lcl = n_liq, n_rai,
+                chem_sgs...,
             ),
             turbconv_model,
         )
@@ -166,6 +194,7 @@ function turbconv_center_variables(
     local_geometry,
     params,
     turbconv_model::EDOnlyEDMFX,
+    _,
     _,
 )
     ρ = air_density(physical_state, params)

--- a/test/diagnostics/unit_diagnostics.jl
+++ b/test/diagnostics/unit_diagnostics.jl
@@ -239,6 +239,14 @@ model_2m_pedmfx = CA.AtmosModel(; microphysics_model = CA.NonEquilibriumMicrophy
 (Y_1m_pedmfx, p_1m_pedmfx) = build_state_cache(FT, model_1m_pedmfx; grid = column);
 (Y_2m_pedmfx, p_2m_pedmfx) = build_state_cache(FT, model_2m_pedmfx; grid = column);
 
+## Chemistry (passive tracer A) + PrognosticEDMFX
+model_chem_pedmfx = CA.AtmosModel(;
+    microphysics_model = CA.EquilibriumMicrophysics0M(),
+    turbconv_model = pedmfx, edmfx_model,
+    chemistry_model = CA.GasPhaseChem(),
+)
+(Y_chem_pedmfx, p_chem_pedmfx) = build_state_cache(FT, model_chem_pedmfx; grid = column);
+
 ## VerticalDiffusion and DecayWithHeightDiffusion (no EDMF)
 vdp = CAP.vert_diff_params(params)
 model_vd = CA.AtmosModel(;
@@ -269,6 +277,7 @@ states = Dict(
     :m0_pedmfx      => (Y_0m_pedmfx,      p_0m_pedmfx),
     :m1_pedmfx      => (Y_1m_pedmfx,      p_1m_pedmfx),
     :m2_pedmfx      => (Y_2m_pedmfx,      p_2m_pedmfx),
+    :chem_pedmfx    => (Y_chem_pedmfx,    p_chem_pedmfx),
     :vd             => (Y_vd,             p_vd),
     :dwh            => (Y_dwh,            p_dwh),
     :allsky         => (Y_allsky,         p_allsky),
@@ -367,6 +376,9 @@ VALID_CASES = [
     cases(("cdncup", "cdncen", "ncraup", "ncraen"), :m2_pedmfx)...,
     # VerticalDiffusion, DecayWithHeightDiffusion, EDMF
     cases(("edt", "evu"), (:vd, :dwh, :m0_pedmfx))...,
+    # GasPhaseChem + PrognosticEDMFX
+    case("q_gas_A",   :chem_pedmfx),
+    case("q_gas_Aup", :chem_pedmfx),
 
     # ---------------------------------------------------------------------------
     # microphysics_diagnostics.jl


### PR DESCRIPTION
This PR adds a passive tracer `A` to the atmospheric model (both grid-mean and EDMF). All SGS tendencies (entrainment, advection, diffusion, mass flux) are auto-discovered via `sgs_tracer_names(Y)`. Grid-mean tendencies (advection, diffusion, hyperdiffusion) are auto-discovered via `gs_tracer_names(Y)` / `foreach_gs_tracer`. The Jacobian is still hard-coded. To be changed in future PRs.

To switch it on set `chemistry_model: "passive"`. As an example, the PR adds an SCM Bomex with passive tracer to the CI. It's switched off by default, so should not affect any of our typical simulations.

I think it's a good test of our sgs vertical transport. So I'm adding it to the CI.

### Chemistry model (`chemistry.jl`)
- New `GasPhaseChem <: AbstractChemistryModel` type, selected via `chemistry_model: "passive"` in the YAML config.

### Physical state (`physical_state.jl`)
- Added `A` field (default `zero(T)`) to the `physical_state` NamedTuple. Present in all setups but only added to the Atmos model state when chemistry is active.

### Prognostic variables (`prognostic_variables.jl`)
- `chemistry_variables(ρ, ps, ::AbstractChemistryModel)` → adds `ρA` to grid-scale state.
- `chemistry_sgs_variables(ps, ::AbstractChemistryModel)` → adds `A` to updraft `sgsʲs`.
- Both return `(;)` when chemistry model is `nothing`, so no impact on existing configs.

### Initial condition (`Bomex.jl`)
- Initializes `A = 1` in the Bomex physical state (a uniform background for testing transport).

### Jacobian (`manual_sparse_jacobian.jl`)
- `ρA` gets a `-I` identity block (explicit treatment).
- `sgsʲs.:(1).A` gets Jacobian entries for SGS vertical advection (TridiagonalRow) and entrainment (Diagonal), matching the implicit treatment of other SGS scalars.
- All entries rely on `MatrixFields.has_field(Y, @name(...))`.

### Diagnostics (`core_diagnostics.jl`, `edmfx_diagnostics.jl`)
- `passiveA`: grid-mean specific concentration `ρA/ρ`.
- `passiveAup`: updraft concentration `sgsʲs.:(1).A`.

### CI (`pipeline.yml`)
- New single-column job using `prognostic_edmfx_bomex_tracerA_column.yml`