### PR TITLE
refactor(diffusion): consolidate the eddy-diffusivity pipeline and diffusive-flux application

### DIFF
--- a/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
+++ b/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
@@ -208,21 +208,6 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
 
     c_amd = les.c_amd
 
-    # Define operators
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
-    ᶜdivᵥ_uₕ = Operators.DivergenceF2C(
-        top = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0))),
-        bottom = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0))),
-    )
-    ᶠdivᵥ = Operators.DivergenceC2F(
-        bottom = Operators.SetDivergence(FT(0)),
-        top = Operators.SetDivergence(FT(0)),
-    )
-    ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(;
-        top = Operators.SetValue(C3(FT(0))),
-        bottom = Operators.SetValue(C3(FT(0))),
-    )
-
     ### AMD ###
 
     (; ᶜu, ᶠu³) = p.precomputed
@@ -296,10 +281,8 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     ## Horizontal momentum tendency
     ᶠρ = @. lazy(ᶠinterp(Y.c.ρ))
     @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(ᶠρ * ᶠτ_amd) / Y.c.ρ)
-    ## Apply boundary condition for momentum flux
-    @. Yₜ.c.uₕ -= ᶜdivᵥ_uₕ(-(FT(0) * ᶠgradᵥ(Y.c.uₕ))) / Y.c.ρ
     ## Vertical momentum tendency
-    @. Yₜ.f.u₃ -= C3(ᶠdivᵥ(Y.c.ρ * ᶜτ_amd) / ᶠρ)
+    @. Yₜ.f.u₃ -= C3(ᶠdiffdivᵥ_u₃(Y.c.ρ * ᶜτ_amd) / ᶠρ)
 
     ## Total energy tendency
     (; ᶜh_tot) = p.precomputed
@@ -316,14 +299,12 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
         ) /
         max(eps(FT), norm_sqr(∇h_tot)),
     )
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠρ * ᶠD_amd * ᶠgradᵥ(ᶜh_tot)))
+    # Materialized here, before the tracer loop overwrites ᶠD_amd.
+    ᶠcoef = @. lazy(ᶠρ * ᶠD_amd)
+    ᶜ∇ᵥρD∇h_totₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜh_tot)
+    @. Yₜ.c.ρe_tot -= ᶜ∇ᵥρD∇h_totₜ
 
     ## Tracer diffusion and associated mass changes
-    ᶜdivᵥ_ρχ = Operators.DivergenceF2C(;
-        top = Operators.SetValue(C3(FT(0))),
-        bottom = Operators.SetValue(C3(FT(0))),
-    )
-
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
         ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
         ∇ᶜχ = @. lazy(Geometry.project(axis_uvw, ᶠgradᵥ_scalar(ᶜχ)))
@@ -338,8 +319,7 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
             ) /
             max(eps(FT), norm_sqr(∇ᶜχ)),
         )
-        ᶜ∇ᵥρD∇χₜ =
-            @. lazy(ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_amd * ᶠgradᵥ(specific(ᶜρχ, Y.c.ρ)))))
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ((@. lazy(ᶠρ * ᶠD_amd)), ᶜχ)
         @. ᶜρχₜ -= ᶜ∇ᵥρD∇χₜ
         # Rain and snow does not affect the mass
         if ρχ_name == @name(ρq_tot)

--- a/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
+++ b/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
@@ -3,7 +3,6 @@
 #####
 
 import ClimaCore.Fields as Fields
-import ClimaCore.Operators as Operators
 import ClimaCore: Geometry
 
 """
@@ -152,21 +151,11 @@ end
 
 function vertical_smagorinsky_lilly_tendency!(Yₜ, Y, p, t, model::SmagorinskyLilly)
     is_smagorinsky_vertical(model) || return nothing
-    FT = eltype(Y)
     (; ᶜS, ᶠS, ᶜνₜ_v) = p.precomputed
     (; ᶜtemp_UVWxUVW, ᶠtemp_UVWxUVW, ᶠtemp_scalar, ᶠtemp_scalar_2) = p.scratch
     Pr_t = CAP.Prandtl_number_0(CAP.turbconv_params(p.params))
     ᶜρ = Y.c.ρ
     ᶠρ = @. ᶠtemp_scalar = ᶠinterp(ᶜρ)
-
-    # Define operators
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
-    divᵥ_uₕ_bc = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0)))
-    ᶜdivᵥ_uₕ = Operators.DivergenceF2C(; bottom = divᵥ_uₕ_bc, top = divᵥ_uₕ_bc)
-    divᵥ_bc = Operators.SetDivergence(FT(0))
-    ᶠdivᵥ = Operators.DivergenceC2F(; bottom = divᵥ_bc, top = divᵥ_bc)
-    divᵥ_ρχ_bc = Operators.SetValue(C3(FT(0)))
-    ᶜdivᵥ_ρχ = Operators.DivergenceF2C(; bottom = divᵥ_ρχ_bc, top = divᵥ_ρχ_bc)
 
     # Subgrid-scale momentum flux tensor, `τ = -2 νₜ ∘ S`
     ᶠνₜ_v = @. lazy(ᶠinterp(ᶜνₜ_v))
@@ -175,23 +164,23 @@ function vertical_smagorinsky_lilly_tendency!(Yₜ, Y, p, t, model::SmagorinskyL
 
     # Turbulent diffusivity
     ᶠD_smag = @. lazy(ᶠνₜ_v / Pr_t)
+    ᶠcoef = @. lazy(ᶠρ * ᶠD_smag)
 
     # Apply to tendencies
     ## Horizontal momentum tendency
     @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(ᶠρ * ᶠτ_smag) / ᶜρ)
-    ## Apply boundary condition for momentum flux
-    @. Yₜ.c.uₕ -= ᶜdivᵥ_uₕ(-(FT(0) * ᶠgradᵥ(Y.c.uₕ))) / ᶜρ
     ## Vertical momentum tendency
-    @. Yₜ.f.u₃ -= C3(ᶠdivᵥ(ᶜρ * ᶜτ_smag) / ᶠρ)
+    @. Yₜ.f.u₃ -= C3(ᶠdiffdivᵥ_u₃(ᶜρ * ᶜτ_smag) / ᶠρ)
 
     ## Total energy tendency
     (; ᶜh_tot) = p.precomputed
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_smag * ᶠgradᵥ(ᶜh_tot)))
+    ᶜ∇ᵥρD∇h_totₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜh_tot)
+    @. Yₜ.c.ρe_tot -= ᶜ∇ᵥρD∇h_totₜ
 
     ## Tracer diffusion and associated mass changes
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
         ᶜχ = @. lazy(specific(ᶜρχ, ᶜρ))
-        ᶜ∇ᵥρD∇χₜ = @. lazy(ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_smag * ᶠgradᵥ(ᶜχ))))
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
         @. ᶜρχₜ -= ᶜ∇ᵥρD∇χₜ
         # Rain and snow does not affect the mass
         if ρχ_name == @name(ρq_tot)

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -469,6 +469,56 @@ function ᶜmixing_length(
 end
 
 """
+    ᶜeddy_diffusivities!(Y, p; ᶜmixing_length_field, grid_scale, buoyancy_gradient, ᶜK_u_field, ᶜK_h_field)
+
+Compute the eddy viscosity `K_u` and eddy diffusivity `K_h` of the TKE-based
+closure. The `ᶜ` prefix reflects the center-space `(; ᶜK_u, ᶜK_h)` return.
+
+# Keyword Arguments
+
+  - `ᶜmixing_length_field`: center field mutated in place with the materialized
+    mixing length.
+  - `grid_scale`: grid-scale limit on the mixing length. By default, the
+    vertical cell thickness.
+  - `buoyancy_gradient`: stability input of the mixing length and the turbulent
+    Prandtl number. By default, the centered `ᶜlinear_buoygrad`.
+  - `ᶜK_u_field`, `ᶜK_h_field`: output fields for `K_u` and `K_h`. By default
+    `nothing`, in which case the corresponding value is lazy.
+
+# Returns
+
+  - `(; ᶜK_u, ᶜK_h)`.
+"""
+function ᶜeddy_diffusivities!(
+    Y, p;
+    ᶜmixing_length_field,
+    grid_scale = Fields.Δz_field(axes(Y.c)),
+    buoyancy_gradient = p.precomputed.ᶜlinear_buoygrad,
+    ᶜK_u_field = nothing,
+    ᶜK_h_field = nothing,
+)
+    (; params) = p
+    (; ᶜstrain_rate_norm) = p.precomputed
+    turbconv_params = CAP.turbconv_params(params)
+    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
+    ᶜmixing_length_field .= ᶜmixing_length(Y, p; grid_scale, buoyancy_gradient)
+    ᶜK_u = if isnothing(ᶜK_u_field)
+        @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
+    else
+        @. ᶜK_u_field =
+            eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field)
+    end
+    ᶜprandtl_nvec =
+        @. lazy(turbulent_prandtl_number(params, buoyancy_gradient, ᶜstrain_rate_norm))
+    ᶜK_h = if isnothing(ᶜK_h_field)
+        @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
+    else
+        @. ᶜK_h_field = eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec)
+    end
+    return (; ᶜK_u, ᶜK_h)
+end
+
+"""
     gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
 
 Calculates the gradient Richardson number (Ri).

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -519,6 +519,35 @@ function ᶜeddy_diffusivities!(
 end
 
 """
+    ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
+
+Lazy vertical divergence of the diffusive scalar flux `F = -ᶠcoef ∇χ`, with
+zero-flux top and bottom boundaries.
+
+`ᶠcoef` must be a face field or a `lazy` broadcast, not a bare `Field * Field`
+product. Fold `ρ`, `K`, and any scaling factor into `ᶠcoef` in left-to-right
+order.
+"""
+ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ) =
+    @. lazy(ᶜdiffdivᵥ(-(ᶠcoef * ᶠgradᵥ(ᶜχ))))
+
+"""
+    ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice)
+
+Lazy face gradient of total enthalpy in dry-static-energy + water-enthalpy form,
+`∇s_d + Σ_μ (h_μ + Φ) ∇q_μ` for `μ ∈ {vap, liq, ice}`.
+
+Summands are combined in a fixed order: dry static energy, then vapor, liquid,
+ice.
+"""
+ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice) = @. lazy(
+    ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
+    ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_vap) +
+    ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_liq) +
+    ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_ice),
+)
+
+"""
     gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
 
 Calculates the gradient Richardson number (Ri).

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -259,29 +259,15 @@ function edmfx_sgs_diffusive_flux_tendency!(
         # consistency with the unscaled ρq_tot diffusion equation, preserves
         # total water invariance under moist-adiabatic processes, and aligns
         # with the implicit solver's Jacobian formulation.
-        ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(FT(0))),
-            bottom = Operators.SetValue(C3(FT(0))),
-        )
         thermo_params = CAP.thermodynamics_params(params)
         (; ᶜΦ) = p.core
         (; ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
         ᶜq_vap = @. lazy(
             TD.vapor_specific_humidity(ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice),
         )
-        @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(
-            -(
-                ᶠρaK_h * (
-                    ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
-                    ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
-                    ᶠgradᵥ(ᶜq_vap) +
-                    ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
-                    ᶠgradᵥ(ᶜq_liq) +
-                    ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
-                    ᶠgradᵥ(ᶜq_ice)
-                )
-            ),
-        )
+        ᶠgrad_h =
+            ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice)
+        @. Yₜ.c.ρe_tot -= ᶜdiffdivᵥ(-(ᶠρaK_h * ᶠgrad_h))
 
         if use_prognostic_tke(turbconv_model)
             # Turbulent TKE transport (diffusion)
@@ -307,22 +293,15 @@ function edmfx_sgs_diffusive_flux_tendency!(
         if !(p.atmos.microphysics_model isa DryModel)
             # Specific humidity diffusion
             ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
-            ᶜdivᵥ_ρq_tot = Operators.DivergenceF2C(
-                top = Operators.SetValue(C3(FT(0))),
-                bottom = Operators.SetValue(C3(FT(0))),
-            )
-            @. ᶜρχₜ_diffusion =
-                ᶜdivᵥ_ρq_tot(-(ᶠρaK_h * ᶠgradᵥ(specific(Y.c.ρq_tot, Y.c.ρ))))
+            ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))
+            ᶜ∇ᵥρD∇q_tot = ᶜdiffusive_flux_divergenceᵥ(ᶠρaK_h, ᶜq_tot)
+            @. ᶜρχₜ_diffusion = ᶜ∇ᵥρD∇q_tot
             @. Yₜ.c.ρq_tot -= ᶜρχₜ_diffusion
             @. Yₜ.c.ρ -= ᶜρχₜ_diffusion  # Effect of moisture diffusion on (moist) air mass
         end
 
         α_vert_diff_microphysics = CAP.α_vert_diff_tracer(params)
         ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar
-        ᶜdivᵥ_ρq = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(FT(0))),
-            bottom = Operators.SetValue(C3(FT(0))),
-        )
         # Auto-discovered grid-scale tracers: sedimenting microphysics species
         # are diffused with α_vert_diff_tracer * K_h, all other tracers (e.g.
         # passive chemistry) with the unscaled K_h, matching
@@ -336,8 +315,10 @@ function edmfx_sgs_diffusive_flux_tendency!(
             α =
                 ρχ_name in gs_sedimenting_tracer_candidates ?
                 α_vert_diff_microphysics : one(α_vert_diff_microphysics)
-            ᶜχ = (@. lazy(specific(ᶜρχ, Y.c.ρ)))
-            @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρq(-(ᶠρaK_h * α * ᶠgradᵥ(ᶜχ)))
+            ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+            ᶠcoef = @. lazy(ᶠρaK_h * α)
+            ᶜ∇ᵥρD∇χ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
+            @. ᶜρχₜ_diffusion = ᶜ∇ᵥρD∇χ
             @. ᶜρχₜ -= ᶜρχₜ_diffusion
         end
 

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -231,21 +231,8 @@ function edmfx_sgs_diffusive_flux_tendency!(
 
     if p.atmos.edmfx_model.sgs_diffusive_flux isa Val{true}
 
-        (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-        # scratch to prevent GPU Kernel parameter memory error
         ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2
-        ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜK_u = @. lazy(
-            eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field),
-        )
-        ᶜprandtl_nvec = @. lazy(
-            turbulent_prandtl_number(
-                params,
-                ᶜlinear_buoygrad,
-                ᶜstrain_rate_norm,
-            ),
-        )
-        ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
+        (; ᶜK_u, ᶜK_h) = ᶜeddy_diffusivities!(Y, p; ᶜmixing_length_field)
 
         ᶠρaK_h = p.scratch.ᶠtemp_scalar
         @. ᶠρaK_h = ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h)
@@ -382,25 +369,21 @@ function edmfx_sgs_horizontal_diffusive_flux_tendency!(
         return nothing
     iscolumn(axes(Y.c)) && return nothing
     (; params) = p
-    turbconv_params = CAP.turbconv_params(params)
-    (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
+    (; ᶜlinear_buoygrad) = p.precomputed
     ᶜρ = Y.c.ρ
     ᶜtke = @. lazy(specific(Y.c.ρtke, ᶜρ))
 
     # Mixing length limited by the horizontal node spacing, with the centered
     # buoyancy gradient as the stability input
     Δx = Spaces.node_horizontal_length_scale(Spaces.horizontal_space(axes(Y.c)))
-    ᶜmixing_length_h = p.scratch.ᶜtemp_scalar_2
-    ᶜmixing_length_h .= ᶜmixing_length(
-        Y, p; grid_scale = Δx, buoyancy_gradient = ᶜlinear_buoygrad,
+    ᶜK = ᶜeddy_diffusivities!(
+        Y, p;
+        ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2,
+        grid_scale = Δx, buoyancy_gradient = ᶜlinear_buoygrad,
+        ᶜK_u_field = p.scratch.ᶜtemp_scalar_4, ᶜK_h_field = p.scratch.ᶜtemp_scalar,
     )
-
-    ᶜK_u_h = p.scratch.ᶜtemp_scalar_4
-    @. ᶜK_u_h = eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_h)
-    ᶜprandtl_nvec =
-        @. lazy(turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm))
-    ᶜK_h_h = p.scratch.ᶜtemp_scalar
-    @. ᶜK_h_h = eddy_diffusivity(ᶜK_u_h, ᶜprandtl_nvec)
+    ᶜK_u_h = ᶜK.ᶜK_u
+    ᶜK_h_h = ᶜK.ᶜK_h
 
     # Total enthalpy, using the dry-static-energy + water-enthalpy
     # decomposition; see the matching vertical term in

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -26,17 +26,9 @@
 edmfx_tke_tendency!(Yₜ, Y, p, t, turbconv_model) = nothing
 
 function edmfx_tke_tendency!(Yₜ, Y, p, t, turbconv_model::EDOnlyEDMFX)
-    (; params) = p
     (; ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
-    turbconv_params = CAP.turbconv_params(p.params)
-    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
-    ᶜmixing_length_field = p.scratch.ᶜtemp_scalar
-    ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-    ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
-    ᶜprandtl_nvec = @. lazy(
-        turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
-    )
-    ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
+    (; ᶜK_u, ᶜK_h) =
+        ᶜeddy_diffusivities!(Y, p; ᶜmixing_length_field = p.scratch.ᶜtemp_scalar)
 
     # shear production
     @. Yₜ.c.ρtke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm
@@ -52,23 +44,11 @@ function edmfx_tke_tendency!(
     turbconv_model::PrognosticEDMFX,
 )
     (; ᶜstrain_rate_norm, ᶜlinear_buoygrad) = p.precomputed
-    turbconv_params = CAP.turbconv_params(p.params)
 
     if use_prognostic_tke(turbconv_model)
-        ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2
-        ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
-        ᶜK_u = @. lazy(
-            eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field),
+        (; ᶜK_u, ᶜK_h) = ᶜeddy_diffusivities!(
+            Y, p; ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_2,
         )
-        ᶜprandtl_nvec = @. lazy(
-            turbulent_prandtl_number(
-                p.params,
-                ᶜlinear_buoygrad,
-                ᶜstrain_rate_norm,
-            ),
-        )
-        ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
 
         # shear production
         @. Yₜ.c.ρtke += 2 * Y.c.ρ * ᶜK_u * ᶜstrain_rate_norm

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -793,12 +793,11 @@ function update_sedimentation_jacobian!(matrix, Y, p, dtγ)
     return nothing
 end
 
-# Eddy diffusivity and viscosity used by both grid-scale and SGS implicit
-# diffusion. May write to ᶜtemp_scalar_3, ᶜtemp_scalar_4, and ᶜtemp_scalar_6.
-function eddy_diffusivity_coefficients!(Y, p)
-    (; params) = p
+# Select the implicit-diffusion eddy viscosity and diffusivity coefficients per
+# scheme, returning center fields. May write to ᶜtemp_scalar_3, ᶜtemp_scalar_4,
+# and ᶜtemp_scalar_6.
+function ᶜimplicit_diffusion_coefficients!(Y, p)
     (; turbconv_model, vertical_diffusion, smagorinsky_lilly) = p.atmos
-    turbconv_params = CAP.turbconv_params(params)
     (; ᶜp) = p.precomputed
     ᶜK_u = p.scratch.ᶜtemp_scalar_4
     ᶜK_h = p.scratch.ᶜtemp_scalar_6
@@ -813,17 +812,13 @@ function eddy_diffusivity_coefficients!(Y, p)
         ᶜK_u = p.precomputed.ᶜνₜ_v
         ᶜK_h = p.precomputed.ᶜD_v
     elseif turbconv_model isa AbstractEDMF
-        (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
-        ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_3
-        ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜK_u = p.scratch.ᶜtemp_scalar_4
-        @. ᶜK_u = eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field)
-        ᶜprandtl_nvec = @. lazy(
-            turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
+        ᶜK = ᶜeddy_diffusivities!(
+            Y, p;
+            ᶜmixing_length_field = p.scratch.ᶜtemp_scalar_3,
+            ᶜK_u_field = p.scratch.ᶜtemp_scalar_4, ᶜK_h_field = p.scratch.ᶜtemp_scalar_6,
         )
-        ᶜK_h = p.scratch.ᶜtemp_scalar_6
-        @. ᶜK_h = eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec)
+        ᶜK_u = ᶜK.ᶜK_u
+        ᶜK_h = ᶜK.ᶜK_h
     end
     return (; ᶜK_u, ᶜK_h)
 end
@@ -1543,7 +1538,7 @@ function update_jacobian!(alg::ManualSparseJacobian, cache, Y, p, dtγ, t)
     update_advection_jacobian!(matrix, Y, p, dtγ, topography_flag)
     update_sedimentation_jacobian!(matrix, Y, p, dtγ)
     eddy_diffusivities =
-        use_derivative(diffusion_flag) ? eddy_diffusivity_coefficients!(Y, p) :
+        use_derivative(diffusion_flag) ? ᶜimplicit_diffusion_coefficients!(Y, p) :
         nothing
     update_diffusion_jacobian!(
         matrix,

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -175,7 +175,6 @@ function edmfx_vertical_diffusion_tendency!(
         (; params) = p
         (; ᶜρʲs) = p.precomputed
         FT = eltype(p.params)
-        turbconv_params = CAP.turbconv_params(params)
         n = n_mass_flux_subdomains(turbconv_model)
         ᶜdivᵥ_mse = Operators.DivergenceF2C(
             top = Operators.SetValue(C3(0)),
@@ -186,16 +185,8 @@ function edmfx_vertical_diffusion_tendency!(
             bottom = Operators.SetValue(C3(0)),
         )
 
-        (; ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-        ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
-        # scratch to prevent GPU Kernel parameter memory error
-        ᶜmixing_length_field = p.scratch.ᶜtemp_scalar
-        ᶜmixing_length_field .= ᶜmixing_length(Y, p)
-        ᶜK_u = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_field))
-        ᶜprandtl_nvec = @. lazy(
-            turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm),
-        )
-        ᶜK_h = @. lazy(eddy_diffusivity(ᶜK_u, ᶜprandtl_nvec))
+        (; ᶜK_h) =
+            ᶜeddy_diffusivities!(Y, p; ᶜmixing_length_field = p.scratch.ᶜtemp_scalar)
 
         for j in 1:n
             ᶜρʲ = ᶜρʲs.:($j)
@@ -244,21 +235,17 @@ function edmfx_horizontal_diffusion_tendency!(
     p.atmos.edmfx_model.horizontal_diffusion isa Val{true} || return nothing
     iscolumn(axes(Y.c)) && return nothing
     (; params) = p
-    (; ᶜρʲs, ᶜlinear_buoygrad, ᶜstrain_rate_norm) = p.precomputed
-    turbconv_params = CAP.turbconv_params(params)
+    (; ᶜρʲs, ᶜlinear_buoygrad) = p.precomputed
     n = n_mass_flux_subdomains(turbconv_model)
 
-    ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
     Δx = Spaces.node_horizontal_length_scale(Spaces.horizontal_space(axes(Y.c)))
-    ᶜmixing_length_h = p.scratch.ᶜtemp_scalar
-    ᶜmixing_length_h .= ᶜmixing_length(
-        Y, p; grid_scale = Δx, buoyancy_gradient = ᶜlinear_buoygrad,
+    ᶜK = ᶜeddy_diffusivities!(
+        Y, p;
+        ᶜmixing_length_field = p.scratch.ᶜtemp_scalar,
+        grid_scale = Δx, buoyancy_gradient = ᶜlinear_buoygrad,
+        ᶜK_h_field = p.scratch.ᶜtemp_scalar_2,
     )
-    ᶜK_u_h = @. lazy(eddy_viscosity(turbconv_params, ᶜtke, ᶜmixing_length_h))
-    ᶜprandtl_nvec =
-        @. lazy(turbulent_prandtl_number(params, ᶜlinear_buoygrad, ᶜstrain_rate_norm))
-    ᶜK_h_h = p.scratch.ᶜtemp_scalar_2
-    @. ᶜK_h_h = eddy_diffusivity(ᶜK_u_h, ᶜprandtl_nvec)
+    ᶜK_h_h = ᶜK.ᶜK_h
 
     ᶜq_totʲₜ_diffusion = p.scratch.ᶜtemp_scalar_3
     α_diff_microphysics = CAP.α_vert_diff_tracer(params)

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -174,16 +174,7 @@ function edmfx_vertical_diffusion_tendency!(
     if p.atmos.edmfx_model.vertical_diffusion isa Val{true}
         (; params) = p
         (; ᶜρʲs) = p.precomputed
-        FT = eltype(p.params)
         n = n_mass_flux_subdomains(turbconv_model)
-        ᶜdivᵥ_mse = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(0)),
-            bottom = Operators.SetValue(C3(0)),
-        )
-        ᶜdivᵥ_q_tot = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(0)),
-            bottom = Operators.SetValue(C3(0)),
-        )
 
         (; ᶜK_h) =
             ᶜeddy_diffusivities!(Y, p; ᶜmixing_length_field = p.scratch.ᶜtemp_scalar)
@@ -194,19 +185,16 @@ function edmfx_vertical_diffusion_tendency!(
             ᶜq_totʲ = Y.c.sgsʲs.:($j).q_tot
             # Note: For this and other diffusive tendencies, we should use ρaʲ instead of ρʲ,
             # but it causes stability issues when ρaʲ is small
-            @. Yₜ.c.sgsʲs.:($$j).mse -=
-                ᶜdivᵥ_mse(-(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜmseʲ))) / ᶜρʲ
-            @. Yₜ.c.sgsʲs.:($$j).q_tot -=
-                ᶜdivᵥ_q_tot(-(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h) * ᶠgradᵥ(ᶜq_totʲ))) / ᶜρʲ
+            ᶠcoef = @. lazy(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h))
+            ᶜ∇ᵥρD∇mseʲ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜmseʲ)
+            @. Yₜ.c.sgsʲs.:($$j).mse -= ᶜ∇ᵥρD∇mseʲ / ᶜρʲ
+            ᶜ∇ᵥρD∇q_totʲ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜq_totʲ)
+            @. Yₜ.c.sgsʲs.:($$j).q_tot -= ᶜ∇ᵥρD∇q_totʲ / ᶜρʲ
         end
 
         if !isempty(sgs_tracer_names(Y))
             α_vert_diff_microphysics = CAP.α_vert_diff_tracer(params)
             ᶜρʲ = ᶜρʲs.:(1)
-            ᶜdivᵥ_q = Operators.DivergenceF2C(
-                top = Operators.SetValue(C3(FT(0))),
-                bottom = Operators.SetValue(C3(FT(0))),
-            )
             # Sedimenting microphysics species are diffused with
             # α_vert_diff_tracer * K_h, passive tracers with the unscaled K_h,
             # matching the grid-mean tracer diffusion and the implicit
@@ -218,10 +206,9 @@ function edmfx_vertical_diffusion_tendency!(
                     one(α_vert_diff_microphysics)
                 ᶜχʲ = MatrixFields.get_field(Y.c.sgsʲs.:(1), χ_name)
                 ᶜχʲₜ = MatrixFields.get_field(Yₜ.c.sgsʲs.:(1), χ_name)
-                @. ᶜχʲₜ -=
-                    ᶜdivᵥ_q(
-                        -(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h) * α * ᶠgradᵥ(ᶜχʲ)),
-                    ) / ᶜρʲ
+                ᶠcoef = @. lazy(ᶠinterp(ᶜρʲ) * ᶠinterp(ᶜK_h) * α)
+                ᶜ∇ᵥρD∇χʲ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχʲ)
+                @. ᶜχʲₜ -= ᶜ∇ᵥρD∇χʲ / ᶜρʲ
             end
         end
     end

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -3,7 +3,6 @@
 #####
 
 import ClimaCore.Geometry: ⊗
-import ClimaCore.Operators as Operators
 
 """
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
@@ -94,7 +93,6 @@ function vertical_diffusion_boundary_layer_tendency!(
     α_vert_diff_microphysics = CAP.α_vert_diff_tracer(p.params)
     thermo_params = CAP.thermodynamics_params(p.params)
     (; ᶜu, ᶜp, ᶜT, ᶜq_liq, ᶜq_ice) = p.precomputed
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
     ᶜK_h = p.scratch.ᶜtemp_scalar
     if vertical_diffusion isa DecayWithHeightDiffusion
         ᶜK_h .= ᶜcompute_eddy_diffusivity_coefficient(Y.c.ρ, vertical_diffusion)
@@ -120,27 +118,12 @@ function vertical_diffusion_boundary_layer_tendency!(
     # vertical diffusion factor α_vert_diff_tracer) to maintain exact energetic
     # consistency with the unscaled ρq_tot diffusion equation, preserve total
     # water invariance, and align with the implicit solver's Jacobian.
-    ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(
-        top = Operators.SetValue(C3(0)),
-        bottom = Operators.SetValue(C3(0)),
-    )
     (; ᶜΦ) = p.core
     (; ᶜq_tot_nonneg) = p.precomputed
     ᶜq_vap = @. lazy(TD.vapor_specific_humidity(ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(
-        -(
-            ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) *
-            (
-                ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
-                ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_vap) +
-                ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_liq) +
-                ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_ice)
-            )
-        ),
-    )
+    ᶠgrad_h =
+        ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice)
+    @. Yₜ.c.ρe_tot -= ᶜdiffdivᵥ(-(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h) * ᶠgrad_h))
 
     ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar_2
     ᶜK_h_scaled = p.scratch.ᶜtemp_scalar_3
@@ -154,17 +137,10 @@ function vertical_diffusion_boundary_layer_tendency!(
         else
             @. ᶜK_h_scaled = ᶜK_h
         end
-        ᶜdivᵥ_ρχ = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(0)),
-            bottom = Operators.SetValue(C3(0)),
-        )
-        @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρχ(
-            -(
-                ᶠinterp(Y.c.ρ) *
-                ᶠinterp(ᶜK_h_scaled) *
-                ᶠgradᵥ(specific(ᶜρχ, Y.c.ρ))
-            ),
-        )
+        ᶠcoef = @. lazy(ᶠinterp(Y.c.ρ) * ᶠinterp(ᶜK_h_scaled))
+        ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
+        @. ᶜρχₜ_diffusion = ᶜ∇ᵥρD∇χₜ
         @. ᶜρχₜ -= ᶜρχₜ_diffusion
         # Only add contribution from total water diffusion to mass tendency
         # (exclude contributions from diffusion of condensate, precipitation)

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -40,6 +40,18 @@ const ᶜadvdivᵥ = Operators.DivergenceF2C(
 # Precipitation has no flux at the top, but it has free outflow at the bottom.
 const ᶜprecipdivᵥ = Operators.DivergenceF2C(top = Operators.SetValue(CT3(0)))
 
+# Diffusive scalar fluxes vanish through the top and bottom cell faces.
+const ᶜdiffdivᵥ = Operators.DivergenceF2C(
+    bottom = Operators.SetValue(C3(0)),
+    top = Operators.SetValue(C3(0)),
+)
+
+# Vertical-momentum (u₃) diffusive flux vanishes through the top and bottom faces.
+const ᶠdiffdivᵥ_u₃ = Operators.DivergenceC2F(
+    bottom = Operators.SetDivergence(0),
+    top = Operators.SetDivergence(0),
+)
+
 const ᶠleft_bias = Operators.LeftBiasedC2F()
 const ᶠright_bias = Operators.RightBiasedC2F() # for free outflow in ᶜprecipdivᵥ
 const ᶜleft_bias = Operators.LeftBiasedF2C()

--- a/test/diffusion_operators.jl
+++ b/test/diffusion_operators.jl
@@ -1,0 +1,89 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaCore: Geometry, Fields, Operators
+
+include("test_helpers.jl")
+
+# The consolidated diffusion operators and lazy flux helpers reproduce the
+# per-function forms they replace. See #4669.
+@testset "Consolidated diffusion operators and flux helpers" begin
+    @testset for FT in (Float32, Float64)
+        (; cent_space, face_space) = get_cartesian_spaces(; FT)
+        ᶜcoord = Fields.coordinate_field(cent_space)
+        ᶠcoord = Fields.coordinate_field(face_space)
+
+        # ᶜdiffdivᵥ reproduces DivergenceF2C with a zero-flux C3 boundary, for
+        # both an integer-zero and a float-zero boundary value.
+        ᶠflux =
+            @. Geometry.Covariant3Vector(sinpi(ᶠcoord.z) * cospi(ᶠcoord.x) + FT(0.5))
+        divc_int = Operators.DivergenceF2C(
+            bottom = Operators.SetValue(Geometry.Covariant3Vector(0)),
+            top = Operators.SetValue(Geometry.Covariant3Vector(0)),
+        )
+        divc_ft = Operators.DivergenceF2C(
+            bottom = Operators.SetValue(Geometry.Covariant3Vector(FT(0))),
+            top = Operators.SetValue(Geometry.Covariant3Vector(FT(0))),
+        )
+        ref = @. CA.ᶜdiffdivᵥ(ᶠflux)
+        @test parent(ref) == parent(@. divc_int(ᶠflux))
+        @test parent(ref) == parent(@. divc_ft(ᶠflux))
+
+        # ᶠdiffdivᵥ_u₃ reproduces DivergenceC2F with a zero-divergence boundary,
+        # for both integer-zero and float-zero, on a Contravariant3 vector flux
+        # and on the production rank-2 momentum flux (ρ * τ, a UVW⊗UVW tensor).
+        divf_int = Operators.DivergenceC2F(
+            bottom = Operators.SetDivergence(0),
+            top = Operators.SetDivergence(0),
+        )
+        divf_ft = Operators.DivergenceC2F(
+            bottom = Operators.SetDivergence(FT(0)),
+            top = Operators.SetDivergence(FT(0)),
+        )
+        ᶜvflux = @. Geometry.Contravariant3Vector(
+            sinpi(ᶜcoord.z) * cospi(ᶜcoord.x) + FT(0.3),
+        )
+        ref_v = @. CA.ᶠdiffdivᵥ_u₃(ᶜvflux)
+        @test parent(ref_v) == parent(@. divf_int(ᶜvflux))
+        @test parent(ref_v) == parent(@. divf_ft(ᶜvflux))
+        ᶜtflux = @. Geometry.outer(
+            Geometry.UVWVector(sinpi(ᶜcoord.z), FT(0.2), cospi(ᶜcoord.x)),
+            Geometry.UVWVector(FT(0.1), cospi(ᶜcoord.z), sinpi(ᶜcoord.x)),
+        )
+        # As in the u₃ call sites, the divergence is projected with C3 rather
+        # than materialized bare, so the scalar boundary value is accepted.
+        ref_t = @. CA.C3(CA.ᶠdiffdivᵥ_u₃(ᶜtflux))
+        @test parent(ref_t) == parent(@. CA.C3(divf_int(ᶜtflux)))
+        @test parent(ref_t) == parent(@. CA.C3(divf_ft(ᶜtflux)))
+
+        # ᶜdiffusive_flux_divergenceᵥ pins the flux sign and composition; a sign
+        # flip fails here.
+        ᶠcoef = @. sinpi(ᶠcoord.z) + FT(1.5)
+        ᶜχ = @. cospi(ᶜcoord.z) * sinpi(ᶜcoord.x)
+        ref_div = @. CA.ᶜdiffdivᵥ(-(ᶠcoef * CA.ᶠgradᵥ(ᶜχ)))
+        flux_div = similar(ref_div)
+        flux_div .= CA.ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
+        @test parent(flux_div) == parent(ref_div)
+
+        # ᶠtotal_enthalpy_gradientᵥ matches the hand-expanded four-term sum.
+        thermo_params = CA.ClimaAtmosParameters(FT).thermodynamics_params
+        ᶜT = @. FT(280) + FT(10) * sinpi(ᶜcoord.z)
+        ᶜΦ = @. FT(9.8) * FT(1000) * ᶜcoord.z
+        ᶜq_vap = @. FT(0.01) * (1 + FT(0.1) * cospi(ᶜcoord.z))
+        ᶜq_liq = @. FT(0.001) * sinpi(ᶜcoord.x)
+        ᶜq_ice = @. FT(0.0005) * cospi(ᶜcoord.x)
+        ref_h = @. CA.ᶠgradᵥ(CA.TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
+           CA.ᶠinterp(CA.TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
+           CA.ᶠgradᵥ(ᶜq_vap) +
+           CA.ᶠinterp(CA.TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
+           CA.ᶠgradᵥ(ᶜq_liq) +
+           CA.ᶠinterp(CA.TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
+           CA.ᶠgradᵥ(ᶜq_ice)
+        grad_h = similar(ref_h)
+        grad_h .= CA.ᶠtotal_enthalpy_gradientᵥ(
+            thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice,
+        )
+        @test parent(grad_h) == parent(ref_h)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ if TEST_GROUP in ("infrastructure", "all")
     @safetestset "Configuration tests" begin @time include("config.jl") end
     @safetestset "Grids" begin @time include("grids.jl") end
     @safetestset "Utilities" begin @time include("utilities.jl") end
+    @safetestset "Diffusion operators" begin @time include("diffusion_operators.jl") end
     @safetestset "Variable manipulations" begin @time include("variable_manipulations_tests.jl") end
     @safetestset "Tracer processes" begin @time include("tracer_processes_tests.jl") end
     @safetestset "Parameter tests" begin @time include("parameter_tests.jl") end


### PR DESCRIPTION
Consolidates the diffusion code in two layers: how eddy diffusivities are computed, and how diffusive fluxes are applied.

**Coefficient layer.** Extracts the TKE → mixing length → Prandtl → eddy viscosity/diffusivity chain, previously duplicated at seven sites, into a single `ᶜeddy_diffusivities!` function. Callers supply the mixing-length output field and optional `K_u`/`K_h` output fields, preserving each site's scratch slots and lazy or materialized policy; the closure inputs (`grid_scale`, `buoyancy_gradient`) pass through unchanged. The implicit-Jacobian scheme dispatcher is renamed `eddy_diffusivity_coefficients!` → `ᶜimplicit_diffusion_coefficients!` to distinguish it from the closure chain. Migrated sites: the vertical and horizontal EDMFX SGS diffusive fluxes, the vertical and horizontal updraft diffusion, the TKE tendency for both EDMF models, and the diffusion Jacobian coefficients.

**Flux-application layer.** Adds two shared zero-flux boundary-condition divergence operators (`ᶜdiffdivᵥ`, `ᶠdiffdivᵥ_u₃`, next to the existing operator constants in `abbreviations.jl`) and two lazy helpers (`ᶜdiffusive_flux_divergenceᵥ`, `ᶠtotal_enthalpy_gradientᵥ`), then migrates the five vertical diffusion sites that rebuilt these per function — vertical Smagorinsky–Lilly, vertical AMD, `vertical_diffusion_boundary_layer_tendency!`, the EDMFX grid-mean SGS diffusive flux, and the EDMFX updraft vertical diffusion — one commit per site.

**Behavior-preserving.** The coefficient-layer extraction reproduces each site's original expression, and every flux-application commit is bit-for-bit identical to its parent. The dynamics test group (`Prognostic equations`, `Tracer/mass transport consistency`, `EDMFX horizontal diffusive flux`) passes on this branch, and a new unit test (`test/diffusion_operators.jl`) pins the shared operators and helpers, including the diffusive-flux sign, at `Float32` and `Float64`.

**Scope and limitations.** The diagnostics that recompute the closure fields lazily (`edt`, `evu`, `edth`, `evuh`) are deliberately not routed through the new function, which mutates scratch; unifying them needs either a lazy variant or cached diffusivity fields. A behavior-changing correction to the vertical-diffusion tracer scaling, surfaced by this refactor, is deferred to a follow-up PR. Unifying the tendency functions themselves (a per-direction driver over a declarative field table) is out of scope here.
