### PR TITLE
Update larcform1 config: Pithan diagnostics set, dt_rad 30mins, tuning

### DIFF
--- a/config/model_configs/larcform1_1M_prognostic_edmfx.yml
+++ b/config/model_configs/larcform1_1M_prognostic_edmfx.yml
@@ -1,12 +1,16 @@
 # Larcform1 — Arctic winter boundary layer SCM (Pithan et al. 2016)
 # 1-moment microphysics, prognostic EDMFx
+
+job_id: larcform1_1M_prognostic_edmfx_base  # Decides file names and output dir if default location is used
+reference_job_id: larcform1                 # Decides ci plotting
+
 #==========================================================================================#
 # Atmosphere #
 initial_condition: Larcform1
 rayleigh_sponge: true
 
 # Surface #
-prognostic_surface: SlabOceanSST     # placeholder until EisenmanSeaIce is implemented
+prognostic_surface: SlabOceanSST            # overwritten to 250K. Using this for now instead of couping to sea ice model
 surface_setup: DefaultMoninObukhov
 disable_surface_flux_tendency: false
 
@@ -15,16 +19,16 @@ disable_surface_flux_tendency: false
 
 # Temporal
 FLOAT_TYPE: Float32
-t_end: 5days
+t_end: 2days
 dt: 30secs
-dt_rad: 60secs
+dt_rad: 30mins  # 5mins→30mins validated 2026-07-04 (lf1e-scm-speedtest-1 s2/s5: rlds −0.4 W/m², onset +1 h)
 
 # Spatial #
 config: "column"
 z_max: 9000.0
 z_elem: 90
-z_stretch: true # clw and z-banding both appear very sensitive to this
-dz_bottom: 10.0
+z_stretch: true
+dz_bottom: 20.0
 
 # Solver #
 approximate_linear_solve_iters: 2
@@ -55,7 +59,7 @@ prognostic_tke: true
 hyperdiff: ~
 
 # Clouds #
-cloud_model: quadrature
+cloud_model: quadrature             # [`grid_scale`, `quadrature` (default), `MLCloud`]"
 microphysics_model: 1M
 
 # Logging and Diagnostics
@@ -66,73 +70,9 @@ netcdf_output_at_levels: true
 output_default_diagnostics: false
 
 diagnostics:
-#== Atmospheric State ==#
-  - short_name: [ta, thetaa, pfull, rhoa, hus, hur, ts, tas]
+  - short_name: [ta, pfull, rhoa, hus, hur, ua, va, cl, clw, cli, lwp, clivi]
     period: 1hours
     reduction_time: average
-#== Winds & Dynamics ==#
-  - short_name: [ua, va, wa]
+  - short_name: [ts, rlds, rlus, rlut, pr, prsn, hfss, hfls]
     period: 1hours
     reduction_time: average
-#== Clouds & Condensates ==#
-  - short_name: [cl, clw, cli, lwp, clivi]
-    period: 1hours
-    reduction_time: average
-#== Radiation Fluxes ==#
-  - short_name: [rlu, rld, rlut, rlus, rlds, rsdt, rlutcs, rldscs]
-    period: 1hours
-    reduction_time: average
-#== Precipitation & Evaporation ==#
-  - short_name: [pr, prsn, evspsbl, husra, hussn]
-    period: 1hours
-    reduction_time: average
-#== Surface Heat Fluxes ==#
-  - short_name: [hfss, hfls]
-    period: 1hours
-    reduction_time: average
-#== Convective Updrafts ==#
-  - short_name: [arup, waup, taup, thetaaup, haup, husup, hurup, clwup, cliup, husraup, hussnup]
-    period: 10mins
-    reduction_time: average
-#== Convective Environment ==#
-  - short_name: [waen, taen, thetaaen, haen, husen, huren, clwen, clien, husraen, hussnen, tke]
-    period: 10mins
-    reduction_time: average
-#== EDMF & Turbulence Diagnostics ==#
-  - short_name: [entr, detr, lmix, bgrad, strain, edt, evu]
-    period: 10mins
-    reduction_time: average
-#== Microphysics Tendencies ==#
-  - short_name: [
-      mp1m_S_phase_change_vap_lcl, mp1m_S_phase_change_vap_icl,
-      mp1m_S_acnv_lcl_rai, mp1m_S_acnv_icl_sno,
-      mp1m_S_accr_lcl_rai, mp1m_S_accr_lcl_sno_cold, mp1m_S_accr_lcl_sno_warm,
-      mp1m_S_accr_melt_lcl_sno,
-      mp1m_S_accr_icl_rai, mp1m_S_accr_freeze_icl_rai, mp1m_S_accr_icl_sno,
-      mp1m_S_accr_rai_sno_cold, mp1m_S_accr_rai_sno_warm, mp1m_S_accr_melt_rai_sno,
-      mp1m_S_phase_change_vap_rai, mp1m_S_phase_change_vap_sno,
-      mp1m_S_melt_icl_lcl, mp1m_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1mup_S_phase_change_vap_lcl, mp1mup_S_phase_change_vap_icl,
-      mp1mup_S_acnv_lcl_rai, mp1mup_S_acnv_icl_sno,
-      mp1mup_S_accr_lcl_rai, mp1mup_S_accr_lcl_sno_cold, mp1mup_S_accr_lcl_sno_warm,
-      mp1mup_S_accr_melt_lcl_sno,
-      mp1mup_S_accr_icl_rai, mp1mup_S_accr_freeze_icl_rai, mp1mup_S_accr_icl_sno,
-      mp1mup_S_accr_rai_sno_cold, mp1mup_S_accr_rai_sno_warm, mp1mup_S_accr_melt_rai_sno,
-      mp1mup_S_phase_change_vap_rai, mp1mup_S_phase_change_vap_sno,
-      mp1mup_S_melt_icl_lcl, mp1mup_S_melt_sno_rai,
-    ]
-    period: 10mins
-  - short_name: [
-      mp1men_S_phase_change_vap_lcl, mp1men_S_phase_change_vap_icl,
-      mp1men_S_acnv_lcl_rai, mp1men_S_acnv_icl_sno,
-      mp1men_S_accr_lcl_rai, mp1men_S_accr_lcl_sno_cold, mp1men_S_accr_lcl_sno_warm,
-      mp1men_S_accr_melt_lcl_sno,
-      mp1men_S_accr_icl_rai, mp1men_S_accr_freeze_icl_rai, mp1men_S_accr_icl_sno,
-      mp1men_S_accr_rai_sno_cold, mp1men_S_accr_rai_sno_warm, mp1men_S_accr_melt_rai_sno,
-      mp1men_S_phase_change_vap_rai, mp1men_S_phase_change_vap_sno,
-      mp1men_S_melt_icl_lcl, mp1men_S_melt_sno_rai,
-    ]
-    period: 10mins

--- a/toml/larcform1_1M_prognostic_edmfx.toml
+++ b/toml/larcform1_1M_prognostic_edmfx.toml
@@ -50,4 +50,4 @@ value = 0
 value = 100
 
 [sublimation_deposition_timescale]
-value = 400
+value = 100


### PR DESCRIPTION
## Purpose

Config-only updates to the larcform1 Arctic winter SCM case (Pithan et al. 2016), extracted from the `jy/coldslab` working branch.

## Changes

- **Diagnostics trimmed** to the variable set the Pithan intercomparison postprocessing consumes (hourly averages). The previous 10-minute EDMF/microphysics-tendency groups (54 accumulated-average variables, computed every timestep) dominated runtime (~90% in local speed tests, 2026-07-04). The full debugging set remains in git history.
- **`dt_rad` 60secs → 30mins** — validated against 5-min radiation stepping: rlds within −0.4 W/m², cloud onset shifted +1 h.
- **`t_end` 5days → 2days**, `dz_bottom` 10 → 20 m
- added `job_id`/`reference_job_id`.
- **`sublimation_deposition_timescale` 400 → 100 s** in the case TOML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)