### PR TITLE
feat(timestepping): add horizontal acoustic substepping

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -525,6 +525,14 @@ steps:
           --job_id box_density_current_test
         artifact_paths: "box_density_current_test/output_active/*"
 
+      - label: ":package: Non-spherical: 3D box, dry density current, acoustic substepping, conservation"
+        retry: *retry_policy
+        command: >
+          julia --color=yes --project=.buildkite .buildkite/ci_driver.jl
+          --config_file $CONFIG_PATH/box_acoustic_substep_conservation.yml
+          --job_id box_acoustic_substep_conservation
+        artifact_paths: "box_acoustic_substep_conservation/output_active/*"
+
       - label: ":package: Non-spherical: Reproducibility test for radiative convective equilibrium in a 3D box"
         retry: *retry_policy
         command: >

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- [#4660](https://github.com/CliMA/ClimaAtmos.jl/pull/4660) ![][badge-✨feature/enhancement] Add an optional horizontal acoustic-substepping timestepping mode (`AcousticMultirate`) that sub-cycles the fast horizontal acoustic terms and the kinetic-energy gradients at a small sub-step while the slow dynamics and physics advance with a larger outer step.
+  Divergence damping (`acoustic_substep_damping_form`, `acoustic_substep_damping`) controls grid-scale acoustic noise.
+  Disabled by default (`acoustic_substeps: 0`), so the default configuration is unchanged.
+  See `docs/src/acoustic_substepping.md`.
 - [#4648](https://github.com/CliMA/ClimaAtmos.jl/pull/4648) ![][badge-🔥behavioralΔ] Carry the energy of sedimenting water at each subdomain's own value under `PrognosticEDMFX`. Each sedimenting species transports its specific internal, potential, and kinetic energy `e_int(T) + Φ + Kin(w, u)`; the grid-mean sedimentation energy flux is set equal to the sum of the updraft and environment fluxes, each the subdomain sedimentation mass flux times its specific energy (with `Φ` common to all subdomains and the environment mass flux taken as the grid-mean residual `ρqw - ρaʲqʲwʲ`). The updraft kinetic energy uses the updraft velocities; the environment kinetic energy uses the grid-mean terminal velocity, since the environment terminal velocity is not stored separately.
 - [#4653](https://github.com/CliMA/ClimaAtmos.jl/pull/4653) ![][badge-🔥behavioralΔ] Improve the manual implicit Jacobian (the tendencies are unchanged; behavior changes only through the single-Newton-iteration implicit solve).
   - Document that the existing height-form pressure-gradient-force Jacobian blocks are the exact linearization of the Exner-form tendency `cp_d θ_v ∇Π` (stencils unchanged): the thermal-buoyancy and pressure-buoyancy terms cancel via the equation-of-state identity `δρ/ρ = (1-κ_d) δp/p - δθ_v/θ_v`, leaving the acoustic operator `∇δp/ρ` in every column perturbed at fixed density plus a single buoyancy term in the `ρ` column, so sound and gravity waves are both treated fully implicitly.

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -71,6 +71,21 @@ max_newton_iters_ode:
 ode_algo:
   help: "ODE algorithm [`ARS343` (default), `SSP333`, `IMKG343a`, etc.]"
   value: "ARS343"
+acoustic_substeps:
+  help: "Acoustic substepping. `0` (default) disables it and uses `ode_algo` directly. A positive integer wraps `ode_algo` in the acoustic-substepping multirate timestepper with that many sub-steps per outer step. `auto` selects the sub-step count from the horizontal acoustic CFL."
+  value: "0"
+acoustic_substep_vertical:
+  help: "Treatment of the vertical acoustic terms within an acoustic sub-step [`implicit` (default), `explicit`]. `implicit` keeps the vertically-implicit (HEVI) solve so the sub-step is limited only by the horizontal acoustic CFL."
+  value: "implicit"
+acoustic_substep_order:
+  help: "Order of the acoustic-substepping outer scheme [`1`, `2` (default)]."
+  value: 2
+acoustic_substep_damping_form:
+  help: "Divergence used by the acoustic-substepping divergence damping [`3d` (default): the three-dimensional divergence of the full velocity; `horizontal`: the horizontal divergence of the horizontal velocity]."
+  value: "3d"
+acoustic_substep_damping:
+  help: "Divergence-damping coefficient for acoustic substepping, in the form nu_d = beta_d c_ref^2 fast_dt. Suppresses the split-explicit resonance between the frozen slow forcing and the sub-cycled acoustic modes [`auto` (default): resolves to 0.4; a number keeps its direct meaning]."
+  value: "auto"
 krylov_rtol:
   help: "Relative tolerance of the Krylov method (only for ClimaTimeSteppers.jl; only used if `use_krylov_method` is `true`)"
   value: 0.1

--- a/config/model_configs/box_acoustic_substep_conservation.yml
+++ b/config/model_configs/box_acoustic_substep_conservation.yml
@@ -1,0 +1,16 @@
+initial_condition: "DryDensityCurrentProfile"
+config: "box"
+hyperdiff: ~
+x_max: 12800.0
+y_max: 12800.0
+z_max: 6400.0
+x_elem: 8
+y_elem: 8
+z_elem: 10
+z_stretch: false
+dt: "0.5secs"
+t_end: "5secs"
+dt_save_state_to_disk: "5secs"
+disable_surface_flux_tendency: true
+check_conservation: true
+acoustic_substeps: "auto"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,7 @@ makedocs(;
             "Dynamics & Numerics" => [
                 "Governing Equations" => "equations.md",
                 "Implicit Solver" => "implicit_solver.md",
+                "Acoustic Substepping" => "acoustic_substepping.md",
                 "Integer Time (ITime)" => "itime.md",
             ],
             "Physics & Parameterizations" => [

--- a/docs/src/acoustic_substepping.md
+++ b/docs/src/acoustic_substepping.md
@@ -27,6 +27,11 @@ Per outer step the scheme:
 
 A first- or second-order outer combination of the sub-cycles is available.
 
+The vertical acoustic terms stay inside the sub-cycle even though they are implicit.
+Implicit treatment removes the vertical acoustic CFL bound, but the terms remain fast: the three-dimensional acoustic response does not separate into independent horizontal and vertical waves, and a vertical response held fixed over the outer step while the horizontal terms sub-cycle would act as a frozen fast term, the same class of parametric source as the frozen kinetic-energy gradient below.
+Each sub-step is therefore a HEVI step for the acoustic system at the sub-step size, as in the split-explicit tradition, where the small acoustic steps contain the vertically implicit solve.
+The added cost is small: the vertical solve is columnwise and needs no horizontal communication.
+
 ## Resonance source and divergence damping
 
 Freezing the slow forcing over an outer step and sub-cycling the acoustic system excites a parametric resonance with the grid-scale acoustic modes.
@@ -139,6 +144,7 @@ On configurations with inexpensive physics the sub-step count needed for stabili
 
 - The sub-cycle treats the whole implicit tendency implicitly at the sub-step size.
   The mode is validated for configurations whose implicit tendency is the vertical-acoustic block; configurations that also place microphysics, turbulence, or vertical diffusion in the implicit tendency re-solve those processes every sub-step.
+  Restricting the sub-cycle implicit solve to the acoustic block, with the remaining implicit terms advanced once per outer step, is follow-up work.
 - The mode advances the vertical acoustic terms implicitly inside each sub-step; the explicit-vertical variant is a reference path limited by the vertical acoustic CFL on anisotropic grids.
 - The sub-cycle refreshes only the acoustic precomputed quantities; diagnostics that read the full cache should refresh it after a step.
 - The divergence-damping coefficient must lie within its stable range; the automatic default targets it.

--- a/docs/src/acoustic_substepping.md
+++ b/docs/src/acoustic_substepping.md
@@ -1,0 +1,147 @@
+# Acoustic substepping
+
+## Motivation
+
+ClimaAtmos integrates the compressible equations with a horizontally-explicit, vertically-implicit (HEVI) split.
+The vertical acoustic (sound-wave) terms are solved implicitly, so thin vertical layers do not restrict the timestep, while the horizontal acoustic terms are explicit and must satisfy the acoustic CFL condition
+
+```math
+\frac{c_\mathrm{sound}\, \Delta t}{\Delta x} \lesssim 1 .
+```
+
+At high horizontal resolution this forces a small timestep even though the advective and physical timescales, set by the wind speed ``|u| \ll c_\mathrm{sound}`` and by the parameterizations, permit a much larger one.
+Most of the model runtime then goes to stepping fast only to keep the sound waves stable.
+The sound waves themselves are not of interest; the goal is to treat them correctly without letting them limit the timestep of the slow dynamics.
+
+Acoustic substepping (a split-explicit scheme) sub-cycles the fast horizontal acoustic terms at a small sub-step inside a larger outer step, while the slow dynamics and physics are evaluated once per outer step.
+The outer step is then limited by the advective and physical timescales, and the parameterizations are evaluated far less often.
+The intended benefit is higher throughput in the convective gray zone (roughly one to ten kilometres of horizontal spacing), where the per-step physics is the dominant cost.
+
+## How it works
+
+Per outer step the scheme:
+
+1. evaluates the slow forcing (the explicit tendency minus the horizontal acoustic terms and the grid-mean momentum advection) and freezes it,
+2. sub-cycles the acoustic system `n_sub` times.
+   Each sub-step advances the horizontal acoustic terms and the grid-mean momentum advection (the kinetic-energy gradients and the rotational momentum flux) explicitly and the vertical acoustic terms implicitly (reusing the existing implicit solver), with the frozen slow forcing added.
+
+A first- or second-order outer combination of the sub-cycles is available.
+
+## Resonance source and divergence damping
+
+Freezing the slow forcing over an outer step and sub-cycling the acoustic system excites a parametric resonance with the grid-scale acoustic modes.
+The resonance grows fastest at the wavenumber where the acoustic phase advances by ``\pi`` per outer step, and that wavenumber migrates to larger scales as the outer step grows, so a damper tuned to the grid scale weakens as the outer step increases.
+
+The dominant source of the resonance is the kinetic-energy gradient.
+The grid-mean momentum tendency includes the gradients ``\nabla_h(K + \Phi - \Phi_r)`` on ``u_h`` and ``\partial_z K`` on ``u_3``, and ``K = |u|^2/2`` oscillates at the acoustic frequency.
+Holding these gradients in the frozen slow forcing would feed an acoustic-frequency signal into the sub-cycle once per outer step, the resonant drive.
+The scheme re-evaluates these gradients at every sub-step, so they follow the sub-cycled state and no longer act as a fixed periodic source.
+Re-evaluation leaves the executed sub-step tendency unchanged at the outer-step start, where the frozen forcing is sampled.
+
+The kinetic-energy gradient and the rotational (vorticity and Coriolis) momentum flux together form the vector-invariant momentum advection ``(\omega \times u) + \nabla K``, which is energy-conserving as a whole but not term by term.
+Re-evaluating the gradient while freezing the rotational flux splits this pair across the sub-cycle and the frozen forcing, leaving a non-conservative residual that grows a spurious vertical mode; the growth rate scales with the flow shear and is negligible on weak-wind boxes but destabilizing on the sphere baroclinic jet.
+The scheme therefore sub-cycles the rotational momentum flux alongside the kinetic-energy gradient, so the sub-step momentum advection stays energy-conserving.
+
+The remaining resonant terms (upwind corrections and frozen tracer/EDMF flux divergences) are weaker at the acoustic frequency and are held by divergence damping on the horizontal momentum.
+The damping adds ``\nu_d \, \nabla_h(\delta)`` to ``u_h``, with the damped divergence ``\delta`` selected by `acoustic_substep_damping_form`:
+
+| Form | Damped divergence ``\delta`` |
+|---|---|
+| `3d` (default) | ``\nabla_h \cdot u + \partial_z u^3``, the three-dimensional divergence of the full velocity. |
+| `horizontal` | ``\nabla_h \cdot u_h``, the horizontal divergence of the horizontal velocity. |
+
+Taking the horizontal divergence of the damped ``u_h`` equation gives a term ``-\nu_d k_h^2 \delta``, so horizontal and mixed acoustic modes are damped in proportion to ``k_h^2`` while purely vertical modes (``k_h = 0``), the rotational flow, and balanced flow are untouched.
+
+### Coefficient conventions
+
+The viscosity is ``\nu_d = \beta_d \, c_\mathrm{ref}^2 \, \Delta t_\mathrm{sub}``, and the per-sub-step grid-mode damping is ``\varepsilon_\mathrm{grid} = 4 \beta_d C_s^2`` with the sub-step acoustic Courant number ``C_s = c_\mathrm{ref} \Delta t_\mathrm{sub}/\Delta x_\mathrm{node} \approx 0.5``.
+Published split-explicit schemes use two normalizations, both of which map into this ``\beta_d``:
+
+| Normalization | Definition | Operational ``\beta_d`` |
+|---|---|---|
+| Forward-weighted pressure filter (WRF `smdiv`) | ``\nu = \gamma_d \, c^2 \Delta\tau`` | ``\gamma_d \approx 0.1`` |
+| Time-adjusted filter (MPAS / Klemp 2018) | ``\nu = a_d \, \Delta x^2/\Delta\tau`` | ``a_d/C_s^2 \approx 0.4`` at ``C_s = 0.5`` |
+
+The two describe different filters, so both are correct in their own convention; expressed in the ``\nu_d = \beta_d c_\mathrm{ref}^2 \Delta t_\mathrm{sub}`` normalization used here they give a canonical band ``\beta_d \in [0.1, 0.6]`` (COSMO operational practice is near ``0.3``).
+With `acoustic_substep_damping: auto` the coefficient resolves to ``0.4``.
+The explicit-diffusion limit ``\varepsilon_\mathrm{grid} \le 1`` gives ``\beta_d \lesssim 2`` at ``C_s = 0.5``; with a manually set sub-step count at a higher per-sub-step Courant number, ``\beta_d`` must shrink in proportion to ``1/C_s^2``.
+
+Because the kinetic-energy gradient is re-evaluated in the sub-cycle, the lower edge of the stable window is ``\beta_d = 0``, so divergence damping is not required for stability and a lighter coefficient is viable: on the dry box, halving the default to ``\beta_d = 0.1`` roughly halves the divergent-flow distortion while remaining stable to the same outer step.
+
+### Outer-step limits
+
+Two limits bound the outer step, both independent of the resonance.
+
+#### Frozen explicit horizontal mixing
+
+Any explicit horizontal mixing tendency is in the frozen slow forcing ``G``, so the outer combination integrates it effectively explicitly at the outer step ``\Delta t``.
+The frozen form has no damping benefit inside the sub-cycle: each scheme's own explicit stability limit applies at the outer step.
+Which scheme is limiting depends on the configuration:
+
+| Scheme | Diffusivity | Explicit limit | Outer-step multiple |
+|---|---|---|---|
+| Hyperdiffusion (4th order) | ``\nu_4 = c_4 h^3`` | ``\Delta t \lesssim C_4/(\nu_4 k_\mathrm{max}^4) \propto h/c_4`` | resolution-independent; ``\approx 3\times`` measured on the dry box |
+| Smagorinsky | ``\nu = (C_s \Delta x)^2 |S|`` | ``\Delta t \le 1/(4 C_s^2 |S|)`` | strain timescale ``1/|S|`` (resolution-independent); ``O(50\text{–}1000)\times``, compressing where ``|S|`` is large |
+| EDMF horizontal | ``\nu \sim \ell \sqrt{\mathrm{TKE}},\ \ell \propto \Delta x`` | ``\Delta t \le \Delta x/(4 c_\ell \sqrt{\mathrm{TKE}})`` | ``\approx c/(4 c_\ell \sqrt{\mathrm{TKE}}\,\mathrm{CFL})``, ``O(50\text{–}100)\times`` |
+
+The hyperdiffusivity scales as ``h^3`` while the baseline acoustic step scales as ``h/c``, so the hyperdiffusion limit expressed as an outer-step multiple is resolution-independent (at fixed polynomial order and the ``\nu_4 \propto h^3`` convention), and the same small multiple applies on production gray-zone grids.
+On hyperdiffusion-on configurations the frozen hyperdiffusion is therefore the limiting term: it is stable at ``\approx 3\times`` and unstable at ``\approx 4\times`` on the dry box.
+Because hyperdiffusion is a numerical filter, its coefficient can be reduced at a large outer step with the `hyperdiffusion_dt_limit_safety` option, which raises this limit in proportion to ``1/\nu_4``.
+The Smagorinsky and EDMF limits are physical timescales (strain rate, eddy turnover), so their outer-step multiples are large; on hyperdiffusion-off gray-zone or LES configurations the frozen-mixing limit is far above the ``4\text{–}6\times`` target and the limiting constraint is elsewhere.
+Because those limits depend on the local flow, they are attributed empirically per configuration.
+
+#### Outer advective consistency
+
+The second-order outer combination freezes advection over the outer step, so at a large outer step the advective Courant number of the frozen forcing approaches its stability limit.
+Both outer orders are available.
+
+## Configuration
+
+| Option | Meaning |
+|---|---|
+| `acoustic_substeps` | `0` disables the mode; a positive integer fixes the sub-step count; `auto` selects it from the horizontal acoustic CFL. |
+| `acoustic_substep_order` | Order of the outer combination (`1` or `2`). |
+| `acoustic_substep_vertical` | `implicit` (default) keeps the vertically-implicit acoustic solve; `explicit` advances it in the sub-cycle. |
+| `acoustic_substep_damping_form` | Divergence used by the divergence damping: `3d` (default) or `horizontal`. |
+| `acoustic_substep_damping` | Divergence-damping coefficient ``\beta_d`` (``\nu_d = \beta_d c_\mathrm{ref}^2 \Delta t_\mathrm{sub}``). `auto` (default) resolves to `0.4`; a number keeps its direct value. |
+
+With `auto`, the sub-step count is
+
+```math
+n_\mathrm{sub} = \left\lceil \frac{\Delta t}{f \, \Delta x_\mathrm{node} / c_\mathrm{ref}} \right\rceil ,
+```
+
+where ``\Delta x_\mathrm{node}`` is the horizontal node spacing, ``c_\mathrm{ref}`` a reference sound speed, and ``f = 0.5`` a CFL safety factor, so enabling the mode requires no manual tuning of the sub-step count.
+
+## Example
+
+A box configuration that enables the mode with an automatic sub-step count:
+
+```yaml
+config: "box"
+x_elem: 30
+y_elem: 30
+z_elem: 30
+dt: "4secs"
+acoustic_substeps: "auto"
+```
+
+The damping form and damping coefficient take their defaults (`3d` and `auto`), so no further keys are needed.
+On a hyperdiffusion-on configuration at a large outer step, set `hyperdiffusion_dt_limit_safety` (recommended `2`) so the frozen hyperdiffusion stays within its explicit stability limit.
+
+## When to use it
+
+Use acoustic substepping when the horizontal acoustic CFL, not the advective CFL or the physics, is what limits the timestep, and when the per-step physics is expensive enough to amortize.
+This is the gray-zone regime.
+On configurations with inexpensive physics the sub-step count needed for stability can outweigh the saving, so the mode is not beneficial there.
+
+## Limitations
+
+- The sub-cycle treats the whole implicit tendency implicitly at the sub-step size.
+  The mode is validated for configurations whose implicit tendency is the vertical-acoustic block; configurations that also place microphysics, turbulence, or vertical diffusion in the implicit tendency re-solve those processes every sub-step.
+- The mode advances the vertical acoustic terms implicitly inside each sub-step; the explicit-vertical variant is a reference path limited by the vertical acoustic CFL on anisotropic grids.
+- The sub-cycle refreshes only the acoustic precomputed quantities; diagnostics that read the full cache should refresh it after a step.
+- The divergence-damping coefficient must lie within its stable range; the automatic default targets it.
+- The stable outer step and the coefficient defaults are established on a flat, dry box.
+  Terrain and moist convection are not yet exercised at large outer steps: the kinetic-energy gradient is evaluated in metric-aware form, but the reference-relative pressure-gradient cancellation over terrain is sensitive in `Float32`, and the moist stable outer step may be set by limits other than the resonance.
+  The `horizontal` damping form is the documented fallback if the vertical divergence term destabilizes on strongly anisotropic grids.

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -139,6 +139,7 @@ include(
     ),
 )
 include(joinpath("prognostic_equations", "advection.jl"))
+include(joinpath("prognostic_equations", "acoustic_substepping.jl"))
 
 include(joinpath("cache", "temporary_quantities.jl"))
 include(joinpath("cache", "tracer_cache.jl"))
@@ -160,6 +161,7 @@ include(joinpath("parameters", "create_parameters.jl"))
 include(joinpath("simulation", "grids.jl"))
 include(joinpath("simulation", "restart.jl"))
 include(joinpath("simulation", "integrator.jl"))
+include(joinpath("simulation", "acoustic_multirate.jl"))
 include(joinpath("simulation", "AtmosSimulations.jl"))
 include(joinpath("simulation", "solve.jl"))
 

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -272,7 +272,7 @@ function jacobian_from_parsed_args(parsed_args)
 end
 
 function ode_configuration(::Type{FT}, args) where {FT}
-    return ode_configuration(
+    inner_algo = ode_configuration(
         FT,
         args["ode_algo"],
         args["update_jacobian_every"],
@@ -285,6 +285,37 @@ function ode_configuration(::Type{FT}, args) where {FT}
         args["newton_rtol"],
         args["jvp_step_adjustment"],
     )
+    substeps = string(args["acoustic_substeps"])
+    substeps == "0" && return inner_algo
+    vertical =
+        args["acoustic_substep_vertical"] == "explicit" ? ExplicitVertical() :
+        ImplicitVertical()
+    n_sub = substeps == "auto" ? 0 : parse(Int, substeps)
+    damping_form = acoustic_damping_form(args["acoustic_substep_damping_form"])
+    β_d = acoustic_damping_coefficient(args["acoustic_substep_damping"])
+    return AcousticMultirate(
+        inner_algo,
+        n_sub,
+        vertical,
+        args["acoustic_substep_order"],
+        β_d,
+        damping_form,
+    )
+end
+
+# Resolve the acoustic-substepping divergence-damping form from its config value.
+function acoustic_damping_form(form)
+    form == "3d" && return FullDivergenceDamping()
+    form == "horizontal" && return HorizontalDivergenceDamping()
+    error("Unknown acoustic_substep_damping_form: $form")
+end
+
+# Resolve the divergence-damping coefficient β_d. "auto" resolves to 0.4; a
+# number or a numeric string keeps its direct value.
+acoustic_damping_coefficient(β_d::Real) = Float64(β_d)
+function acoustic_damping_coefficient(β_d::AbstractString)
+    β_d == "auto" || return parse(Float64, β_d)
+    return 0.4
 end
 
 function get_comms_context(parsed_args)

--- a/src/config/yaml_helper.jl
+++ b/src/config/yaml_helper.jl
@@ -50,11 +50,14 @@ function override_default_config(::Nothing)
 end
 
 # Keys that bypass scalar coercion: `named String | nothing` unions
-# (hyperdiff has a String default but accepts `~` to disable) and structured
-# values (`diagnostics` is a list of dicts).
+# (hyperdiff has a String default but accepts `~` to disable), structured
+# values (`diagnostics` is a list of dicts), and keys that accept either a
+# String sentinel or a number (`acoustic_substep_damping` takes `"auto"` or a
+# coefficient).
 const EXCEPTED_KEYS = Set([
     "hyperdiff",
     "diagnostics",
+    "acoustic_substep_damping",
 ])
 
 """

--- a/src/prognostic_equations/acoustic_substepping.jl
+++ b/src/prognostic_equations/acoustic_substepping.jl
@@ -1,0 +1,104 @@
+#####
+##### Horizontal acoustic tendency (fast modes for acoustic substepping)
+#####
+
+"""
+    horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+
+Compute the horizontal acoustic (sound-wave) contributions to the grid-mean
+prognostic tendencies: the horizontal mass-flux divergence on `ρ`, the
+horizontal total-enthalpy-flux divergence on `ρe_tot`, and the horizontal
+pressure-gradient (split θᵥ-Exner form) on `uₕ`.
+
+The horizontal acoustic subset of `horizontal_dynamics_tendency!`, sub-cycled by
+the acoustic-substepping timestepper.
+"""
+NVTX.@annotate function horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+    (; ᶜu, ᶜp, ᶜT, ᶜh_tot, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+    (; params) = p
+    thermo_params = CAP.thermodynamics_params(params)
+    cp_d = thermo_params.cp_d
+
+    @. Yₜ.c.ρ -= split_divₕ(Y.c.ρ * ᶜu, 1)
+    @. Yₜ.c.ρe_tot -= split_divₕ(Y.c.ρ * ᶜu, ᶜh_tot)
+
+    ᶜθ_v = p.scratch.ᶜtemp_scalar
+    @. ᶜθ_v = theta_v(thermo_params, ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice)
+    ᶜθ_vr = @. lazy(theta_vr(thermo_params, ᶜp))
+    ᶜΠ = @. lazy(TD.exner_given_pressure(thermo_params, ᶜp))
+    ᶜθ_v_diff = @. lazy(ᶜθ_v - ᶜθ_vr)
+    # symmetric split-form pressure gradient in θᵥ′ = θᵥ − θᵥ,ref:
+    # ½ cp_d (θᵥ′ ∇Π + ∇(θᵥ′ Π) − Π ∇θᵥ′)
+    @. Yₜ.c.uₕ -= C12(
+        cp_d *
+        (
+            ᶜθ_v_diff * gradₕ(ᶜΠ) + gradₕ(ᶜθ_v_diff * ᶜΠ) - ᶜΠ * gradₕ(ᶜθ_v_diff)
+        ) / 2,
+    )
+    return nothing
+end
+
+"""
+    kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
+
+Compute the kinetic-energy-gradient contributions to the grid-mean momentum
+tendencies: the horizontal gradient of `K + Φ − Φ_r` on `uₕ` and the vertical
+gradient of `K` on `u₃`.
+
+The gradient-form subset of the grid-mean momentum advection, re-evaluated inside
+the acoustic sub-cycle rather than held in the frozen slow forcing. Its
+energy-conserving partner, the rotational momentum flux, is sub-cycled alongside
+it by `rotational_momentum_flux_tendency!`. The `uₕ` term matches
+`horizontal_dynamics_tendency!` and the `u₃` term matches
+`explicit_vertical_advection_tendency!`.
+"""
+NVTX.@annotate function kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
+    (; ᶜK, ᶜp) = p.precomputed
+    (; ᶜΦ) = p.core
+    thermo_params = CAP.thermodynamics_params(p.params)
+    ᶜΦ_r = @. lazy(phi_r(thermo_params, ᶜp))
+    @. Yₜ.c.uₕ -= C12(gradₕ(ᶜK + ᶜΦ - ᶜΦ_r))
+    @. Yₜ.f.u₃ -= ᶠgradᵥ(ᶜK)
+    return nothing
+end
+
+"""
+    rotational_momentum_flux_tendency!(Yₜ, Y, p, t)
+
+Compute the rotational (vorticity and Coriolis) momentum-flux contributions to the
+grid-mean momentum tendencies: `-(ω × u)` on `uₕ` and `u₃`, split into the
+horizontal (`uₕ`) and vertical (`u₃`) covariant components.
+
+The rotational subset of the grid-mean momentum advection, re-evaluated inside the
+acoustic sub-cycle. It is the energy-conserving partner of the kinetic-energy
+gradient in `kinetic_energy_gradient_tendency!` and is sub-cycled together with it.
+The `uₕ` and `u₃` terms match the momentum flux in
+`explicit_vertical_advection_tendency!`.
+"""
+function rotational_momentum_flux_tendency!(Yₜ, Y, p, t)
+    (; ᶜf³, ᶠf¹²) = p.core
+    (; ᶜu, ᶠu³) = p.precomputed
+    ᶜJ = Fields.local_geometry_field(Y.c).J
+    point_type = eltype(Fields.coordinate_field(Y.c))
+    ᶜω³ = p.scratch.ᶜtemp_CT3
+    ᶠω¹² = p.scratch.ᶠtemp_CT12
+    if point_type <: Geometry.Abstract3DPoint
+        @. ᶜω³ = wcurlₕ(Y.c.uₕ)
+    else
+        @. ᶜω³ = zero(ᶜω³)
+    end
+    @. ᶠω¹² = ᶠcurlᵥ(Y.c.uₕ)
+    @. ᶠω¹² += CT12(wcurlₕ(Y.f.u₃))
+    if isnothing(ᶠf¹²)
+        @. Yₜ.c.uₕ -=
+            ᶜinterp(ᶠω¹² × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
+            (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.f.u₃ -= ᶠω¹² × ᶠinterp(CT12(ᶜu))
+    else
+        @. Yₜ.c.uₕ -=
+            ᶜinterp((ᶠf¹² + ᶠω¹²) × (ᶠinterp(Y.c.ρ * ᶜJ) * ᶠu³)) / (Y.c.ρ * ᶜJ) +
+            (ᶜf³ + ᶜω³) × CT12(ᶜu)
+        @. Yₜ.f.u₃ -= (ᶠf¹² + ᶠω¹²) × ᶠinterp(CT12(ᶜu))
+    end
+    return nothing
+end

--- a/src/simulation/acoustic_multirate.jl
+++ b/src/simulation/acoustic_multirate.jl
@@ -1,0 +1,246 @@
+#####
+##### Acoustic substepping timestepper. See `docs/src/acoustic_substepping.md`.
+#####
+##### The generic step-exchange multirate method (the frozen-forcing pass, the
+##### inner IMEX sub-cycle, and the outer combination) is in ClimaTimeSteppers, as
+##### the `LieSplitOuter`/`TrapezoidalSplitOuter` outer family. This file supplies
+##### the acoustic fast tendency, the forcing-freeze operation, the sub-step
+##### count, the implicit operator, and the config wiring.
+#####
+
+import ClimaTimeSteppers as CTS
+import ClimaUtilities.TimeManager: ITime
+import Dates
+
+"""
+    ImplicitVertical()
+    ExplicitVertical()
+
+Treatment of the vertical acoustic terms within an acoustic sub-step.
+`ImplicitVertical` keeps the vertically-implicit (HEVI) acoustic solve;
+`ExplicitVertical` advances the vertical acoustic terms explicitly.
+"""
+struct ImplicitVertical end
+struct ExplicitVertical end
+
+"""
+    HorizontalDivergenceDamping()
+    FullDivergenceDamping()
+
+Divergence used by the acoustic-substepping divergence damping.
+`HorizontalDivergenceDamping` damps the horizontal divergence of the horizontal
+velocity `divₕ(uₕ)`; `FullDivergenceDamping` damps the three-dimensional
+divergence `δ = divₕ(ᶜu) + ᶜdivᵥ(ᶠu³)`.
+"""
+struct HorizontalDivergenceDamping end
+struct FullDivergenceDamping end
+
+"""
+    divergence_damping_tendency!(Yₜ, Y, p, form, ν_d)
+
+Add the acoustic-substepping divergence-damping tendency `ν_d wgradₕ(δ)` to `uₕ`,
+with the damped divergence `δ` selected by `form`.
+"""
+function divergence_damping_tendency!(
+    Yₜ,
+    Y,
+    p,
+    ::HorizontalDivergenceDamping,
+    ν_d,
+)
+    @. Yₜ.c.uₕ += ν_d * wgradₕ(divₕ(Y.c.uₕ))
+    return nothing
+end
+function divergence_damping_tendency!(Yₜ, Y, p, ::FullDivergenceDamping, ν_d)
+    (; ᶜu, ᶠu³) = p.precomputed
+    ᶜδ = p.scratch.ᶜtemp_scalar_2
+    # Accumulate the horizontal (spectral) and vertical (column-stencil)
+    # divergences separately.
+    @. ᶜδ = divₕ(ᶜu)
+    @. ᶜδ += ᶜdivᵥ(ᶠu³)
+    @. Yₜ.c.uₕ += ν_d * wgradₕ(ᶜδ)
+    return nothing
+end
+
+"""
+    AcousticSubstepTendency(vertical, ν_d, damping_form)
+
+Fast (sub-cycled) explicit tendency: the horizontal acoustic terms, the grid-mean
+momentum advection (kinetic-energy gradients and rotational momentum flux) (and,
+for `ExplicitVertical`, the vertical acoustic terms) and the divergence damping.
+
+# Fields
+
+  - `vertical`: vertical-acoustic treatment, `ExplicitVertical` or `ImplicitVertical`.
+  - `ν_d`: divergence-damping viscosity [m² s⁻¹]; `0` disables divergence damping.
+  - `damping_form`: divergence-damping form, `HorizontalDivergenceDamping` or
+    `FullDivergenceDamping`.
+
+The call form `(f::AcousticSubstepTendency)(Yₜ, Yₜ_lim, Y, p, t)` writes the
+sub-step tendency into `Yₜ`, `Yₜ_lim` in place. The frozen slow forcing is added
+by the inner integrator's forcing wrapper.
+"""
+struct AcousticSubstepTendency{V, FT, D}
+    vertical::V
+    ν_d::FT
+    damping_form::D
+end
+function (f::AcousticSubstepTendency)(Yₜ, Yₜ_lim, Y, p, t)
+    Yₜ .= zero(eltype(Yₜ))
+    Yₜ_lim .= zero(eltype(Yₜ_lim))
+    horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+    kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
+    rotational_momentum_flux_tendency!(Yₜ, Y, p, t)
+    if f.vertical isa ExplicitVertical
+        implicit_vertical_advection_tendency!(Yₜ, Y, p, t)
+    end
+    if f.ν_d > 0
+        divergence_damping_tendency!(Yₜ, Y, p, f.damping_form, f.ν_d)
+    end
+    return nothing
+end
+
+"""
+    AcousticMultirate(inner_alg, n_sub, vertical, outer_stages = 2, β_d = 0.0,
+        damping_form = FullDivergenceDamping())
+
+A multirate `TimeSteppingAlgorithm` that sub-cycles the acoustic modes. See
+`docs/src/acoustic_substepping.md`.
+
+# Fields
+
+  - `inner_alg`: algorithm used for the acoustic sub-cycle (an `IMEXAlgorithm` for
+    `ImplicitVertical`, an explicit algorithm for `ExplicitVertical`).
+  - `n_sub`: sub-steps per outer step; `0` selects it from the acoustic CFL.
+  - `vertical`: vertical-acoustic treatment.
+  - `outer_stages`: order of the outer combination, `1` or `2`.
+  - `β_d`: divergence-damping coefficient (`ν_d = β_d c_ref² fast_dt`).
+  - `damping_form`: divergence-damping form, `HorizontalDivergenceDamping` or
+    `FullDivergenceDamping`.
+"""
+struct AcousticMultirate{A, V, D} <: CTS.TimeSteppingAlgorithm
+    inner_alg::A
+    n_sub::Int
+    vertical::V
+    outer_stages::Int
+    β_d::Float64
+    damping_form::D
+end
+AcousticMultirate(
+    inner_alg,
+    n_sub,
+    vertical,
+    outer_stages = 2,
+    β_d = 0.0,
+) = AcousticMultirate(
+    inner_alg,
+    n_sub,
+    vertical,
+    outer_stages,
+    β_d,
+    FullDivergenceDamping(),
+)
+
+"""
+    AcousticMultirateCache(f, cts_cache)
+
+Cache for an [`AcousticMultirate`](@ref) step. `f` is the full model
+`ClimaODEFunction`; `cts_cache` is the ClimaTimeSteppers step-exchange
+`Multirate` cache that drives the step.
+"""
+struct AcousticMultirateCache{F, C}
+    f::F
+    cts_cache::C
+end
+
+CTS.step_u!(integrator, cache::AcousticMultirateCache) =
+    CTS.step_u!(integrator, cache.cts_cache)
+
+# Reference sound speed √(γ R_d T_ref). T_ref is an upper-bound reference
+# temperature [K] so that c ≤ c_ref and the auto sub-step count is conservative.
+function reference_sound_speed(p)
+    R_d = CAP.R_d(p.params)
+    cp_d = CAP.cp_d(p.params)
+    cv_d = cp_d - R_d
+    T_ref = oftype(R_d, 300)
+    return sqrt(cp_d / cv_d * R_d * T_ref)
+end
+
+# Auto sub-step count from the horizontal acoustic CFL:
+# n_sub = ceil(dt / (cfl_safety · Δx_node / c_ref)).
+function auto_n_sub(dt, Δx, c_ref)
+    cfl_safety = oftype(c_ref, 0.5)
+    safe_dt = cfl_safety * Δx / c_ref
+    return max(1, ceil(Int, float(dt) / safe_dt))
+end
+
+# Smallest sub-step count ≥ `n_min` for which `dt / ·` is exact.
+# Any count divides a floating-point `dt`; an `ITime` requires a divisor of its
+# nanosecond count, so round up to the next such divisor.
+exact_n_sub(dt, n_min) = n_min
+function exact_n_sub(dt::ITime, n_min)
+    dt_ns = dt.counter * Dates.tons(dt.period)
+    n = n_min
+    while !iszero(rem(dt_ns, n))
+        n += 1
+    end
+    return n
+end
+
+# G = T_exp(u) - sub-cycled acoustic terms(u), evaluated and left in `G`/`G_lim`.
+# The sub-cycled terms are the horizontal acoustic tendency and the grid-mean
+# momentum advection (kinetic-energy gradients and rotational momentum flux), so
+# `G` holds exactly the tendency not re-evaluated inside the sub-cycle. Refreshes
+# the cache `p` to be consistent with `u`.
+function acoustic_slow_forcing!(G, G_lim, A_buf, f, u, p, t)
+    f.cache!(u, p, t)
+    G .= zero(eltype(G))
+    G_lim .= zero(eltype(G_lim))
+    f.T_exp_T_lim!(G, G_lim, u, p, t)
+    A_buf .= zero(eltype(A_buf))
+    horizontal_acoustic_tendency!(A_buf, u, p, t)
+    kinetic_energy_gradient_tendency!(A_buf, u, p, t)
+    rotational_momentum_flux_tendency!(A_buf, u, p, t)
+    G .-= A_buf
+    return nothing
+end
+
+function CTS.init_cache(prob, alg::AcousticMultirate; dt, kwargs...)
+    (; u0, p) = prob
+    f = prob.f
+    FT = eltype(u0)
+    Δx = FT(Spaces.node_horizontal_length_scale(Spaces.horizontal_space(axes(u0.c))))
+    c_ref = FT(reference_sound_speed(p))
+    requested_n_sub = alg.n_sub == 0 ? auto_n_sub(dt, Δx, c_ref) : alg.n_sub
+    n_sub = exact_n_sub(dt, requested_n_sub)
+    fast_dt = dt / n_sub
+    # Divergence-damping viscosity ν_d = β_d c_ref² fast_dt.
+    ν_d = FT(alg.β_d) * c_ref^2 * FT(float(fast_dt))
+    fast! = AcousticSubstepTendency(alg.vertical, ν_d, alg.damping_form)
+    A_buf = zero(u0)
+    freeze!(G, G_lim, U, p, t) = acoustic_slow_forcing!(G, G_lim, A_buf, f, U, p, t)
+    inner_T_imp! = alg.vertical isa ImplicitVertical ? f.T_imp! : nothing
+    # The fast sub-cycle is a full `ClimaODEFunction`: the acoustic fast tendency
+    # (with the frozen forcing added by the outer step), the implicit operator, and
+    # the reused implicit cache, limiter, and DSS.
+    f_fast = CTS.ClimaODEFunction(;
+        T_exp_T_lim! = fast!,
+        T_imp! = inner_T_imp!,
+        cache! = f.cache!,
+        cache_imp! = f.cache_imp!,
+        lim! = f.lim!,
+        dss! = f.dss!,
+        initialize_imp! = f.initialize_imp!,
+    )
+    outer =
+        alg.outer_stages == 1 ? CTS.LieSplitOuter(nothing) :
+        CTS.TrapezoidalSplitOuter(nothing)
+    split_prob = CTS.SplitODEProblem(f_fast, freeze!, u0, prob.tspan, p)
+    cts_cache = CTS.init_cache(
+        split_prob,
+        CTS.Multirate(alg.inner_alg, outer);
+        dt,
+        fast_dt,
+    )
+    return AcousticMultirateCache(f, cts_cache)
+end

--- a/src/simulation/acoustic_multirate.jl
+++ b/src/simulation/acoustic_multirate.jl
@@ -9,7 +9,7 @@
 #####
 
 import ClimaTimeSteppers as CTS
-import ClimaUtilities.TimeManager: ITime
+import ClimaUtilities.TimeManager: ITime, seconds
 import Dates
 
 """
@@ -171,7 +171,7 @@ end
 function auto_n_sub(dt, Δx, c_ref)
     cfl_safety = oftype(c_ref, 0.5)
     safe_dt = cfl_safety * Δx / c_ref
-    return max(1, ceil(Int, float(dt) / safe_dt))
+    return max(1, ceil(Int, seconds(dt) / safe_dt))
 end
 
 # Smallest sub-step count ≥ `n_min` for which `dt / ·` is exact.
@@ -215,7 +215,7 @@ function CTS.init_cache(prob, alg::AcousticMultirate; dt, kwargs...)
     n_sub = exact_n_sub(dt, requested_n_sub)
     fast_dt = dt / n_sub
     # Divergence-damping viscosity ν_d = β_d c_ref² fast_dt.
-    ν_d = FT(alg.β_d) * c_ref^2 * FT(float(fast_dt))
+    ν_d = FT(alg.β_d) * c_ref^2 * FT(seconds(fast_dt))
     fast! = AcousticSubstepTendency(alg.vertical, ν_d, alg.damping_form)
     A_buf = zero(u0)
     freeze!(G, G_lim, U, p, t) = acoustic_slow_forcing!(G, G_lim, A_buf, f, U, p, t)

--- a/src/simulation/integrator.jl
+++ b/src/simulation/integrator.jl
@@ -10,6 +10,7 @@ function get_jacobian(
     ode_algo, Y, atmos, jacobian::JacobianAlgorithm, debug_jacobian;
     verbose = false,
 )
+    ode_algo isa AcousticMultirate && (ode_algo = ode_algo.inner_alg)
     ode_algo isa Union{CTS.IMEXAlgorithm, CTS.RosenbrockAlgorithm} ||
         return nothing
     verbose && @info "Jacobian algorithm: $(summary_string(jacobian))"

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -1,0 +1,224 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaTimeSteppers as CTS
+
+# Unit tests for the acoustic-substepping timestepper: config resolution, the
+# sub-cycled kinetic-energy gradient, the exact tendency split, and the
+# divergence-damping forms.
+
+const CAP = CA.Parameters
+
+function box_config(;
+    damping_form = "3d",
+    damping = "auto",
+    vertical = "implicit",
+    order = 2,
+    substeps = "3",
+    dt = "0.5secs",
+)
+    return Dict{String, Any}(
+        "initial_condition" => "DryDensityCurrentProfile",
+        "config" => "box",
+        "FLOAT_TYPE" => "Float64",
+        "hyperdiff" => nothing,
+        "smagorinsky_lilly" => nothing,
+        "x_max" => 6400.0,
+        "y_max" => 6400.0,
+        "z_max" => 6400.0,
+        "x_elem" => 2,
+        "y_elem" => 2,
+        "z_elem" => 8,
+        "z_stretch" => false,
+        "dt" => dt,
+        "t_end" => "60secs",
+        "disable_surface_flux_tendency" => true,
+        "output_default_diagnostics" => false,
+        "dt_save_state_to_disk" => "Inf",
+        "log_progress" => false,
+        "acoustic_substeps" => substeps,
+        "acoustic_substep_vertical" => vertical,
+        "acoustic_substep_order" => order,
+        "acoustic_substep_damping_form" => damping_form,
+        "acoustic_substep_damping" => damping,
+        "output_dir" => mktempdir(),
+    )
+end
+
+resolved_alg(; kwargs...) = CA.ode_configuration(
+    Float64,
+    CA.AtmosConfig(box_config(; kwargs...); job_id = "resolve_probe").parsed_args,
+)
+
+box_integrator(; kwargs...) =
+    CA.get_simulation(CA.AtmosConfig(box_config(; kwargs...); job_id = "unit")).integrator
+
+@testset "config resolution" begin
+    a = resolved_alg()  # defaults: 3d / auto
+    @test a isa CA.AcousticMultirate
+    @test a.damping_form isa CA.FullDivergenceDamping
+    @test a.β_d == 0.4  # auto
+
+    b = resolved_alg(damping_form = "horizontal", damping = 0.8)
+    @test b.damping_form isa CA.HorizontalDivergenceDamping
+    @test b.β_d == 0.8                                 # Real
+    @test resolved_alg(damping = "0.8").β_d == 0.8     # numeric String
+
+    # acoustic_substeps = 0 leaves the plain ODE algorithm (no substepping wrapper).
+    @test !(resolved_alg(substeps = "0") isa CA.AcousticMultirate)
+end
+
+@testset "kinetic-energy gradient discrete form" begin
+    integ = box_integrator()
+    Y, p, t, f = integ.u, integ.p, integ.t, integ.cache.f
+    f.cache!(Y, p, t)
+
+    Yₜ = zero(Y)
+    CA.kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
+
+    # Momentum-only: mass and energy tendencies stay zero.
+    @test all(iszero, parent(Yₜ.c.ρ))
+    @test all(iszero, parent(Yₜ.c.ρe_tot))
+
+    ᶜK = p.precomputed.ᶜK
+    ᶜp = p.precomputed.ᶜp
+    ᶜΦ = p.core.ᶜΦ
+    thermo_params = CAP.thermodynamics_params(p.params)
+
+    u₃_ref = zero(Y.f.u₃)
+    @. u₃_ref = -CA.ᶠgradᵥ(ᶜK)
+    @test parent(Yₜ.f.u₃) == parent(u₃_ref)
+
+    uₕ_ref = zero(Y.c.uₕ)
+    @. uₕ_ref = -CA.C12(CA.gradₕ(ᶜK + ᶜΦ - CA.phi_r(thermo_params, ᶜp)))
+    @test parent(Yₜ.c.uₕ) == parent(uₕ_ref)
+end
+
+@testset "exact-split identity" begin
+    # At the freeze state, the horizontal acoustic tendency plus the sub-cycled
+    # momentum advection (kinetic-energy gradient and rotational momentum flux)
+    # plus the frozen slow forcing reconstructs the full explicit tendency, for
+    # both vertical treatments.
+    for vertical in ("implicit", "explicit")
+        integ = box_integrator(; vertical, damping = 0.0)
+        Y, p, t, f = integ.u, integ.p, integ.t, integ.cache.f
+
+        f.cache!(Y, p, t)
+        T_exp, T_lim = zero(Y), zero(Y)
+        f.T_exp_T_lim!(T_exp, T_lim, Y, p, t)
+
+        G, G_lim, A_buf = zero(Y), zero(Y), zero(Y)
+        CA.acoustic_slow_forcing!(G, G_lim, A_buf, f, Y, p, t)
+        Ah, B, C = zero(Y), zero(Y), zero(Y)
+        CA.horizontal_acoustic_tendency!(Ah, Y, p, t)
+        CA.kinetic_energy_gradient_tendency!(B, Y, p, t)
+        CA.rotational_momentum_flux_tendency!(C, Y, p, t)
+
+        recon = zero(Y)
+        @. recon = Ah + B + C + G
+        for name in (:ρ, :ρe_tot, :uₕ)
+            @test parent(getproperty(recon.c, name)) ≈
+                  parent(getproperty(T_exp.c, name))
+        end
+        @test parent(recon.f.u₃) ≈ parent(T_exp.f.u₃)
+    end
+end
+
+@testset "divergence-damping forms" begin
+    integ = box_integrator()
+    Y, p, t, f = integ.u, integ.p, integ.t, integ.cache.f
+    f.cache!(Y, p, t)
+    ν_d = 1.234
+
+    Yh = zero(Y)
+    CA.divergence_damping_tendency!(Yh, Y, p, CA.HorizontalDivergenceDamping(), ν_d)
+    Y3 = zero(Y)
+    CA.divergence_damping_tendency!(Y3, Y, p, CA.FullDivergenceDamping(), ν_d)
+
+    # On the flat box the horizontal divergence of the full velocity equals that
+    # of the horizontal velocity, so `3d` = `horizontal` + the vertical term.
+    ᶜu = p.precomputed.ᶜu
+    ᶠu³ = p.precomputed.ᶠu³
+    δu, δuₕ = zero(Y.c.ρ), zero(Y.c.ρ)
+    @. δu = CA.divₕ(ᶜu)
+    @. δuₕ = CA.divₕ(Y.c.uₕ)
+    @test parent(δu) ≈ parent(δuₕ)
+
+    ᶜdivᵥu³ = zero(Y.c.ρ)
+    @. ᶜdivᵥu³ = CA.ᶜdivᵥ(ᶠu³)
+    vert = zero(Y.c.uₕ)
+    @. vert = ν_d * CA.wgradₕ(ᶜdivᵥu³)
+    diff = zero(Y.c.uₕ)
+    @. diff = Y3.c.uₕ - Yh.c.uₕ
+    @test parent(diff) ≈ parent(vert)
+end
+
+function run_steps!(integ, n_steps)
+    for _ in 1:n_steps
+        CTS.step!(integ)
+    end
+    return integ
+end
+
+@testset "state update" begin
+    integ = box_integrator()
+    u_before = deepcopy(integ.u)
+    CTS.step!(integ)
+    Δρ = maximum(abs, parent(integ.u.c.ρ) .- parent(u_before.c.ρ))
+    Δu₃ = maximum(abs, parent(integ.u.f.u₃) .- parent(u_before.f.u₃))
+    @test Δρ > 0
+    @test Δu₃ > 0
+    @test all(isfinite, parent(integ.u.c.ρ))
+end
+
+@testset "mass and energy conservation" begin
+    integ = box_integrator(damping = 0.0)
+    mass_0 = sum(integ.u.c.ρ)
+    energy_0 = sum(integ.u.c.ρe_tot)
+    run_steps!(integ, 20)
+    mass_error = abs(sum(integ.u.c.ρ) - mass_0) / abs(mass_0)
+    energy_error = abs(sum(integ.u.c.ρe_tot) - energy_0) / abs(energy_0)
+    @test mass_error < 1e-8
+    @test energy_error < 1e-4
+end
+
+@testset "small-timestep agreement with the plain scheme" begin
+    n_steps = 5
+    plain = box_integrator(substeps = "0", dt = "0.2secs", order = 1)
+    substepped = box_integrator(substeps = "3", dt = "0.2secs", order = 1)
+    run_steps!(plain, n_steps)
+    run_steps!(substepped, n_steps)
+    for name in (:ρ, :ρe_tot)
+        reference = parent(getproperty(plain.u.c, name))
+        candidate = parent(getproperty(substepped.u.c, name))
+        relative_difference =
+            maximum(abs, reference .- candidate) / maximum(abs, reference)
+        @test relative_difference < 5e-2
+    end
+end
+
+@testset "timestep sweep" begin
+    for dt in ("0.5secs", "1secs", "2secs")
+        integ = box_integrator(substeps = "auto", dt = dt, order = 1)
+        t_start = integ.t
+        run_steps!(integ, 5)
+        @test integ.t > t_start
+        @test all(isfinite, parent(integ.u.c.ρ))
+        @test all(isfinite, parent(integ.u.f.u₃))
+    end
+end
+
+@testset "sub-step count is rounded up to divide dt exactly" begin
+    # See CliMA/ClimaTimeSteppers.jl#442: an ITime dt that the count does not
+    # divide exactly throws in `dt / n_sub` rather than truncating, so
+    # exact_n_sub rounds the resolved count up to a divisor.
+    dt = CA.ITime(0.5)                       # 5e8 ns, not divisible by 3
+    @test_throws ErrorException dt / 3
+    @test CA.exact_n_sub(dt, 3) == 4         # next count that divides 5e8 ns
+    @test CA.exact_n_sub(dt, 5) == 5         # already a divisor, left unchanged
+    @test dt / CA.exact_n_sub(dt, 3) isa CA.ITime
+    # The CFL-derived auto count is snapped through the same helper.
+    n_auto = CA.exact_n_sub(dt, CA.auto_n_sub(dt, 130.0, 340.0))
+    @test dt / n_auto isa CA.ITime
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ if TEST_GROUP in ("dynamics", "all")
     @safetestset "Tracer/mass transport consistency" begin @time include("prognostic_equations/tracer_mass_consistency_tests.jl") end
     @safetestset "Vertical water borrowing limiter" begin @time include("prognostic_equations/vertical_water_borrowing_tests.jl") end
     @safetestset "Enforce physical constraints" begin @time include("prognostic_equations/enforce_physical_constraints_tests.jl") end
+    @safetestset "Acoustic substepping" begin @time include("acoustic_substepping.jl") end
 
     # Conservation tests
     @safetestset "Mass conservation" begin @time include("conservation/mass_conservation.jl") end


### PR DESCRIPTION
## What

Add an optional horizontal acoustic-substepping mode (`AcousticMultirate`): the fast horizontal acoustic terms and the grid-mean momentum advection sub-cycle at a small sub-step while the slow dynamics and physics advance with the outer step, so the expensive physics is evaluated once per outer step. The generic step-exchange multirate (frozen forcing, inner IMEX sub-cycle, `LieSplitOuter`/`TrapezoidalSplitOuter` combination) comes from CliMA/ClimaTimeSteppers.jl#442; this PR supplies the acoustic fast tendency, the forcing freeze, the sub-step count and divergence damping (both defaulting from the horizontal acoustic CFL), the implicit operator, and the config wiring. The vertically implicit solve is unchanged, and `acoustic_substeps: 0` (default) leaves existing behavior unchanged.

The sub-cycle advances the vector-invariant momentum advection as a pair, the kinetic-energy gradient and the rotational (vorticity and Coriolis) momentum flux. Sub-cycling only the gradient leaves a non-conservative residual that grows a shear-driven vertical mode, negligible on weak-wind boxes but destabilizing for the sphere baroclinic jet.

## Dependencies

CliMA/ClimaTimeSteppers.jl#442 and ClimaUtilities >= 0.1.31 (CliMA/ClimaUtilities.jl#232, exact `ITime` division). CI resolves once both are released; the branch was validated locally against develop pins (session artifacts, not part of this branch).

## Verification

- Unit suite (`test/acoustic_substepping.jl`): the tendency-split identity (fast tendency plus frozen forcing reconstructs the full explicit tendency at the freeze state, for both vertical treatments), the divergence-damping forms, config resolution, a state-update check, a timestep sweep, and the exact sub-step-count rounding.
- Conservation: the dry box conserves mass and energy at the reference budget level (`box_acoustic_substep_conservation`).
- Sphere: the dry baroclinic wave (h_elem 6) at dt 800 s with the auto sub-step count completes one day and tracks the baseline extrema, in shallow and deep geometries.
- Quasi-equilibrium: the RCEMIP-II gray-zone 2 km box at dt 10 s (outer Courant 1.74) runs 50 days to a stationary radiative-convective moisture state; the implicit-split and no-split arms agree to 0.2% in column water at day 20, and the ARS343 dt 2 s baseline dries along the same trajectory, so the pre-equilibrium drift is spin-up rather than the integrator. Throughput at the matched 20-day horizon is 3.3x the baseline (sypd 0.60 versus 0.184). The 533 m box holds 5 days; the Bomex prognostic-EDMF box reaches steady shallow convection.

The soak evidence was generated on the earlier ClimaAtmos-hosted driver; the split identity and conservation checks tie it to this CTS-consumer driver (same fast tendency, same frozen forcing), and the throughput is expected to carry over rather than re-measured here.

## Scope

- Active hyperdiffusion limits the outer step to about three times the baseline; a coefficient clamp is proposed as follow-up work.
- Configurations with implicit physics re-solve those terms every sub-step; restricting the sub-cycle implicit solve to the acoustic block is follow-up work.
- Terrain at large outer steps is untested.
- An `ITime` outer step must divide exactly into sub-steps; `auto` rounds the resolved count up to the next such divisor.
