### PR TITLE
Print all microphysics options

### DIFF
--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -60,6 +60,11 @@ function get_atmos(config::AtmosConfig, params; setup_type = nothing)
     @assert !@any_reltype(atmos, (UnionAll, DataType))
 
     @info "AtmosModel: \n$(summary(atmos))"
+    if !isnothing(params.microphysics_1m_params)
+        microphysics_model = atmos.water.microphysics_model
+        options = params.microphysics_1m_params.options
+        @info "Microphysics settings: $(sprint(summary_microphysics, microphysics_model, options))"
+    end
     return atmos
 end
 

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -277,3 +277,31 @@ function Base.summary(io::IO, atmos::AtmosModel)
         print(io, s)
     end
 end
+
+"""
+    summary_microphysics(io::IO, microphysics_model, options)
+
+Print the microphysics settings that `summary(::AtmosModel)` does not surface:
+the substep counts of `NonEquilibriumMicrophysics1M` (struct fields, hidden by
+`typeof`) and the per-process option selections (e.g. which autoconversion or
+accretion scheme is active, or `disabled` when the option is `nothing`). The
+process options live in the parameter set, not in the `AtmosModel`.
+"""
+function summary_microphysics(io::IO, microphysics_model, options)
+    keys = collect(string.(propertynames(options)))
+    is_1m = microphysics_model isa NonEquilibriumMicrophysics1M
+    is_1m && append!(keys, ("n_substeps", "n_substeps_quad"))
+    buf = maximum(length, keys)
+    print(io, '\n')
+    pad(k) = repeat(" ", buf - length(k) + 2)
+    line(k, v) = print(io, "  ", pad(k), '`', k, '`', "::", '`', v, '`', '\n')
+    if is_1m
+        line("n_substeps", microphysics_model.n_substeps)
+        line("n_substeps_quad", microphysics_model.n_substeps_quad)
+    end
+    for pn in propertynames(options)
+        opt = getproperty(options, pn)
+        label = isnothing(opt) ? "disabled" : string(nameof(typeof(opt)))
+        line(string(pn), label)
+    end
+end


### PR DESCRIPTION
With the recent microphysics additions, some options are not printed to the log. This prints all options to aid reproducibility.

Sample output:
```
┌ Info: Making AtmosConfig with config files:
│    config/default_configs/default_config.yml
└    config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml
┌ Info: numerics
│        `energy_q_tot_upwinding`::`Val{:vanleer_limiter}`
│              `tracer_upwinding`::`Val{:vanleer_limiter}`
│     `edmfx_mse_q_tot_upwinding`::`Val{:first_order}`
│       `edmfx_sgsflux_upwinding`::`Val{:none}`
│        `edmfx_tracer_upwinding`::`Val{:first_order}`
│       `test_dycore_consistency`::`Nothing`
│          `reproducible_restart`::`Nothing`
│                       `limiter`::`Nothing`
│                     `diff_mode`::`ClimaAtmos.Implicit`
└                     `hyperdiff`::`ClimaAtmos.Hyperdiffusion{Float32}`
┌ Info: AtmosModel:
│ 
│                             `water`::`ClimaAtmos.AtmosWater{ClimaAtmos.NonEquilibriumMicrophysics1M, ClimaAtmos.MLCloud{Flux.Chain{Tuple{Flux.Dense{typeof(NNlib.relu), StaticArraysCore.SMatrix{8, 4, Float32, 32}, StaticArraysCore.SVector{8, Float32}}, Flux.Dense{typeof(NNlib.relu), StaticArraysCore.SMatrix{8, 8, Float32, 64}, StaticArraysCore.SVector{8, Float32}}, Flux.Dense{typeof(identity), StaticArraysCore.SMatrix{1, 8, Float32, 8}, StaticArraysCore.SVector{1, Float32}}}}}, ClimaAtmos.Implicit, Nothing, ClimaAtmos.SGSQuadrature{3, StaticArraysCore.SVector{3, Float32}, StaticArraysCore.SVector{3, Float32}, ClimaAtmos.GaussianSGS, Float32}, ClimaAtmos.FixedTerminalVelocity{Float32}}`
│                         `scm_setup`::`ClimaAtmos.SCMSetup{ClimaAtmos.Subsidence{AtmosphericProfilesLibrary.ZProfile{AtmosphericProfilesLibrary.var"#31#32"{Float32}}}, Nothing, ClimaAtmos.LargeScaleAdvection{ClimaAtmos.var"#555#557"{@NamedTuple{prof_dTdt::AtmosphericProfilesLibrary.ΠZProfile{AtmosphericProfilesLibrary.var"#27#28"}, prof_dqtdt::AtmosphericProfilesLibrary.ZProfile{AtmosphericProfilesLibrary.var"#29#30"{Float32}}}}, ClimaAtmos.var"#554#556"{@NamedTuple{prof_dTdt::AtmosphericProfilesLibrary.ΠZProfile{AtmosphericProfilesLibrary.var"#27#28"}, prof_dqtdt::AtmosphericProfilesLibrary.ZProfile{AtmosphericProfilesLibrary.var"#29#30"{Float32}}}}}, Bool, @NamedTuple{prof_ug::AtmosphericProfilesLibrary.ZProfile{AtmosphericProfilesLibrary.var"#23#24"{Float32}}, prof_vg::ClimaAtmos.Setups.var"#11#12"{Float32}, coriolis_param::Float32}}`
│                         `radiation`::`ClimaAtmos.AtmosRadiation{Nothing, ClimaAtmos.IdealizedInsolation}`
│                          `turbconv`::`ClimaAtmos.AtmosTurbconv{ClimaAtmos.EDMFXModel{ClimaAtmos.InvZEntrainment, ClimaAtmos.BuoyancyVelocityDetrainment, Val{true}, Val{true}, Val{true}, Val{true}, Val{true}, ClimaAtmos.SmoothMinimumBlending}, ClimaAtmos.PrognosticEDMFX{1, true, Float32}, Nothing, Nothing, Nothing}`
│                   `prescribed_flow`::`Nothing`
│                      `gravity_wave`::`ClimaAtmos.AtmosGravityWave{Nothing, Nothing}`
│                `vertical_diffusion`::`Nothing`
│                            `sponge`::`ClimaAtmos.AtmosSponge{Nothing, Nothing}`
│                           `surface`::`ClimaAtmos.AtmosSurface{ClimaAtmos.SurfaceConditions.MoninObukhov{Float32, ClimaAtmos.SurfaceConditions.θAndQFluxes{Float32, Float32}, Float32}, ClimaAtmos.SurfaceConditions.AnalyticTemperature{Returns{Float32}}, ClimaAtmos.SurfaceConditions.SurfaceBoundaryOverrides{Float32, Float32, Nothing, Nothing, Nothing, Nothing}, ClimaAtmos.ConstantAlbedo{Float32}}`
│                          `numerics`::`ClimaAtmos.AtmosNumerics{Val{:vanleer_limiter}, Val{:vanleer_limiter}, Val{:first_order}, Val{:none}, Val{:first_order}, Nothing, Nothing, Nothing, ClimaAtmos.Implicit, ClimaAtmos.Hyperdiffusion{Float32}}`
└                         `chemistry`::`ClimaAtmos.AtmosChem{ClimaAtmos.GasPhaseChem}`
┌ Info: Microphysics settings:
│                        `n_substeps`::`3`
│                   `n_substeps_quad`::`2`
│            `cloud_liquid_formation`::`CloudLiquidFormation`
│               `cloud_ice_formation`::`ConstantTimescale`
│                    `cloud_ice_melt`::`CloudIceMelt`
│               `rain_autoconversion`::`Kessler1M`
│               `snow_autoconversion`::`NoSupersaturation`
│     `rain_condensation_evaporation`::`RainEvaporation`
│       `snow_deposition_sublimation`::`DepositionAndSublimation`
│                         `snow_melt`::`SnowMelt`
│       `cloud_liquid_rain_accretion`::`CloudLiquidRainAccretion`
│       `cloud_liquid_snow_accretion`::`CloudLiquidSnowAccretion`
│          `cloud_ice_rain_accretion`::`CloudIceRainAccretion`
│          `cloud_ice_snow_accretion`::`CloudIceSnowAccretion`
└               `rain_snow_accretion`::`RainSnowAccretion`
```