### PR TITLE
fix(setups): GPU-compatible single-column setups and finer hydrostatic-pressure integration

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -483,6 +483,17 @@ steps:
         agents:
           slurm_gpus: 1
 
+  - group: "Setups"
+    steps:
+      - label: ":crown: Setup hydrostatic pressure profiles are GPU-compatible"
+        retry: *retry_policy
+        command: >
+          julia --color=yes --project=.buildkite test/gpu_setups.jl
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
   - group: "Conservation Tests"
     steps:
       - label: ":computer: Conservation tests: Dry baroclinic wave, no sources"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+- [#4664](https://github.com/CliMA/ClimaAtmos.jl/pull/4664) ![][badge-🔥behavioralΔ] Initialize the AtmosphericProfilesLibrary single-column setups (Bomex, DYCOMS, GABLS, GATE_III, ISDAC, Larcform1, PrecipitatingColumn, Rico, Soares, ShipwayHill2012, TRMM_LBA) on GPU spaces. `hydrostatic_pressure_profile` integrates the hydrostatic initial value problem on a dedicated 1000-element column (previously 100) and returns a `ClimaInterpolations` interpolant over host arrays. Because the setup profiles are host-resident interpolants, the initial condition of these setups is evaluated on the host and copied to the device rather than broadcast on the device. Initial center pressures change by about `2e-4` to `4e-4` relative, dominated by the removed interpolation error of the coarser grid; the new profiles are within about `4e-6` relative of a reference solution on a 16 times finer grid. The `ShipwayHill2012` constructor now returns the setup type (its interface methods were previously unreachable).
 
 0.42.2
 -------

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-391
+392
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+392
+- Integrate the hydrostatic pressure of the single-column setups on a
+  1000-element column instead of a 100-element column. Initial center
+  pressures change by about 2e-4 to 4e-4 relative to the previous profile.
+
 391
 - Update SurfaceFluxes 1.0.1 → 1.1.0
 

--- a/src/prognostic_equations/constrain_state.jl
+++ b/src/prognostic_equations/constrain_state.jl
@@ -155,17 +155,17 @@ function prescribe_flow!(Y, p, t, flow::PrescribedFlow)
     z = Fields.coordinate_field(Y.f).z
     @. Y.f.u₃ = C3(Geometry.WVector(flow(z, t)), ᶠlg)
 
-    ᶜlg = Fields.local_geometry_field(Y.c)
-    thermo_params = CAP.thermodynamics_params(p.params)
+    params = p.params
+    thermo_params = CAP.thermodynamics_params(params)
     setup = Setups.ShipwayHill2012(; thermo_params)
     function _shipway_ρ_dry(lg)
-        ps = Setups.center_initial_condition(setup, lg, p.params)
-        ρ = Setups.air_density(ps, p.params)
+        ps = Setups.center_initial_condition(setup, lg, params)
+        ρ = Setups.air_density(ps, params)
         return ρ * (1 - ps.q_tot)
     end
-    _shipway_T(lg) = Setups.center_initial_condition(setup, lg, p.params).T
-    ᶜρ_init_dry = @. lazy(_shipway_ρ_dry(ᶜlg))
-    ᶜT_init = @. lazy(_shipway_T(ᶜlg))
+    _shipway_T(lg) = Setups.center_initial_condition(setup, lg, params).T
+    ᶜρ_init_dry = Setups.initial_condition_field(_shipway_ρ_dry, axes(Y.c))
+    ᶜT_init = Setups.initial_condition_field(_shipway_T, axes(Y.c))
 
     # Clamp ρq_tot to non-negative to prevent the feedback loop:
     # negative ρq_tot → lower ρ → more negative q_tot → blowup

--- a/src/setups/Setups.jl
+++ b/src/setups/Setups.jl
@@ -1,5 +1,9 @@
 module Setups
 
+import Adapt
+
+import StaticArrays as SA
+import ClimaInterpolations.Interpolation1D as CI1D
 import ClimaCore.Geometry as Geometry
 import ClimaCore: Fields
 import Thermodynamics as TD
@@ -210,6 +214,31 @@ include("common/prognostic_variables.jl")
 # ============================================================================
 
 """
+    initial_condition_field(f, space)
+
+Evaluate the pointwise initial-condition closure `f` over the local geometry of
+`space`. When the closure can be broadcast on `space`'s device it is; otherwise
+it is broadcast on the host and the result is copied to the device.
+
+A closure is broadcast on the device when it is isbits after adapting to the
+device array type. Closures that capture host-resident data - such as the
+interpolant profiles of the AtmosphericProfilesLibrary setups - are not, so
+they are evaluated on the host.
+"""
+function initial_condition_field(f, space)
+    local_geometry = Fields.local_geometry_field(space)
+    device = ClimaComms.device(space)
+    if device isa ClimaComms.AbstractCPUDevice ||
+       isbits(Adapt.adapt(ClimaComms.array_type(device), f))
+        return f.(local_geometry)
+    end
+    field_host = f.(Adapt.adapt(Array, local_geometry))
+    field = Fields.Field(eltype(field_host), space)
+    copyto!(parent(field), parent(field_host))
+    return field
+end
+
+"""
     initial_state(setup, params, atmos_model, center_space, face_space)
 
 Construct the full prognostic state vector `Y` (a `Fields.FieldVector`) for the
@@ -244,8 +273,8 @@ function initial_state(
     surface_space = Fields.level(face_space, Fields.half)
 
     return Fields.FieldVector(;
-        c = center_ic.(Fields.local_geometry_field(center_space)),
-        f = face_ic.(Fields.local_geometry_field(face_space)),
+        c = initial_condition_field(center_ic, center_space),
+        f = initial_condition_field(face_ic, face_space),
         surface_kwargs(surface_space, atmos_model.surface.temperature)...,
     )
 end

--- a/src/setups/ShipwayHill2012.jl
+++ b/src/setups/ShipwayHill2012.jl
@@ -19,13 +19,16 @@ function ShipwayHill2012(; thermo_params)
     rv_values = FT[0.015, 0.0138, 0.0024]
     θ_values = FT[297.9, 297.9, 312.66]
 
-    linear_profile(zs, vals) = Intp.extrapolate(
-        Intp.interpolate((zs,), vals, Intp.Gridded(Intp.Linear())),
-        Intp.Linear(),
+    linear_profile(zs, vals) = CI1D.Interpolate1D(
+        SA.SVector{length(zs)}(zs), SA.SVector{length(vals)}(vals);
+        interpolationorder = CI1D.Linear(),
+        extrapolationorder = CI1D.LinearExtrapolation(),
     )
-    rv(z) = max(linear_profile(z_values, rv_values)(z), zero(z))
+    rv_itp = linear_profile(z_values, rv_values)
+    θ_itp = linear_profile(z_values, θ_values)
+    rv(z) = max(rv_itp(z), zero(z))
     q_tot(z) = rv(z) / (1 + rv(z))
-    θ(z) = linear_profile(z_values, θ_values)(z)
+    θ(z) = θ_itp(z)
 
     p_0 = FT(100_700)
     p = hydrostatic_pressure_profile(; thermo_params, p_0, θ, q_tot)

--- a/src/setups/ShipwayHill2012.jl
+++ b/src/setups/ShipwayHill2012.jl
@@ -29,7 +29,7 @@ function ShipwayHill2012(; thermo_params)
 
     p_0 = FT(100_700)
     p = hydrostatic_pressure_profile(; thermo_params, p_0, θ, q_tot)
-    return (; θ, q_tot, p)
+    return ShipwayHill2012((; θ, q_tot, p))
 end
 
 function center_initial_condition(setup::ShipwayHill2012, local_geometry, params)

--- a/src/setups/TRMM_LBA.jl
+++ b/src/setups/TRMM_LBA.jl
@@ -39,13 +39,11 @@ function trmm_lba_profiles(thermo_params)
         q_v_sat = p_v_sat * (1 / Rv_over_Rd) / denominator
         return q_v_sat * measured_RH(z) / 100
     end
-    q_tot = Intp.extrapolate(
-        Intp.interpolate(
-            (measured_z_values,),
-            measured_q_tot_values,
-            Intp.Gridded(Intp.Linear()),
-        ),
-        Intp.Flat(),
+    n = length(measured_z_values)
+    q_tot = CI1D.Interpolate1D(
+        SA.SVector{n}(measured_z_values), SA.SVector{n}(measured_q_tot_values);
+        interpolationorder = CI1D.Linear(),
+        extrapolationorder = CI1D.Flat(),
     )
 
     p = hydrostatic_pressure_profile(; thermo_params, p_0, T = T_profile, q_tot)

--- a/src/setups/common/physical_state.jl
+++ b/src/setups/common/physical_state.jl
@@ -126,68 +126,81 @@ import ClimaCore.Topologies as Topologies
 import ClimaCore.Spaces as Spaces
 
 const FunctionOrSpline =
-    Union{Function, APL.AbstractProfile, Intp.Extrapolation}
+    Union{Function, APL.AbstractProfile, Intp.Extrapolation, CI1D.Interpolate1D}
 
 """
-    ColumnInterpolatableField(::Fields.ColumnField)
+    column_indefinite_integral(f, ϕ₀, zspan; nelems = 1000)
 
-A column field object that can be interpolated
-in the z-coordinate. For example:
-
-!!! warn
-
-    This function allocates and is not GPU-compatible
-    so please avoid using this inside `step!` only use
-    this for initialization.
-"""
-struct ColumnInterpolatableField{F, D}
-    f::F
-    data::D
-    function ColumnInterpolatableField(f::Fields.ColumnField)
-        zdata = vec(parent(Fields.Fields.coordinate_field(f).z))
-        fdata = vec(parent(f))
-        data = Intp.extrapolate(
-            Intp.interpolate((zdata,), fdata, Intp.Gridded(Intp.Linear())),
-            Intp.Flat(),
-        )
-        return new{typeof(f), typeof(data)}(f, data)
-    end
-end
-(f::ColumnInterpolatableField)(z) = Spaces.undertype(axes(f.f))(f.data(z))
-
-"""
-    column_indefinite_integral(f, ϕ₀, zspan; nelems = 100)
-
-The column integral, returned as an interpolate-able field.
+The column integral of `ϕ' = f(ϕ, z)` from `ϕ(first(zspan)) = ϕ₀`, computed
+with `Operators.column_integral_indefinite!` on a dedicated column of `nelems`
+elements, returned as a callable
+`ClimaInterpolations.Interpolation1D.Interpolate1D` in height, with linear
+interpolation and flat extrapolation. The column is built on the host, so the
+interpolant holds host arrays and is evaluated on the host.
 """
 function column_indefinite_integral(
     f::Function,
     ϕ₀::FT,
     zspan::Tuple{FT, FT};
-    nelems = 100, # sets resolution for integration
+    nelems = 1000,
 ) where {FT <: Real}
-    # --- Make a space for integration:
     z_domain = Domains.IntervalDomain(
         Geometry.ZPoint(first(zspan)),
         Geometry.ZPoint(last(zspan));
         boundary_names = (:bottom, :top),
     )
     z_mesh = Meshes.IntervalMesh(z_domain; nelems)
-    context = ClimaComms.SingletonCommsContext()
+    context = ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded())
     z_topology = Topologies.IntervalTopology(context, z_mesh)
-    cspace = Spaces.CenterFiniteDifferenceSpace(z_topology)
     fspace = Spaces.FaceFiniteDifferenceSpace(z_topology)
-    # ---
-    zc = Fields.coordinate_field(cspace)
     ᶠintegral = Fields.Field(FT, fspace)
     Operators.column_integral_indefinite!(f, ᶠintegral, ϕ₀)
-    return ColumnInterpolatableField(ᶠintegral)
+    zdata = copy(vec(parent(Fields.coordinate_field(fspace).z)))
+    fdata = copy(vec(parent(ᶠintegral)))
+    return CI1D.Interpolate1D(
+        zdata, fdata;
+        interpolationorder = CI1D.Linear(),
+        extrapolationorder = CI1D.Flat(),
+    )
+end
+
+"""
+    ρ_from_profile(thermo_params, p, z, T, θ, q_tot)
+
+Compute air density at pressure `p` and height `z`,
+given either temperature `T(z)` or potential temperature `θ(z)`
+and, optionally, total specific humidity `q_tot(z)`.
+
+Exactly one of `T` or `θ` must be provided.
+"""
+ρ_from_profile(_, _, _, ::Nothing, ::Nothing, _) = error("Either T or θ must be specified")
+ρ_from_profile(_, _, _, _::FunctionOrSpline, _::FunctionOrSpline, _) =
+    error("Only one of T and θ can be specified")
+ρ_from_profile(thermo_params, p, z, T::FunctionOrSpline, ::Nothing, ::Nothing) =
+    TD.air_density(thermo_params, oftype(p, T(z)), p)
+function ρ_from_profile(thermo_params, p, z, ::Nothing, θ::FunctionOrSpline, ::Nothing)
+    T_val = TD.air_temperature(thermo_params, TD.pθ_li(), p, oftype(p, θ(z)))
+    return TD.air_density(thermo_params, T_val, p)
+end
+function ρ_from_profile(
+    thermo_params, p, z, T::FunctionOrSpline, ::Nothing, q_tot::FunctionOrSpline,
+)
+    FT = eltype(thermo_params)
+    return TD.air_density(thermo_params, FT(T(z)), p, FT(q_tot(z)), FT(0), FT(0))
+end
+function ρ_from_profile(
+    thermo_params, p, z, ::Nothing, θ::FunctionOrSpline, q_tot::FunctionOrSpline,
+)
+    FT = eltype(thermo_params)
+    q = FT(q_tot(z))
+    T_val = TD.air_temperature(thermo_params, TD.pθ_li(), p, FT(θ(z)), q)
+    return TD.air_density(thermo_params, T_val, p, q, FT(0), FT(0))
 end
 
 """
     hydrostatic_pressure_profile(; thermo_params, p_0, [T, θ, q_tot, z_max])
 
-Solves the initial value problem `p'(z) = -g * ρ(z)` for all `z ∈ [0, z_max]`,
+Solve the initial value problem `p'(z) = -g * ρ(z)` for all `z ∈ [0, z_max]`,
 given `p(0)`, either `T(z)` or `θ(z)`, and optionally also `q_tot(z)`. If
 `q_tot(z)` is not given, it is assumed to be 0. If `z_max` is not given, it is
 assumed to be 30 km. Note that `z_max` should be the maximum elevation to which
@@ -204,29 +217,7 @@ function hydrostatic_pressure_profile(;
     FT = eltype(thermo_params)
     grav = TD.Parameters.grav(thermo_params)
 
-    # Compute air density from (p, z) using either T(z) or θ(z), with optional q_tot(z)
-    function ρ_from_profile(p, z, ::Nothing, ::Nothing, _)
-        error("Either T or θ must be specified")
-    end
-    function ρ_from_profile(p, z, T::FunctionOrSpline, θ::FunctionOrSpline, _)
-        error("Only one of T and θ can be specified")
-    end
-    function ρ_from_profile(p, z, T::FunctionOrSpline, ::Nothing, ::Nothing)
-        TD.air_density(thermo_params, oftype(p, T(z)), p)
-    end
-    function ρ_from_profile(p, z, ::Nothing, θ::FunctionOrSpline, ::Nothing)
-        T_val = TD.air_temperature(thermo_params, TD.pθ_li(), p, oftype(p, θ(z)))
-        TD.air_density(thermo_params, T_val, p)
-    end
-    function ρ_from_profile(p, z, T::FunctionOrSpline, ::Nothing, q_tot::FunctionOrSpline)
-        TD.air_density(thermo_params, oftype(p, T(z)), p, oftype(p, q_tot(z)), FT(0), FT(0))
-    end
-    function ρ_from_profile(p, z, ::Nothing, θ::FunctionOrSpline, q_tot::FunctionOrSpline)
-        q = oftype(p, q_tot(z))
-        T_val = TD.air_temperature(thermo_params, TD.pθ_li(), p, oftype(p, θ(z)), q)
-        TD.air_density(thermo_params, T_val, p, q, FT(0), FT(0))
-    end
-    dp_dz(p, z) = -grav * ρ_from_profile(p, z, T, θ, q_tot)
+    dp_dz(p, z) = -grav * ρ_from_profile(thermo_params, p, z, T, θ, q_tot)
 
-    return column_indefinite_integral(dp_dz, p_0, (FT(0), FT(z_max)))
+    return column_indefinite_integral(dp_dz, FT(p_0), (FT(0), FT(z_max)))
 end

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -166,24 +166,6 @@ Base.show(io::IO, x::RRTMGPI.AbstractRRTMGPMode) =
 Base.show(io::IO, x::Setups.RCEMIPIIProfile) =
     parseable_show_with_fields_no_type_header(io, x)
 
-import ClimaCore: Fields, Spaces
-function Base.show(
-    io::IO, ::MIME"text/plain", x::Setups.ColumnInterpolatableField,
-)
-    # Extract z grid from the wrapped column field
-    z = Fields.coordinate_field(x.f).z
-    nz = Spaces.nlevels(z)
-    zmin, zmax = extrema(z)
-    val_eltype = eltype(x.f)
-    # These are fixed by the constructor
-    interp_str = "Linear"
-    extrap_str = "Flat"
-    print(io,
-        "ColumnInterpolatableField(Nz=$nz, z∈[$zmin, $zmax], value_eltype=$val_eltype, ",
-        "interpolation=$interp_str, extrapolation=$extrap_str)",
-    )
-end
-
 # src/simulation/AtmosSimulations.jl
 import ClimaComms
 function Base.show(io::IO, ::MIME"text/plain", sim::AtmosSimulation)

--- a/test/gpu_setups.jl
+++ b/test/gpu_setups.jl
@@ -1,0 +1,65 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaAtmos.Setups as Setups
+import ClimaCore: CommonSpaces, Fields, Grids, Meshes, Spaces
+
+center_column_space(FT, device) = CommonSpaces.ColumnSpace(
+    FT;
+    z_min = 0, z_max = 15000, z_elem = 32,
+    device, staggering = Grids.CellCenter(),
+)
+
+center_box_space(FT, device) = CommonSpaces.Box3DSpace(
+    FT;
+    x_min = 0, x_max = 1000, x_elem = 2,
+    y_min = 0, y_max = 1000, y_elem = 2,
+    z_min = 0, z_max = 15000, z_elem = 16,
+    periodic_x = true, periodic_y = true,
+    n_quad_points = 3,
+    stretch = Meshes.GeneralizedExponentialStretching(FT(300), FT(2000)),
+    device, staggering = Grids.CellCenter(),
+)
+
+function monotone_decreasing_in_z(field)
+    nz = Spaces.nlevels(axes(field))
+    for level in 1:(nz - 1)
+        below = Array(parent(Fields.level(field, level)))
+        above = Array(parent(Fields.level(field, level + 1)))
+        all(below .> above) || return false
+    end
+    return true
+end
+
+# Evaluate the hydrostatic pressure profile of each AtmosphericProfilesLibrary
+# setup on the active device through `initial_condition_field`, on a uniform
+# single column and on a vertically stretched multi-column box. See PR #4664.
+# Reference pressure values are checked in test/larcform1.jl.
+device = ClimaComms.device()
+@testset "Hydrostatic pressure profiles on $(nameof(typeof(device)))" begin
+    @testset "$FT" for FT in (Float64, Float32)
+        params = CA.ClimaAtmosParameters(FT)
+        thermo_params = CA.Parameters.thermodynamics_params(params)
+        larcform1 = Setups.Larcform1(; prognostic_tke = true, thermo_params)
+        shipwayhill = Setups.ShipwayHill2012(; thermo_params)
+        trmm_lba = Setups.TRMM_LBA(; prognostic_tke = true, thermo_params)
+        @test shipwayhill isa Setups.ShipwayHill2012
+
+        spaces = (center_column_space(FT, device), center_box_space(FT, device))
+        for space in spaces, setup in (larcform1, shipwayhill, trmm_lba)
+            ic_p(lg) = Setups.center_initial_condition(setup, lg, params).p
+            ᶜp = Setups.initial_condition_field(ic_p, space)
+            @test ᶜp isa Fields.Field
+            @test parent(ᶜp) isa ClimaComms.array_type(device)
+            p_dev = Array(parent(ᶜp))
+            @test all(isfinite, p_dev)
+            @test all(>(0), p_dev)
+            @test monotone_decreasing_in_z(ᶜp)
+            # The device-resident field equals the host interpolant evaluated at
+            # the field's own heights.
+            z = Array(parent(Fields.coordinate_field(space).z))
+            @test setup.profiles.p.(z) == p_dev
+        end
+    end
+end

--- a/test/larcform1.jl
+++ b/test/larcform1.jl
@@ -19,7 +19,7 @@ import Thermodynamics as TD
     )
     simulation = CA.get_simulation(config)
     thermo_params = CAP.thermodynamics_params(simulation.integrator.p.params)
-    FT = Float64
+    FT = eltype(thermo_params)
     LC = APL.Larcform1_constants
 
     setup = Setups.Larcform1(; prognostic_tke = true, thermo_params)
@@ -30,7 +30,7 @@ import Thermodynamics as TD
     @test profs.T(FT(LC.z_tropopause)) ≈ FT(LC.T_tropopause) atol = 0.5
 
     # Pressure: surface and tropopause match Pithan 2016 Table 1
-    @test profs.p(0) ≈ FT(LC.P_0) atol = 10
+    @test profs.p(FT(0)) ≈ FT(LC.P_0) atol = 10
     @test profs.p(FT(LC.z_tropopause)) ≈ FT(LC.P_tropopause) rtol = 0.01
 
     # Humidity: moist at surface, fixed q_top above tropopause


### PR DESCRIPTION
Initializes the AtmosphericProfilesLibrary single-column setups (Bomex, DYCOMS, GABLS, GATE_III, ISDAC, Larcform1, PrecipitatingColumn, Rico, Soares, ShipwayHill2012, TRMM_LBA) on GPU spaces, and integrates their hydrostatic pressure on a finer grid.

These setups build host-resident profile interpolants, so broadcasting the initial-condition closure on a device fails. `initial_condition_field` now broadcasts the closure on the device when it is isbits after adapting to the device array type, and otherwise evaluates it on the host and copies the result to the device. Interpolant setups take the host path, so no interpolant enters a device kernel, while analytic setups keep their device broadcast. The setup API is unchanged, with profiles remaining plain callables of height and no GPU-specific code.

`hydrostatic_pressure_profile` integrates the initial value problem on a 1000-element column instead of 100, returning a `ClimaInterpolations.Interpolation1D.Interpolate1D`. The finer grid removes the interpolation error of the coarser 300 m spacing, changing initial center pressures by about `2e-4` to `4e-4` relative, within about `4e-6` of a reference on a 16 times finer grid. This changes the reproducibility reference, so the counter is bumped; the difference is a chaotic decorrelation of the convective fields with the thermodynamic climate preserved (see the comment below).

Also: `ρ_from_profile` is hoisted to a top-level function; the ShipwayHill2012 and TRMM_LBA `θ` and `q_tot` profiles use `ClimaInterpolations` interpolants; and the `ShipwayHill2012` constructor returns the setup type (its interface methods were previously unreachable). A new buildkite GPU test evaluates the pressure profiles on a column and a stretched box for Float64 and Float32, with exact values checked in `test/larcform1.jl`.
