### PR TITLE
EDMFX corrections: TKE buoyancy production, enthalpy-flux decomposition, cloud-fraction floor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- [#4644](https://github.com/CliMA/ClimaAtmos.jl/pull/4644) ![][badge-🔥behavioralΔ]
+  - Remove the coherent (mass-flux) buoyancy production from the EDMFX TKE budget; the coherent updraft/environment buoyancy flux belongs to the resolved SGS circulation, not the isotropic turbulence that TKE represents.
+  - Decompose the diffusive enthalpy flux into dry static energy + water enthalpy, `F_h = -K_h ∇s_d + Σ_μ h_tot,μ (-K_h ∇q_μ)` with unit turbulent Lewis number, at both diffusion sites; diffusing `h_tot` directly implied a spurious enthalpy flux carried by dry-air diffusion that systematically warmed entrained air across capping inversions. The implicit-Jacobian diffusion factors are updated to match.
+  - Damp the relative part of the cloud-fraction floor as the subdomain mean saturates (`D = x/√(1+x²)`, `x = max(-μ_S, 0)/(ε_rel·q_sat)`), so an equilibrated overcast deck is no longer capped below full cloud cover by the patchiness floor. No new parameters.
 - [#4638](https://github.com/CliMA/ClimaAtmos.jl/pull/4638) ![][badge-🔥behavioralΔ] Fix the subsidence top boundary condition: the advective-form subsidence operator now uses the zero-boundary-flux divergence (`ᶜadvdivᵥ`), which is equivalent to a zero-gradient inflow condition `χ = χ_top` above the lid, instead of `Extrapolate` (which copied the cell below into the top cell). Remove the two `external_forcing.jl` blocks that hard-zeroed the accumulated top-cell `ρe_tot`/`ρq_tot` tendencies to mask that defect; GCM/ERA5-driven top-cell tendencies (radiation, nudging, subsidence) are no longer discarded.
 - [#4637](https://github.com/CliMA/ClimaAtmos.jl/pull/4637) ![][badge-🔥behavioralΔ]
   - Fix the spurious mass flux through the model top over sloped terrain-following coordinates: `set_velocity_at_top!` now cancels the contravariant projection of the horizontal wind (`u₃ = -uₕ³/g³³`, mirroring the surface treatment), and the continuity equation uses the same zero-boundary-flux divergence (`ᶜadvdivᵥ`) as the tracers, which also makes the `ρ`-row Jacobian exact.

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-374
+375
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+375
+- Remove coherent buoyancy production from TKE; decompose diffusive enthalpy
+  flux into dry static energy + water enthalpy; damp the cloud-fraction floor
+  as the subdomain mean saturates.
+
 374
 - Fix subsidence top BC (zero-gradient inflow at the lid instead of Extrapolate);
   remove the external-forcing top-cell tendency-zeroing workaround.

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -447,7 +447,7 @@ dependent logic.
 end
 
 """
-    _compute_cloud_fraction(q_c, sigma_S, q_sat, α, ε_rel, σ_abs)
+    _compute_cloud_fraction(q_c, mu_S, sigma_S, q_sat, α, ε_rel, σ_abs)
 
 Cloud fraction `CF = Φ(z)`, where `z` solves the truncated-Gaussian condensate
 relation `q_c/σ_aug = z·Φ(z) + φ(z)` (see [`_compute_z`](@ref)) with the
@@ -459,7 +459,7 @@ the quadrature (`σ_S`), and partly through non-equilibrium variations not
 captured by the equilibrium SGS PDF. `σ_S_floor` models the latter and is scaled
 with the saturation specific humidity,
 
-    σ_S_floor² = (ε_rel · q_sat)² + σ_abs².
+    σ_S_floor² = (D · ε_rel · q_sat)² + σ_abs².
 
 The q_sat-scaling implies saturation-excess fluctuations scale with q_sat.
 The parameter `ε_rel` is a condensate-patchiness scale: it indicates the
@@ -474,12 +474,34 @@ only; the inter-subdomain (convective) spread is carried explicitly by the
 drafts. The parameter `ε_rel` is a q_sat-scaling whose magnitude should grow
 with grid spacing.
 
+Saturation-dependent damping `D`. Non-equilibrium patchiness is a property of
+*partially* saturated air: in a subdomain whose mean state is saturated (an
+equilibrated overcast deck maintained by radiative cooling), the patchiness the
+floor parameterizes is near zero, and an undamped floor spuriously caps CF well
+below 1 whenever `q_c ≲ ε_rel·q_sat` — cutting cloud-top longwave cooling in
+exactly the stratocumulus regime. The relative floor is therefore damped as the
+mean saturation excess `μ_S = q_tot − q_sat` approaches zero from below:
+
+    x = max(−μ_S, 0) / (ε_rel · q_sat),    D = x / sqrt(1 + x²),
+
+so `D → 0` for a saturated mean (`μ_S ≥ 0`, overcast limit: CF is then
+controlled by the equilibrium `σ_S` and `σ_abs` alone, and `CF → 1` for
+`q_c ≫ σ_aug`), while `D → 1` once the mean is subsaturated by a few floor
+scales (cumulus regime: floor fully active). The transition width is the
+patchiness scale `ε_rel·q_sat` itself, so no new parameter is introduced.
+
 The floor enters *only* the CF computation; the Lagrange multiplier `λ` (in
 `_compute_sgs_moments`) uses the equilibrium `σ_S`, so mass conservation
 `E[max(0, λ + α·S′)] = q_c` is exactly preserved for the microphysics tendencies.
 """
-@inline function _compute_cloud_fraction(q_c, sigma_S, q_sat, α, ε_rel, σ_abs)
-    σ_S_floor_sq = (ε_rel * q_sat)^2 + σ_abs^2
+@inline function _compute_cloud_fraction(q_c, mu_S, sigma_S, q_sat, α, ε_rel, σ_abs)
+    FT = typeof(q_c)
+    # Damp the relative floor as the subdomain mean saturates (μ_S → 0⁻):
+    # patchiness vanishes in an equilibrated overcast deck. The denominator
+    # guard keeps x finite (and D well-defined) when ε_rel·q_sat → 0.
+    x = max(-mu_S, zero(FT)) / max(ε_rel * q_sat, ϵ_numerics(FT))
+    D = x / sqrt(1 + x^2)
+    σ_S_floor_sq = (D * ε_rel * q_sat)^2 + σ_abs^2
     σ_aug = α * sqrt(sigma_S^2 + σ_S_floor_sq)
     C = q_c / σ_aug
     z = _compute_z(C)
@@ -518,7 +540,7 @@ materialized to a Field.
     )
     q_sat = TD.q_vap_saturation(thermo_params, T, ρ, q_liq, q_ice)
     return _compute_cloud_fraction(
-        q_liq + q_ice, moments.sigma_S, q_sat, α, ε_rel, σ_abs,
+        q_liq + q_ice, moments.mu_S, moments.sigma_S, q_sat, α, ε_rel, σ_abs,
     )
 end
 
@@ -590,6 +612,9 @@ NVTX.@annotate function set_sgs_moments_and_cloud_fraction!(Y, p)
     # applied it during Picard.
     @. p.precomputed.ᶜcloud_fraction = _compute_cloud_fraction(
         ᶜq_lcl + ᶜq_icl,
+        # μ_S recomputed analytically, matching `_sgs_saturation_moments`
+        # (condensate-free q_sat, consistent with the linear excess S).
+        ᶜq_mean - TD.q_vap_saturation(thermo_params, ᶜT_mean, ᶜρ_env),
         p.precomputed.ᶜsgs_moments.sigma_S,
         TD.q_vap_saturation(thermo_params, ᶜT_mean, ᶜρ_env, ᶜq_lcl, ᶜq_icl),
         FT(α),

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -60,7 +60,9 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, VFT1, VFT2, VTF3} <: ATCP
     cloud_fraction_steepness_scale::FT
     cloud_fraction_param_vec::VTF3
     # Augmented-σ floor for `_compute_cloud_fraction`:
-    # σ_S_floor² = (cloud_fraction_eps_rel · q_sat)² + cloud_fraction_sigma_abs².
+    # σ_S_floor² = (D · cloud_fraction_eps_rel · q_sat)² + cloud_fraction_sigma_abs²,
+    # with D ∈ [0, 1] damping the relative floor as the subdomain mean
+    # saturates (see `_compute_cloud_fraction`).
     cloud_fraction_eps_rel::FT
     cloud_fraction_sigma_abs::FT
     # Surface mass flux closure (`set_edmfx_surface_conditions!`).

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -252,13 +252,49 @@ function edmfx_sgs_diffusive_flux_tendency!(
         ᶠρaK_u = p.scratch.ᶠtemp_scalar_2
         @. ᶠρaK_u = ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_u)
 
-        # Total enthalpy diffusion
+        # Total enthalpy diffusion, using the dry-static-energy + water-
+        # enthalpy decomposition
+        #   F_h = -K_h ∇s_d + Σ_μ h_tot,μ F_qμ,   F_qμ = -K_h ∇q_μ,
+        # with s_d = h_d + Φ, h_tot,μ = h_μ(T) + Φ for μ ∈ {vap, liq, ice},
+        # and unit turbulent Lewis number (K_qμ = K_h). Diffusing h_tot
+        # directly would imply a spurious enthalpy flux carried by dry-air
+        # diffusion (h_tot depends on 1 - q_t through the dry-air mass
+        # fraction), systematically warming entrained air at inversions where
+        # h_tot jumps up while q_t jumps down. The thermal piece diffuses dry
+        # static energy (constant under dry-adiabatic displacement), and each
+        # water constituent carries its own enthalpy with its diffusive mass
+        # flux, consistent with the ρq_tot and ρ updates below.
+        #
+        # Note: F_qμ for liquid and ice uses unscaled K_h (omitting the tracer
+        # vertical diffusion factor α_vert_diff_tracer). While microphysics
+        # tracers are diffused with α * K_h to prevent unphysical upward
+        # transport of precipitation, omitting α here maintains exact energetic
+        # consistency with the unscaled ρq_tot diffusion equation, preserves
+        # total water invariance under moist-adiabatic processes, and aligns
+        # with the implicit solver's Jacobian formulation.
         ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(
             top = Operators.SetValue(C3(FT(0))),
             bottom = Operators.SetValue(C3(FT(0))),
         )
-        (; ᶜh_tot) = p.precomputed
-        @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠρaK_h * ᶠgradᵥ(ᶜh_tot)))
+        thermo_params = CAP.thermodynamics_params(params)
+        (; ᶜΦ) = p.core
+        (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+        ᶜq_vap = @. lazy(
+            TD.vapor_specific_humidity(ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice),
+        )
+        @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(
+            -(
+                ᶠρaK_h * (
+                    ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
+                    ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
+                    ᶠgradᵥ(ᶜq_vap) +
+                    ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
+                    ᶠgradᵥ(ᶜq_liq) +
+                    ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
+                    ᶠgradᵥ(ᶜq_ice)
+                )
+            ),
+        )
 
         if use_prognostic_tke(turbconv_model)
             # Turbulent TKE transport (diffusion)

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -51,15 +51,10 @@ function edmfx_tke_tendency!(
     t,
     turbconv_model::PrognosticEDMFX,
 )
-    n = n_mass_flux_subdomains(turbconv_model)
-    (; ᶠu³, ᶠu³ʲs, ᶠu³⁰, ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
+    (; ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
     turbconv_params = CAP.turbconv_params(p.params)
-    FT = eltype(p.params)
-    thermo_params = CAP.thermodynamics_params(p.params)
 
     if use_prognostic_tke(turbconv_model)
-        (; ᶜρʲs) = p.precomputed
-        ᶠz = Fields.coordinate_field(Y.f).z
         ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2
         ᶜmixing_length_field .= ᶜmixing_length(Y, p)
         ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
@@ -77,37 +72,15 @@ function edmfx_tke_tendency!(
 
         # shear production
         @. Yₜ.c.ρtke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
-        # buoyancy production
+        # Buoyancy production: only the diffusive (intra-subdomain) piece,
+        # -ρ K_h ∂b/∂z, of the Favre-averaged buoyancy flux enters the
+        # isotropic-TKE budget. The coherent (mass-flux) piece
+        # Σ_m ρa^m (w^m - w) b^m powers the inter-subdomain (coherent)
+        # kinetic energy through the buoyancy term of the subdomain momentum
+        # equations, which the prognostic subdomain velocities already carry;
+        # adding it here double-counts buoyancy production and spuriously
+        # inflates K near cloud tops with active drafts.
         @. Yₜ.c.ρtke -= Y.c.ρ * ᶜK_h * ᶜlinear_buoygrad
-        grav = CAP.grav(p.params)
-        for j in 1:n
-            ᶜρaʲ =
-                turbconv_model isa PrognosticEDMFX ? Y.c.sgsʲs.:($j).ρa :
-                p.precomputed.ᶜρaʲs.:($j)
-            @. Yₜ.c.ρtke -=
-                ᶜρaʲ * adjoint(CT3(ᶜinterp(ᶠu³ʲs.:($$j) - ᶠu³))) *
-                (ᶜρʲs.:($$j) - Y.c.ρ) *
-                ᶜgradᵥ(grav * ᶠz) / ᶜρʲs.:($$j)
-        end
-        # Note: Adding the following tendency breaks bm_aquaplanet_progedmf_dense_autodiff
-        if turbconv_model isa PrognosticEDMFX
-            ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
-            (; ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
-            ᶜρ⁰ = @. lazy(
-                TD.air_density(
-                    thermo_params,
-                    ᶜT⁰,
-                    ᶜp,
-                    ᶜq_tot_nonneg⁰,
-                    ᶜq_liq⁰,
-                    ᶜq_ice⁰,
-                ),
-            )
-            @. Yₜ.c.ρtke -=
-                ᶜρa⁰ * adjoint(CT3(ᶜinterp(ᶠu³⁰ - ᶠu³))) *
-                (ᶜρ⁰ - Y.c.ρ) *
-                ᶜgradᵥ(grav * ᶠz) / ᶜρ⁰
-        end
     end
     return nothing
 end

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -806,17 +806,43 @@ function update_diffusion_jacobian!(
         @. ᶜdiffusion_u_matrix = ᶜadvdivᵥ_matrix() ⋅ ∂ᶠρχ_dif_flux_∂ᶜχ
     end
 
+    # Jacobian of the decomposed diffusive enthalpy flux
+    #   F_h = -K_h ∇s_d + Σ_μ h_tot,μ (-K_h ∇q_μ)
+    # (see edmfx_sgs_diffusive_flux_tendency! and
+    # vertical_diffusion_boundary_layer_tendency!). The derivatives below hold
+    # the h_tot,μ prefactors and the equilibrium condensate partition fixed
+    # (consistent with the other approximations in this Jacobian): each block
+    # is ∂(flux argument)/∂(prognostic variable), with ∂s_d/∂e_tot = cp_d/cv_m
+    # through T, plus the constituent enthalpy carried by the corresponding
+    # water-gradient term. The SGS mass-flux enthalpy Jacobian
+    # (update_sgs_massflux_jacobian!) is not decomposed: it transports whole
+    # parcels at h_tot and so does not incur the dry-air-diffusion artifact.
+    thermo_params = CAP.thermodynamics_params(params)
+    (; ᶜΦ) = p.core
+    (; ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+    cp_d = FT(CAP.cp_d(params))
+    Δcv_v = FT(CAP.cv_v(params)) - FT(CAP.cv_d(params))
+    e_int_v0 = FT(CAP.e_int_v0(params))
+    ᶜcv_m = @. lazy(TD.cv_m(thermo_params, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
+
     ∂ᶜρe_tot_err_∂ᶜρ = matrix[@name(c.ρe_tot), @name(c.ρ)]
     @. ∂ᶜρe_tot_err_∂ᶜρ = zero(typeof(∂ᶜρe_tot_err_∂ᶜρ))
     @. ∂ᶜρe_tot_err_∂ᶜρe_tot +=
-        dtγ * ᶜdiffusion_h_matrix ⋅ DiagonalMatrixRow((1 + ᶜkappa_m) / ᶜρ)
+        dtγ * ᶜdiffusion_h_matrix ⋅ DiagonalMatrixRow(cp_d / (ᶜcv_m * ᶜρ))
 
     if MatrixFields.has_field(Y, @name(c.ρq_tot))
         ∂ᶜρe_tot_err_∂ᶜρq_tot = matrix[@name(c.ρe_tot), @name(c.ρq_tot)]
         ∂ᶜρq_tot_err_∂ᶜρ = matrix[@name(c.ρq_tot), @name(c.ρ)]
         ∂ᶜρq_tot_err_∂ᶜρq_tot = matrix[@name(c.ρq_tot), @name(c.ρq_tot)]
+        # ∂F/∂q_tot: T changes at fixed e_tot (through cv_m and e_int_v0),
+        # and the vapor-gradient term carries h_tot,v = h_v + Φ.
         @. ∂ᶜρe_tot_err_∂ᶜρq_tot +=
-            dtγ * ᶜdiffusion_h_matrix ⋅ DiagonalMatrixRow(ᶜ∂p∂ρq_tot / ᶜρ)
+            dtγ * ᶜdiffusion_h_matrix ⋅ DiagonalMatrixRow(
+                (
+                    TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ -
+                    cp_d * (e_int_v0 + Δcv_v * (ᶜT - T_0)) / ᶜcv_m
+                ) / ᶜρ,
+            )
         @. ∂ᶜρq_tot_err_∂ᶜρ = zero(typeof(∂ᶜρq_tot_err_∂ᶜρ))
         @. ∂ᶜρq_tot_err_∂ᶜρq_tot +=
             dtγ * ᶜdiffusion_h_matrix ⋅ DiagonalMatrixRow(1 / ᶜρ)
@@ -830,12 +856,20 @@ function update_diffusion_jacobian!(
             phase = condensate_phase(ρq_name)
             e_int_q = condensate_e_int_offset(phase, params)
             ∂cv∂q = condensate_cv_difference(phase, params)
+            h_cond_func = enthalpy_function(phase)
             ∂ᶜρe_tot_err_∂ᶜρq =
                 matrix[@name(c.ρe_tot), center_state_name(ρq_name)]
+            # ∂F/∂q_cond at fixed q_tot: vapor→condensate conversion changes T
+            # (latent heating enters s_d) and moves water-gradient enthalpy
+            # from h_tot,v to h_tot,cond (the Φ parts cancel).
             @. ∂ᶜρe_tot_err_∂ᶜρq +=
                 dtγ * ᶜdiffusion_h_matrix ⋅
                 DiagonalMatrixRow(
-                    (ᶜkappa_m * (e_int_q - ∂cv∂q * (ᶜT - T_0)) - R_v * ᶜT) / ᶜρ,
+                    (
+                        cp_d * (e_int_q - ∂cv∂q * (ᶜT - T_0)) / ᶜcv_m +
+                        h_cond_func(thermo_params, ᶜT) -
+                        TD.enthalpy_vapor(thermo_params, ᶜT)
+                    ) / ᶜρ,
                 )
         end
     end

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -35,10 +35,13 @@ This function is dispatched based on the type of the vertical diffusion model
       `1/ρ ∇ ⋅ τ`. Default zero-flux boundary
       conditions are assumed for this diffusive term, as surface stresses
       are often handled by `surface_flux_tendency!`.
-    - **Total Energy (`ρe_tot`)**: Based on the divergence of an enthalpy flux,
-      `F_E = - ρ K_h ∇_v h_{tot}`, where `K_h` is the eddy diffusivity for
-      heat and `h_{tot}` is the specific total enthalpy. Zero-flux boundary
-      conditions are explicitly applied at the top and bottom for this term.
+    - **Total Energy (`ρe_tot`)**: Based on the divergence of an enthalpy flux
+      in dry-static-energy + water-enthalpy form,
+      `F_E = - ρ K_h (∇_v s_d + Σ_μ h_tot,μ ∇_v q_μ)`, where `K_h` is the eddy
+      diffusivity for heat, `s_d = h_d + Φ` is the dry static energy, and
+      `h_tot,μ = h_μ + Φ` is the total enthalpy carried by water constituent
+      `μ ∈ {vap, liq, ice}`. Zero-flux boundary conditions are explicitly
+      applied at the top and bottom for this term.
     - **Tracers (e.g., `ρq_tot`, `ρq_lcl`)**: Based on the divergence of tracer fluxes,
       `F_χ = - ρ K_{h,scaled} ∇_v χ`, where `χ` is the specific
       tracer quantity and `K_{h,scaled}` is the (potentially scaled for certain
@@ -110,12 +113,34 @@ function vertical_diffusion_boundary_layer_tendency!(
         ) # assumes ᶜK_u = ᶜK_h
     end
 
+    # Total enthalpy diffusion, using the dry-static-energy + water-enthalpy
+    # decomposition F_h = -K_h ∇s_d + Σ_μ h_tot,μ (-K_h ∇q_μ); see the
+    # matching term in `edmfx_sgs_diffusive_flux_tendency!` for details.
+    # Note: F_qμ for liquid and ice uses unscaled K_h (omitting the tracer
+    # vertical diffusion factor α_vert_diff_tracer) to maintain exact energetic
+    # consistency with the unscaled ρq_tot diffusion equation, preserve total
+    # water invariance, and align with the implicit solver's Jacobian.
     ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(
         top = Operators.SetValue(C3(0)),
         bottom = Operators.SetValue(C3(0)),
     )
-    (; ᶜh_tot) = p.precomputed
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜh_tot)))
+    (; ᶜΦ) = p.core
+    (; ᶜq_tot_nonneg) = p.precomputed
+    ᶜq_vap = @. lazy(TD.vapor_specific_humidity(ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
+    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(
+        -(
+            ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) *
+            (
+                ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
+                ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
+                ᶠgradᵥ(ᶜq_vap) +
+                ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
+                ᶠgradᵥ(ᶜq_liq) +
+                ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
+                ᶠgradᵥ(ᶜq_ice)
+            )
+        ),
+    )
 
     ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar_2
     ᶜK_h_scaled = p.scratch.ᶜtemp_scalar_3

--- a/src/utils/tracer_processes.jl
+++ b/src/utils/tracer_processes.jl
@@ -173,6 +173,17 @@ internal_energy_function(::TD.Liquid) = TD.internal_energy_liquid
 internal_energy_function(::TD.Ice) = TD.internal_energy_ice
 
 """
+    enthalpy_function(phase)
+
+The `Thermodynamics` function that computes the specific enthalpy of a
+condensate with the given phase (`TD.Liquid()` or `TD.Ice()`). Used by the
+dry-static-energy + water-enthalpy decomposition of the diffusive enthalpy
+flux and its Jacobian.
+"""
+enthalpy_function(::TD.Liquid) = TD.enthalpy_liquid
+enthalpy_function(::TD.Ice) = TD.enthalpy_ice
+
+"""
     condensate_e_int_offset(phase, params)
 
 Reference internal energy offset `e_int_χ0` of a condensate phase, used in

--- a/test/parameterized_tendencies/microphysics/allocations.jl
+++ b/test/parameterized_tendencies/microphysics/allocations.jl
@@ -89,10 +89,11 @@ function _allocs_cloud_fraction_simple()
     ε_rel = FT(0.02)
     σ_abs = FT(1e-7)
     CA._compute_cloud_fraction(
-        FT(1e-3), FT(3.16e-4), FT(5e-5), FT(1), ε_rel, σ_abs,
+        FT(1e-3), FT(-1e-4), FT(3.16e-4), FT(5e-5), FT(1), ε_rel, σ_abs,
     )
     return @allocated CA._compute_cloud_fraction(
         FT(1e-3),
+        FT(-1e-4),
         FT(3.16e-4),
         FT(5e-5),
         FT(1),

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -2,9 +2,11 @@
 Unit tests for cloud_fraction.jl
 
 Tests cover:
-1. `_compute_cloud_fraction(q_c, sigma_S, q_sat, α, ε_rel, σ_abs)` -
+1. `_compute_cloud_fraction(q_c, mu_S, sigma_S, q_sat, α, ε_rel, σ_abs)` -
    truncated-Gaussian CF closure with the smooth non-equilibrium floor
-   `σ_S_floor² = (ε_rel·q_sat)² + σ_abs²` controlled by the two parameters.
+   `σ_S_floor² = (D·ε_rel·q_sat)² + σ_abs²` controlled by the two parameters,
+   where `D = x/√(1+x²)`, `x = max(−μ_S, 0)/(ε_rel·q_sat)` damps the floor
+   as the subdomain mean saturates (overcast limit).
 =#
 
 using Test
@@ -19,40 +21,43 @@ import ClimaAtmos as CA
                 α = FT(1)
                 ε_rel = FT(0.02)
                 σ_abs = FT(1e-7)
+                # Well-subsaturated mean: x = 1e-3/(0.02·5e-5) ≫ 1 ⇒ D ≈ 1,
+                # floor fully active (legacy behavior).
+                μ_sub = FT(-1e-3)
 
                 @testset "No condensate → zero cloud fraction" begin
                     cf = CA._compute_cloud_fraction(
-                        FT(0), FT(1e-4), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(0), μ_sub, FT(1e-4), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf < eps(FT)
                 end
 
                 @testset "Condensate present, nonzero sigma → cf > 0" begin
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-3), FT(3.16e-4), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-3), μ_sub, FT(3.16e-4), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test FT(0) < cf <= FT(1)
                 end
 
                 @testset "Zero sigma, large condensate → cf ≈ 1" begin
-                    # σ_S = 0 ⇒ σ_aug = σ_S_floor = √((ε_rel·q_sat)² + σ_abs²)
+                    # σ_S = 0 ⇒ σ_aug = σ_S_floor ≈ √((ε_rel·q_sat)² + σ_abs²)
                     # ≈ 0.02·5e-5 = 1e-6; C = 1e-3/1e-6 ≫ 1 → CF ≈ 1.
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-3), FT(0), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-3), μ_sub, FT(0), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf > FT(0.99)
                 end
 
                 @testset "Large condensate, small sigma → cf ≈ 1" begin
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-2), FT(1e-5), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-2), μ_sub, FT(1e-5), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf > FT(0.99)
                 end
 
                 @testset "Type stability" begin
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-3), FT(3.16e-4), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-3), μ_sub, FT(3.16e-4), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf isa FT
                 end
@@ -60,7 +65,7 @@ import ClimaAtmos as CA
                 @testset "CF monotone in σ_S at fixed q_c" begin
                     cfs = [
                         CA._compute_cloud_fraction(
-                            FT(1e-3), σ, FT(5e-5), α, ε_rel, σ_abs,
+                            FT(1e-3), μ_sub, σ, FT(5e-5), α, ε_rel, σ_abs,
                         ) for σ in FT[1e-4, 3.16e-4, 1e-3, 3.16e-3]
                     ]
                     for i in 2:length(cfs)
@@ -70,7 +75,7 @@ import ClimaAtmos as CA
 
                 @testset "Large σ_S, small q_c → cf approaching 0" begin
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-6), FT(3.16e-2), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-6), μ_sub, FT(3.16e-2), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf < FT(0.01)
                 end
@@ -78,9 +83,69 @@ import ClimaAtmos as CA
                 @testset "Tiny q_c with tiny σ_S → cf stays bounded (smooth floor)" begin
                     # σ_aug ≈ σ_S_floor ≈ 1e-6; C = q_c/σ_aug small ⇒ CF small.
                     cf = CA._compute_cloud_fraction(
-                        FT(1e-9), FT(1e-12), FT(5e-5), α, ε_rel, σ_abs,
+                        FT(1e-9), μ_sub, FT(1e-12), FT(5e-5), α, ε_rel, σ_abs,
                     )
                     @test cf < FT(0.51)
+                end
+
+                @testset "Overcast limit: saturated mean damps the floor → cf ≈ 1" begin
+                    # Stratocumulus-like: q_c = 0.25 g/kg ≪ ε_rel·q_sat with
+                    # ε_rel = 0.15, q_sat = 10 g/kg (floor = 1.5 g/kg). The
+                    # undamped floor caps CF well below 1; with the mean
+                    # saturated (μ_S = q_c > 0) the floor collapses to σ_abs
+                    # and CF → 1.
+                    q_c = FT(2.5e-4)
+                    q_sat = FT(1e-2)
+                    σ_S = FT(1e-5)
+                    cf_sat = CA._compute_cloud_fraction(
+                        q_c, q_c, σ_S, q_sat, α, FT(0.15), σ_abs,
+                    )
+                    @test cf_sat > FT(0.99)
+                    cf_undamped = CA._compute_cloud_fraction(
+                        q_c, FT(-1e-1), σ_S, q_sat, α, FT(0.15), σ_abs,
+                    )
+                    @test cf_undamped < FT(0.6)
+                end
+
+                @testset "CF monotone in μ_S at fixed q_c (floor grows with subsaturation)" begin
+                    q_c = FT(2.5e-4)
+                    q_sat = FT(1e-2)
+                    σ_S = FT(1e-5)
+                    cfs = [
+                        CA._compute_cloud_fraction(
+                            q_c, μ, σ_S, q_sat, α, FT(0.15), σ_abs,
+                        ) for μ in FT[0, -1e-4, -1e-3, -1e-2, -1e-1]
+                    ]
+                    for i in 2:length(cfs)
+                        @test cfs[i] <= cfs[i - 1] + FT(1e-6)
+                    end
+                end
+
+                @testset "Damping continuous across μ_S = 0" begin
+                    q_c = FT(2.5e-4)
+                    q_sat = FT(1e-2)
+                    σ_S = FT(1e-5)
+                    cf0 = CA._compute_cloud_fraction(
+                        q_c, FT(0), σ_S, q_sat, α, FT(0.15), σ_abs,
+                    )
+                    cf⁻ = CA._compute_cloud_fraction(
+                        q_c, -eps(FT), σ_S, q_sat, α, FT(0.15), σ_abs,
+                    )
+                    cf⁺ = CA._compute_cloud_fraction(
+                        q_c, FT(1e-6), σ_S, q_sat, α, FT(0.15), σ_abs,
+                    )
+                    @test abs(cf0 - cf⁻) < FT(1e-4)
+                    @test abs(cf0 - cf⁺) < FT(1e-4)
+                end
+
+                @testset "ε_rel = 0 → guard keeps result finite" begin
+                    for μ in FT[0, -1e-3]
+                        cf = CA._compute_cloud_fraction(
+                            FT(1e-3), μ, FT(3.16e-4), FT(5e-5), α, FT(0), σ_abs,
+                        )
+                        @test isfinite(cf)
+                        @test FT(0) <= cf <= FT(1)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Three physics corrections for prognostic EDMFX, stacked on #4638 (which stacks on #4637):

1. **Remove coherent (mass-flux) buoyancy production from the TKE budget.** The coherent updraft/environment buoyancy flux belongs to the resolved SGS circulation, not to the isotropic turbulence that TKE represents; retaining it double-counts buoyancy production already accounted for by the mass-flux transport. This affects TKE budgets (e.g., Sc: TKE peaks at cloud tops, drops sharply above, and is significantly lower below too--as it should be).

2. **Decompose the diffusive enthalpy flux into dry static energy + water enthalpy** (`F_h = -K_h ∇s_d + Σ_μ h_tot,μ (-K_h ∇q_μ)`, unit turbulent Lewis number), at both diffusion sites (`edmfx_sgs_diffusive_flux_tendency!` and `vertical_diffusion_boundary_layer_tendency!`). Diffusing `h_tot` directly implies a spurious enthalpy flux carried by dry-air diffusion, which systematically warms entrained air across capping inversions where `h_tot` jumps up while `q_t` jumps down, contributing to Sc bias. The implicit-Jacobian diffusion factors are updated to match. In DYCOMS RF01, air just above cloud top is now ~1.6 K cooler. May affect mid-troposphere biases too.

3. **Damp the relative part of the cloud-fraction floor as the subdomain mean saturates** (`D = x/√(1+x²)`, `x = max(-μ_S, 0)/(ε_rel·q_sat)`), so an equilibrated overcast deck is no longer capped below CF = 1 by the patchiness floor. No new parameter; the floor still enters only the CF diagnosis, so quadrature mass conservation is untouched. DYCOMS RF01 deck cloud fraction 96–99% (was 74–89%), hour-6 LWP 145 g/m² (was 51).