### PR TITLE
Fix a > a_max growth

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-367
+368
 
 # **README**
 #
@@ -32,6 +32,10 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+368
+- Apply upper-area limiter to the implicit mass-flux-divergence detrainment
+  prefactor so updraft area cannot grow past a_max via advection.
+
 367
 - SGS saturation moments: use linearized analytic μ_S and accumulate σ_S²
   as E[(S − μ_S)²] in one quadrature pass to avoid Float32 catastrophic

--- a/src/prognostic_equations/edmfx_boundary_condition.jl
+++ b/src/prognostic_equations/edmfx_boundary_condition.jl
@@ -176,9 +176,9 @@ end
 Volumetric mass source rate `F_sfc / dz_int` [kg/m³/s] at the first
 cell for one EDMF updraft, equivalent to `div(F·ẑ)` at level 1.
 `F_sfc` is the capped surface mass flux with the
-`entr_upper_area_limiter_factor(a)` baked in:
+`upper_area_limiter_factor(a)` baked in:
 
-    F_pre   = surface_mass_flux(...) · entr_upper_area_limiter_factor(a),
+    F_pre   = surface_mass_flux(...) · upper_area_limiter_factor(a),
     F_max_χ = α · sfc_ρ_flux_χ / max(ϵ, χ_buoyant − χ_env)
                                               for χ ∈ {mse, q_tot},
     F_sfc   = max(0, min(F_pre, F_max_mse, F_max_q_tot)).
@@ -221,7 +221,7 @@ consumed elsewhere by the mse/q_tot tendency.
             ustar,
             a_s_max,
             c_u,
-        ) * entr_upper_area_limiter_factor(
+        ) * upper_area_limiter_factor(
             draft_area(ρaʲ_int, ρʲ_int),
             turbconv_params,
         )
@@ -250,7 +250,7 @@ updraft variables this gives a flux-form tendency at the first cell:
     d(val)/dt += mass_flux_source · (val_buoyant − val) / max(ρa, ρ·a_min),
 
 where `mass_flux_source` already includes the env-positivity cap and
-the `entr_upper_area_limiter_factor(a)` that smoothly shuts the source
+the `upper_area_limiter_factor(a)` that smoothly shuts the source
 off as the plume area approaches `a_max`. The `max(ρa, ρ·a_min)` floor
 keeps the divisor finite when the updraft is small.
 

--- a/src/prognostic_equations/edmfx_entr_detr.jl
+++ b/src/prognostic_equations/edmfx_entr_detr.jl
@@ -63,7 +63,7 @@ function calculate_pi_groups(
 end
 
 """
-    entr_upper_area_limiter_factor(a, turbconv_params)
+    upper_area_limiter_factor(a, turbconv_params)
 
 Return a multiplicative limiter for the entrainment rate based on the
 current subdraft area `a`.
@@ -76,11 +76,11 @@ bound `a_max` (preventing the area from being driven above `a_max`):
 The upper bound `a_max` is obtained from `turbconv_params` through
 `CAP.max_area`, and `max_area_limiter_power` from `CAP.max_area_limiter_power`.
 
-This is the entrainment counterpart of [`detr_lower_area_limiter_factor`](@ref),
+This is the entrainment counterpart of [`lower_area_limiter_factor`](@ref),
 which damps detrainment near the lower bound `a_min`. Together they keep
 `a ∈ [a_min, a_max]` without requiring a comparison between `entr` and `detr`.
 """
-@inline function entr_upper_area_limiter_factor(a::FT, turbconv_params) where {FT}
+@inline function upper_area_limiter_factor(a::FT, turbconv_params) where {FT}
     a_max = CAP.max_area(turbconv_params)
     max_area_limiter_power = CAP.max_area_limiter_power(turbconv_params)
     a_safe = max(eps(FT), a)
@@ -88,7 +88,7 @@ which damps detrainment near the lower bound `a_min`. Together they keep
 end
 
 """
-    detr_lower_area_limiter_factor(a, turbconv_params)
+    lower_area_limiter_factor(a, turbconv_params)
 
 Return a multiplicative limiter for the detrainment rate based on the current
 subdraft area `a`.
@@ -101,11 +101,11 @@ The factor smoothly damps detrainment as the area approaches the lower bound
 The lower bound `a_min` is obtained from `turbconv_params` through
 `CAP.min_area`, and `min_area_limiter_power` from `CAP.min_area_limiter_power`.
 
-This is the detrainment counterpart of [`entr_upper_area_limiter_factor`](@ref),
+This is the detrainment counterpart of [`upper_area_limiter_factor`](@ref),
 which damps entrainment near the upper bound `a_max`. Together they keep
 `a ∈ [a_min, a_max]` without requiring a comparison between `entr` and `detr`.
 """
-@inline function detr_lower_area_limiter_factor(a::FT, turbconv_params) where {FT}
+@inline function lower_area_limiter_factor(a::FT, turbconv_params) where {FT}
     a_min = CAP.min_area(turbconv_params)
     min_area_limiter_power = CAP.min_area_limiter_power(turbconv_params)
     a_safe = max(eps(FT), a)
@@ -266,7 +266,7 @@ function entrainment_velocity_scale(
         entr_param_vec[5] * abs(Π₅) +
         entr_param_vec[6]
 
-    area_limiter_factor = entr_upper_area_limiter_factor(ᶜaʲ, turbconv_params)
+    area_limiter_factor = upper_area_limiter_factor(ᶜaʲ, turbconv_params)
     entr_vel_scale = area_limiter_factor * max(0, pi_sum) / elev_above_sfc
     return max(0, entr_vel_scale)
 end
@@ -298,7 +298,7 @@ function entrainment_velocity_scale(
         return 0
     end
 
-    area_limiter_factor = entr_upper_area_limiter_factor(ᶜaʲ, turbconv_params)
+    area_limiter_factor = upper_area_limiter_factor(ᶜaʲ, turbconv_params)
     entr_vel_scale = area_limiter_factor * entr_vel_scale_param / elev_above_sfc
     return max(0, entr_vel_scale)
 end
@@ -350,7 +350,7 @@ end
 
 Total detrainment rate [1/s] as the sum of the model-specific rate from
 `detrainment_rate` (which internally applies
-[`detr_lower_area_limiter_factor`](@ref) so that detrainment is damped as
+[`lower_area_limiter_factor`](@ref) so that detrainment is damped as
 `a → a_min`) with the negative part of the signed area-bounding rate:
 
     detr = detrainment_rate(...) + max(0, -area_bounding_entr_detr)
@@ -443,7 +443,7 @@ function detrainment_rate(
     detr_massflux_vertdiv_coeff =
         CAP.detr_massflux_vertdiv_coeff(turbconv_params)
 
-    area_limiter_factor = detr_lower_area_limiter_factor(ᶜaʲ, turbconv_params)
+    area_limiter_factor = lower_area_limiter_factor(ᶜaʲ, turbconv_params)
     detr =
         area_limiter_factor *
         (

--- a/src/prognostic_equations/implicit/initialize_implicit_problem.jl
+++ b/src/prognostic_equations/implicit/initialize_implicit_problem.jl
@@ -341,16 +341,37 @@ function solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
         @. ᶠw = Y.f.sgsʲs.:($$j).u₃.components.data.:1 / ᶠdz
 
         # entr and detr
-        ᶜarea_limiter_factor = @. lazy(
-            detr_lower_area_limiter_factor(
+        ᶜlower_limiter_factor = @. lazy(
+            lower_area_limiter_factor(
                 draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
                 turbconv_params,
             ),
         )
+        ᶜupper_limiter_factor = @. lazy(
+            upper_area_limiter_factor(
+                draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)),
+                turbconv_params,
+            ),
+        )
+        # Effective mass-flux-divergence detrainment fraction (Lagrangian fraction
+        # of converging mass detrained at this level):
+        #
+        #     detr_coeff = 1 − U · (1 − L · C),
+        #
+        # where U = `upper_area_limiter_factor(a)` (→ 0 as a → a_max),
+        # L = `lower_area_limiter_factor(a)` (→ 0 as a → a_min), and
+        # C = `detr_massflux_vertdiv_coeff`. Endpoint behavior:
+        #   - U = 1 (a ≪ a_max): detr_coeff = L · C — standard regime.
+        #   - U = 0 (a → a_max): detr_coeff = 1 — implicit detrainment soaks up
+        #     100% of the converging mass regardless of C, capping area at a_max
+        #     even when advection alone would push it past.
+        # The recurrence consumes `one_minus_prefactor = 1 − detr_coeff
+        # = U · (1 − L · C)`.
         ᶜone_minus_implicit_detr_prefactor = @. lazy(
             ifelse(
                 ᶜdivᵥ(ᶠleft_bias(Y.c.sgsʲs.:($$j).ρa) * Y.f.sgsʲs.:($$j).u₃) < 0,
-                FT(1) - ᶜarea_limiter_factor * detr_massflux_vertdiv_coeff,
+                ᶜupper_limiter_factor *
+                (FT(1) - ᶜlower_limiter_factor * detr_massflux_vertdiv_coeff),
                 FT(1),
             ),
         )
@@ -373,7 +394,7 @@ function solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
         @. ᶜexplicit_entr_minus_detr =
             ᶜarea_bounding_entr_detrʲs.:($$j) +
             ᶜentr_vel_scaleʲs.:($$j) * ᶜinterp(ᶠw) -
-            ᶜarea_limiter_factor * detr_buoy_coeff * ᶜbuoy_inv_time_scale
+            ᶜlower_limiter_factor * detr_buoy_coeff * ᶜbuoy_inv_time_scale
 
         @. ᶜnumerator = Y.c.sgsʲs.:($$j).ρa / dtγ
         # Floor at 0.1 / dtγ so (ε − δ) is effectively bounded by 0.9/dtγ,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose
In AMIP runs, the updraft area a was growing close to 1 and breaking the simulation. The root cause was the implicit massflux-divergence detrainment prefactor in `initialize_implicit_problem.jl`: when `detr_massflux_vertdiv_coeff < 1`, the prefactor stayed strictly positive, so advection kept pumping mass into the updraft even past `a_max`.

## Fix
Multiply the prefactor by `upper_area_limiter_factor` so the effective detrainment fraction is `detr_coeff = 1 − U·(1 − L·C)` with `U → 0` as `a → a_max`. In that limit the implicit step detrains all of the converging mass regardless of `C`, capping a at a_max.
Also renamed `entr_upper_area_limiter_factor`/`detr_lower_area_limiter_factor` to `upper_area_limiter_factor` / `lower_area_limiter_factor` since they are now used outside entr/detr (e.g. surface mass flux).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
