### PR TITLE
Fix sig_S cancellation

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-366
+367
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+367
+- SGS saturation moments: use linearized analytic μ_S and accumulate σ_S²
+  as E[(S − μ_S)²] in one quadrature pass to avoid Float32 catastrophic
+  cancellation when Var[S] ≪ (E[S])².
+
 366
 - Update to ClimaParams v1.1 (changing threshold_smooth_transition_steepness default value)
 

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -870,7 +870,7 @@ function set_microphysics_tendency_cache!(
         @. ᶜmp_tendency = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, Y.c.ρ, ᶜT,
             ᶜq_tot_nonneg, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
-            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments.λ_lagrange, ᶜsgs_moments.mu_S, α,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments.λ_lagrange, α,
             dt, nsubs_quad,
         )
     end
@@ -924,7 +924,7 @@ function set_microphysics_tendency_cache!(
         @. ᶜmp_tendency⁰ = microphysics_tendencies_1m(
             BMT.Microphysics1Moment(), sgs_quad, cmp, thp, ᶜρ⁰, ᶜT⁰,
             ᶜq_tot_nonneg⁰, ᶜq_lcl⁰, ᶜq_icl⁰, ᶜq_rai⁰, ᶜq_sno⁰,
-            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments.λ_lagrange, ᶜsgs_moments.mu_S, α,
+            ᶜT′T′, ᶜq′q′, corr_Tq, ᶜsgs_moments.λ_lagrange, α,
             dt, nsubs_quad,
         )
     end

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -156,14 +156,13 @@ function precomputed_quantities(Y, atmos)
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M} ||
         atmos.cloud_model isa Union{QuadratureCloud, MLCloud}
-    # `ᶜsgs_moments` caches `(mu_S, sigma_S, λ_lagrange)` — the SGS mean
-    # saturation variable, the standard deviation, and the Lagrange multiplier
-    # used by `Microphysics1MEvaluator`. Allocated only for 1M/2M schemes.
     uses_microphysics_quadrature_moments =
         atmos.microphysics_model isa
         Union{NonEquilibriumMicrophysics1M, NonEquilibriumMicrophysics2M}
+    # `ᶜsgs_moments` caches `(sigma_S, λ_lagrange)` — the SGS standard
+    # deviation and the Lagrange multiplier used by `Microphysics1MEvaluator`.
+    #  Allocated only for 1M/2M schemes.
     SGSMomentsNT = @NamedTuple{
-        mu_S::FT,
         sigma_S::FT,
         λ_lagrange::FT,
     }

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -129,7 +129,7 @@ function set_covariance_cache_and_cloud_fraction!(Y, p)
     set_covariance_cache!(Y, p, thermo_params)
 
     # Final post-Aitken update: one quadrature pass refreshes both CF and the
-    # microphysics SGS moments (μ_S, λ) using the final covariance.
+    # microphysics SGS moments (σ_S, λ_lagrange) using the final covariance.
     set_sgs_moments_and_cloud_fraction!(Y, p)
 
     return nothing
@@ -273,21 +273,24 @@ end
 # inversion for the Lagrange multiplier, so the linear S is used universally.)
 
 """
-    SGSMomentsEvaluator(tps, ρ)
+    SGSVarianceEvaluator(tps, ρ, mu_S)
 
-GPU-safe functor returning `(mu_S = S(ξ), s_sq = S(ξ)²)` at each quadrature
-point, where S = q_tot_hat − q_sat_hat is the linear saturation excess.
-Used by `_sgs_saturation_moments` to compute μ_S = E[S] and σ_S² = Var[S].
+GPU-safe functor returning `(S(ξ) − μ_S)²` at each quadrature point, where
+S = q_tot_hat − q_sat_hat is the linear saturation excess and `μ_S` is the
+linearized SGS mean of S (see [`_sgs_saturation_moments`](@ref)). Used to
+accumulate σ_S² = E[(S − μ_S)²] in one quadrature pass; avoids catastrophic
+cancellation in `E[S²] − (E[S])²` in Float32 when Var[S] ≪ (E[S])².
 """
-struct SGSMomentsEvaluator{TPS, FT}
+struct SGSVarianceEvaluator{TPS, FT}
     tps::TPS
     ρ::FT
+    mu_S::FT
 end
 
-@inline function (eval::SGSMomentsEvaluator)(T_hat, q_tot_hat)
+@inline function (eval::SGSVarianceEvaluator)(T_hat, q_tot_hat)
     q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
     s = q_tot_hat - q_sat_hat
-    return (mu_S = s, s_sq = s^2)
+    return (s - eval.mu_S)^2
 end
 
 
@@ -295,12 +298,21 @@ end
     _sgs_saturation_moments(thp, ρ, T_mean, q_tot_mean,
                             sgs_quad, T′T′, q′q′, corr_Tq)
 
-Compute μ_S = E[S] and σ_S = sqrt(Var[S]) of the linear saturation excess
-S = q_tot − q_sat via a single Gauss-Hermite quadrature pass over the SGS PDF.
+Compute μ_S and σ_S of the linear saturation excess S = q_tot − q_sat over
+the SGS PDF.
 
-The variance is guarded against negative values from quadrature cancellation
-(clipped at zero) and the standard deviation is floored at `ϵ_numerics(FT)`
-so the normalised closure (`C = q_c / (α·σ_S)`) is well-conditioned.
+The mean is set analytically to the linearized value
+
+    μ_S = q_tot_mean − q_sat(T_mean, ρ),
+
+which is exact under the same linearization of `q_sat(T)` that makes S
+Gaussian to begin with: any difference from `E[S]` evaluated by quadrature
+is the q_sat-curvature term that is already discarded in the truncated-
+Gaussian closure. Using this analytic μ_S lets us accumulate σ_S² as
+`E[(S − μ_S)²]` in a single pass.
+
+`σ_S` is floored at `ϵ_numerics(FT)` so the normalised closure
+`C = q_c / (α·σ_S)` stays well-conditioned.
 
 Returns `(; mu_S, sigma_S)`.
 """
@@ -309,14 +321,14 @@ Returns `(; mu_S, sigma_S)`.
     sgs_quad, T′T′, q′q′, corr_Tq,
 )
     FT = typeof(ρ)
+    mu_S = q_tot_mean - TD.q_vap_saturation(thp, T_mean, ρ)
     sgs_quad_eff = isnothing(sgs_quad) ? GridMeanSGS() : sgs_quad
-    evaluator = SGSMomentsEvaluator(thp, ρ)
-    raw = integrate_over_sgs(
+    evaluator = SGSVarianceEvaluator(thp, ρ, mu_S)
+    sigma_S_sq = integrate_over_sgs(
         evaluator, sgs_quad_eff, q_tot_mean, T_mean, q′q′, T′T′, corr_Tq,
     )
-    sigma_S_sq = max(raw.s_sq - raw.mu_S * raw.mu_S, zero(FT))
     return (;
-        mu_S = raw.mu_S,
+        mu_S,
         sigma_S = max(sqrt(sigma_S_sq), ϵ_numerics(FT)),
     )
 end
@@ -326,9 +338,12 @@ end
 # ============================================================================
 #
 # **Physical model**: the subgrid saturation excess S = q_tot − q_sat is
-# assumed Gaussian: S ~ N(μ_S, σ_S²), with σ_S computed by the pre-pass
-# quadrature.  Working with the centred excess S′ = S − μ_S ~ N(0, σ_S²),
-# we seek a Lagrange multiplier λ that enforces mass conservation:
+# assumed Gaussian: S ~ N(μ_S, σ_S²), with μ_S set analytically to the
+# linearized mean μ_S = q_tot_mean − q_sat(T_mean, ρ) (exact under the
+# same linearization that justifies Gaussianity of S) and σ_S accumulated
+# in one pass as E[(S − μ_S)²] (see `_sgs_saturation_moments`).
+# Working with the centred excess S′ = S − μ_S ~ N(0, σ_S²), we seek a
+# Lagrange multiplier λ that enforces mass conservation:
 #
 #     E[max(0, λ + α·S′)] = q_c,                                     (*)
 #
@@ -510,13 +525,16 @@ end
 """
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
-Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
+Single quadrature pass returning `(sigma_S, λ_lagrange)`:
 
-  - `mu_S       = E[S]`: SGS mean saturation variable.
-  - `sigma_S    = sqrt(Var[S])`: SGS standard deviation, clipped at
+  - `sigma_S    = sqrt(E[(S − μ_S)²])`: SGS standard deviation, clipped at
     `ϵ_numerics(FT)` (see [`_sgs_saturation_moments`](@ref)).
   - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
     `E[max(0, λ + α·S′)] = q_c`.
+
+The SGS mean `μ_S = q_tot − q_sat(T, ρ)` is analytic under the closure's
+linearization (see [`_sgs_saturation_moments`](@ref)) and is recomputed
+on demand wherever it is needed downstream.
 """
 @inline function _compute_sgs_moments(
     thp, ρ, T, q_tot, q_c,
@@ -528,11 +546,7 @@ Single quadrature pass returning `(mu_S, sigma_S, λ_lagrange)`:
     C = q_c / σ_S_eff
     z = _compute_z(C)
     λ_lagrange = z * σ_S_eff
-    return (;
-        moments.mu_S,
-        moments.sigma_S,
-        λ_lagrange,
-    )
+    return (; moments.sigma_S, λ_lagrange)
 end
 
 """
@@ -541,7 +555,7 @@ end
 Final post-Aitken update. No-op when `ᶜsgs_moments` is not allocated (dry / 0M).
 
 Uses ONE quadrature pass via `_compute_sgs_moments` to fill
-`ᶜsgs_moments = (mu_S, sigma_S, λ_lagrange)`, then computes
+`ᶜsgs_moments = (sigma_S, λ_lagrange)`, then computes
 `ᶜcloud_fraction` consistently with the augmented `σ_aug` closure (see
 [`_compute_cloud_fraction`](@ref)) and applies EDMF updraft weighting.
 """
@@ -562,7 +576,7 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     σ_abs = CAP.cloud_fraction_sigma_abs(p.params)
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
 
-    # ONE quadrature pass → (mu_S, sigma_S, λ_lagrange).
+    # ONE quadrature pass → (sigma_S, λ_lagrange).
     @. p.precomputed.ᶜsgs_moments = _compute_sgs_moments(
         thermo_params, ᶜρ_env, ᶜT_mean, ᶜq_mean, ᶜq_lcl + ᶜq_icl,
         $(sgs_quad), ᶜT′T′, ᶜq′q′, corr_Tq, FT(α),

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -215,7 +215,7 @@ struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     # Truncated-Gaussian Lagrange multiplier, μ_S, and liquid fraction
     λ::FT              # liquid fraction (from thermodynamics, held fixed)
     λ_lagrange::FT # Lagrange multiplier for centred S′: λ = z·α·σ_S
-    mu_S::FT       # SGS mean saturation variable μ_S = E[S]
+    mu_S::FT       # linearized SGS mean μ_S = q_tot_mean − q_sat(T_mean, ρ)
     α::FT          # variance fidelity parameter (from sgs_variance_fidelity)
     # Numerical parameters
     dt::FT
@@ -259,7 +259,7 @@ end
     microphysics_tendencies_1m(
         scheme, sgs_quad, cmp, thp, ρ, T, q_tot,
         q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
-        λ_lagrange, mu_S, α, dt, nsubs,
+        λ_lagrange, α, dt, nsubs,
     )
 
 Computes time-averaged 1-moment microphysics tendencies.
@@ -269,8 +269,10 @@ used in EDMF updrafts or wherever a grid-mean state is to be evaluated
 directly (single BMT call, no SGS averaging).
 
 The quadrature form integrates over the SGS PDF using the truncated-Gaussian
-Lagrange-multiplier closure (see [`Microphysics1MEvaluator`](@ref)). At each
-quadrature point `(T_hat, q_tot_hat)` the centred saturation excess is
+Lagrange-multiplier closure (see [`Microphysics1MEvaluator`](@ref)). The
+linearized SGS mean `μ_S = q_tot − q_sat(T, ρ)` is computed locally from
+the mean state (no caching required). At each quadrature point
+`(T_hat, q_tot_hat)` the centred saturation excess is
 `S′_hat = (q_tot_hat − q_sat_hat) − μ_S` and the local condensate is
 
     shifted_excess = max(0, λ_lagrange + α·S′_hat)
@@ -296,7 +298,6 @@ sublimation; saturated points drive autoconversion and accretion.
   - `corr_Tq`: Correlation coefficient ρ(T′, q′) from `correlation_Tq(params)`
   - `λ_lagrange`: Lagrange multiplier `z·α·σ_S` from `ᶜsgs_moments`, pre-computed
     to enforce mass conservation `E[max(0, λ_lagrange + α·S′)] = q_c`
-  - `mu_S`: SGS mean saturation variable `E[S]` from `ᶜsgs_moments`
   - `α`: Variance fidelity parameter from `sgs_variance_fidelity`
   - `dt`: Timestep [s]
   - `nsubs`: Number of substeps for tendency averaging
@@ -323,7 +324,7 @@ end
 @inline function microphysics_tendencies_1m( #microphysics_tendencies_quadrature_1m
     scheme, sgs_quad, cmp, thp, ρ, T, q_tot_nonneg,
     q_lcl, q_icl, q_rai, q_sno, T′T′, q′q′, corr_Tq,
-    λ_lagrange, mu_S, α, dt, nsubs, args...,
+    λ_lagrange, α, dt, nsubs, args...,
 )
     FT = typeof(ρ)
     # Clamp specific humidities to non-negative.
@@ -334,6 +335,10 @@ end
 
     # Liquid fraction held fixed across quadrature.
     λ = TD.liquid_fraction(thp, T, q_lcl_nonneg, q_icl_nonneg)
+
+    # Linearized SGS mean of S = q_tot − q_sat, computed at the mean state
+    # (same approximation that justifies the truncated-Gaussian closure).
+    mu_S = q_tot_nonneg - TD.q_vap_saturation(thp, T, ρ)
 
     evaluator = Microphysics1MEvaluator(
         scheme, cmp, thp, ρ,

--- a/test/parameterized_tendencies/microphysics/sgs_moments.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_moments.jl
@@ -1,8 +1,9 @@
 #=
 Unit tests for the SGS quadrature infrastructure.
 
-Tests `SGSMomentsEvaluator` and `_sgs_saturation_moments`, verifying:
-  - S = q_tot − q_sat always, regardless of SGS distribution type
+Tests `SGSVarianceEvaluator` and `_sgs_saturation_moments`, verifying:
+  - μ_S equals the linearized analytic mean q_tot_mean − q_sat(T_mean, ρ)
+  - `SGSVarianceEvaluator` evaluated at the mean point gives zero
   - σ_S ≥ ϵ_numerics in the zero-variance limit (T′T′ = q′q′ = 0)
   - σ_S is monotonically increasing with σ_q
   - grid-mean fallback: nothing and GridMeanSGS give the same result
@@ -17,10 +18,9 @@ const CA = ClimaAtmos
 
 @testset "SGS Moments" begin
 
-    @testset "SGSMomentsEvaluator: S = q_tot − q_sat for all distribution types" begin
-        # The saturation variable is always the linear excess S = q_tot − q_sat.
-        # The SGS distribution type (Gaussian / lognormal) controls how quadrature
-        # points are sampled, not the definition of S.
+    @testset "SGSVarianceEvaluator: (S − μ_S)² with linearized μ_S" begin
+        # μ_S is set analytically to q_tot_mean − q_sat(T_mean, ρ).
+        # At the mean state, S = μ_S, so the evaluator returns 0.
         for FT in (Float32, Float64)
             @testset "FT = $FT" begin
                 toml_dict = CP.create_toml_dict(FT)
@@ -29,13 +29,21 @@ const CA = ClimaAtmos
                 T_mean = FT(280.0)
                 q_sat_mean = TD.q_vap_saturation(thp, T_mean, ρ)
                 q_tot_mean = q_sat_mean + FT(2e-3)
-                expected_S = q_tot_mean - q_sat_mean
+                mu_S = q_tot_mean - q_sat_mean
 
-                eval = CA.SGSMomentsEvaluator(thp, ρ)
-                out = eval(T_mean, q_tot_mean)
+                eval = CA.SGSVarianceEvaluator(thp, ρ, mu_S)
+                @test eval(T_mean, q_tot_mean) ≈ FT(0) atol = eps(FT)
 
-                @test out.mu_S ≈ expected_S rtol = FT(1e-5)
-                @test out.s_sq ≈ expected_S^2 rtol = FT(1e-5)
+                # Off-mean point gives (S − μ_S)² > 0.
+                δq = FT(1e-4)
+                out = eval(T_mean, q_tot_mean + δq)
+                @test out ≈ δq^2 rtol = FT(1e-5)
+
+                # `_sgs_saturation_moments` exposes μ_S = analytic value.
+                mom = CA._sgs_saturation_moments(
+                    thp, ρ, T_mean, q_tot_mean, nothing, FT(0), FT(0), FT(0),
+                )
+                @test mom.mu_S ≈ mu_S rtol = FT(1e-6)
             end
         end
     end

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -359,7 +359,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad_1pt, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, λ_lagrange, mu_S, α, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, λ_lagrange, α, dt, nsubs_quad,
                     )
 
                     result_direct = BMT.bulk_microphysics_tendencies(
@@ -383,7 +383,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), λ_lagrange, mu_S, α, dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), λ_lagrange, α, dt, nsubs_quad,
                     )
 
                     result_direct = BMT.bulk_microphysics_tendencies(
@@ -405,7 +405,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, λ_lagrange, mu_S, α, dt, nsubs_quad,
+                        T′T′, q′q′, corr_Tq, λ_lagrange, α, dt, nsubs_quad,
                     )
 
                     @test haskey(result, :dq_lcl_dt)
@@ -423,14 +423,14 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.8), λ_lagrange, mu_S, α, dt, nsubs_quad,
+                        FT(4.0), FT(1e-5), FT(0.8), λ_lagrange, α, dt, nsubs_quad,
                     )
 
                     result_no_var = microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(),
                         quad, mp, tps, ρ,
                         T_mean, q_tot_mean, q_lcl_mean, q_icl_mean, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), λ_lagrange, mu_S, α, dt, nsubs_quad,
+                        FT(0), FT(0), FT(0), λ_lagrange, α, dt, nsubs_quad,
                     )
 
                     @test isfinite(result_var.dq_lcl_dt)
@@ -505,7 +505,7 @@ using ClimaAtmos
                 result = microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, λ_lagrange, mu_S, α, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, λ_lagrange, α, dt, nsubs_quad,
                 )
 
                 # Total condensed water tendency
@@ -574,7 +574,7 @@ using ClimaAtmos
                 result = @inferred microphysics_tendencies_1m(
                     BMT.Microphysics1Moment(),
                     quad, mp, thp, ρ, T, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, λ_lagrange, mu_S, α, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, λ_lagrange, α, dt, nsubs_quad,
                 )
 
                 # Verify return type
@@ -702,7 +702,7 @@ using ClimaAtmos
                     BMT.Microphysics1Moment(),
                     quad_gm, mp, tps, ρ,
                     T_mean, q_tot, q_liq, q_ice, q_rai, q_sno,
-                    T′T′, q′q′, corr_Tq, λ_lagrange_gm, mu_S_gm, α_gm, dt, nsubs_quad,
+                    T′T′, q′q′, corr_Tq, λ_lagrange_gm, α_gm, dt, nsubs_quad,
                 )
 
                 # Direct BMT call
@@ -807,7 +807,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(0), FT(0), FT(0), λ_lagrange_gm, mu_S_gm, α_gm, dt,
+                        FT(0), FT(0), FT(0), λ_lagrange_gm, α_gm, dt,
                         nsubs_quad,
                     )
 
@@ -832,7 +832,7 @@ using ClimaAtmos
                         BMT.Microphysics1Moment(),
                         quad, mp_1m, thp, ρ, T,
                         q_tot, q_liq, q_ice, q_rai, q_sno,
-                        FT(4.0), FT(1e-5), FT(0.6), λ_lagrange_gm, mu_S_gm, α_gm, dt,
+                        FT(4.0), FT(1e-5), FT(0.6), λ_lagrange_gm, α_gm, dt,
                         nsubs_quad,
                     )
                     for field in (:dq_lcl_dt, :dq_icl_dt, :dq_rai_dt, :dq_sno_dt)
@@ -994,7 +994,7 @@ using ClimaAtmos
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, λ_lagrange_perf, mu_S_perf, α_perf, dt,
+                        T′T′, q′q′, corr_Tq, λ_lagrange_perf, α_perf, dt,
                         nsubs_quad,
                     )
                 end
@@ -1002,7 +1002,7 @@ using ClimaAtmos
                     microphysics_tendencies_1m(
                         BMT.Microphysics1Moment(), quad, mp_1m, thp, ρ, T,
                         q_tot, q_lcl, q_icl, q_rai, q_sno,
-                        T′T′, q′q′, corr_Tq, λ_lagrange_perf, mu_S_perf, α_perf, dt,
+                        T′T′, q′q′, corr_Tq, λ_lagrange_perf, α_perf, dt,
                         nsubs_quad,
                     )
                 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Use linearized analytic μ_S (q_t - q_sat(mean variables)), and accumulate σ_S² as E[(S − μ_S)²] in one quadrature pass to avoid Float32 catastrophic cancellation when Var[S] ≪ (E[S])².

## Why
In Float32, computing σ_S² = E[S²] − (E[S])² via quadrature loses all precision when Var[S] ≪ (E[S])² (the subtraction cancels out the variance and σ_S collapses to zero, causing unusual snow and cloud production at high altitudes). This PR replaces that with an analytic linearized mean μ_S = q_tot_mean − q_sat(T_mean, ρ) and accumulates σ_S² = E[(S − μ_S)²] directly in one quadrature pass — no cancellation. Using the linearized μ_S is consistent with the same linearization of q_sat(T) that already underlies the truncated-Gaussian closure (any difference from the true E[S] is the q_sat-curvature term we already discard), and as a bonus we no longer need to cache mu_S since it's a cheap analytic expression of the mean state.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
