### PR TITLE
fix(setups): make ColumnInterpolatableField GPU-compatible

### DIFF
--- a/src/setups/Setups.jl
+++ b/src/setups/Setups.jl
@@ -1,5 +1,6 @@
 module Setups
 
+import StaticArrays as SA
 import ClimaCore.Geometry as Geometry
 import ClimaCore: Fields
 import Thermodynamics as TD

--- a/src/setups/common/physical_state.jl
+++ b/src/setups/common/physical_state.jl
@@ -131,29 +131,36 @@ const FunctionOrSpline =
 """
     ColumnInterpolatableField(::Fields.ColumnField)
 
-A column field object that can be interpolated
-in the z-coordinate. For example:
-
-!!! warn
-
-    This function allocates and is not GPU-compatible
-    so please avoid using this inside `step!` only use
-    this for initialization.
+Wrap a column field so it can be evaluated at any height `z` by linear
+interpolation between grid levels, with flat extrapolation outside the column
+bounds.
 """
-struct ColumnInterpolatableField{F, D}
-    f::F
-    data::D
-    function ColumnInterpolatableField(f::Fields.ColumnField)
-        zdata = vec(parent(Fields.Fields.coordinate_field(f).z))
-        fdata = vec(parent(f))
-        data = Intp.extrapolate(
-            Intp.interpolate((zdata,), fdata, Intp.Gridded(Intp.Linear())),
-            Intp.Flat(),
-        )
-        return new{typeof(f), typeof(data)}(f, data)
-    end
+struct ColumnInterpolatableField{N, FT}
+    z::SA.SVector{N, FT}
+    value::SA.SVector{N, FT}
+    z_min::FT
+    z_max::FT
 end
-(f::ColumnInterpolatableField)(z) = Spaces.undertype(axes(f.f))(f.data(z))
+function ColumnInterpolatableField(f::Fields.ColumnField)
+    zdata = vec(parent(Fields.coordinate_field(f).z))
+    fdata = vec(parent(f))
+    n = length(zdata)
+    z = SA.SVector{n}(zdata)
+    value = SA.SVector{n}(fdata)
+    return ColumnInterpolatableField(z, value, first(z), last(z))
+end
+@inline function (itp::ColumnInterpolatableField{N})(z) where {N}
+    zs = itp.z
+    zc = clamp(oftype(itp.z_min, z), itp.z_min, itp.z_max)
+    i = searchsortedfirst(zs, zc)
+    i = ifelse(i < 2, 2, ifelse(i > N, N, i))
+    z0 = @inbounds zs[i - 1]
+    z1 = @inbounds zs[i]
+    v0 = @inbounds itp.value[i - 1]
+    v1 = @inbounds itp.value[i]
+    w = (zc - z0) / (z1 - z0)
+    return (1 - w) * v0 + w * v1
+end
 
 """
     column_indefinite_integral(f, ϕ₀, zspan; nelems = 100)

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -166,21 +166,14 @@ Base.show(io::IO, x::RRTMGPI.AbstractRRTMGPMode) =
 Base.show(io::IO, x::Setups.RCEMIPIIProfile) =
     parseable_show_with_fields_no_type_header(io, x)
 
-import ClimaCore: Fields, Spaces
 function Base.show(
     io::IO, ::MIME"text/plain", x::Setups.ColumnInterpolatableField,
 )
-    # Extract z grid from the wrapped column field
-    z = Fields.coordinate_field(x.f).z
-    nz = Spaces.nlevels(z)
-    zmin, zmax = extrema(z)
-    val_eltype = eltype(x.f)
-    # These are fixed by the constructor
-    interp_str = "Linear"
-    extrap_str = "Flat"
+    nz = length(x.z)
+    val_eltype = eltype(x.value)
     print(io,
-        "ColumnInterpolatableField(Nz=$nz, z∈[$zmin, $zmax], value_eltype=$val_eltype, ",
-        "interpolation=$interp_str, extrapolation=$extrap_str)",
+        "ColumnInterpolatableField(Nz=$nz, z∈[$(x.z_min), $(x.z_max)], value_eltype=$val_eltype, ",
+        "interpolation=Linear, extrapolation=Flat)",
     )
 end
 


### PR DESCRIPTION
`ColumnInterpolatableField` was backed by an Interpolations.jl object holding host arrays, so evaluating a hydrostatic pressure profile inside a broadcast over a GPU space failed to compile with a non-isbits kernel argument. This replaces that backing with a linear interpolation over knot and value vectors stored as `SVector`s, making the interpolant an isbits value that embeds directly into a device broadcast kernel; evaluation uses `searchsortedfirst` with flat extrapolation. CPU results are bitwise-identical to the previous Interpolations.jl implementation, and the profile now evaluates correctly inside a GPU broadcast, verified end-to-end for a Bomex-style pressure profile on an A100. Stacked on #4664, which removed the closure-boxing kernel-compilation failure in `hydrostatic_pressure_profile`; this was the remaining blocker for building these initial conditions on GPU.