### PR TITLE
Change the default: update_cache_every step

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -383,7 +383,7 @@ version = "0.5.22"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.41.2"
+version = "0.41.3"
 
     [deps.ClimaAtmos.extensions]
     ClimaAtmosMusica = "Musica"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.41.2"
+version = "0.41.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -93,8 +93,8 @@ update_jacobian_every:
   help: "Frequency at which the Jacobian matrix should be updated (once per timestep, once per timestepper stage, or once per linear solve) [`dt`, `stage`, `solve` (default)]"
   value: "solve"
 update_cache_every:
-  help: "Frequency at which `set_precomputed_quantities!` is called by ClimaTimeSteppers [`step`, `stage` (default)]"
-  value: "stage"
+  help: "Frequency at which `set_precomputed_quantities!` is called by ClimaTimeSteppers [`step` (default), `stage`]"
+  value: "step"
 update_constrain_state_every:
   help: "Frequency at which `constrain_state!` is called by ClimaTimeSteppers [`step` (default), `stage`, `dss`]"
   value: "step"

--- a/config/model_configs/aquaplanet_equil_allsky_gw_raw.yml
+++ b/config/model_configs/aquaplanet_equil_allsky_gw_raw.yml
@@ -3,7 +3,6 @@ implicit_diffusion: false
 approximate_linear_solve_iters: 1
 rad: "allskywithclear"
 dt_save_state_to_disk: "1days"
-ode_algo: "SSPKnoth"
 orographic_gravity_wave: "raw_topo"
 dt: "400secs"
 surface_setup: "DefaultMoninObukhov"

--- a/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
+++ b/config/model_configs/prognostic_edmfx_dycoms_rf02_column.yml
@@ -11,7 +11,6 @@ edmfx_nh_pressure: true
 edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
-update_cache_every: "step"
 microphysics_model: "1M"
 config: "column"
 x_elem: 2

--- a/config/model_configs/prognostic_edmfx_rico_column.yml
+++ b/config/model_configs/prognostic_edmfx_rico_column.yml
@@ -11,7 +11,6 @@ edmfx_nh_pressure: true
 edmfx_vertical_diffusion: true
 edmfx_filter: true
 prognostic_tke: true
-update_cache_every: "step"
 microphysics_model: "1M"
 config: "column"
 z_max: 4e3

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-378
+379
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+379
+- By default update the cache once per step and not stage
+
 378
 - Apply ρe_tot/ρq_tot upwind correction as a post-Newton hook (`T_post_imp!`
   on `ClimaODEFunction`, requires ClimaTimeSteppers 0.10.4). Implicit vertical


### PR DESCRIPTION
I tested it in nightly AMIP:
- All simulations were stable
- The bias is slightly larger
- The simulation with prognostic EDMF 1M integrated land was 2 hours faster.

I think we should change the defaults to always use it.