### PR TITLE
 Skip merge queue if only one up-to-date PR is being tested 

### DIFF
--- a/.buildkite/decide_pipeline.sh
+++ b/.buildkite/decide_pipeline.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Decider step for non-`main` climaatmos-ci builds (see .buildkite/pipeline.yml).
+#
+# Merge-queue fast path: when the merge group's only change over `main` is a
+# single PR whose reproducibility bundle was already staged by that PR's build
+# (see should_skip_merge_queue.sh), re-running the full pipeline would only
+# reproduce an already-tested state. In that case upload nothing and let the
+# build pass green -- a build must still report success for the merge queue to
+# merge, but it need not repeat the PR's work.
+#
+# We deliberately do NOT run reproducibility_tests/stage_output.jl here, so the
+# PR's staged bundle is left in place; the post-merge `main` build then publishes
+# it via reproducibility_tests/publish_reference.jl exactly as in the off-queue
+# flow. The "bundle gets copied on merge" behaviour is unchanged.
+#
+# Otherwise (ordinary PR build, or a merge group combining multiple PRs, or one
+# with no staged results) upload the full CI pipeline.
+set -euo pipefail
+
+if .buildkite/should_skip_merge_queue.sh; then
+    buildkite-agent annotate --style success --context skip-ci \
+        "Merge-queue CI skipped: reused this PR's staged results." || true
+    echo "Skipping full pipeline: reusing already-tested PR results."
+    exit 0
+fi
+
+echo "--- Uploading full pipeline"
+buildkite-agent pipeline upload .buildkite/full_pipeline.yml

--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -16,24 +16,14 @@ env:
   PERF_CONFIG_PATH: "config/perf_configs"
   MPI_CONFIG_PATH: "config/mpi_configs"
 
+# NOTE: this pipeline is uploaded by .buildkite/decide_pipeline.sh, which only
+# runs on non-`main` builds.
 steps:
-  - label: ":robot_face: Move reproducibility results to reference store"
-    if: 'build.branch == "main"'
+  - label: "Initialize"
     retry: &retry_policy
       automatic:
         - exit_status: -1  # Retry on agent lost
           limit: 1
-    concurrency: 1
-    concurrency_group: "depot/climaatmos-ci"
-    command:
-      # update_registry=false: the registry lives in the read-only depot/shared;
-      # skip the git-pull that would fail against it (see .buildkite/build_depot.sh).
-      - "julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(; update_registry=false)'"
-      - "julia --color=yes --project=.buildkite reproducibility_tests/publish_reference.jl"
-
-  - label: "Initialize"
-    if: 'build.branch != "main"'
-    retry: *retry_policy
     key: "init_cpu_env"
     command:
       - echo $$JULIA_DEPOT_PATH
@@ -49,14 +39,12 @@ steps:
   - wait
 
   - group: "Reproducibility"
-    if: 'build.branch != "main"'
     steps:
       - label: ":green_book: Reproducibility: Test infrastructure"
         retry: *retry_policy
         command: "julia --color=yes --project=.buildkite test/unit_reproducibility_infra.jl"
 
   - group: "Radiation"
-    if: 'build.branch != "main"'
     steps:
       - label: ":sun_with_face: Radiation: Gray"
         retry: *retry_policy
@@ -95,7 +83,6 @@ steps:
         artifact_paths: "single_column_radiative_equilibrium_allsky_idealized_clouds/output_active/*"
 
   - group: "Microphysics"
-    if: 'build.branch != "main"'
     steps:
       - label: ":umbrella: Microphysics: 1-moment sanity check"
         retry: *retry_policy
@@ -114,7 +101,6 @@ steps:
       #   artifact_paths: "single_column_precipitation_2M_test/output_active/*"
 
   - group: "Gravity wave"
-    if: 'build.branch != "main"'
     steps:
       - label: ":wavy_dash: Non-orograpic gravity wave: 3D unit test"
         retry: *retry_policy
@@ -156,7 +142,6 @@ steps:
         artifact_paths: "orographic_gravity_wave_test_garner2005/*"
 
   - group: "Prognostic EDMF"
-    if: 'build.branch != "main"'
     steps:
       - label: ":genie: Prognostic EDMF: Vertical advection test"
         retry: *retry_policy
@@ -414,7 +399,6 @@ steps:
           slurm_mem: 12GB
 
   - group: "Analytic Tests"
-    if: 'build.branch != "main"'
     steps:
       - label: ":crown: Analytic tests: No topography, 2D, Float64, GPU"
         retry: *retry_policy
@@ -465,7 +449,6 @@ steps:
           slurm_gpus: 1
 
   - group: "Conservation Tests"
-    if: 'build.branch != "main"'
     steps:
       - label: ":computer: Conservation tests: Dry baroclinic wave, no sources"
         retry: *retry_policy
@@ -493,7 +476,6 @@ steps:
       #  soft_fail: true
 
   - group: "Non-spherical Examples"
-    if: 'build.branch != "main"'
     steps:
       - label: ":package: Non-spherical: Reproducibility test for single column hydrostatic balance, Float64"
         retry: *retry_policy
@@ -553,7 +535,6 @@ steps:
         artifact_paths: "rcemipii_box_CRM_1M/output_active/*"
 
   - group: "Dry Spherical Examples"
-    if: 'build.branch != "main"'
     steps:
       - label: ":cyclone: Dycore: Global hydrostatic balance, Float64"
         retry: *retry_policy
@@ -616,7 +597,6 @@ steps:
         artifact_paths: "held_suarez/output_active/*"
 
   - group: "Spherical Examples"
-    if: 'build.branch != "main"'
     steps:
       - label: ":large_blue_circle: Sphere: Reproducibility test for moist baroclinic wave, 0M"
         retry: *retry_policy
@@ -722,7 +702,6 @@ steps:
           slurm_mem: 20GB
 
   - group: "Topography"
-    if: 'build.branch != "main"'
     steps:
       - label: ":mount_fuji: Topography: Idealized mountain (dcmip)"
         retry: *retry_policy
@@ -752,7 +731,6 @@ steps:
         artifact_paths: "baroclinic_wave_hughes2023/output_active/*"
 
   - group: "Restarting"
-    if: 'build.branch != "main"'
     steps:
       - label: ":computer: Restart: Basic correctness"
         retry: *retry_policy
@@ -855,7 +833,6 @@ steps:
       #  soft_fail: true
 
   - group: "MPI"
-    if: 'build.branch != "main"'
     steps:
       - label: ":metro: MPI: Prepare files for baroclininc wave restart test"
         retry: *retry_policy
@@ -956,7 +933,6 @@ steps:
           slurm_mem: 16GB
 
   - group: "Autodiff"
-    if: 'build.branch != "main"'
     steps:
       #- label: "Autodiff: Moist baroclinic wave, check conservation, sparse autodiff, Float64"
       #  command: >
@@ -1033,7 +1009,6 @@ steps:
       #     slurm_mem: 20GB
 
   - group: "Timestep cost"
-    if: 'build.branch != "main"'
     steps:
       - label: ":alarm_clock: Timestep cost: Moist baroclinic wave"
         retry: *retry_policy
@@ -1098,7 +1073,6 @@ steps:
           slurm_gpus: 1
 
   - group: "Allocations budget"
-    if: 'build.branch != "main"'
     steps:
       - label: ":fire: Allocations budget: Moist baroclininc wave, GPU"
         retry: *retry_policy
@@ -1225,7 +1199,6 @@ steps:
           slurm_mem: 24GB
 
   - group: "Checkbounds/Invalidations"
-    if: 'build.branch != "main"'
     steps:
       # TODO: we should somehow decouple this unit test from the perf env / scripts
       # Checkbounds
@@ -1255,17 +1228,14 @@ steps:
     continue_on_failure: true
 
   - label: ":robot_face: Print new rms tables"
-    if: 'build.branch != "main"'
     retry: *retry_policy
     command: "julia --color=yes --project=.buildkite reproducibility_tests/rms_summary.jl"
 
   - label: ":robot_face: Print new reference counter"
-    if: 'build.branch != "main"'
     retry: *retry_policy
     command: "julia --color=yes --project=.buildkite reproducibility_tests/print_new_ref_counter.jl"
 
   - label: ":bar_chart: Tabulate performance summary"
-    if: 'build.branch != "main"'
     retry: *retry_policy
     command: "julia --color=yes --project=.buildkite perf/tabulate_perf_summary.jl"
 
@@ -1278,6 +1248,5 @@ steps:
   - wait
 
   - label: ":robot_face: Stage reproducibility results"
-    if: 'build.branch != "main"'
     retry: *retry_policy
     command: "julia --color=yes --project=.buildkite reproducibility_tests/stage_output.jl"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,52 @@
+# Bootstrap pipeline. This is the file the Buildkite UI uploads:
+#     buildkite-agent pipeline upload .buildkite/pipeline.yml
+#
+#   - On `main`: publish the merged PR's staged reproducibility reference.
+#   - Otherwise (PR or merge-queue build): a decider step runs
+#     .buildkite/decide_pipeline.sh, which either
+#       * reuses an already-tested PR's results and skips the build
+#         (merge-queue fast path, see .buildkite/should_skip_merge_queue.sh), or
+#       * uploads the full CI pipeline (.buildkite/full_pipeline.yml).
+#
+# Keeping the full pipeline out of the initially-loaded steps is what lets the
+# decider suppress it: a merge-queue build must still report success for the
+# queue to merge, but it does not have to re-run work the PR already did.
+
+agents:
+  queue: central
+  slurm_mem: 8G
+  modules: climacommon/2025_03_18
+
+env:
+  JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
+  OPENBLAS_NUM_THREADS: 1
+  SLURM_KILL_BAD_EXIT: 1
+  JULIA_NVTX_CALLBACKS: gc
+  JULIA_MAX_NUM_PRECOMPILE_FILES: 100
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/depot:${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/shared"
+  COMMON_CONFIG_PATH: "config/common_configs"
+  CONFIG_PATH: "config/model_configs"
+  GPU_CONFIG_PATH: "config/gpu_configs"
+  PERF_CONFIG_PATH: "config/perf_configs"
+  MPI_CONFIG_PATH: "config/mpi_configs"
+
+steps:
+  - label: ":robot_face: Move reproducibility results to reference store"
+    if: 'build.branch == "main"'
+    retry: &retry_policy
+      automatic:
+        - exit_status: -1  # Retry on agent lost
+          limit: 1
+    concurrency: 1
+    concurrency_group: "depot/climaatmos-ci"
+    command:
+      # update_registry=false: the registry lives in the read-only depot/shared;
+      # skip the git-pull that would fail against it (see .buildkite/build_depot.sh).
+      - "julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(; update_registry=false)'"
+      - "julia --color=yes --project=.buildkite reproducibility_tests/publish_reference.jl"
+
+  - label: ":arrows_counterclockwise: Decide pipeline"
+    if: 'build.branch != "main"'
+    retry: *retry_policy
+    command:
+      - ".buildkite/decide_pipeline.sh"

--- a/.buildkite/should_skip_merge_queue.sh
+++ b/.buildkite/should_skip_merge_queue.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Decide whether the merge-queue build can reuse an already-tested PR's results.
+#
+# Exit 0  => skip full CI (reuse). Exit non-zero => run full CI.
+#
+# All of the following must hold to skip. ANY uncertainty (unparseable branch,
+# failed fetch, missing staging) falls through to running the full pipeline, so
+# a wrong guess can never merge untested code:
+#
+#   1. This is a GitHub merge-queue build. Its branch has the form
+#          gh-readonly-queue/main/pr-<pr_number>-<base_sha>
+#      where <base_sha> is the commit the merge group is stacked on.
+#
+#   2. <base_sha> is a real commit on `main` (checked below with `is-ancestor`).
+#      This is how we know the merge group is exactly ONE PR on top of `main`:
+#
+#      The merge queue tests PRs by stacking them. The group's <base_sha> is
+#      whatever it was built on top of:
+#        - front of the queue  -> stacked directly on `main`, so <base_sha> is
+#          a commit on `main`.
+#        - a PR behind another  -> stacked on the PR-ahead's temporary
+#          gh-readonly-queue commit, which is synthetic and never reaches
+#          `main`, so <base_sha> is NOT on `main`.
+#
+#      So "<base_sha> is on `main`" holds only when nothing is stacked beneath
+#      this PR -- i.e. the group adds exactly this one PR. Groups that combine
+#      multiple PRs fail this check and are never reused.
+#
+#   3. The merge group's tree equals the PR head's tree, i.e. the merged code is
+#      identical to what the PR build tested and staged. Needed to reject a stale
+#      PR: if `main` advanced past what the PR contains, the merged code differs
+#      from the staged bundle, the trees differ, and full CI runs. Compares tree
+#      content, not commit structure, so it works for the squash, rebase, and
+#      merge-commit queue methods alike.
+#
+#   4. That PR already has a non-empty staged reproducibility bundle from its PR
+#      build. stage_pr_data() overwrites this on every push, so it reflects the
+#      PR head now being merged.
+#
+# Note there is NO stale-`main` correctness gap: condition 3 skips only when the
+# merged code matches the staged code exactly, so the merge-queue reproducibility
+# test is skipped only when re-running it is provably a no-op.
+#
+# NOTE: staging_root must match reproducibility_tests/reproducibility_utils.jl
+# (STAGING_ROOT / pr_staging_dir); keep the two in sync.
+set -euo pipefail
+
+branch="${BUILDKITE_BRANCH:-}"
+
+# (1) merge-queue branch + parse PR number and base sha.
+[[ "$branch" =~ ^gh-readonly-queue/main/pr-([0-9]+)-([0-9a-fA-F]+)$ ]] || exit 1
+pr_number="${BASH_REMATCH[1]}"
+base_sha="${BASH_REMATCH[2]}"
+
+# (2) <base_sha> must be a real commit on `main` (single-PR delta).
+git fetch -q origin main || exit 1
+git merge-base --is-ancestor "$base_sha" FETCH_HEAD || exit 1
+
+# (3) the merge-group code must equal the PR head that was staged. Fetch the PR
+#     head (GitHub exposes it at refs/pull/<n>/head) and require its tree to
+#     match the checked-out merge commit (HEAD). This compares content, so it
+#     holds for the squash, rebase, and merge-commit queue methods alike. Fails
+#     (-> full CI) if pull refs are not fetchable.
+git fetch -q origin "refs/pull/${pr_number}/head" || exit 1
+pr_head="$(git rev-parse FETCH_HEAD)" || exit 1
+git diff --quiet "$pr_head" HEAD || exit 1
+
+# (4) staged reproducibility bundle for this PR exists and is non-empty.
+#     SKIP_CI_STAGING_ROOT overrides the path for tests; production uses the
+#     default below.
+staging_root="${SKIP_CI_STAGING_ROOT:-/resnick/scratch/esm/slurm-buildkite/climaatmos-main-staging}"
+bundle="${staging_root}/pr-${pr_number}/reproducibility_bundle"
+{ [ -d "$bundle" ] && [ -n "$(ls -A "$bundle" 2>/dev/null)" ]; } || exit 1
+
+exit 0


### PR DESCRIPTION
This PR enables us to skip redundant buildkite builds when the only PR in merge queue has already had CI run on its commit. Merge queue still requires a successful build for status checks, so we still run a minimal build. 

## Content

The large diff is misleading due to a rename, if you look at the commits separately you can see the changes more clearly.

- Rename `pipeline.yml` to `full_pipeline.yml`. This is not necessary but makes it easier to revert.
- Add script `.buildkite/should_skip_merge_queue.sh` which determine whether to skip CI or not. This skips the normal pipeline upload if it is in merge queue, the base commit is on main, the merge group tree is identical to the PR tree, and that the PR has a reproducibility bundle staged.
- Add script `.buildkite/decide_pipeline.sh` which runs the `.buildkite/should_skip_merge_queue.sh` script to decide whether to upload the full pipeline. For now, to ensure it works properly, it just reports when it would have skipped the build, then uploads the full pipeline as before. 
- Add new `pipeline.yml` to run `.buildkite/decide_pipeline.sh`.

See dry run build https://buildkite.com/clima/climaatmos-ci/builds/30795#annotation-skip-ci