### PR TITLE
modify cloud water diagnostics and change detr_massflux_vertdiv_coeff

### DIFF
--- a/calibration/experiments/perfect_scm/run_calibration.jl
+++ b/calibration/experiments/perfect_scm/run_calibration.jl
@@ -14,7 +14,7 @@ config = joinpath("config", "model_configs", "prognostic_edmfx_trmm_column.yml")
 output_dir = "perfect_scm_calibration"
 diagnostic_dict =
     Dict(
-        "short_name" => ["lwp", "rwp", "clivi", "swp"],
+        "short_name" => ["lwp", "rwp", "iwp", "swp"],
         "period" => "20mins",
         "reduction_time" => "average",
     )

--- a/config/common_configs/diagnostics_column_progedmf_0M.yml
+++ b/config/common_configs/diagnostics_column_progedmf_0M.yml
@@ -1,7 +1,7 @@
 diagnostics:
   - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
     period: 10mins
-  - short_name: [ts, hfss, hfls, pr, lwp, clivi]
+  - short_name: [ts, hfss, hfls, pr, lwp, iwp]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
     period: 10mins

--- a/config/common_configs/diagnostics_column_progedmf_1M.yml
+++ b/config/common_configs/diagnostics_column_progedmf_1M.yml
@@ -1,7 +1,7 @@
 diagnostics:
   - short_name: [ta, thetaa, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, husra, hussn]
     period: 10mins
-  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+  - short_name: [ts, hfss, hfls, pr, lwp, iwp, rwp, swp]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, husup, hurup, clwup, cliup, husraup, hussnup]
     period: 10mins

--- a/config/model_configs/prognostic_edmfx_adv_test_column.yml
+++ b/config/model_configs/prognostic_edmfx_adv_test_column.yml
@@ -21,7 +21,7 @@ diagnostics:
   - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli]
     period: 10mins
     reduction_time: average
-  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+  - short_name: [ts, hfss, hfls, pr, lwp, iwp, rwp, swp]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
     period: 10mins

--- a/config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml
+++ b/config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml
@@ -27,7 +27,7 @@ chemistry_model: "passive"
 diagnostics:
   - short_name: [ta, thetaa, ha, pfull, rhoa, ua, va, wa, hur, hus, cl, clw, cli, husra, hussn]
     period: 10mins
-  - short_name: [ts, hfss, hfls, pr, lwp, clivi, rwp, swp]
+  - short_name: [ts, hfss, hfls, pr, lwp, iwp, rwp, swp]
     period: 10mins
   - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup, waen, taen, thetaaen, haen, husen, huren, clwen, clien, tke, lmix]
     period: 10mins

--- a/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
+++ b/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml
@@ -42,7 +42,7 @@ diagnostics:
     period: 10mins
   - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
     period: 10mins
-  - short_name: [rlut, rlutcs, rsut, rsutcs, clwvi, lwp, clivi, dsevi, clvi, prw, hurvi, husv]
+  - short_name: [rlut, rlutcs, rsut, rsutcs, clwvi, lwp, iwp, dsevi, clvi, prw, hurvi, husv]
     period: 10mins
   - reduction_time: max
     short_name: tke

--- a/post_processing/ci_plots.jl
+++ b/post_processing/ci_plots.jl
@@ -1576,7 +1576,7 @@ function make_plots(
 
     # Timeseries line plots for column-integrated variables (no z dimension)
     # This is the final assembling call — merges all summary_files into summary.pdf
-    timeseries_names = ["lwp", "clivi", "rwp", "swp", "pr"]
+    timeseries_names = ["lwp", "iwp", "rwp", "swp", "pr"]
     timeseries_names_avail =
         timeseries_names ∩ collect(keys(simdirs[1].vars))
     vars_timeseries =
@@ -1666,7 +1666,7 @@ function make_plots(
         "rsutcs",
         "clwvi",
         "lwp",
-        "clivi",
+        "iwp",
         "dsevi",
         "clvi",
         "prw",

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,5 @@
-363
+364
+
 # **README**
 #
 # What is the ref_counter?
@@ -31,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+364
+- Change detr_massflux_vertdiv_coeff
+
 363
 - SGS cloud-fraction: non-dimensionalize variance floor.
   Replace hardcoded `σ_S_floor = 1e-6` with a scale-aware

--- a/src/cache/cache.jl
+++ b/src/cache/cache.jl
@@ -19,7 +19,9 @@ struct AtmosCache{
     SSV,
     CONSCHECK,
 }
-    """Timestep of the simulation (in seconds). This is also used by callbacks and tendencies"""
+    """
+    Timestep of the simulation (in seconds). This is also used by callbacks and tendencies
+    """
     dt::FT
 
     """AtmosModel"""

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -674,17 +674,9 @@ compute_clwvi(state, cache, time) =
     compute_clwvi(state, cache, time, cache.atmos.microphysics_model)
 compute_clwvi(_, _, _, model) = error_diagnostic_variable("clwvi", model)
 
-function compute_clwvi(state, cache, _, ::EquilibriumMicrophysics0M)
+function compute_clwvi(state, cache, _, ::MoistMicrophysics)
     out = cache.scratch.ᶠtemp_field_level
-    (; ᶜq_liq, ᶜq_ice) = cache.precomputed
-    clw = @. lazy(state.c.ρ * (ᶜq_liq + ᶜq_ice))
-    Operators.column_integral_definite!(out, clw)
-    return out
-end
-
-function compute_clwvi(state, cache, _, ::NonEquilibriumMicrophysics)
-    out = cache.scratch.ᶠtemp_field_level
-    clw = @. lazy(state.c.ρq_lcl + state.c.ρq_icl)
+    clw = @. lazy(state.c.ρ * (cache.precomputed.ᶜq_liq + cache.precomputed.ᶜq_ice))
     Operators.column_integral_definite!(out, clw)
     return out
 end
@@ -695,7 +687,7 @@ add_diagnostic_variable!(short_name = "clwvi", units = "kg m^-2",
     comments = """
     Mass of condensed (liquid + ice) water in the column divided by
     the area of the column (not just the cloudy portion).
-    Does not include precipitating hydrometeors.
+    Includes precipitating hydrometeors (rain + snow) for NonEquilibriumMicrophysics.
     """,
     compute = compute_clwvi,
 )
@@ -727,6 +719,35 @@ add_diagnostic_variable!(short_name = "lwp", units = "kg m^-2",
     comments = "The total mass of liquid water in cloud per unit area. \
                 Does not include precipitating hydrometeors.",
     compute = compute_lwp,
+)
+
+###
+# Ice water path (2d)
+###
+compute_iwp(state, cache, time) =
+    compute_iwp(state, cache, time, cache.atmos.microphysics_model)
+compute_iwp(_, _, _, model) = error_diagnostic_variable("iwp", model)
+
+function compute_iwp(state, cache, _, ::EquilibriumMicrophysics0M)
+    out = cache.scratch.ᶠtemp_field_level
+    iw = @. lazy(state.c.ρ * cache.precomputed.ᶜq_ice)
+    Operators.column_integral_definite!(out, iw)
+    return out
+end
+
+function compute_iwp(state, cache, _, ::NonEquilibriumMicrophysics)
+    out = cache.scratch.ᶠtemp_field_level
+    iw = state.c.ρq_icl
+    Operators.column_integral_definite!(out, iw)
+    return out
+end
+
+add_diagnostic_variable!(short_name = "iwp", units = "kg m^-2",
+    long_name = "Ice Water Path",
+    standard_name = "atmosphere_mass_content_of_cloud_ice",
+    comments = "The total mass of ice in cloud per unit area. \
+                Does not include precipitating hydrometeors.",
+    compute = compute_iwp,
 )
 
 ###

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -264,6 +264,7 @@ function _moist_default_diagnostics(duration, start_date, t_start; output_writer
         "prsn",
         "prw",
         "lwp",
+        "iwp",
         "clwvi",
         "clivi",
     ]

--- a/test/diagnostics/unit_diagnostics.jl
+++ b/test/diagnostics/unit_diagnostics.jl
@@ -321,12 +321,12 @@ VALID_CASES = [
     # MoistMicrophysics, single path
     cases((
         "hus", "hur", "husv", "hussfc", "evspsbl", "hfls",
-        "clivi", "clvi", "prw", "hurvi", "cape", "mslp"
+        "clivi", "clwvi", "clvi", "prw", "hurvi", "cape", "mslp"
     ), :m0)...,
     # Union{DryModel, MoistMicrophysics}: single method
     cases(("pr", "prra", "prsn"), :dry)...,
     # EquilibriumMicrophysics0M (precomputed cache), NonEquilibriumMicrophysics (state)
-    cases(("clw", "cli", "clwvi", "lwp"), (:m0, :m1))...,
+    cases(("clw", "cli", "lwp", "iwp"), (:m0, :m1))...,
     # DryModel, MoistMicrophysics (different flux computation)
     case("hfss",  (:dry, :m0)),
     # Non-EDMF (Smagorinsky formula), EDMF (mixing-length closure)
@@ -445,7 +445,7 @@ end
 
 @testset "Model dispatch error paths" begin
     for name in ("hus", "hur", "husv", "clw", "cli", "hussfc",
-        "evspsbl", "hfls", "clwvi", "lwp", "clivi", "clvi",
+        "evspsbl", "hfls", "lwp", "iwp", "clivi", "clwvi", "clvi",
         "prw", "hurvi", "husra", "hussn", "rwp",
         "cdnc", "ncra", "utendnogw", "vtendnogw")
         @testset "$name errors on dry model" begin

--- a/toml/longrun_aquaplanet_progedmf.toml
+++ b/toml/longrun_aquaplanet_progedmf.toml
@@ -41,7 +41,7 @@ value = 1
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0.001

--- a/toml/prognostic_edmfx.toml
+++ b/toml/prognostic_edmfx.toml
@@ -38,7 +38,7 @@ value = 1
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0.001

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -32,7 +32,7 @@ value = 1
 value = 1
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0.001

--- a/toml/prognostic_edmfx_bomex.toml
+++ b/toml/prognostic_edmfx_bomex.toml
@@ -23,13 +23,13 @@ value = 0
 value = 0
 
 [detr_buoy_coeff]
-value = 0
+value = 1
 
 [detr_vertdiv_coeff]
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0

--- a/toml/prognostic_edmfx_gcmdriven.toml
+++ b/toml/prognostic_edmfx_gcmdriven.toml
@@ -26,13 +26,13 @@ value = 0
 value = 0
 
 [detr_buoy_coeff]
-value = 0
+value = 1
 
 [detr_vertdiv_coeff]
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0

--- a/toml/prognostic_edmfx_simpleplume.toml
+++ b/toml/prognostic_edmfx_simpleplume.toml
@@ -26,13 +26,13 @@ value = 0
 value = 0
 
 [detr_buoy_coeff]
-value = 0
+value = 1
 
 [detr_vertdiv_coeff]
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0

--- a/toml/rcemip_SCM_prognostic_edmfx_1M.toml
+++ b/toml/rcemip_SCM_prognostic_edmfx_1M.toml
@@ -29,13 +29,13 @@ value = 0.0001
 value = 0
 
 [detr_buoy_coeff]
-value = 0
+value = 1
 
 [detr_vertdiv_coeff]
 value = 0
 
 [detr_massflux_vertdiv_coeff]
-value = 1
+value = 0.1
 
 [max_area_limiter_scale]
 value = 0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Modify `clwvi` to include rain and snow, following the cmip convention. Also adds `iwp` which only includes cloud ice (no snow). Also changes detr_massflux_vertdiv_coeff to 0.1 as it gives better TRMM (compared to LES).

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
