### PR TITLE
feat(timestepping): forward-backward acoustic inner sub-step scheme

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -89,6 +89,12 @@ acoustic_substep_damping:
 acoustic_substep_implicit_split:
   help: "Solve the non-acoustic implicit terms once per outer step instead of every acoustic sub-step (inner/outer implicit split). Requires `acoustic_substep_vertical: implicit`."
   value: false
+acoustic_substep_scheme:
+  help: "Inner sub-step scheme for acoustic substepping [`imex` (default): the IMEX-ARK inner sub-step; `forward_backward`: a forward-backward inner sub-step with an off-centered vertically-implicit solve and an end-of-sub-step divergence filter, roughly three times cheaper per sub-step]. `forward_backward` requires `acoustic_substep_vertical: implicit`."
+  value: "imex"
+acoustic_substep_off_centering:
+  help: "Off-centering weight beta_off in [0, 1] for the forward-backward vertically-implicit solve, theta = (1 + beta_off) / 2. Only used by `acoustic_substep_scheme: forward_backward` [`0.1` (default)]."
+  value: 0.1
 krylov_rtol:
   help: "Relative tolerance of the Krylov method (only for ClimaTimeSteppers.jl; only used if `use_krylov_method` is `true`)"
   value: 0.1

--- a/docs/src/acoustic_substepping.md
+++ b/docs/src/acoustic_substepping.md
@@ -108,6 +108,27 @@ The first-order outer combination performs one outer solve per step; the second-
 The split is additive: the full implicit tendency and its Jacobian are unchanged, and the restricted operator duplicates the acoustic subset rather than extracting it, so the mode-off and unsplit paths are unchanged.
 The split requires `acoustic_substep_vertical: implicit`.
 
+## Forward-backward inner sub-step
+
+By default each sub-step is an IMEX-ARK inner sub-cycle (`acoustic_substep_scheme: imex`).
+The forward-backward scheme (`acoustic_substep_scheme: forward_backward`) replaces it with a cheaper split-explicit advance, following the practice of split-explicit dynamical cores (Klemp, Skamarock, and Dudhia 2007).
+Each sub-step of size ``\Delta\tau``
+
+1. advances the horizontal momentum forward with the horizontal pressure gradient, the horizontal kinetic-energy gradient, and the frozen slow momentum forcing;
+2. advances the scalars and the vertical kinetic-energy gradient against the updated horizontal momentum (backward), together with the frozen slow forcing;
+3. performs one off-centered vertically-implicit Newton iteration for the vertical grid-mean acoustic block, reusing the restricted block-arrowhead Jacobian at ``\Delta t_\gamma = \theta \Delta\tau``;
+4. applies a time-adjusted divergence filter on ``u_h`` at the post-solve state.
+
+The off-centering weight is ``\theta = (1 + \beta_\mathrm{off}) / 2``, set by `acoustic_substep_off_centering` (default ``\beta_\mathrm{off} = 0.1``, ``\theta = 0.55``); ``\theta = 1`` is backward Euler.
+Off-centering is required, not a margin: the divergence filter damps only ``u_h``, so the vertical ``\rho'``-``u_3`` acoustic oscillator is damped only by ``\theta > 1/2``.
+
+The scheme is a cost feature at matched stability: it reuses the same fast tendency, off-centered solve, and divergence-damping coefficient as the IMEX inner, replacing three implicit solves, three Jacobian factorizations, and roughly ten direct-stiffness summations per sub-step with one, one, and two.
+The divergence filter is applied as a post-solve forward-Euler increment ``\Delta\tau \, \nu_d \, \mathrm{wgrad}_h(\delta)`` rather than integrated by the ERK, so it is somewhat more dissipative at the grid scale and stable only for ``\beta_d \, \mathrm{CFL}_h^2 \le 2``.
+
+The forward-backward scheme requires `acoustic_substep_vertical: implicit`.
+With prognostic EDMF it requires `acoustic_substep_implicit_split: true`, so the SGS implicit terms are carried by the outer half-step rather than the sub-cycle.
+Horizontal SEM limiters are not supported inside the forward-backward sub-cycle.
+
 ## Configuration
 
 | Option | Meaning |
@@ -118,6 +139,8 @@ The split requires `acoustic_substep_vertical: implicit`.
 | `acoustic_substep_damping_form` | Divergence used by the divergence damping: `3d` (default) or `horizontal`. |
 | `acoustic_substep_damping` | Divergence-damping coefficient ``\beta_d`` (``\nu_d = \beta_d c_\mathrm{ref}^2 \Delta t_\mathrm{sub}``). `auto` (default) resolves to `0.4`; a number keeps its direct value. |
 | `acoustic_substep_implicit_split` | Restrict the sub-cycle implicit solve to the vertical grid-mean acoustic block and solve the remaining implicit terms once per outer step (default `false`). Requires `acoustic_substep_vertical: implicit`. |
+| `acoustic_substep_scheme` | Inner sub-step scheme: `imex` (default) or `forward_backward`. `forward_backward` requires `acoustic_substep_vertical: implicit`. |
+| `acoustic_substep_off_centering` | Off-centering weight ``\beta_\mathrm{off}`` for the forward-backward vertically-implicit solve, ``\theta = (1 + \beta_\mathrm{off}) / 2`` (default `0.1`). Only used by `acoustic_substep_scheme: forward_backward`. |
 
 With `auto`, the sub-step count is
 
@@ -160,6 +183,7 @@ On configurations with inexpensive physics the sub-step count needed for stabili
 - The sub-cycle refreshes only the acoustic precomputed quantities; diagnostics that read the full cache should refresh it after a step.
   `update_cache_every` has no effect inside the sub-cycle: the full cache is refreshed only at whole-step states (when the slow forcing is frozen, at the restart of the second sub-cycle in the second-order combination, before the second outer implicit solve, and at the end of the outer step).
 - The state constraint `constrain_state!` is applied once per outer step, to the combined end-of-step state, matching the plain scheme's end-of-step cadence.
+  The forward-backward inner additionally applies it after every sub-step, as part of its advance.
   The `stage` and `dss` settings of `update_constrain_state_every` are not honored inside the sub-cycle.
 - The divergence-damping coefficient must lie within its stable range; the automatic default targets it.
 - The stable outer step and the coefficient defaults are established on a flat, dry box.

--- a/src/ClimaAtmos.jl
+++ b/src/ClimaAtmos.jl
@@ -162,6 +162,7 @@ include(joinpath("simulation", "grids.jl"))
 include(joinpath("simulation", "restart.jl"))
 include(joinpath("simulation", "integrator.jl"))
 include(joinpath("simulation", "acoustic_multirate.jl"))
+include(joinpath("simulation", "acoustic_forward_backward.jl"))
 include(joinpath("simulation", "AtmosSimulations.jl"))
 include(joinpath("simulation", "solve.jl"))
 

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -293,6 +293,7 @@ function ode_configuration(::Type{FT}, args) where {FT}
     n_sub = substeps == "auto" ? 0 : parse(Int, substeps)
     damping_form = acoustic_damping_form(args["acoustic_substep_damping_form"])
     β_d = acoustic_damping_coefficient(args["acoustic_substep_damping"])
+    inner_scheme = acoustic_inner_scheme(FT, args)
     return AcousticMultirate(
         inner_algo,
         n_sub,
@@ -301,7 +302,36 @@ function ode_configuration(::Type{FT}, args) where {FT}
         β_d,
         args["acoustic_substep_implicit_split"],
         damping_form,
+        inner_scheme,
     )
+end
+
+# Resolve the acoustic-substepping inner sub-step scheme and validate its
+# configuration. `imex` returns `nothing` (the IMEX-ARK inner sub-cycle);
+# `forward_backward` returns an `AcousticForwardBackward` with θ = (1 + β_off) / 2.
+function acoustic_inner_scheme(::Type{FT}, args) where {FT}
+    scheme = args["acoustic_substep_scheme"]
+    scheme == "imex" && return nothing
+    scheme == "forward_backward" || error(
+        "Unknown acoustic_substep_scheme: $scheme; expected `imex` or `forward_backward`",
+    )
+    args["acoustic_substep_vertical"] == "implicit" || error(
+        "acoustic_substep_scheme: forward_backward requires \
+         acoustic_substep_vertical: implicit",
+    )
+    if args["turbconv"] == "prognostic_edmfx" &&
+       !args["acoustic_substep_implicit_split"]
+        error(
+            "acoustic_substep_scheme: forward_backward with turbconv: \
+             prognostic_edmfx requires acoustic_substep_implicit_split: true",
+        )
+    end
+    args["apply_sem_quasimonotone_limiter"] && error(
+        "acoustic_substep_scheme: forward_backward does not support \
+         apply_sem_quasimonotone_limiter",
+    )
+    β_off = FT(args["acoustic_substep_off_centering"])
+    return AcousticForwardBackward((1 + β_off) / 2)
 end
 
 # Resolve the acoustic-substepping divergence-damping form from its config value.

--- a/src/prognostic_equations/acoustic_substepping.jl
+++ b/src/prognostic_equations/acoustic_substepping.jl
@@ -3,24 +3,31 @@
 #####
 
 """
-    horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+    horizontal_acoustic_scalar_tendency!(Yₜ, Y, p, t)
 
-Compute the horizontal acoustic (sound-wave) contributions to the grid-mean
-prognostic tendencies: the horizontal mass-flux divergence on `ρ`, the
-horizontal total-enthalpy-flux divergence on `ρe_tot`, and the horizontal
-pressure-gradient (split θᵥ-Exner form) on `uₕ`.
+Compute the horizontal acoustic mass-flux divergence on `ρ` and the horizontal
+total-enthalpy-flux divergence on `ρe_tot`.
 
-The horizontal acoustic subset of `horizontal_dynamics_tendency!`, sub-cycled by
-the acoustic-substepping timestepper.
+The scalar subset of [`horizontal_acoustic_tendency!`](@ref).
 """
-NVTX.@annotate function horizontal_acoustic_tendency!(Yₜ, Y, p, t)
-    (; ᶜu, ᶜp, ᶜT, ᶜh_tot, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
-    (; params) = p
-    thermo_params = CAP.thermodynamics_params(params)
-    cp_d = thermo_params.cp_d
-
+NVTX.@annotate function horizontal_acoustic_scalar_tendency!(Yₜ, Y, p, t)
+    (; ᶜu, ᶜh_tot) = p.precomputed
     @. Yₜ.c.ρ -= split_divₕ(Y.c.ρ * ᶜu, 1)
     @. Yₜ.c.ρe_tot -= split_divₕ(Y.c.ρ * ᶜu, ᶜh_tot)
+    return nothing
+end
+
+"""
+    horizontal_acoustic_momentum_tendency!(Yₜ, Y, p, t)
+
+Compute the horizontal pressure-gradient (split θᵥ-Exner form) on `uₕ`.
+
+The `uₕ` subset of [`horizontal_acoustic_tendency!`](@ref).
+"""
+NVTX.@annotate function horizontal_acoustic_momentum_tendency!(Yₜ, Y, p, t)
+    (; ᶜp, ᶜT, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
+    thermo_params = CAP.thermodynamics_params(p.params)
+    cp_d = thermo_params.cp_d
 
     ᶜθ_v = p.scratch.ᶜtemp_scalar
     @. ᶜθ_v = theta_v(thermo_params, ᶜT, ᶜp, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice)
@@ -39,6 +46,57 @@ NVTX.@annotate function horizontal_acoustic_tendency!(Yₜ, Y, p, t)
 end
 
 """
+    horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+
+Compute the horizontal acoustic (sound-wave) contributions to the grid-mean
+prognostic tendencies: the horizontal mass-flux divergence on `ρ`, the
+horizontal total-enthalpy-flux divergence on `ρe_tot`, and the horizontal
+pressure-gradient (split θᵥ-Exner form) on `uₕ`.
+
+The horizontal acoustic subset of `horizontal_dynamics_tendency!`, sub-cycled by
+the acoustic-substepping timestepper. Its scalar and momentum parts,
+[`horizontal_acoustic_scalar_tendency!`](@ref) and
+[`horizontal_acoustic_momentum_tendency!`](@ref), are advanced separately by the
+forward-backward inner sub-stepper.
+"""
+function horizontal_acoustic_tendency!(Yₜ, Y, p, t)
+    horizontal_acoustic_scalar_tendency!(Yₜ, Y, p, t)
+    horizontal_acoustic_momentum_tendency!(Yₜ, Y, p, t)
+    return nothing
+end
+
+"""
+    kinetic_energy_gradient_uₕ_tendency!(Yₜ, Y, p, t)
+
+Compute the horizontal gradient of `K + Φ − Φ_r` on `uₕ`.
+
+The `uₕ` subset of [`kinetic_energy_gradient_tendency!`](@ref); matches
+`horizontal_dynamics_tendency!`.
+"""
+NVTX.@annotate function kinetic_energy_gradient_uₕ_tendency!(Yₜ, Y, p, t)
+    (; ᶜK, ᶜp) = p.precomputed
+    (; ᶜΦ) = p.core
+    thermo_params = CAP.thermodynamics_params(p.params)
+    ᶜΦ_r = @. lazy(phi_r(thermo_params, ᶜp))
+    @. Yₜ.c.uₕ -= C12(gradₕ(ᶜK + ᶜΦ - ᶜΦ_r))
+    return nothing
+end
+
+"""
+    kinetic_energy_gradient_u₃_tendency!(Yₜ, Y, p, t)
+
+Compute the vertical gradient of `K` on `u₃`.
+
+The `u₃` subset of [`kinetic_energy_gradient_tendency!`](@ref); matches
+`explicit_vertical_advection_tendency!`.
+"""
+NVTX.@annotate function kinetic_energy_gradient_u₃_tendency!(Yₜ, Y, p, t)
+    (; ᶜK) = p.precomputed
+    @. Yₜ.f.u₃ -= ᶠgradᵥ(ᶜK)
+    return nothing
+end
+
+"""
     kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
 
 Compute the kinetic-energy-gradient contributions to the grid-mean momentum
@@ -48,17 +106,14 @@ gradient of `K` on `u₃`.
 The gradient-form subset of the grid-mean momentum advection, re-evaluated inside
 the acoustic sub-cycle rather than held in the frozen slow forcing. Its
 energy-conserving partner, the rotational momentum flux, is sub-cycled alongside
-it by `rotational_momentum_flux_tendency!`. The `uₕ` term matches
-`horizontal_dynamics_tendency!` and the `u₃` term matches
-`explicit_vertical_advection_tendency!`.
+it by [`rotational_momentum_flux_tendency!`](@ref). Its `uₕ` and `u₃` parts,
+[`kinetic_energy_gradient_uₕ_tendency!`](@ref) and
+[`kinetic_energy_gradient_u₃_tendency!`](@ref), are advanced separately by the
+forward-backward inner sub-stepper.
 """
-NVTX.@annotate function kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
-    (; ᶜK, ᶜp) = p.precomputed
-    (; ᶜΦ) = p.core
-    thermo_params = CAP.thermodynamics_params(p.params)
-    ᶜΦ_r = @. lazy(phi_r(thermo_params, ᶜp))
-    @. Yₜ.c.uₕ -= C12(gradₕ(ᶜK + ᶜΦ - ᶜΦ_r))
-    @. Yₜ.f.u₃ -= ᶠgradᵥ(ᶜK)
+function kinetic_energy_gradient_tendency!(Yₜ, Y, p, t)
+    kinetic_energy_gradient_uₕ_tendency!(Yₜ, Y, p, t)
+    kinetic_energy_gradient_u₃_tendency!(Yₜ, Y, p, t)
     return nothing
 end
 

--- a/src/simulation/acoustic_forward_backward.jl
+++ b/src/simulation/acoustic_forward_backward.jl
@@ -1,0 +1,173 @@
+#####
+##### Forward-backward acoustic inner sub-stepper. See `docs/src/acoustic_substepping.md`.
+#####
+##### `AcousticForwardBackward` is a ClimaTimeSteppers `TimeSteppingAlgorithm`
+##### used as the inner algorithm of the acoustic-substepping `Multirate`, in
+##### place of the IMEX-ARK inner sub-cycle. Each sub-step advances the horizontal
+##### momentum forward, the scalars backward against the updated momentum, one
+##### off-centered vertically-implicit Newton iteration, and an end-of-sub-step
+##### divergence filter. The generic step-exchange skeleton (forcing freeze,
+##### sub-cycle loop, outer combination) is unchanged and lives in
+##### ClimaTimeSteppers.
+#####
+
+import ClimaTimeSteppers as CTS
+import LinearAlgebra
+
+"""
+    AcousticForwardBackward(θ)
+
+Inner sub-stepper for acoustic substepping: a forward-backward advance with an
+off-centered vertically-implicit solve and an end-of-sub-step divergence filter.
+Used as the inner algorithm of [`AcousticMultirate`](@ref) when
+`acoustic_substep_scheme: forward_backward`.
+
+`θ = (1 + β_off) / 2` is the off-centering weight of the vertically-implicit
+solve; `θ = 1` is backward Euler.
+"""
+struct AcousticForwardBackward{FT, C} <: CTS.TimeSteppingAlgorithm
+    θ::FT
+    # Model `constrain_state!`, applied after each sub-step. Set by
+    # `AcousticMultirate` in `init_cache`; defaults to a no-op.
+    constrain_state!::C
+end
+AcousticForwardBackward(θ) = AcousticForwardBackward(θ, Returns(nothing))
+
+"""
+    frozen_forcing(f)
+
+Return the frozen slow-forcing pair `(G, G_lim)` carried by the inner sub-cycle
+function `f`. For the step-exchange host, `f` is a
+`ClimaTimeSteppers.DualOffsetODEFunction`.
+"""
+frozen_forcing(f::CTS.DualOffsetODEFunction) = (f.G, f.G_lim)
+
+"""
+    AcousticFBCache
+
+Cache for an [`AcousticForwardBackward`](@ref) sub-step: the inner implicit
+operator `L_v` and its Jacobian, the aliased frozen forcing `(G, G_lim)`, the
+reused DSS/constraint/cache hooks, the divergence-filter form and viscosity, the
+off-centering weight, and the sub-step buffers.
+"""
+struct AcousticFBCache{L, J, B, DSS, CS, CI, D, FT, S, U}
+    L_v::L
+    jac::J
+    G::B
+    G_lim::B
+    dss!::DSS
+    constrain_state!::CS
+    cache_imp!::CI
+    damping_form::D
+    ν_d::FT
+    θ::FT
+    A::B
+    B_buf::B
+    R::B
+    ΔY::B
+    ᶜδ::S
+    ᶜu::U
+end
+
+function CTS.init_cache(prob, alg::AcousticForwardBackward; dt, kwargs...)
+    f = prob.f
+    u0 = prob.u0
+    FT = eltype(u0)
+    dof = f.T_exp_T_lim!
+    G, G_lim = frozen_forcing(dof)
+    fast_tend = dof.f
+    return AcousticFBCache(
+        f.T_imp!.f,
+        f.T_imp!.jac_prototype,
+        G,
+        G_lim,
+        f.dss!,
+        alg.constrain_state!,
+        f.cache_imp!,
+        fast_tend.damping_form,
+        FT(fast_tend.ν_d),
+        FT(alg.θ),
+        zero(u0),
+        zero(u0),
+        zero(u0),
+        zero(u0),
+        similar(u0.c, FT),
+        similar(u0.c, C123{FT}),
+    )
+end
+
+# End-of-sub-step divergence filter on uₕ (Klemp 2018 placement), evaluated at
+# the post-solve state as a forward-Euler increment Δτ ν_d wgradₕ(δ), with δ the
+# strong-form velocity divergence selected by `damping_form`.
+function acoustic_fb_divergence_filter!(cache, Y, dtτ, ::HorizontalDivergenceDamping)
+    ᶜδ = cache.ᶜδ
+    @. ᶜδ = divₕ(Y.c.uₕ)
+    @. Y.c.uₕ += dtτ * cache.ν_d * wgradₕ(ᶜδ)
+    return nothing
+end
+function acoustic_fb_divergence_filter!(cache, Y, dtτ, ::FullDivergenceDamping)
+    ᶜu = cache.ᶜu
+    ᶜδ = cache.ᶜδ
+    @. ᶜu = C123(Y.c.uₕ) + ᶜinterp(C123(Y.f.u₃))
+    ᶠuₕ³ = compute_ᶠuₕ³(Y.c.uₕ, Y.c.ρ)
+    @. ᶜδ = divₕ(ᶜu)
+    @. ᶜδ += ᶜdivᵥ(ᶠuₕ³ + CT3(Y.f.u₃))
+    @. Y.c.uₕ += dtτ * cache.ν_d * wgradₕ(ᶜδ)
+    return nothing
+end
+
+function CTS.step_u!(integrator, cache::AcousticFBCache)
+    (; L_v, jac, G, dss!, constrain_state!, cache_imp!, θ) = cache
+    A, B, R, ΔY = cache.A, cache.B_buf, cache.R, cache.ΔY
+    Y = integrator.u
+    p = integrator.p
+    t = integrator.t
+    dtτ = float(integrator.dt)
+    dtγ = θ * dtτ
+
+    # S1. Vertical implicit tendency at the old level (skipped at θ = 1).
+    A .= zero(eltype(A))
+    θ < 1 && L_v(A, Y, p, t)
+
+    # S2. Horizontal momentum forward, with the frozen slow momentum forcing.
+    B .= zero(eltype(B))
+    horizontal_acoustic_momentum_tendency!(B, Y, p, t)
+    kinetic_energy_gradient_uₕ_tendency!(B, Y, p, t)
+    @. Y.c.uₕ += dtτ * (B.c.uₕ + G.c.uₕ)
+
+    # S3. Assemble uₕ and refresh the sub-cycle cache.
+    dss!(Y, p, t)
+    constrain_state!(Y, p, t)
+    cache_imp!(Y, p, t)
+
+    # S4. Scalars backward against the updated momentum, plus the vertical-K
+    # predictor, the frozen slow forcing, and the implicit predictor `A`. The
+    # increment is assembled for every block; `uₕ` is then overridden to `A.c.uₕ`
+    # (the implicit-diffusion predictor, zero for the restricted inner) so the
+    # frozen momentum forcing reaches `uₕ` only once, in S2.
+    B .= zero(eltype(B))
+    horizontal_acoustic_scalar_tendency!(B, Y, p, t)
+    kinetic_energy_gradient_u₃_tendency!(B, Y, p, t)
+    @. R = B + G + A
+    @. R.c.uₕ = A.c.uₕ
+    @. Y += dtτ * R
+
+    # S5. Off-centered vertical implicit solve, one Newton iteration.
+    cache_imp!(Y, p, t)
+    update_jacobian!(jac, Y, p, dtγ, t)
+    B .= zero(eltype(B))
+    L_v(B, Y, p, t)
+    @. R = dtγ * (A - B)
+    LinearAlgebra.ldiv!(ΔY, jac, R)
+    @. Y += ΔY
+
+    # S6. Time-adjusted divergence filter on uₕ, at the post-solve state.
+    cache.ν_d > 0 && acoustic_fb_divergence_filter!(cache, Y, dtτ, cache.damping_form)
+
+    # S7. Final assembly and cache for the next sub-step.
+    dss!(Y, p, t)
+    constrain_state!(Y, p, t)
+    cache_imp!(Y, p, t)
+
+    return integrator.u
+end

--- a/src/simulation/acoustic_multirate.jl
+++ b/src/simulation/acoustic_multirate.jl
@@ -144,7 +144,8 @@ end
 
 """
     AcousticMultirate(inner_alg, n_sub, vertical, outer_stages = 2, β_d = 0.0,
-        implicit_split = false, damping_form = FullDivergenceDamping())
+        implicit_split = false, damping_form = FullDivergenceDamping(),
+        inner_scheme = nothing)
 
 A multirate `TimeSteppingAlgorithm` that sub-cycles the acoustic modes. See
 `docs/src/acoustic_substepping.md`.
@@ -152,7 +153,8 @@ A multirate `TimeSteppingAlgorithm` that sub-cycles the acoustic modes. See
 # Fields
 
   - `inner_alg`: algorithm used for the acoustic sub-cycle (an `IMEXAlgorithm` for
-    `ImplicitVertical`, an explicit algorithm for `ExplicitVertical`).
+    `ImplicitVertical`, an explicit algorithm for `ExplicitVertical`). Also used
+    for the outer implicit half-step of the inner/outer split.
   - `n_sub`: sub-steps per outer step; `0` selects it from the acoustic CFL.
   - `vertical`: vertical-acoustic treatment.
   - `outer_stages`: order of the outer combination, `1` or `2`.
@@ -164,8 +166,10 @@ A multirate `TimeSteppingAlgorithm` that sub-cycles the acoustic modes. See
     step. When `false`, the inner solve uses the full `implicit_tendency!`.
   - `damping_form`: divergence-damping form, `HorizontalDivergenceDamping` or
     `FullDivergenceDamping`.
+  - `inner_scheme`: inner sub-step scheme. `nothing` uses the IMEX-ARK `inner_alg`;
+    an [`AcousticForwardBackward`](@ref) uses the forward-backward inner sub-step.
 """
-struct AcousticMultirate{A, V, D} <: CTS.TimeSteppingAlgorithm
+struct AcousticMultirate{A, V, D, S} <: CTS.TimeSteppingAlgorithm
     inner_alg::A
     n_sub::Int
     vertical::V
@@ -173,6 +177,7 @@ struct AcousticMultirate{A, V, D} <: CTS.TimeSteppingAlgorithm
     β_d::Float64
     implicit_split::Bool
     damping_form::D
+    inner_scheme::S
 end
 AcousticMultirate(
     inner_alg,
@@ -189,6 +194,7 @@ AcousticMultirate(
     β_d,
     implicit_split,
     FullDivergenceDamping(),
+    nothing,
 )
 
 """
@@ -352,14 +358,22 @@ function CTS.init_cache(prob, alg::AcousticMultirate; dt, kwargs...)
         else
             nothing
         end
+    # The forward-backward inner nulls `initialize_imp!` inside the sub-cycle so its
+    # analytic EDMF stage solve is carried by the outer half-step; the IMEX inner
+    # keeps `f.initialize_imp!`.
+    is_forward_backward = alg.inner_scheme isa AcousticForwardBackward
+    inner_initialize_imp! =
+        is_forward_backward ? Returns(nothing) : f.initialize_imp!
     # The fast sub-cycle is a full `ClimaODEFunction`: the acoustic fast tendency
     # (with the frozen forcing added by the outer step), the restricted or full
     # implicit operator, and the reused implicit cache, limiter, DSS, and state
-    # constraint. `constrain_state!` is applied once per outer step, to the
-    # combined end-of-step state; constraint application inside the sub-cycle
-    # is not supported. Under the implicit split the sub-cycle keeps a no-op
-    # `initialize_imp!`: the restricted inner operator excludes the SGS block,
-    # so the analytic SGS initialization pairs with the outer complement below.
+    # constraint. `constrain_state!` and `update_constrain_state` drive the
+    # end-of-outer-step constraint applied by the step-exchange outer method; the
+    # forward-backward inner also applies the constraint every sub-step, from its
+    # own captured copy. Constraint cadences finer than end-of-step are not applied
+    # inside the sub-cycle. Under the implicit split the sub-cycle keeps a no-op
+    # `initialize_imp!`: the restricted inner operator excludes the SGS block, so
+    # the analytic SGS initialization pairs with the outer complement below.
     f_fast = CTS.ClimaODEFunction(;
         T_exp_T_lim! = fast!,
         T_imp! = inner_T_imp!,
@@ -370,7 +384,7 @@ function CTS.init_cache(prob, alg::AcousticMultirate; dt, kwargs...)
         constrain_state! = f.constrain_state!,
         update_constrain_state = f.update_constrain_state,
         initialize_imp! = implicit_split ? Returns(nothing) :
-                          f.initialize_imp!,
+                          inner_initialize_imp!,
     )
     # The outer implicit half-step solves the full implicit tendency minus the
     # inner subset, once per outer step, pairing that residual with the matching
@@ -414,10 +428,19 @@ function CTS.init_cache(prob, alg::AcousticMultirate; dt, kwargs...)
     outer =
         alg.outer_stages == 1 ? CTS.LieSplitOuter(outer_complement) :
         CTS.TrapezoidalSplitOuter(outer_complement)
+    # The inner sub-cycle uses the forward-backward stepper when configured,
+    # otherwise the IMEX-ARK `inner_alg`. The outer implicit half-step always uses
+    # `inner_alg`. The step-exchange inner function does not forward
+    # `constrain_state!`, so the forward-backward stepper carries the model
+    # `constrain_state!` on its algorithm for its per-sub-step application.
+    inner_alg =
+        is_forward_backward ?
+        AcousticForwardBackward(alg.inner_scheme.θ, f.constrain_state!) :
+        alg.inner_alg
     split_prob = CTS.SplitODEProblem(f_fast, freeze!, u0, prob.tspan, p)
     cts_cache = CTS.init_cache(
         split_prob,
-        CTS.Multirate(alg.inner_alg, outer);
+        CTS.Multirate(inner_alg, outer);
         dt,
         fast_dt,
     )

--- a/src/simulation/acoustic_multirate.jl
+++ b/src/simulation/acoustic_multirate.jl
@@ -144,7 +144,7 @@ end
 
 """
     AcousticMultirate(inner_alg, n_sub, vertical, outer_stages = 2, β_d = 0.0,
-        implicit_split = false, damping_form = FullDivergenceDamping(),
+        implicit_split = false, damping_form = FullDivergenceDamping();
         inner_scheme = nothing)
 
 A multirate `TimeSteppingAlgorithm` that sub-cycles the acoustic modes. See
@@ -186,6 +186,8 @@ AcousticMultirate(
     outer_stages = 2,
     β_d = 0.0,
     implicit_split = false,
+    damping_form = FullDivergenceDamping();
+    inner_scheme = nothing,
 ) = AcousticMultirate(
     inner_alg,
     n_sub,
@@ -193,8 +195,8 @@ AcousticMultirate(
     outer_stages,
     β_d,
     implicit_split,
-    FullDivergenceDamping(),
-    nothing,
+    damping_form,
+    inner_scheme,
 )
 
 """

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -71,6 +71,37 @@ box_integrator(; kwargs...) =
     @test !(resolved_alg(substeps = "0") isa CA.AcousticMultirate)
 end
 
+@testset "constructor argument defaults" begin
+    # The seven-argument form (through `damping_form`) predates `inner_scheme`.
+    # It constructs and selects the IMEX inner sub-cycle. See #4677.
+    seven_arg = CA.AcousticMultirate(
+        nothing,
+        3,
+        CA.ImplicitVertical(),
+        2,
+        0.0,
+        false,
+        CA.FullDivergenceDamping(),
+    )
+    @test seven_arg isa CA.AcousticMultirate
+    @test seven_arg.inner_scheme === nothing
+    @test seven_arg.damping_form isa CA.FullDivergenceDamping
+
+    # The forward-backward inner scheme is opt-in through the keyword.
+    fb = CA.AcousticForwardBackward(0.5)
+    eight_arg = CA.AcousticMultirate(
+        nothing,
+        3,
+        CA.ImplicitVertical(),
+        2,
+        0.0,
+        false,
+        CA.FullDivergenceDamping();
+        inner_scheme = fb,
+    )
+    @test eight_arg.inner_scheme === fb
+end
+
 @testset "kinetic-energy gradient discrete form" begin
     integ = box_integrator()
     Y, p, t, f = integ.u, integ.p, integ.t, integ.cache.f

--- a/test/acoustic_substepping_split.jl
+++ b/test/acoustic_substepping_split.jl
@@ -14,7 +14,7 @@ import LinearAlgebra: I
 # the covariant-vector DSS). Both outer orders are covered; order 1 also exercises
 # the first-order `outer_half!` timestep path.
 
-function acoustic_box_config(; order, implicit_split)
+function acoustic_box_config(; order, implicit_split, scheme = "imex")
     return Dict{String, Any}(
         "initial_condition" => "DryDensityCurrentProfile",
         "config" => "box",
@@ -39,14 +39,15 @@ function acoustic_box_config(; order, implicit_split)
         "acoustic_substep_order" => order,
         "acoustic_substep_damping" => 1.5,
         "acoustic_substep_implicit_split" => implicit_split,
+        "acoustic_substep_scheme" => scheme,
     )
 end
 
 # Step a fresh simulation and snapshot the state at the requested step counts.
-function stepped_states(; order, implicit_split, checkpoints)
-    config = acoustic_box_config(; order, implicit_split)
+function stepped_states(; order, implicit_split, checkpoints, scheme = "imex")
+    config = acoustic_box_config(; order, implicit_split, scheme)
     config["output_dir"] = mktempdir()
-    job_id = "acoustic_o$(order)_$(implicit_split ? "split" : "unsplit")"
+    job_id = "acoustic_$(scheme)_o$(order)_$(implicit_split ? "split" : "unsplit")"
     integrator = CA.get_simulation(CA.AtmosConfig(config; job_id)).integrator
     states = Dict{Int, Any}()
     for step in 1:maximum(checkpoints)
@@ -59,10 +60,12 @@ end
 @testset "Acoustic substepping: implicit split reproduces the unsplit sub-cycle" begin
     checkpoints = (2, 4)
     uₕ_relative_tolerance = 1e-12
-    for order in (1, 2)
-        @testset "outer order $order" begin
-            unsplit = stepped_states(; order, implicit_split = false, checkpoints)
-            split = stepped_states(; order, implicit_split = true, checkpoints)
+    for scheme in ("imex", "forward_backward"), order in (1, 2)
+        @testset "$scheme outer order $order" begin
+            unsplit =
+                stepped_states(; order, implicit_split = false, checkpoints, scheme)
+            split =
+                stepped_states(; order, implicit_split = true, checkpoints, scheme)
             for n in checkpoints
                 u_unsplit, u_split = unsplit[n], split[n]
                 # ρ, ρe_tot, u₃ are bitwise identical.


### PR DESCRIPTION
This adds a forward-backward inner sub-step scheme for acoustic substepping, selected by `acoustic_substep_scheme: forward_backward`. It is a cost feature at matched stability: it replaces the IMEX-ARK inner sub-cycle with a cheaper split-explicit advance, so each acoustic sub-step is roughly three times cheaper while the outer combination, the frozen slow forcing, the restricted implicit operator, and the divergence-damping coefficient are unchanged. The default `acoustic_substep_scheme: imex` is byte-identical to the current driver.

The scheme is `AcousticForwardBackward`, a ClimaAtmos-defined `ClimaTimeSteppers.TimeSteppingAlgorithm` used as the inner algorithm of the acoustic `Multirate`. It is the second consumer of the step-exchange inner-stepper slot added in CliMA/ClimaTimeSteppers.jl#442; the first is the IMEX-ARK inner of the substepping driver in #4660. This PR is stacked on #4661. The dependency chain is #442 then #4660 then #4661 then this, and it also requires ClimaUtilities >= 0.1.30.

Each sub-step of size Δτ advances the horizontal momentum forward with the horizontal pressure gradient, the horizontal kinetic-energy gradient, and the frozen slow momentum forcing; advances the scalars and the vertical kinetic-energy gradient against the updated momentum (backward), with the frozen slow forcing; performs one off-centered vertically-implicit Newton iteration on the vertical grid-mean acoustic block, reusing the restricted block-arrowhead Jacobian at Δt_γ = θ Δτ; and applies a time-adjusted divergence filter on the horizontal velocity at the post-solve state. The off-centering weight θ = (1 + β_off) / 2 is set by `acoustic_substep_off_centering` (default β_off = 0.1). Off-centering is required rather than a margin: the divergence filter damps only the horizontal velocity, so the vertical density-vertical-velocity acoustic oscillator is damped only by θ > 1/2.

The forward-backward inner calls `constrain_state!` explicitly and nulls `initialize_imp!`, so the analytic EDMF SGS stage solve does not fire inside the acoustic sub-cycle; with prognostic EDMF the SGS implicit terms are carried by the outer half-step, which is why the scheme requires `acoustic_substep_implicit_split: true` there. Three `check_config` errors enforce the supported surface: `forward_backward` requires `acoustic_substep_vertical: implicit`, requires `acoustic_substep_implicit_split: true` with prognostic EDMF, and rejects the horizontal SEM limiter.

Two fast tendency functions are split into per-block parts (`horizontal_acoustic_tendency!` into scalar and momentum parts, `kinetic_energy_gradient_tendency!` into horizontal-velocity and vertical-velocity parts), with the originals kept as their composition, so the IMEX path is unchanged and the existing exact-split identity test covers the refactor. The frozen forcing reaches the horizontal velocity exactly once per sub-step (in the forward momentum step); the backward scalar step advances every other prognostic block, leaving the horizontal-velocity increment as the implicit-diffusion predictor alone (zero for the restricted inner).

The `constrain_state!` threading through the step-exchange inner assembler lives in ClimaTimeSteppers (`init_inner`), alongside `dss!` and `lim!`; it is a no-op for the IMEX inner (whose inner function keeps the default) and load-bearing for the forward-backward inner. As with #4660 and #4661, the `.buildkite` develop pins of the local ClimaTimeSteppers and ClimaUtilities are uncommitted artifacts and are not part of this branch.

Verification covers dry and moist boxes (CPU, Float32 unless noted) and a GPU smoke. On the dry 340 m box the forward-backward scheme matches the IMEX inner's stability window at the shipped defaults across outer steps of 2x to 6x the baseline, with the horizontal-velocity peak within a few percent and mass and energy drift at the Float32 floor. The probe horizon is 120 steps, twice the 60-step campaign standard; the nearest measured crash at 4x is the beta_d=0.8 forward-Euler stability bound at step 2, so every stable point clears the two-times-crash-count probe rule by a wide margin. Mass and energy are conserved to Float64 machine precision on the accuracy box, and the density and total-energy error is the same 1e-5 class as the IMEX inner, with the horizontal-velocity perturbation within the IMEX worst-case bound. The extended split test reproduces the unsplit sub-cycle bitwise for the forward-backward scheme at both outer orders. The per-sub-step cost ratio, measured by differencing ms/step across n_sub at fixed outer step so the fixed per-step cost cancels, is 3.06x on the dry box and 3.44x on a moist 1M box, clearing the 2.5x threshold and the 3x target. On the coarse-Bomex prognostic-EDMF box the forward-backward scheme is stable through 60 steps with physical updraft area fraction at dt=4s. The GPU smoke runs the sub-step loop on an A100 and stays finite.

Two limitations are worth a reviewer's attention.

The forward-backward filter is a post-solve forward-Euler increment rather than an ERK-integrated term, so it is stable only for beta_d CFL_h^2 <= 2; at the auto sub-step the upper beta_d edge sits near 0.8, where the IMEX inner still runs. The shipped default 0.4 is stable with margin, so this narrower upper edge does not affect the default.

The forward-backward inner is a weak-shear-only scheme. Under vertical wind shear it degrades scalar acoustic refraction, and the onset is at realistic boundary-layer shear, not only extreme shear. On the shear-refraction plane benchmark (a log-law wind with a near-surface acoustic pulse, measured by the surface density variance J and the downwind trapping centroid at a fixed horizon, referenced to a fine no-substepping run), the forward-backward scheme matches the IMEX inner with no shear and loses the refraction as soon as shear is present:

| max wind | IMEX J rel. dev. | IMEX centroid | FB J rel. dev. | FB centroid | reference centroid |
| --- | --- | --- | --- | --- | --- |
| 0 (no shear) | 0.36 | +0.0 m | 0.36 | +0.0 m | -0.1 m |
| ~23 m/s | 0.36 | +13.7 m | 9.1 | +3.8 m | +14.4 m |
| ~92 m/s | 0.36 | +54.7 m | 1540 | +1.7 m | +55.6 m |

At about 23 m/s, a realistic boundary-layer maximum wind, the forward-backward surface density variance is already an order of magnitude too large and the trapping centroid collapses to roughly a quarter of the reference; at about 92 m/s it is catastrophic. The velocity field tracks the IMEX inner in every case (the covariant horizontal-velocity peak differs by a few percent), so this is a scalar refraction-accuracy degradation, not a velocity instability.

The degradation is structural, a property of the inner stage composition rather than a term-placement or solver-tuning defect. With the sub-step size, the restricted Jacobian, the frozen forcing, and every other ingredient held identical to the IMEX inner, one converged single-theta acoustic solve per sub-step cannot represent the horizontal-velocity, vertical-velocity, and scalar phase coupling that shear-mediated refraction requires at per-sub-step acoustic CFL 0.5 to 0.8, while the three-stage IMEX inner at the same sub-step size can. Every term-placement and solver hypothesis was falsified: the horizontal and vertical kinetic-energy gradients are already explicit in the forward and predictor stages; raising the inner Newton count to two or three leaves J unchanged while eroding the cost win to 2.3x and 1.8x; freezing the vertical kinetic-energy gradient is indistinguishable from the base; a uniform wind at the same peak speed sits in the IMEX band, so the failure requires shear specifically; and off-centering only modulates the error, since a centered (Crank-Nicolson) solve still fails by roughly twenty times.

The consequence is scope, not a pending fix. The scheme is a documented weak-shear-only inner for quiescent and weakly-sheared regimes, and #4677 is kept in draft on that basis rather than pending a shear repair. A design-level rework to a two-solve predictor-corrector forward-backward inner would land near a 1.5x per-sub-step cost ratio, marginal against the IMEX inner, and is not pursued here. The cost win of the shipped single-solve inner is real and retained: 3.1x to 3.4x per sub-step at one Newton iteration.

Off-centering was measured non-binding on the anisotropic box tested; the 0.1 default stands as the vertical-mode margin from the theta-scheme analysis. Horizontal SEM limiters and the vertical-explicit path are rejected by check_config.
