### PR TITLE
Fix UndefVarError in `update_jacobian!`

### DIFF
--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -1108,7 +1108,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
                             ᶜq_ice⁰,
                         ),
                     )
-                    ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
+                    ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, p.atmos.turbconv_model))
                     ᶠu³⁰_data = ᶠu³⁰.components.data.:1
 
                     # pull common subexpressions that don't depend on which


### PR DESCRIPTION
Current main errors in `update_jacobian!` when the following options are enabled. No tested config uses all of these.
- `turbconv: prognostic_edmfx`
- `edmfx_sgs_mass_flux: true`
- `microphysics_model: 1M` or `2M`
- `implicit_diffusion: false`


This error happens because `turbconv_model` is undefined in local scope, fixed by replacing it with `p.atmos.turbconv_model`.

Error:
```
ERROR: UndefVarError: `turbconv_model` not defined in local scope
Suggestion: check for an assignment to a local variable that shadows a global of the same name.
Stacktrace:
  [1] update_jacobian!(alg::ClimaAtmos.ManualSparseJacobian, cache::@NamedTuple{…}, Y::ClimaCore.Fields.FieldVector{…}, p::ClimaAtmos.AtmosCache{…}, dtγ::Float32, t::ClimaUtilities.TimeManager.ITime{…})
    @ ClimaAtmos ~/clima/ClimaAtmos.jl/src/prognostic_equations/implicit/manual_sparse_jacobian.jl:1111
  [2] macro expansion
    @ ~/clima/ClimaAtmos.jl/src/prognostic_equations/implicit/jacobian.jl:47 [inlined]
  [3] update_jacobian!(jacobian::ClimaAtmos.Jacobian{…}, Y::ClimaCore.Fields.FieldVector{…}, p::ClimaAtmos.AtmosCache{…}, dtγ::Float64, t::ClimaUtilities.TimeManager.ITime{…})
    @ ClimaAtmos ~/.julia/packages/NVTX/IqPon/src/macro.jl:194
  [4] (::ClimaTimeSteppers.var"#92#95"{…})(jacobian::ClimaAtmos.Jacobian{…}, U′::ClimaCore.Fields.FieldVector{…})
    @ ClimaTimeSteppers ~/.julia/packages/ClimaTimeSteppers/lQpni/src/solvers/imex_ark.jl:287
  [5] macro expansion
    @ ~/.julia/packages/ClimaTimeSteppers/lQpni/src/nl_solvers/newtons_method.jl:625 [inlined]
  [6] solve_newton!(alg::ClimaTimeSteppers.NewtonsMethod{…}, cache::@NamedTuple{…}, x::ClimaCore.Fields.FieldVector{…}, f!::ClimaTimeSteppers.var"#91#94"{…}, j!::ClimaTimeSteppers.var"#92#95"{…}, prepare_for_f!::ClimaTimeSteppers.var"#93#96"{…})
    @ ClimaTimeSteppers ~/.julia/packages/NVTX/IqPon/src/macro.jl:194
```

Reproducer:
```julia
import ClimaComms
ClimaComms.@import_required_backends
import ClimaAtmos as CA

config = CA.AtmosConfig(
    Dict(
        "initial_condition" => "Bomex",
        "turbconv" => "prognostic_edmfx",
        "edmfx_sgs_mass_flux" => true,
        "edmfx_entr_model" => "Generalized",
        "edmfx_detr_model" => "Generalized",
        "prognostic_tke" => true,
        "microphysics_model" => "1M",
        "config" => "column",
        "implicit_diffusion" => false,   # <-- the trigger
        "z_elem" => 60, "z_max" => 3000.0, "z_stretch" => false,
        "dt" => "120secs", "t_end" => "120secs",
        "ode_algo" => "ARS222",
        "toml" => ["toml/prognostic_edmfx_bomex.toml"],
    )
)
sim = CA.get_simulation(config)
CA.solve_atmos!(sim) 
```