### PR TITLE
Speed up cloud-fraction quadrature kernel on GPU

### DIFF
--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -287,7 +287,7 @@ struct SGSVarianceEvaluator{TPS, FT}
     mu_S::FT
 end
 
-@inline function (eval::SGSVarianceEvaluator)(T_hat, q_tot_hat)
+@inline @fastmath function (eval::SGSVarianceEvaluator)(T_hat, q_tot_hat)
     q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
     s = q_tot_hat - q_sat_hat
     return (s - eval.mu_S)^2
@@ -316,7 +316,7 @@ Gaussian closure. Using this analytic μ_S lets us accumulate σ_S² as
 
 Returns `(; mu_S, sigma_S)`.
 """
-@inline function _sgs_saturation_moments(
+@inline @fastmath function _sgs_saturation_moments(
     thp, ρ, T_mean, q_tot_mean,
     sgs_quad, T′T′, q′q′, corr_Tq,
 )
@@ -429,7 +429,7 @@ for computing it (typically with `σ_eff = α · σ_S` or `σ_eff = σ_aug` for
 the smooth-floored CF formula) so this helper stays free of parameter-
 dependent logic.
 """
-@inline function _compute_z(C)
+@inline @fastmath function _compute_z(C)
     FT = typeof(C)
 
     # 1. Initial guess: Φ(z₀) = tanh(1.35 · C).
@@ -478,7 +478,7 @@ The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
 `_compute_sgs_moments`) uses the equilibrium `σ_S`, so mass conservation
 `E[max(0, λ + α·S′)] = q_c` is exactly preserved for the microphysics tendencies.
 """
-@inline function _compute_cloud_fraction(q_c, sigma_S, q_sat, α, ε_rel, σ_abs)
+@inline @fastmath function _compute_cloud_fraction(q_c, sigma_S, q_sat, α, ε_rel, σ_abs)
     σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs^2
     σ_aug = α * sqrt(sigma_S^2 + σ_S_floor_sq)
     C = q_c / σ_aug
@@ -650,7 +650,8 @@ NVTX.@annotate function set_cloud_fraction!(
     microphysics_model = p.atmos.microphysics_model
 
     # Get environment density, temperature, and total specific humidity
-    ᶜρ_env, ᶜT_mean, ᶜq_mean = _get_env_ρ_T_q(Y, p, thermo_params, turbconv_model)
+    ᶜρ_env_raw, ᶜT_mean, ᶜq_mean =
+        _get_env_ρ_T_q(Y, p, thermo_params, turbconv_model)
 
     # Get condensate means (dispatches on microphysics_model)
     ᶜq_lcl, ᶜq_icl = _get_condensate_means(Y, p, turbconv_model, microphysics_model)
@@ -663,6 +664,13 @@ NVTX.@annotate function set_cloud_fraction!(
     σ_abs = CAP.cloud_fraction_sigma_abs(p.params)
 
     (; ᶜT′T′, ᶜq′q′) = p.precomputed
+
+    # For PrognosticEDMFX, `ᶜρ_env_raw` is a lazy `air_density` broadcast.
+    # Materialize it here so its Field arguments (ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰,
+    # ᶜq_liq⁰, ᶜq_ice⁰) don't get fused into the quadrature kernel below,
+    # which otherwise inflates that kernel's argument/type footprint.
+    ᶜρ_env = p.scratch.ᶜtemp_scalar_2
+    @. ᶜρ_env = ᶜρ_env_raw
 
     # Hybrid cloud fraction: the σ_S² quadrature pass is fused into this
     # broadcast kernel, so the moments stay in registers and are never written

--- a/src/utils/utilities.jl
+++ b/src/utils/utilities.jl
@@ -755,7 +755,7 @@ correctly captures the Gaussian-tail scaling Φ⁻¹(p) ~ −√(−2 ln p)
 for small p, avoiding the extreme underestimate that causes the Newton
 step to diverge.
 """
-@inline function normal_cdf_inv(p::FT) where {FT}
+@inline @fastmath function normal_cdf_inv(p::FT) where {FT}
     p_safe = clamp(p, ϵ_numerics(FT), one(FT) - ϵ_numerics(FT))
     q = min(p_safe, one(FT) - p_safe)   # work in the lower tail
     t = sqrt(-FT(2) * log(q))
@@ -781,7 +781,7 @@ The approximation for z ≥ 0 is
 where `p` is a degree-5 polynomial with the A&S coefficients, and
 `Φ(z) = 1 − Φ(−z)` for z < 0.
 """
-@inline function normal_cdf(z::FT) where {FT}
+@inline @fastmath function normal_cdf(z::FT) where {FT}
     inv_sqrt2pi = one(FT) / sqrt(FT(2) * FT(π))
     z_abs = abs(z)
     t = one(FT) / (one(FT) + FT(0.2316419) * z_abs)


### PR DESCRIPTION
## Disclosure

This PR was written by **Claude** (Anthropic's Claude Code), working from a prompt to profile `ClimaTimeSteppers.step!(integrator)` on the GPU (`longrun_aquaplanet_allsky_progedmf_1M` config) and find a speedup, explicitly excluding `set_microphysics_tendency_cache!` from consideration. Everything below — the profiling, the two dead ends, and the fix — was done by Claude in that session; I'm flagging this explicitly per the user's request so reviewers know the provenance and can scrutinize accordingly.

## Summary

- Materializes the lazy `air_density` broadcast (`ᶜρ_env`) into a scratch field before the fused cloud-fraction quadrature broadcast in `set_cloud_fraction!` (`QuadratureCloud` dispatch), so its `Field` arguments no longer get fused into that kernel's argument/type footprint.
- Marks the SGS-quadrature scalar math (`_sgs_saturation_moments`, the `SGSVarianceEvaluator` functor, `_compute_z`, `_compute_cloud_fraction`, and `normal_cdf`/`normal_cdf_inv` in `utilities.jl`) `@fastmath`.

## How I got here

1. Set up a GPU REPL in `.buildkite`, built the aquaplanet EDMF simulation via `.buildkite/prof.jl`, and profiled `step!` with `CUDA.@profile` (with `NAME_KERNELS_FROM_STACK_TRACE` enabled for readable kernel names).
2. Excluding `set_microphysics_tendency_cache!`, the next largest kernel was the fused cloud-fraction quadrature broadcast inside `set_cloud_fraction!` — **~1.44–1.50 ms/call**, called ~8×/step (~5.5% of total step time). That's 20–70× more expensive than comparably-sized kernels elsewhere in the step, which pointed at a broadcast-fusion/kernel-footprint problem rather than raw arithmetic cost.
3. **First attempt — `@fastmath` alone**: no measurable effect on the dominant kernel (1.44 ms → 1.50 ms, within noise). It did shave ~10% off two much smaller sub-kernels, but those are negligible slices of the step budget. Kept anyway since it's free and harmless.
4. **Second attempt — `@noinline` function barrier** on `_sgs_saturation_moments` (mirroring a register-pressure fix that worked for an analogous kernel in `CloudMicrophysics.jl` on a prior GPU-optimization pass): also no effect. Reverted.
5. Dug into the actual mangled CUDA kernel name and found the fused broadcast pulls in a full nested `air_density` computation (over `ᶜT⁰`, `ᶜp`, `ᶜq_tot_nonneg⁰`, `ᶜq_liq⁰`, `ᶜq_ice⁰`) as part of its argument tree — the same pattern already flagged elsewhere in this file (`set_ml_cloud_fraction!`'s comment about the 4 KiB GPU kernel parameter limit). **Third attempt** — materializing that one lazy field before the broadcast — is the actual fix.

## Measured results (GPU, `longrun_aquaplanet_allsky_progedmf_1M`)

All numbers are from clean, warmed-up `CUDA.@profile` captures over 5 steps (re-verified after catching that an initial comparison was contaminated by first-call JIT compilation):

| | Before | After |
|---|---|---|
| `set_cloud_fraction!` dominant kernel | ~1.44–1.50 ms/call | ~459 µs/call |
| Total GPU busy time (5 steps) | ~1.04–1.05 s | ~1.02 s |
| Steady-state wall time per step | ~0.204–0.206 s | ~0.201 s (~2% faster) |

Verified no NaNs / errors introduced in the state after each rebuild.

## Notes for reviewers

- `set_microphysics_tendency_cache!` was intentionally left untouched (out of scope per the original request; it's the subject of separate, ongoing GPU-optimization work).
- The materialization change reuses `p.scratch.ᶜtemp_scalar_2`. I checked that this scratch slot is free at that point in the call sequence (used by `set_covariance_cache!`'s internal `compute_∂T_∂θ!`, which always completes and returns before `set_cloud_fraction!` is invoked within `picard_step!`), and that nothing downstream in `set_cloud_fraction!` (`_apply_edmf_cloud_weighting!`) reads `p.scratch` at all — but please double check this reasoning, since scratch-field lifetime bugs can be silent (wrong physics, no crash).
- Formatted with the pinned JuliaFormatter version per this repo's contributing guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)