### PR TITLE
Implicit moisture and energy unwinding

### DIFF
--- a/config/model_configs/baroclinic_wave.yml
+++ b/config/model_configs/baroclinic_wave.yml
@@ -2,6 +2,9 @@ dt_save_state_to_disk: "2days"
 initial_condition: "DryBaroclinicWave"
 t_end: "10days"
 disable_surface_flux_tendency: true
+# Implicit vertical upwind advection of ρe_tot/ρq_tot with a central-only
+# Wfact needs ~3 Newton iterations to converge at large baroclinic-wave dt.
+max_newton_iters_ode: 3
 diagnostics:
   - short_name: [pfull, ua, wa, va, rv, ta, ke]
     period: 1days

--- a/config/model_configs/baroclinic_wave_conservation.yml
+++ b/config/model_configs/baroclinic_wave_conservation.yml
@@ -3,6 +3,9 @@ t_end: "5days"
 dt_save_state_to_disk: "5days"
 disable_surface_flux_tendency: true
 check_conservation: true
+# Implicit vertical upwind advection of ρe_tot/ρq_tot with a central-only
+# Wfact needs ~3 Newton iterations to converge at large baroclinic-wave dt.
+max_newton_iters_ode: 3
 diagnostics:
   - short_name: [massa, energya]
     period: 1days

--- a/config/model_configs/baroclinic_wave_equil.yml
+++ b/config/model_configs/baroclinic_wave_equil.yml
@@ -5,6 +5,9 @@ initial_condition: "MoistBaroclinicWave"
 dt: "450secs"
 t_end: "6days"
 disable_surface_flux_tendency: true
+# Implicit vertical upwind advection of ρe_tot/ρq_tot with a central-only
+# Wfact needs ~3 Newton iterations to converge at large baroclinic-wave dt.
+max_newton_iters_ode: 3
 diagnostics:
   - short_name: [pfull, wa, va, rv, hus, ke]
     period: 1days

--- a/config/model_configs/baroclinic_wave_equil_conservation_source.yml
+++ b/config/model_configs/baroclinic_wave_equil_conservation_source.yml
@@ -7,9 +7,8 @@ microphysics_model: "0M"
 vert_diff: "VerticalDiffusion"
 dt_save_state_to_disk: "5days"
 check_conservation: true
-# Implicit 0M + SGS quadrature produces nonlinear precipitation
-# tendencies that require multiple Newton iterations to converge.
-# Conservation test may fail with only one Newton iteration.
+# Implicit vertical upwind advection of ρe_tot/ρq_tot with a central-only
+# Wfact needs ~3 Newton iterations to converge at large baroclinic-wave dt.
 max_newton_iters_ode: 3
 diagnostics:
   - short_name: [massa, energya, watera, energyo, watero]

--- a/config/mpi_configs/mpi_make_restart.yml
+++ b/config/mpi_configs/mpi_make_restart.yml
@@ -1,3 +1,4 @@
 dt_save_state_to_disk: "5days"
 initial_condition: "DryBaroclinicWave"
 disable_surface_flux_tendency: true
+max_newton_iters_ode: 3

--- a/config/mpi_configs/prep_remap.yml
+++ b/config/mpi_configs/prep_remap.yml
@@ -1,1 +1,2 @@
 dt_save_state_to_disk: "5days"
+max_newton_iters_ode: 3

--- a/config/mpi_configs/restart_mpi_baroclinic_wave.yml
+++ b/config/mpi_configs/restart_mpi_baroclinic_wave.yml
@@ -2,3 +2,4 @@ t_end: "20days"
 initial_condition: "DryBaroclinicWave"
 restart_file: "mpi_make_restart/output_active/day5.0.hdf5"
 disable_surface_flux_tendency: true
+max_newton_iters_ode: 3

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-369
+370
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+370
+- Move ρe_tot/ρq_tot upwind correction into implicit advection (Wfact unchanged)
+
 369
 - Clamp implicit ρa stage value to `[0, ρ·a_max]` per-cell in the column
   sweep so updraft area cannot exceed a_max when the explicit area

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -218,7 +218,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     (; ᶜu, ᶠu³, ᶜK) = p.precomputed
     (; edmfx_mse_q_tot_upwinding) = n > 0 || advect_tke ? p.atmos.numerics : all_nothing
     (; ᶜuʲs, ᶜKʲs, ᶠKᵥʲs) = n > 0 ? p.precomputed : all_nothing
-    (; energy_q_tot_upwinding, tracer_upwinding) = p.atmos.numerics
+    (; tracer_upwinding) = p.atmos.numerics
     thermo_params = CAP.thermodynamics_params(p.params)
 
     ᶜtke =
@@ -261,20 +261,7 @@ NVTX.@annotate function explicit_vertical_advection_tendency!(Yₜ, Y, p, t)
             end
         end
     end
-    # ... and upwinding correction of energy and total water.
-    # (The central advection of energy and total water is done implicitly.)
-    if energy_q_tot_upwinding != Val(:none)
-        (; ᶜh_tot) = p.precomputed
-        vtt = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, dt, energy_q_tot_upwinding)
-        vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜh_tot, dt, Val(:none))
-        @. Yₜ.c.ρe_tot += vtt - vtt_central
-    end
-
-    if !(p.atmos.microphysics_model isa DryModel) && energy_q_tot_upwinding != Val(:none)
-        ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
-        vtt = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, dt, energy_q_tot_upwinding)
-        vtt_central = vertical_transport(ᶜρ, ᶠu³, ᶜq_tot, dt, Val(:none))
-        @. Yₜ.c.ρq_tot += vtt - vtt_central
+    if !(p.atmos.microphysics_model isa DryModel)
         vtt_bc =
             ᶜρq_tot_vertical_transport_bc(prescribed_flow, thermo_params, t, ᶠu³)
         @. Yₜ.c.ρq_tot += vtt_bc

--- a/src/prognostic_equations/implicit/implicit_tendency.jl
+++ b/src/prognostic_equations/implicit/implicit_tendency.jl
@@ -114,17 +114,21 @@ function implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
     ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
     (; ᶠgradᵥ_ᶜΦ) = p.core
     (; ᶠu³, ᶜp, ᶜh_tot, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+    (; energy_q_tot_upwinding) = p.atmos.numerics
     thermo_params = CAP.thermodynamics_params(params)
     cp_d = CAP.cp_d(params)
 
     @. Yₜ.c.ρ -= ᶜdivᵥ(ᶠinterp(Y.c.ρ * ᶜJ) / ᶠJ * ᶠu³)
 
-    # Central vertical advection of active tracers (e_tot and q_tot)
-    vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜh_tot, dt, Val(:none))
+    # Full vertical advection (central + upwind correction) of active tracers
+    # (ρe_tot and ρq_tot). The Wfact linearization uses only the central
+    # operator (see `manual_sparse_jacobian.jl`), so this is "implicit with
+    # incomplete Jacobian".
+    vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜh_tot, dt, energy_q_tot_upwinding)
     @. Yₜ.c.ρe_tot += vtt
     if !(microphysics_model isa DryModel)
         ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
-        vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜq_tot, dt, Val(:none))
+        vtt = vertical_transport(Y.c.ρ, ᶠu³, ᶜq_tot, dt, energy_q_tot_upwinding)
         @. Yₜ.c.ρq_tot += vtt
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Move ρe_tot/ρq_tot upwind correction into implicit advection (Wfact unchanged)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
