### PR TITLE
Fix method overwrite and tests in ClimaAtmosMusica extension

### DIFF
--- a/ext/ClimaAtmosMusica/ClimaAtmosMusica.jl
+++ b/ext/ClimaAtmosMusica/ClimaAtmosMusica.jl
@@ -16,7 +16,7 @@ function ClimaAtmos.chemistry_tendency!(
     t,
     ::ClimaAtmos.GasPhaseChem,
 )
-    @info "MUSICA version: $(Musica.get_version())"
+    @info "MUSICA version: $(pkgversion(Musica))"
     return nothing
 end
 

--- a/src/parameterized_tendencies/chemistry/chemistry.jl
+++ b/src/parameterized_tendencies/chemistry/chemistry.jl
@@ -18,4 +18,4 @@ chemistry_tendency!(Yₜ, Y, p, t, ::Nothing) = nothing
 
 Source terms are provided by Musica extension.
 """
-chemistry_tendency!(Yₜ, Y, p, t, ::GasPhaseChem) = nothing
+function chemistry_tendency!(Yₜ, Y, p, t, ::GasPhaseChem) end

--- a/test/parameterized_tendencies/chemistry/chemistry_tendency.jl
+++ b/test/parameterized_tendencies/chemistry/chemistry_tendency.jl
@@ -2,6 +2,7 @@ using Test
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaAtmos as CA
+Sys.iswindows() || import Musica
 
 @testset "Chemistry Tendencies" begin
 
@@ -10,17 +11,19 @@ import ClimaAtmos as CA
     # ========================================================================
     @testset "Default chemistry model is nothing" begin
         model = CA.AtmosModel()
-        @test model.chemistry_model === nothing
+        @test isnothing(model.chemistry_model)
     end
 
     @testset "chemistry_tendency! with nothing is a no-op" begin
         result = CA.chemistry_tendency!(nothing, nothing, nothing, 0.0, nothing)
-        @test result === nothing
+        @test isnothing(result)
     end
 
     # ========================================================================
     # With Musica loaded: GasPhaseChem prints the version string
     # ========================================================================
+    # Musica is not compatible with Windows
+    Sys.iswindows() && return
     @testset "GasPhaseChem prints MUSICA version" begin
         import Musica
         @test_logs (:info, r"MUSICA version: .+") CA.chemistry_tendency!(


### PR DESCRIPTION
closes #4640 - In this extension, a function stub should be defined for `chemistry_tendency!(Yₜ, Y, p, t, ::ClimaAtmos.GasPhaseChem)` instead of overwriting the method. Furthermore, `Musica.get_version` doesn't exist, so `pkgversion` is used instead.