### PR TITLE
Update hash used on downstream performance checks

### DIFF
--- a/.buildkite/coupler_perf/pipeline.yml
+++ b/.buildkite/coupler_perf/pipeline.yml
@@ -10,7 +10,7 @@ env:
   GKSwstype: 100
   SLURM_KILL_BAD_EXIT: 1
   COUPLER_PATH: ".buildkite/perf/ClimaCoupler.jl"
-  COUPLER_COMMIT: "8f827b9118a6a0edfa2199c6b7340ae509168ac4"
+  COUPLER_COMMIT: "173e871b7e43c5838d9d7b45f3e1dfb671f45b49"
   CONFIG_PATH: "$COUPLER_PATH/config/nightly_configs"
   BENCHMARK_CONFIG_PATH: "$COUPLER_PATH/config/benchmark_configs"
 
@@ -49,7 +49,7 @@ steps:
     env:
       CLIMACOMMS_DEVICE: "CUDA"
       # Fallback used when no passing main build metadata is available yet.
-      BASELINE_SYPD: "0.175"
+      BASELINE_SYPD: "0.223"
       MIN_PERCENT_CHANGE: "-1"
     agents:
       slurm_gpus_per_task: 1


### PR DESCRIPTION
Performance pipeline is broken


## Content
Updates coupler hash and SYPD from last night's amip

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
