### PR TITLE
feat(simulation): add reuseexisting output directory style

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -145,7 +145,7 @@ output_dir:
   help: "Output directory"
   value: ~
 output_dir_style:
-  help: "What to do when `output_dir` already exists. With `RemovePreexisting`, `output_dir` is overwritten with a new one. With `ActiveLink`, `output_dir` is treated as a base folder and numbered subfolders are created inside. A new subfolder is created every time a simulation is run, with `output_dir/output_active` pointing to the most recent results. Check out ClimaUtilities.OutputPathGenerator for more information. [`ActiveLink` (default), `RemovePreexisting`]"
+  help: "What to do when `output_dir` already exists. With `RemovePreexisting`, `output_dir` is overwritten with a new one. With `ActiveLink`, `output_dir` is treated as a base folder and numbered subfolders are created inside. A new subfolder is created every time a simulation is run, with `output_dir/output_active` pointing to the most recent results. With `ReuseExisting`, output is written directly into `output_dir` without creating a numbered subfolder and without removing existing contents, so a continuation run appends to the existing diagnostic files; `restart_file` must be passed explicitly. Check out ClimaUtilities.OutputPathGenerator for more information. [`ActiveLink` (default), `RemovePreexisting`, `ReuseExisting`]"
   value: "ActiveLink"
 device:
   help: "Device type to use [`auto` (default) `CPUSingleThreaded`, `CPUMultiThreaded`, `CUDADevice`]"

--- a/src/simulation/restart.jl
+++ b/src/simulation/restart.jl
@@ -1,3 +1,4 @@
+import ClimaComms
 import ClimaCore: InputOutput
 import ClimaUtilities.OutputPathGenerator
 import ClimaUtilities.TimeManager: ITime
@@ -68,6 +69,34 @@ function handle_restart(
     spaces = (; center_space = axes(Y.c), face_space = axes(Y.f))
 
     return Y, t_start, spaces
+end
+
+"""
+    ReuseExistingStyle <: OutputPathGenerator.OutputPathGeneratorStyle
+
+Output directory style that writes directly into `output_dir` without creating an
+`output_NNNN` subdirectory and without removing any existing contents.
+
+Intended for continuing a simulation into an existing output directory, appending new
+time slices to the existing per-diagnostic NetCDF files and adding further checkpoint
+files alongside the existing ones.
+
+The diagnostics configuration of the continuation run must match the original run's;
+otherwise appending to an existing NetCDF file fails schema validation or corrupts it.
+"""
+struct ReuseExistingStyle <: OutputPathGenerator.OutputPathGeneratorStyle end
+
+function OutputPathGenerator.generate_output_path(
+    ::ReuseExistingStyle,
+    output_path;
+    context = nothing,
+)
+    output_path == "" && error("output_path cannot be empty")
+    if ClimaComms.iamroot(context)
+        isdir(output_path) || mkpath(output_path)
+    end
+    OutputPathGenerator.maybe_wait_filesystem(context, output_path)
+    return output_path
 end
 
 auto_detect_restart_file(::OutputPathGenerator.OutputPathGeneratorStyle, _) =
@@ -153,12 +182,22 @@ function setup_output_dir(
     allowed_dir_styles = Dict(
         "activelink" => OutputPathGenerator.ActiveLinkStyle(),
         "removepreexisting" => OutputPathGenerator.RemovePreexistingStyle(),
+        "reuseexisting" => ReuseExistingStyle(),
     )
 
     haskey(allowed_dir_styles, lowercase(output_dir_style)) ||
         error("output_dir_style $(output_dir_style) not available")
 
     output_dir_style_obj = allowed_dir_styles[lowercase(output_dir_style)]
+
+    if detect_restart_file &&
+       isnothing(restart_file) &&
+       output_dir_style_obj isa ReuseExistingStyle
+        error(
+            "detect_restart_file=true is not supported with " *
+            "output_dir_style=\"reuseexisting\"; pass restart_file explicitly.",
+        )
+    end
 
     final_restart_file = if detect_restart_file && isnothing(restart_file)
         auto_detect_restart_file(output_dir_style_obj, base_output_dir)


### PR DESCRIPTION
## What

Add `ReuseExistingStyle`, a new `output_dir_style` option (`"reuseexisting"`) for `setup_output_dir`. Unlike the existing styles, it writes directly into the given `output_dir`:

- No `output_NNNN` subdirectory is created (`ActiveLinkStyle` behavior is skipped).
- Existing contents are preserved (`RemovePreexistingStyle` deletion is skipped).
- The directory is created if it does not already exist.

As a result, a continuation run appends new time slices to the existing per-diagnostic NetCDF files and drops new checkpoint files alongside the existing ones, rather than starting a fresh numbered output directory.

The style is wired into the `allowed_dir_styles` map in `setup_output_dir` and documented in the `output_dir_style` config help text.

## Why

Continuing a run currently produces a new `output_NNNN` increment each time, splitting a single logical simulation across multiple directories and separate NetCDF files. `ReuseExisting` keeps all output for a continued simulation in one directory with continuous diagnostic time series.

## Scope and limitations

- Automatic restart-file detection (`detect_restart_file=true`) is only implemented for `ActiveLinkStyle` layouts. When combined with `reuseexisting` and no explicit `restart_file`, `setup_output_dir` raises an error directing the caller to pass `restart_file` explicitly.
- Correct appending requires the continuation run's diagnostics configuration (short names, reductions, periods) and model/grid configuration to match the original run; a mismatch can corrupt or invalidate the existing NetCDF files. This constraint is documented in the `ReuseExistingStyle` docstring.
- No changes to the default behavior: `output_dir_style` still defaults to `ActiveLink`.
