### PR TITLE
fix(edmf): include the microphysics mass source in the implicit ρa solve

### DIFF
--- a/src/parameterized_tendencies/microphysics/tendency.jl
+++ b/src/parameterized_tendencies/microphysics/tendency.jl
@@ -91,8 +91,8 @@ function microphysics_tendency!(Yₜ, Y, p, t,
         @. Yₜ.c.ρe_tot +=
             Y.c.sgsʲs.:($$j).ρa * ᶜmp_tendencyʲs.:($$j).dq_tot_dt *
             ᶜmp_tendencyʲs.:($$j).e_tot_hlpr
-        # ... and updraft tendency
-        @. Yₜ.c.sgsʲs.:($$j).ρa += Y.c.sgsʲs.:($$j).ρa * ᶜmp_tendencyʲs.:($$j).dq_tot_dt
+        # ... and updraft tendency. The updraft `ρa` mass source is applied
+        # implicitly by `solve_sgs_ρa_implicit_stage_analytic!`.
         @. Yₜ.c.sgsʲs.:($$j).q_tot +=
             ᶜmp_tendencyʲs.:($$j).dq_tot_dt *
             (1 - Y.c.sgsʲs.:($$j).q_tot)

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -304,13 +304,16 @@ Computes tendencies due to vertical advection and buoyancy for EDMFX subgrid-sca
 
 This function handles:
 
-  - Vertical advection of updraft density-area product (`ρaʲ`).
   - Vertical advection of updraft moist static energy (`mseʲ`) and total specific humidity (`q_totʲ`).
   - Vertical advection of other updraft moisture species (`q_lclʲ`, `q_iclʲ`, `q_raiʲ`, `q_snoʲ`)
     if using a `NonEquilibriumMicrophysics1M` or `NonEquilibriumMicrophysics2M` microphysics
     model. If the `NonEquilibriumMicrophysics2M` model is used, `n_liqʲ` and `n_raiʲ` are also advected.
   - Buoyancy source term in the updraft `mseʲ` equation (geopotential work done against
     the density anomaly).
+
+Vertical transport of the updraft density-area product (`ρaʲ`) is not handled
+here; it is solved analytically at the implicit stage by
+[`solve_sgs_ρa_implicit_stage_analytic!`](@ref).
 
 Arguments:
 

--- a/src/prognostic_equations/implicit/initialize_implicit_problem.jl
+++ b/src/prognostic_equations/implicit/initialize_implicit_problem.jl
@@ -249,21 +249,38 @@ function sgs_ρa_implicit_tendency!(
 end
 
 """
+    microphysics_ρa_source_rate(p, microphysics_model, j)
+
+Fractional microphysics mass-source rate `S_mp = (∂ₜρaʲ)/ρaʲ` for mass-flux
+subdomain `j`. Nonzero only for microphysics models with an updraft mass
+source. The term is linear in `ρaʲ` and is treated implicitly in
+[`solve_sgs_ρa_implicit_stage_analytic!`](@ref), which applies it under both
+explicit and implicit microphysics timestepping.
+"""
+microphysics_ρa_source_rate(p, microphysics_model, j) = zero(eltype(p.params))
+microphysics_ρa_source_rate(p, ::EquilibriumMicrophysics0M, j) =
+    p.precomputed.ᶜmp_tendencyʲs.:($j).dq_tot_dt
+
+"""
     solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
 
 Analytic IMEX/ARK implicit-stage solve for the updraft area-weighted
 density `ρa` in each EDMFX mass-flux subdomain.
 
-The flux-form stage equation `∂ρa/∂t + ∂(ρa·w)/∂z = (ε − δ)·ρa` reduces
-under first-order upwinding (for upward `ᶠu₃ʲ`) to the forward recurrence
+The flux-form stage equation
+`∂ρa/∂t + ∂(ρa·w)/∂z = (ε − δ)·ρa + S_mp·ρa` reduces under first-order
+upwinding (for upward `ᶠu₃ʲ`) to the forward recurrence
 
     ρa_new[i] = (ρa_old[i]/dtγ + α_bot · ρa_new[i−1]) / denominator[i],
-    denominator[i] = 1/dtγ + α_top − (ε − δ)[i],
+    denominator[i] = 1/dtγ + α_top − (ε − δ + S_mp)[i],
     α_face = (ᶠinterp(ρʲ·J)/ᶠJ · ᶠu₃ʲ/Δz_face) / (ρʲ_upwind · Δz[i]),
 
 `(ε − δ)` is assembled inline from area-bounding, velocity-scale, and
-buoyancy-driven pieces (see [`detr_buoy_inv_time_scale`](@ref)). The
-mass-flux-divergence component of detrainment is folded into a
+buoyancy-driven pieces (see [`detr_buoy_inv_time_scale`](@ref)), and
+`S_mp` is the microphysics mass-source rate (see
+[`microphysics_ρa_source_rate`](@ref)); a sink (`S_mp < 0`) increases the
+denominator, so the implicit treatment preserves `ρa ≥ 0` for any `dtγ`.
+The mass-flux-divergence component of detrainment is folded into a
 multiplicative prefactor on the implicit advection term instead of
 `(ε − δ)`, so it is treated implicitly together with the flux divergence.
 
@@ -300,19 +317,21 @@ function solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
 
     # Cell-centred coefficients of the recurrence:
     #   ᶜnumerator            = ρa_old[i] / dtγ
-    #   ᶜdenominator          = 1/dtγ + α_top · (1 − implicit_detr_prefactor) − (ε − δ)
+    #   ᶜdenominator          = 1/dtγ + α_top · (1 − implicit_detr_prefactor)
+    #                           − (ε − δ + S_mp)
     #   ᶜmass_flux_factor_bot = α_bot · (1 − implicit_detr_prefactor)
     # where α_face = (ᶠinterp(ρʲ·J)/ᶠJ · ᶠu₃ʲ/Δz_face) / (ρʲ_upwind · Δz).
     # For upward flow the upwind density at the bottom face is ρʲ[i−1], which we
     # extract via `ᶠleft_bias(ᶜρʲs)`. The mass-flux-divergence component of the
     # detrainment is folded into `ᶜone_minus_implicit_detr_prefactor` (a
     # multiplicative correction on the implicit advection term), leaving the
-    # `(ε − δ)` term to carry only the area-bounding, velocity-scale
-    # entrainment, and buoyancy-based detrainment pieces.
+    # `(ε − δ + S_mp)` term to carry the area-bounding, velocity-scale
+    # entrainment, buoyancy-based detrainment, and microphysics mass-source
+    # pieces, with coefficients evaluated at the previous iterate.
     ᶜnumerator = p.scratch.ᶜtemp_scalar
     ᶜdenominator = p.scratch.ᶜtemp_scalar_2
     ᶜmass_flux_factor_bot = p.scratch.ᶜtemp_scalar_3
-    ᶜexplicit_entr_minus_detr = p.scratch.ᶜtemp_scalar_4
+    ᶜexplicit_linear_rate = p.scratch.ᶜtemp_scalar_4
     ᶠw = p.scratch.ᶠtemp_scalar
 
     n = n_mass_flux_subdomains(turbconv_model)
@@ -362,17 +381,20 @@ function solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
                 ),
             ),
         )
-        @. ᶜexplicit_entr_minus_detr =
+        ᶜmicrophysics_rate =
+            microphysics_ρa_source_rate(p, p.atmos.microphysics_model, j)
+        @. ᶜexplicit_linear_rate =
             ᶜarea_bounding_entr_detrʲs.:($$j) +
             ᶜentr_vel_scaleʲs.:($$j) * ᶜinterp(ᶠw) -
-            ᶜlower_limiter_factor * detr_buoy_coeff * ᶜbuoy_inv_time_scale
+            ᶜlower_limiter_factor * detr_buoy_coeff * ᶜbuoy_inv_time_scale +
+            ᶜmicrophysics_rate
 
         @. ᶜnumerator = Y.c.sgsʲs.:($$j).ρa / dtγ
-        # Floor at 0.1/dtγ ⇒ (ε − δ) ≤ 0.9/dtγ (≈10× per-step growth cap).
+        # Floor at 0.1/dtγ ⇒ (ε − δ + S_mp) ≤ 0.9/dtγ (≈10× per-step growth bound).
         @. ᶜdenominator =
             max(
                 FT(0.1) / dtγ,
-                1 / dtγ - ᶜexplicit_entr_minus_detr +
+                1 / dtγ - ᶜexplicit_linear_rate +
                 ᶜone_minus_implicit_detr_prefactor * ᶜright_bias(
                     ᶠinterp(ᶜρʲs.:($$j) * ᶜJ) / ᶠJ * ᶠw,
                 ) / ᶜρʲs.:($$j) / ᶜdz,

--- a/src/simulation/integrator.jl
+++ b/src/simulation/integrator.jl
@@ -124,12 +124,71 @@ function update_constrain_state_signal_handler(freq_str)
     end
 end
 
+"""
+    imex_weights_Timp_at_uninitialized_stage(tableau)
+
+Return `true` if the IMEX `tableau` weights the implicit tendency `T_imp` at a
+stage whose implicit diagonal coefficient is zero.
+
+At such a stage the IMEX ARK solver evaluates `T_imp` explicitly without first
+calling `initialize_imp!`, so a tendency cached by `initialize_imp!` and
+replayed through `T_imp!` is read from an earlier stage.
+"""
+function imex_weights_Timp_at_uninitialized_stage(tableau)
+    a_imp = tableau.a_imp.coeffs
+    b_imp = tableau.b_imp.coeffs
+    n_stages = size(a_imp, 1)
+    for i in 1:n_stages
+        iszero(a_imp[i, i]) || continue
+        (any(!iszero, a_imp[:, i]) || !iszero(b_imp[i])) && return true
+    end
+    return false
+end
+
+"""
+    assert_prognostic_edmf_stage_solver_supported(ode_algo, atmos, prescribed_flow)
+
+Error if the time-stepping configuration cannot support the `PrognosticEDMFX`
+updraft stage solve. No-op for other turbulence-convection models.
+
+`PrognosticEDMFX` advances the updraft `u₃` and `ρa` (including the microphysics
+mass source) with an analytic implicit-stage solve set up in
+[`initialize_implicit_stage_problem!`](@ref) and replayed through `T_imp!`. The
+replayed tendency is stage-consistent only when `initialize_imp!` runs before
+each `T_imp` evaluation, which excludes `prescribed_flow` (fully explicit) and
+IMEX tableaux that weight `T_imp` at a stage with a zero implicit diagonal (see
+[`imex_weights_Timp_at_uninitialized_stage`](@ref)).
+"""
+function assert_prognostic_edmf_stage_solver_supported(
+    ode_algo,
+    atmos,
+    prescribed_flow,
+)
+    atmos.turbconv_model isa PrognosticEDMFX || return nothing
+    isnothing(prescribed_flow) || error(
+        "PrognosticEDMFX requires the implicit solver for its updraft stage \
+         solve, but `prescribed_flow` advances the state fully explicitly, so \
+         `initialize_imp!` never runs.",
+    )
+    if ode_algo isa CTS.IMEXAlgorithm &&
+       imex_weights_Timp_at_uninitialized_stage(ode_algo.tableau)
+        error(
+            "PrognosticEDMFX is incompatible with the selected IMEX algorithm: \
+             it weights the implicit tendency at a stage with a zero implicit \
+             diagonal, where the cached updraft stage solve is not refreshed. \
+             Use an ARS-type scheme such as ARS343 or ARS222.",
+        )
+    end
+    return nothing
+end
+
 function args_integrator(Y, p, tspan, ode_algo, callback,
     jacobian, debug_jacobian, prescribed_flow, dt_integrator,
     update_cache_every, update_constrain_state_every;
     verbose = false,
 )
     (; atmos) = p
+    assert_prognostic_edmf_stage_solver_supported(ode_algo, atmos, prescribed_flow)
     @timed_log verbose "Built tendency function" begin
         if isnothing(prescribed_flow)
 

--- a/test/prognostic_equations/sgs_rhoa_implicit_solve_tests.jl
+++ b/test/prognostic_equations/sgs_rhoa_implicit_solve_tests.jl
@@ -12,6 +12,7 @@ using Test
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaAtmos as CA
+import ClimaTimeSteppers as CTS
 
 include("../test_helpers.jl")
 
@@ -145,4 +146,50 @@ end
         @test parent(Y.c.sgsʲs.:($j).ρa) ≈
               parent(ρa_old.:($j).ρa) ./ (1 - dtγ * rate)
     end
+end
+
+# The cached updraft stage solve is replayed through `T_imp!`, so it is only
+# stage-consistent when `initialize_imp!` runs before each `T_imp` evaluation.
+# See #4683.
+@testset "Implicit-stage solver compatibility guard" begin
+    newton = CTS.NewtonsMethod()
+    ars343 = CTS.IMEXAlgorithm(CTS.ARS343(), newton)
+    ars222 = CTS.IMEXAlgorithm(CTS.ARS222(), newton)
+    ssp333 = CTS.IMEXAlgorithm(CTS.SSP333(), newton)
+
+    # ARS schemes never weight `T_imp` at their explicit first stage; SSP333 does.
+    @test !CA.imex_weights_Timp_at_uninitialized_stage(ars343.tableau)
+    @test !CA.imex_weights_Timp_at_uninitialized_stage(ars222.tableau)
+    @test CA.imex_weights_Timp_at_uninitialized_stage(ssp333.tableau)
+
+    config = create_sgs_ρa_config("sgs_rhoa_guard"; implicit_microphysics = true)
+    (; Y, p) = generate_test_simulation(config)
+    FT = eltype(Y)
+    edmf_atmos = p.atmos # PrognosticEDMFX
+    non_edmf_atmos = (; turbconv_model = nothing)
+
+    # Supported: an ARS scheme with the implicit solver.
+    @test CA.assert_prognostic_edmf_stage_solver_supported(
+        ars343,
+        edmf_atmos,
+        nothing,
+    ) === nothing
+    # Unsupported: a `T_imp`-weighted explicit stage.
+    @test_throws ErrorException CA.assert_prognostic_edmf_stage_solver_supported(
+        ssp333,
+        edmf_atmos,
+        nothing,
+    )
+    # Unsupported: `prescribed_flow` advances the state fully explicitly.
+    @test_throws ErrorException CA.assert_prognostic_edmf_stage_solver_supported(
+        ars343,
+        edmf_atmos,
+        CA.ShipwayHill2012VelocityProfile{FT}(),
+    )
+    # No-op for non-`PrognosticEDMFX` turbulence-convection models.
+    @test CA.assert_prognostic_edmf_stage_solver_supported(
+        ssp333,
+        non_edmf_atmos,
+        nothing,
+    ) === nothing
 end

--- a/test/prognostic_equations/sgs_rhoa_implicit_solve_tests.jl
+++ b/test/prognostic_equations/sgs_rhoa_implicit_solve_tests.jl
@@ -1,0 +1,148 @@
+#=
+Unit tests for the analytic implicit-stage solve of the updraft `ρa`
+(`solve_sgs_ρa_implicit_stage_analytic!`), focused on the microphysics
+mass source `ρa · dq_tot_dt`:
+  - the source enters the implicit stage value and the cached tendency
+    forwarded by `implicit_tendency!` (implicit microphysics timestepping),
+  - a strong sink at large `dtγ` keeps `ρa ≥ 0`,
+  - under explicit microphysics timestepping the source is applied by the
+    implicit-stage solve, not by `microphysics_tendency!`.
+=#
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+
+include("../test_helpers.jl")
+
+function create_sgs_ρa_config(job_id; implicit_microphysics)
+    config_dict = Dict(
+        "config" => "column",
+        "initial_condition" => "DecayingProfile",
+        "turbconv" => "prognostic_edmfx",
+        "microphysics_model" => "0M",
+        "FLOAT_TYPE" => "Float32",
+        "implicit_microphysics" => implicit_microphysics,
+        "output_default_diagnostics" => false,
+    )
+    return CA.AtmosConfig(config_dict; job_id)
+end
+
+# Zero all recurrence inputs except the microphysics mass source, so the
+# solve reduces to `ρa_new = ρa_old / (1 - dtγ · dq_tot_dt)` per cell.
+function isolate_microphysics_source!(Y, p)
+    n = CA.n_mass_flux_subdomains(p.atmos.turbconv_model)
+    for j in 1:n
+        parent(Y.f.sgsʲs.:($j).u₃) .= 0
+        parent(p.precomputed.ᶜentr_vel_scaleʲs.:($j)) .= 0
+        parent(p.precomputed.ᶜarea_bounding_entr_detrʲs.:($j)) .= 0
+        parent(p.precomputed.ᶜρ_diffʲs.:($j)) .= 0
+        parent(p.precomputed.sfc_mass_flux_sourceʲs.:($j)) .= 0
+    end
+    return nothing
+end
+
+function set_updraft_state!(Y, p; area, rate)
+    FT = eltype(Y)
+    n = CA.n_mass_flux_subdomains(p.atmos.turbconv_model)
+    for j in 1:n
+        parent(Y.c.sgsʲs.:($j).ρa) .= FT(area) .* parent(Y.c.ρ)
+        parent(p.precomputed.ᶜmp_tendencyʲs.:($j).dq_tot_dt) .= FT(rate)
+    end
+    return nothing
+end
+
+@testset "Microphysics ρa source in the implicit stage solve" begin
+    config = create_sgs_ρa_config(
+        "sgs_rhoa_implicit_micro";
+        implicit_microphysics = true,
+    )
+    (; Y, p, simulation) = generate_test_simulation(config)
+    FT = eltype(Y)
+    t = simulation.integrator.t
+    n = CA.n_mass_flux_subdomains(p.atmos.turbconv_model)
+    dtγ = FT(100)
+    rate = FT(-0.005) # sink: 1 - dtγ · rate = 1.5
+
+    isolate_microphysics_source!(Y, p)
+    set_updraft_state!(Y, p; area = 0.1, rate)
+    ρa_old = copy(Y.c.sgsʲs)
+
+    CA.initialize_implicit_stage_problem!(Y, p, dtγ)
+
+    (; ᶜρa_tendencyʲs) = p.precomputed
+    for j in 1:n
+        @test parent(Y.c.sgsʲs.:($j).ρa) ≈
+              parent(ρa_old.:($j).ρa) ./ (1 - dtγ * rate)
+        @test parent(ᶜρa_tendencyʲs.:($j)) ≈
+              (parent(Y.c.sgsʲs.:($j).ρa) .- parent(ρa_old.:($j).ρa)) ./ dtγ
+    end
+
+    # `implicit_tendency!` forwards the cached tendency, so the microphysics
+    # ρa source is not dropped by the overwrite in `sgs_ρa_implicit_tendency!`.
+    Yₜ = similar(Y)
+    CA.implicit_tendency!(Yₜ, Y, p, t)
+    for j in 1:n
+        @test parent(Yₜ.c.sgsʲs.:($j).ρa) ≈ parent(ᶜρa_tendencyʲs.:($j))
+    end
+end
+
+@testset "Sign safety for a strong microphysics sink at large dtγ" begin
+    config = create_sgs_ρa_config(
+        "sgs_rhoa_sign_safety";
+        implicit_microphysics = true,
+    )
+    (; Y, p) = generate_test_simulation(config)
+    FT = eltype(Y)
+    n = CA.n_mass_flux_subdomains(p.atmos.turbconv_model)
+
+    set_updraft_state!(Y, p; area = 0.1, rate = -1e3)
+    CA.solve_sgs_ρa_implicit_stage_analytic!(Y, p, FT(1e4))
+
+    for j in 1:n
+        @test all(isfinite, parent(Y.c.sgsʲs.:($j).ρa))
+        @test minimum(parent(Y.c.sgsʲs.:($j).ρa)) >= 0
+    end
+end
+
+@testset "Explicit microphysics timestepping: ρa source location" begin
+    config = create_sgs_ρa_config(
+        "sgs_rhoa_explicit_micro";
+        implicit_microphysics = false,
+    )
+    (; Y, p, simulation) = generate_test_simulation(config)
+    FT = eltype(Y)
+    t = simulation.integrator.t
+    n = CA.n_mass_flux_subdomains(p.atmos.turbconv_model)
+    dtγ = FT(100)
+    rate = FT(-0.005)
+
+    set_updraft_state!(Y, p; area = 0.1, rate)
+
+    # `microphysics_tendency!` does not apply the updraft ρa source; the
+    # grid-mean sources are unaffected.
+    Yₜ = similar(Y)
+    Yₜ .= zero(eltype(Yₜ))
+    CA.microphysics_tendency!(
+        Yₜ,
+        Y,
+        p,
+        t,
+        p.atmos.microphysics_model,
+        p.atmos.turbconv_model,
+    )
+    for j in 1:n
+        @test all(iszero, parent(Yₜ.c.sgsʲs.:($j).ρa))
+    end
+    @test !all(iszero, parent(Yₜ.c.ρq_tot))
+
+    # The implicit-stage solve applies the source under explicit microphysics
+    # timestepping as well.
+    isolate_microphysics_source!(Y, p)
+    ρa_old = copy(Y.c.sgsʲs)
+    CA.solve_sgs_ρa_implicit_stage_analytic!(Y, p, dtγ)
+    for j in 1:n
+        @test parent(Y.c.sgsʲs.:($j).ρa) ≈
+              parent(ρa_old.:($j).ρa) ./ (1 - dtγ * rate)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,7 @@ if TEST_GROUP in ("dynamics", "all")
     @safetestset "Tendency computations" begin @time include("prognostic_equations/tendency_tests.jl") end
     @safetestset "Tracer/mass transport consistency" begin @time include("prognostic_equations/tracer_mass_consistency_tests.jl") end
     @safetestset "Post-Newton implicit-advection correction" begin @time include("prognostic_equations/correct_implicit_advection_tests.jl") end
+    @safetestset "EDMF updraft rho_a implicit-stage solve" begin @time include("prognostic_equations/sgs_rhoa_implicit_solve_tests.jl") end
     @safetestset "Vertical water borrowing limiter" begin @time include("prognostic_equations/vertical_water_borrowing_tests.jl") end
     @safetestset "Enforce physical constraints" begin @time include("prognostic_equations/enforce_physical_constraints_tests.jl") end
 


### PR DESCRIPTION
With implicit microphysics timestepping, `sgs_ρa_implicit_tendency!` overwrites the updraft `ρa` tendency with the cached analytic-stage tendency, discarding the mass source `ρa · dq_tot_dt` that `microphysics_tendency!` had accumulated earlier in `implicit_tendency!`. 0M microphysics then removed water and energy from the grid mean without removing the corresponding updraft mass.

The source is linear in `ρa`, so this PR folds it into the linear coefficient of the analytic implicit-stage recurrence, alongside entrainment minus detrainment. A sink increases the recurrence denominator, so the solve preserves `ρa ≥ 0` for any `dtγ`. `microphysics_tendency!` no longer applies the updraft `ρa` source; the implicit-stage solve applies it under both explicit and implicit microphysics timestepping, which moves the explicit-microphysics application from the explicit tendency into the implicit stage.

Also corrects the `edmfx_sgs_vertical_advection_tendency!` docstring, which still claimed the function advects `ρaʲ`; that transport is handled by the analytic implicit-stage solve.

Unit tests cover the implicit stage value and the cached tendency forwarded by `implicit_tendency!`, nonnegativity for a strong sink at large `dtγ`, and the source location under explicit microphysics timestepping.
