### PR TITLE
fix(setups): make ShipwayHill2012 and TRMM_LBA profiles GPU-compatible

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -146,10 +146,10 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [[deps.AtmosphericProfilesLibrary]]
-deps = ["Interpolations", "LinearAlgebra"]
-git-tree-sha1 = "4f22cccc46fc221f3fa36c31ea6f57098aef8632"
+deps = ["ClimaInterpolations", "Interpolations", "LinearAlgebra", "StaticArrays"]
+git-tree-sha1 = "3e053ef899873642ac6a87b4a43be4a26333d376"
 uuid = "86bc3604-9858-485a-bdbe-831ec50de11d"
-version = "0.1.8"
+version = "0.1.9"
 
 [[deps.Atomix]]
 deps = ["UnsafeAtomics"]

--- a/src/setups/ShipwayHill2012.jl
+++ b/src/setups/ShipwayHill2012.jl
@@ -19,13 +19,17 @@ function ShipwayHill2012(; thermo_params)
     rv_values = FT[0.015, 0.0138, 0.0024]
     θ_values = FT[297.9, 297.9, 312.66]
 
-    linear_profile(zs, vals) = Intp.extrapolate(
-        Intp.interpolate((zs,), vals, Intp.Gridded(Intp.Linear())),
-        Intp.Linear(),
+    linear_profile(zs, vals) = CI1D.Interpolate1D(
+        SA.SVector{length(zs)}(zs),
+        SA.SVector{length(vals)}(vals);
+        interpolationorder = CI1D.Linear(),
+        extrapolationorder = CI1D.LinearExtrapolation(),
     )
-    rv(z) = max(linear_profile(z_values, rv_values)(z), zero(z))
+    rv_itp = linear_profile(z_values, rv_values)
+    θ_itp = linear_profile(z_values, θ_values)
+    rv(z) = max(rv_itp(z), zero(z))
     q_tot(z) = rv(z) / (1 + rv(z))
-    θ(z) = linear_profile(z_values, θ_values)(z)
+    θ(z) = θ_itp(z)
 
     p_0 = FT(100_700)
     p = hydrostatic_pressure_profile(; thermo_params, p_0, θ, q_tot)

--- a/src/setups/TRMM_LBA.jl
+++ b/src/setups/TRMM_LBA.jl
@@ -39,13 +39,12 @@ function trmm_lba_profiles(thermo_params)
         q_v_sat = p_v_sat * (1 / Rv_over_Rd) / denominator
         return q_v_sat * measured_RH(z) / 100
     end
-    q_tot = Intp.extrapolate(
-        Intp.interpolate(
-            (measured_z_values,),
-            measured_q_tot_values,
-            Intp.Gridded(Intp.Linear()),
-        ),
-        Intp.Flat(),
+    n = length(measured_z_values)
+    q_tot = CI1D.Interpolate1D(
+        SA.SVector{n}(measured_z_values),
+        SA.SVector{n}(measured_q_tot_values);
+        interpolationorder = CI1D.Linear(),
+        extrapolationorder = CI1D.Flat(),
     )
 
     p = hydrostatic_pressure_profile(; thermo_params, p_0, T = T_profile, q_tot)

--- a/src/setups/common/physical_state.jl
+++ b/src/setups/common/physical_state.jl
@@ -126,7 +126,7 @@ import ClimaCore.Topologies as Topologies
 import ClimaCore.Spaces as Spaces
 
 const FunctionOrSpline =
-    Union{Function, APL.AbstractProfile, Intp.Extrapolation}
+    Union{Function, APL.AbstractProfile, Intp.Extrapolation, CI1D.Interpolate1D}
 
 """
     ColumnInterpolatableField(::Fields.ColumnField)


### PR DESCRIPTION
Replace the ad hoc Interpolations.jl interpolants in the ShipwayHill2012 initial condition (θ and q_tot) and the TRMM_LBA q_tot profile with ClimaInterpolations.Interpolation1D.Interpolate1D over SVector knots, following the pattern of #4664; the interpolants become isbits and evaluate inside a device broadcast, so these setups' center initial conditions can be built on a GPU space.

The CI environment manifest moves to AtmosphericProfilesLibrary 0.1.9, which provides isbits data-backed profiles (tke and sounding data) for the setups audited in #4664. The existing compat entry already admits it, and the pinned calibration experiment environments are unchanged.

Stacked on #4664. Validated on an A100: the audited setups construct isbits and the affected initial conditions evaluate in a GPU broadcast with CPU values unchanged.