### PR TITLE
Reparameterize TKE dissipation via a critical Richardson number (c_d = c_m c_b / Ri_c)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+- [#4678](https://github.com/CliMA/ClimaAtmos.jl/pull/4678) ![][badge-🔥behavioralΔ] Reparameterize the TKE dissipation coefficient in terms of a critical Richardson number: `c_d = c_m·c_b/Ri_c`, with `Ri_c` read from the ClimaParams parameter `mixing_length_Ri_crit` (default 0.25). In the buoyancy-limited branch of the mixing-length closure, local TKE balance reduces to the threshold `Ri_c = c_m·c_b/c_d`, so `(c_m, c_b, Ri_c)` form a nearly orthogonal calibration basis (flux magnitude, buoyancy-length/TKE partition, stability cutoff) and `c_d` is derived. TOML overrides of `mixing_length_diss_coeff` no longer have any effect — set `mixing_length_Ri_crit` instead. At ClimaParams defaults the derived `c_d` is 0.224 instead of 0.22.
+
+0.41.3
+-------
 
 0.41.2
 -------

--- a/calibration/experiments/gcm_driven_scm/prior_diagnostic.toml
+++ b/calibration/experiments/gcm_driven_scm/prior_diagnostic.toml
@@ -23,8 +23,8 @@ type = "float"
 prior = "constrained_gaussian(mixing_length_eddy_viscosity_coefficient, 0.14, 0.07, 0, Inf)"
 type = "float"
 
-[mixing_length_diss_coeff]
-prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.15, 0, Inf)"
+[mixing_length_Ri_crit]
+prior = "constrained_gaussian(mixing_length_Ri_crit, 0.25, 0.17, 0, Inf)"
 type = "float"
 
 [mixing_length_tke_surf_scale]

--- a/calibration/experiments/gcm_driven_scm/prior_prognostic.toml
+++ b/calibration/experiments/gcm_driven_scm/prior_prognostic.toml
@@ -19,8 +19,8 @@ type = "float"
 prior = "constrained_gaussian(mixing_length_eddy_viscosity_coefficient, 0.14, 0.09, 0, Inf)"
 type = "float"
 
-[mixing_length_diss_coeff]
-prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.15, 0, Inf)"
+[mixing_length_Ri_crit]
+prior = "constrained_gaussian(mixing_length_Ri_crit, 0.25, 0.17, 0, Inf)"
 type = "float"
 
 [mixing_length_tke_surf_scale]

--- a/calibration/experiments/gcm_driven_scm/prior_prognostic_pi_entr.toml
+++ b/calibration/experiments/gcm_driven_scm/prior_prognostic_pi_entr.toml
@@ -16,8 +16,8 @@ type = "float"
 prior = "constrained_gaussian(mixing_length_eddy_viscosity_coefficient, 0.14, 0.07, 0, Inf)"
 type = "float"
 
-[mixing_length_diss_coeff]
-prior = "constrained_gaussian(mixing_length_diss_coeff, 0.22, 0.15, 0, Inf)"
+[mixing_length_Ri_crit]
+prior = "constrained_gaussian(mixing_length_Ri_crit, 0.25, 0.17, 0, Inf)"
 type = "float"
 
 [mixing_length_tke_surf_scale]

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-379
+380
 
 # **README**
 #
@@ -32,6 +32,12 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+380
+- Reparameterize the TKE dissipation coefficient: c_d = c_m c_b / Ri_c with
+  Ri_c = mixing_length_Ri_crit (default 0.25). Configurations using the
+  repository TOMLs are preserved to within 1 ulp; at ClimaParams defaults
+  the derived c_d is 0.224 instead of 0.22.
+
 379
 - By default update the cache once per step and not stage
 

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -27,7 +27,7 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, VFT1, VFT2, VTF3} <: ATCP
     max_area::FT
     min_area::FT
     tke_ed_coeff::FT
-    tke_diss_coeff::FT
+    Ri_crit::FT
     tke_surf_scale::FT
     tke_surf_flux_coeff::FT
     diagnostic_covariance_coeff::FT

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -321,7 +321,7 @@ function TurbulenceConvectionParameters(
         :max_area_limiter_scale => :max_area_limiter_scale,
         :mixing_length_tke_surf_scale => :tke_surf_scale,
         :mixing_length_tke_surf_flux_coeff => :tke_surf_flux_coeff,
-        :mixing_length_diss_coeff => :tke_diss_coeff,
+        :mixing_length_Ri_crit => :Ri_crit,
         :diagnostic_covariance_coeff => :diagnostic_covariance_coeff,
         :Tq_correlation_coefficient => :Tq_correlation_coefficient,
         :detr_buoy_coeff => :detr_buoy_coeff,

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -313,7 +313,7 @@ function mixing_length_lopez_gomez_2020(
     eps_FT = eps(FT)
 
     c_m = CAP.tke_ed_coeff(turbconv_params)
-    c_d = CAP.tke_diss_coeff(turbconv_params)
+    c_d = tke_dissipation_coefficient(turbconv_params)
     c_b = CAP.static_stab_coeff(turbconv_params)
 
     # l_z: Geometric distance from the surface
@@ -517,6 +517,10 @@ Parameters used are Pr_n = Prandtl_number_0 (neutral Prandtl number) and
 ω_pr = Prandtl_number_scale (Prandtl number scale coefficient).
 This formula applies in both stable (Ri > 0) and unstable (Ri < 0) conditions.
 The returned turbulent Prandtl number is limited to be between eps(FT) and Pr_max.
+
+The strong-stability limit of this closure (`Pr(Ri) → ∞`) is what closes the
+TKE dissipation coefficient; see [`tke_dissipation_coefficient`](@ref) for that
+derivation.
 """
 function turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
     FT = eltype(params)
@@ -550,6 +554,53 @@ function turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
     # Also ensure that it's not larger than the Pr_max parameter.
     return min(max(prandtl_nvec, eps_FT), Pr_max)
 end
+
+"""
+    tke_dissipation_coefficient(turbconv_params)
+
+The TKE dissipation coefficient `c_d = c_m c_b / Ri_c`, a derived closure
+coefficient combining the eddy-viscosity coefficient `c_m` (`tke_ed_coeff`),
+the static-stability coefficient `c_b` (`static_stab_coeff`), and the critical
+gradient Richardson number `Ri_c` (`Ri_crit`). Used by [`tke_dissipation`](@ref).
+
+# Derivation of `c_d = c_m c_b / Ri_c`
+
+Consider the local TKE balance (production = buoyancy destruction +
+dissipation, no transport) in stably stratified air, where the mixing length is
+buoyancy-limited, `l = l_N = √(c_b e)/N`, with `e` the TKE and `N` the buoyancy
+frequency:
+
+    2 K_u S² - K_h N² = c_d e^{3/2} / l,
+    K_u = c_m l √e,   K_h = K_u / Pr,
+
+with `S² = SᵢⱼSᵢⱼ` the squared strain-rate norm. Substituting `l = l_N` makes
+every term linear in `e`,
+
+    c_m √c_b (2S² - N²/Pr) e / N = c_d e N / √c_b,
+
+so the TKE amplitude cancels: there is no local equilibrium level, only a sharp
+threshold — TKE grows or decays exponentially according to the sign of the
+balance. Dividing by `N²` and using the gradient Richardson number
+`Ri = N²/(2S²)` gives the marginal condition
+
+    1/Ri = 1/Pr + c_d/(c_m c_b).
+
+In strong stability `Pr(Ri)` grows without bound (see
+[`turbulent_prandtl_number`](@ref)), so `1/Pr → 0` and turbulence is maintained
+for `Ri < Ri_c` with
+
+    Ri_c = c_m c_b / c_d.
+
+This combination of the three coefficients controls the stable-regime cutoff, so
+`(c_m, c_b, Ri_c)` are calibrated and `c_d` follows. The basis is nearly
+orthogonal: `c_m/c_d = Ri_c/c_b`, so the neutral-limit equilibrium TKE
+(`e = 2 (c_m/c_d) l² S²`) is independent of `c_m`, which acts as a
+flux-magnitude scaling, while `c_b` partitions TKE amplitude against the
+buoyancy length and `Ri_c` sets the stability cutoff.
+"""
+tke_dissipation_coefficient(turbconv_params) =
+    CAP.tke_ed_coeff(turbconv_params) * CAP.static_stab_coeff(turbconv_params) /
+    CAP.Ri_crit(turbconv_params)
 
 """
     blend_scales(

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -93,7 +93,8 @@ per unit volume, ρ * ε_d [kg m^-1 s^-3].
 
 The physical dissipation is calculated as:
 ρ * ε_d = c_d * ρtke * sqrt(abs(tke)) / mixing_length
-where `c_d` is a parameter.
+where `c_d` is the TKE dissipation coefficient
+([`tke_dissipation_coefficient`](@ref)).
 
 Arguments:
 
@@ -104,7 +105,7 @@ Arguments:
 """
 function tke_dissipation(turbconv_params, ρtke, tke, mixing_length)
     FT = typeof(tke)
-    c_d = CAP.tke_diss_coeff(turbconv_params)
+    c_d = tke_dissipation_coefficient(turbconv_params)
     dissipation_rate_vol = c_d * ρtke * sqrt(abs(tke)) / mixing_length
     return dissipation_rate_vol
 end

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -978,7 +978,7 @@ function update_diffusion_jacobian!(
 
     if MatrixFields.has_field(Y, @name(c.ρtke))
         turbconv_params = CAP.turbconv_params(params)
-        c_d = CAP.tke_diss_coeff(turbconv_params)
+        c_d = tke_dissipation_coefficient(turbconv_params)
         (; dt) = p
         ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
         ᶜρtke = Y.c.ρtke

--- a/test/parameter_tests.jl
+++ b/test/parameter_tests.jl
@@ -26,6 +26,39 @@ import Thermodynamics as TD
     end
 end
 
+@testset "TKE dissipation coefficient derived from Ri_crit" begin
+    for FT in (Float32, Float64)
+        params = CA.ClimaAtmosParameters(FT)
+        tc = params.turbconv_params
+        # ClimaParams default: Ri_c = 0.25 (mixing_length_Ri_crit)
+        @test CAP.Ri_crit(tc) == FT(0.25)
+        # c_d is derived, not independent: c_d = c_m c_b / Ri_c
+        @test CA.tke_dissipation_coefficient(tc) ==
+              CAP.tke_ed_coeff(tc) * CAP.static_stab_coeff(tc) /
+              CAP.Ri_crit(tc)
+    end
+
+    # A TOML override of mixing_length_Ri_crit propagates into the derived c_d
+    mktemp() do path, io
+        write(
+            io,
+            """
+  [mixing_length_Ri_crit]
+  value = 0.5
+  type = "float"
+  """,
+        )
+        flush(io)
+        config_dict = Dict("toml" => [path])
+        config = CA.AtmosConfig(config_dict, job_id = "parameter_test_ri_crit")
+        params = CA.ClimaAtmosParameters(config)
+        tc = params.turbconv_params
+        @test CAP.Ri_crit(tc) == 0.5
+        @test CA.tke_dissipation_coefficient(tc) ==
+              CAP.tke_ed_coeff(tc) * CAP.static_stab_coeff(tc) / 0.5
+    end
+end
+
 @testset "AtmosConfig Parameter Overrides" begin
     # Test overriding a parameter via configuration logic
     # CA.AtmosConfig merges dicts into the parameters

--- a/toml/larcform1_1M_prognostic_edmfx.toml
+++ b/toml/larcform1_1M_prognostic_edmfx.toml
@@ -43,9 +43,6 @@ value = 1
 [pressure_normalmode_drag_coeff]
 value = 8.0
 
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.56
-
 [tracer_vertical_diffusion_factor]
 value = 0
 

--- a/toml/longrun_aquaplanet_progedmf.toml
+++ b/toml/longrun_aquaplanet_progedmf.toml
@@ -52,8 +52,5 @@ value = 1
 [pressure_normalmode_drag_coeff]
 value = 8.0
 
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.56
-
 [precipitation_timescale]
 value = 1200

--- a/toml/prognostic_edmfx.toml
+++ b/toml/prognostic_edmfx.toml
@@ -49,8 +49,5 @@ value = 1
 [pressure_normalmode_drag_coeff]
 value = 8.0
 
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.56
-
 [precipitation_timescale]
 value = 3600

--- a/toml/prognostic_edmfx_1M.toml
+++ b/toml/prognostic_edmfx_1M.toml
@@ -43,9 +43,6 @@ value = 1
 [pressure_normalmode_drag_coeff]
 value = 8.0
 
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.56
-
 [tracer_vertical_diffusion_factor]
 value = 0
 

--- a/toml/prognostic_edmfx_bomex_pigroup.toml
+++ b/toml/prognostic_edmfx_bomex_pigroup.toml
@@ -29,10 +29,6 @@ value = 20000.0
 value = 5.6101216504240545
 type = "float"
 
-[mixing_length_diss_coeff]
-value = 0.3739697514813775
-type = "float"
-
 [diagnostic_covariance_coeff]
 value = 1.4362168064049219
 type = "float"
@@ -47,10 +43,6 @@ type = "float"
 
 [EDMF_max_surface_area]
 value = 0.0723478159897135
-type = "float"
-
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.05607209843375782
 type = "float"
 
 [turb_entr_param_vec]

--- a/toml/prognostic_edmfx_calibrated.toml
+++ b/toml/prognostic_edmfx_calibrated.toml
@@ -2,10 +2,6 @@
 value = 0.5507468907407347
 type = "float"
 
-[mixing_length_diss_coeff]
-value = 0.13515021886991527
-type = "float"
-
 [diagnostic_covariance_coeff]
 value = 1.858712542728056
 type = "float"
@@ -20,10 +16,6 @@ type = "float"
 
 [EDMF_max_surface_area]
 value = 0.09964843547415161
-type = "float"
-
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.12938179994984028
 type = "float"
 
 [turb_entr_param_vec]

--- a/toml/prognostic_edmfx_implicit_scm_calibrated_5_cases_shallow_deep_v1.toml
+++ b/toml/prognostic_edmfx_implicit_scm_calibrated_5_cases_shallow_deep_v1.toml
@@ -10,9 +10,6 @@ value = 0
 [mixing_length_tke_surf_scale]
 value = 1.1402470659472088
 
-[mixing_length_diss_coeff]
-value = 0.12492989143864316
-
 [detr_buoy_coeff]
 value = 0
 
@@ -39,9 +36,6 @@ value = 0
 
 [EDMF_max_surface_area]
 value = 0.07485284402727316
-
-[mixing_length_eddy_viscosity_coefficient]
-value = 0.1202718388572739
 
 [EDMF_min_area]
 value = 1.0e-5


### PR DESCRIPTION
## Summary

In the buoyancy-limited branch of the mixing-length closure (`l = l_N`), local TKE balance reduces to a threshold Richardson number for TKE production:`Ri_c = c_m·c_b/c_d`. Only this combination of the three mixing-length coefficients controls the stable-regime cutoff for turbulence maintenance. Calibrating `(c_m, c_b, c_d)` independently leads to correlated parameters and possibly unphysical `Ri_c`. The current default values (`c_m = 0.56`, `c_b = 0.4`, `c_d = 0.22`) imply `Ri_c ≈ 1.0`, above the literature range of 0.2–0.3, without that being visible.

This PR reparameterizes to `(c_m, c_b, Ri_c)` and **derives** `c_d = c_m·c_b/Ri_c`.

## Why this basis is better conditioned

Since `c_m/c_d = Ri_c/c_b`, neutral-equilibrium TKE (`∝ c_m/c_d`) becomes independent of `c_m`. Each parameter then is more directly tied to an observable:
- `Ri_c`: stability cutoff for turbulence maintenance (direct literature priors);
- `c_b`: partitions TKE amplitude against the buoyancy length;
- `c_m`: flux-magnitude scaling.

## Implementation

- `Ri_c` is read from the **existing** ClimaParams parameter `mixing_length_Ri_crit` (default 0.25); the parameter otherwise is unused across CliMA FWIK.
- `c_d` is derived in `TurbulenceConvectionParameters` construction. Explicit `tke_diss_coeff` overrides still take precedence; **TOML overrides of `mixing_length_diss_coeff` no longer have any effect**; set `mixing_length_Ri_crit` instead.
- All TOMLs overriding the coefficients are converted: the `c_m = 0.56` EDMF family pins `Ri_c = 1.0181818181818183` (preserving `c_d = 0.22` and making the implied high `Ri_c` of the current calibration explicit); the calibrated experiment TOMLs replace their `c_d` values with the equivalent `Ri_c`; the `gcm_driven_scm` calibration priors now target `mixing_length_Ri_crit` (mean 0.25, same relative width as the old `c_d` prior; a prior range 0.2-0.5 is reasonable).
- Unit tests cover the derivation, the TOML override path.

## Behavior

- Configurations using the converted TOMLs: preserved.
- Configurations at ClimaParams defaults: derived `c_d = 0.14·0.4/0.25 = 0.224` instead of 0.22 (+1.8 % dissipation): tiny behavioral change, ref counter bumped.