### PR TITLE
Add verbose logging option for AtmosSimulation

### DIFF
--- a/perf/benchmark_step.jl
+++ b/perf/benchmark_step.jl
@@ -70,10 +70,10 @@ else
     # Profile with Julia's built-in profiler
     n_steps = 10
     local e
-    s = CA.@timed_str begin
+    CA.@timed_log true "Ran step! $n_steps times" begin
         e = ClimaComms.elapsed(device) do
             benchmark_step!(integrator, Y₀, n_steps) # run
         end
     end
-    @info "Ran step! $n_steps times in $s, ($(CA.prettytime(e/n_steps*1e9)) per step)"
+    @info "$(CA.prettytime(e / n_steps * 1e9)) per step"
 end

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -248,8 +248,7 @@ function get_steady_state_velocity(params, Y, topo, initial_condition, mesh_warp
     top_level = Spaces.nlevels(axes(Y.c)) + Fields.half
     z_top = Fields.level(Fields.coordinate_field(Y.f).z, top_level)
 
-    @info "Approximating steady-state velocity"
-    s = @timed_str begin
+    @timed_log true "Approximating steady-state velocity" begin
         ᶜu = steady_state_velocity.(topo, params, Fields.coordinate_field(Y.c), z_top)
         ᶠu =
             steady_state_velocity.(topo, params, Fields.coordinate_field(Y.f), z_top)
@@ -546,6 +545,7 @@ function get_simulation(config::AtmosConfig)
         diagnostics = diagnostics_config_from_config(config),
         checkpoint_frequency = pa["dt_save_state_to_disk"],
         log_to_file = pa["log_to_file"],
+        verbose = true,  # Config-based runs are always verbose
     )
 
     @info "Simulation info" job_id = sim.job_id output_dir = sim.output_dir

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -26,7 +26,8 @@ function setup_diagnostics_and_writers(
     t_start,
     t_end,
     start_date,
-    output_dir,
+    output_dir;
+    verbose = false,
 )
     (; default, additional, interpolation_num_points, output_at_levels) =
         diagnostics_config
@@ -67,7 +68,8 @@ function setup_diagnostics_and_writers(
             topography = has_topography(axes(Y.c)),
         )
         append!(all_diagnostics, default_diag_list)
-        @info "Added $(length(default_diag_list)) default ClimaAtmos diagnostics"
+        verbose &&
+            @info "Added $(length(default_diag_list)) default ClimaAtmos diagnostics"
     end
 
     # Add user-provided diagnostics
@@ -78,7 +80,8 @@ function setup_diagnostics_and_writers(
 
         if !isempty(prebuilt)
             append!(all_diagnostics, prebuilt)
-            @info "Added $(length(prebuilt)) user-provided ScheduledDiagnostic objects"
+            verbose &&
+                @info "Added $(length(prebuilt)) user-provided ScheduledDiagnostic objects"
         end
 
         if !isempty(dict_specs)
@@ -108,7 +111,8 @@ function setup_diagnostics_and_writers(
                 dict_specs, Y, t_start, start_date, writers,
             )
             append!(all_diagnostics, user_scheduled_diagnostics)
-            @info "Added $(length(user_scheduled_diagnostics)) user-provided YAML-style diagnostics"
+            verbose &&
+                @info "Added $(length(user_scheduled_diagnostics)) user-provided YAML-style diagnostics"
         end
     end
 
@@ -116,7 +120,8 @@ function setup_diagnostics_and_writers(
     periods_reductions = CAD.extract_diagnostic_periods(all_diagnostics)
     if !isempty(periods_reductions)
         periods_str = join(promote_period.(periods_reductions), ", ")
-        @info "Saving accumulated diagnostics to disk with frequency: $(periods_str)"
+        verbose &&
+            @info "Saving accumulated diagnostics to disk with frequency: $(periods_str)"
     end
 
     return all_diagnostics, writers, periods_reductions
@@ -267,7 +272,11 @@ function AtmosSimulation{FT}(;
     # Misc
     checkpoint_frequency = Inf,
     log_to_file = false,
+    verbose = false,
 ) where {FT}
+    # Log only on root process
+    verbose = ClimaComms.iamroot(context) && verbose
+
     # Set up output directory and restart file detection
     output_dir, restart_file = setup_output_dir(
         job_id, output_dir, output_dir_style,
@@ -276,8 +285,8 @@ function AtmosSimulation{FT}(;
 
     if !isnothing(restart_file)
         # Handle restart: validates t_start, loads state, logs info, extracts spaces
-        (Y, t_start, spaces) = handle_restart(
-            restart_file, t_start, start_date, model, context,
+        (Y, t_start, spaces) = @timed_log verbose "Loaded restart file" handle_restart(
+            restart_file, t_start, start_date, model, context; verbose,
         )
         # t_start is already converted from restart file, but we still need to convert dt and t_end
         dt = ITime(time_to_seconds(dt))
@@ -287,14 +296,16 @@ function AtmosSimulation{FT}(;
     else
         dt, t_start, t_end = convert_time_args(dt, t_start, t_end, start_date)
         spaces = get_spaces(grid)
-        Y = Setups.initial_state(
-            setup, params, model,
-            spaces.center_space,
-            spaces.face_space,
-        )
-        Setups.overwrite_initial_state!(
-            setup, Y, params.thermodynamics_params,
-        )
+        @timed_log verbose "Initialized state" begin
+            Y = Setups.initial_state(
+                setup, params, model,
+                spaces.center_space,
+                spaces.face_space,
+            )
+            Setups.overwrite_initial_state!(
+                setup, Y, params.thermodynamics_params,
+            )
+        end
     end
 
     # Resolve steady_state_velocity: accept nothing, a precomputed velocity field,
@@ -303,14 +314,14 @@ function AtmosSimulation{FT}(;
         steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
         steady_state_velocity
 
-    p = build_cache(
+    p = @timed_log verbose "Built cache" build_cache(
         Y, model, params, dt, start_date, aerosol_names,
         time_varying_trace_gases, resolved_steady_state_velocity,
         vertical_water_borrowing_species,
     )
 
     # Combine all callbacks
-    discrete_callbacks = if default_callbacks
+    discrete_callbacks = @timed_log verbose "Assembled callbacks" if default_callbacks
         checkpoint_frequency = parse_checkpoint_frequency(checkpoint_frequency)
         (
             default_model_callbacks(
@@ -333,17 +344,23 @@ function AtmosSimulation{FT}(;
         callback_set,
         jacobian, debug_jacobian,
         model.prescribed_flow,
-        dt,
+        dt;
+        verbose,
     )
 
-    integrator = CTS.init(integrator_args...; integrator_kwargs...)
-
-    all_diagnostics, writers, periods_reductions = setup_diagnostics_and_writers(
-        diagnostics, model,
-        Y, p, dt,
-        t_start, t_end, start_date,
-        output_dir,
+    integrator = @timed_log verbose "Initialized integrator" CTS.init(
+        integrator_args...;
+        integrator_kwargs...,
     )
+
+    all_diagnostics, writers, periods_reductions =
+        @timed_log verbose "Set up diagnostics" setup_diagnostics_and_writers(
+            diagnostics, model,
+            Y, p, dt,
+            t_start, t_end, start_date,
+            output_dir;
+            verbose,
+        )
 
     validate_checkpoint_diagnostics_consistency(
         checkpoint_frequency, periods_reductions,
@@ -355,7 +372,7 @@ function AtmosSimulation{FT}(;
             integrator,
             all_diagnostics,
         )
-        @info "Initialized $(length(all_diagnostics)) total diagnostics"
+        verbose && @info "Initialized $(length(all_diagnostics)) total diagnostics"
     end
 
     reset_graceful_exit(output_dir)

--- a/src/simulation/integrator.jl
+++ b/src/simulation/integrator.jl
@@ -7,13 +7,14 @@ import ClimaUtilities.TimeManager: ITime
 #####
 
 function get_jacobian(
-    ode_algo, Y, atmos, jacobian::JacobianAlgorithm, debug_jacobian,
+    ode_algo, Y, atmos, jacobian::JacobianAlgorithm, debug_jacobian;
+    verbose = false,
 )
     ode_algo isa Union{CTS.IMEXAlgorithm, CTS.RosenbrockAlgorithm} ||
         return nothing
-    @info "Jacobian algorithm: $(summary_string(jacobian))"
+    verbose && @info "Jacobian algorithm: $(summary_string(jacobian))"
     jac = Jacobian(jacobian, Y, atmos; verbose = debug_jacobian)
-    if hasproperty(jac.cache, :derivative_flags)
+    if verbose && hasproperty(jac.cache, :derivative_flags)
         flags_str = join(
             ("$k = $(typeof(v).name.name)" for (k, v) in pairs(jac.cache.derivative_flags)),
             ", ",
@@ -83,10 +84,11 @@ function ode_configuration(::Type{FT}, ode_name, update_jacobian_every,
 end
 
 function args_integrator(Y, p, tspan, ode_algo, callback,
-    jacobian, debug_jacobian, prescribed_flow, dt_integrator,
+    jacobian, debug_jacobian, prescribed_flow, dt_integrator;
+    verbose = false,
 )
     (; atmos) = p
-    s = @timed_str begin
+    @timed_log verbose "Built tendency function" begin
         if isnothing(prescribed_flow)
 
             # This is the default case
@@ -94,7 +96,7 @@ function args_integrator(Y, p, tspan, ode_algo, callback,
             T_imp! = CTS.ODEFunction(
                 implicit_tendency!;
                 jac_prototype = get_jacobian(
-                    ode_algo, Y, atmos, jacobian, debug_jacobian,
+                    ode_algo, Y, atmos, jacobian, debug_jacobian; verbose,
                 ),
                 Wfact = update_jacobian!,
             )

--- a/src/simulation/restart.jl
+++ b/src/simulation/restart.jl
@@ -29,7 +29,7 @@ function get_state_restart(
 end
 
 """
-    handle_restart(restart_file, t_start_original, start_date, model, context)
+    handle_restart(restart_file, t_start_original, start_date, model, context; verbose = false)
 
 Handle restart file loading with validation and logging.
 
@@ -47,7 +47,8 @@ function handle_restart(
     t_start_original,
     start_date,
     model,
-    context,
+    context;
+    verbose = false,
 )
     # Validate t_start before restart (matches get_simulation behavior)
     t_start_seconds = time_to_seconds(t_start_original)
@@ -59,7 +60,10 @@ function handle_restart(
         restart_file, start_date, hash(model), context,
     )
 
-    @info "Restarting simulation from file" restart_file restart_time = string(t_start)
+    if verbose
+        @info "Restarting simulation from file" restart_file restart_time =
+            string(t_start)
+    end
 
     spaces = (; center_space = axes(Y.c), face_space = axes(Y.f))
 

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -521,15 +521,32 @@ function prettymemory(b)
 end
 
 """
-    @timed_str expr
-    @timed_str "description" expr
+    @timed_log verbose "message" expr
 
-Returns a string containing `@timed` information.
+Evaluate `expr` and return its value. If `verbose` is true, also `@info` the
+message with elapsed time and allocations appended, e.g.
+`"Building cache (1.2 s, 340.0 MiB)"`. When `verbose` is false the expression is
+evaluated without any logging or timing overhead.
+
+`stats.value` is returned so the macro can wrap the right-hand side of a
+destructuring assignment, e.g. `(Y, t_start, spaces) = @timed_log verbose "..." f()`.
 """
-macro timed_str(ex)
+macro timed_log(verbose, message, ex)
     quote
-        local stats = @timed $(esc(ex))
-        "$(prettytime(stats.time*1e9)) ($(Base.gc_alloc_count(stats.gcstats)) allocations: $(prettymemory(stats.gcstats.allocd)))"
+        if $(esc(verbose))
+            local stats = @timed $(esc(ex))
+            @info string(
+                $(esc(message)),
+                " (",
+                prettytime(stats.time * 1e9),
+                ", ",
+                prettymemory(stats.gcstats.allocd),
+                ")",
+            )
+            stats.value
+        else
+            $(esc(ex))
+        end
     end
 end
 


### PR DESCRIPTION
This PR adds a verbose logging option for the AtmosSimulation constructor, false by default. Config-based simulations always run with this option on, with no logging removed. This PR also replaced the `@timed_str` macro with a `@timed_log` macro that takes the `verbose` boolean. No existing log messages have been removed, a few have been added.