### PR TITLE
refactor(diffusion): consolidate vertical diffusive-flux operators and helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+- [#4699](https://github.com/CliMA/ClimaAtmos.jl/pull/4699) ![][badge-🔥behavioralΔ] Select the tracers that receive the `α_vert_diff_tracer` eddy-diffusivity scaling in the boundary-layer vertical diffusion from the shared `gs_sedimenting_tracer_candidates` list instead of a hardcoded tuple of species. The tracer diffusivity scaling is now consistent across the boundary-layer diffusion, the EDMFX SGS flux, the EDMFX updraft vertical diffusion, and the implicit Jacobian.
 
 0.42.0
 -------

--- a/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
+++ b/src/parameterized_tendencies/les_sgs_models/anisotropic_minimum_dissipation.jl
@@ -208,21 +208,6 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
 
     c_amd = les.c_amd
 
-    # Define operators
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
-    ᶜdivᵥ_uₕ = Operators.DivergenceF2C(
-        top = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0))),
-        bottom = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0))),
-    )
-    ᶠdivᵥ = Operators.DivergenceC2F(
-        bottom = Operators.SetDivergence(FT(0)),
-        top = Operators.SetDivergence(FT(0)),
-    )
-    ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(;
-        top = Operators.SetValue(C3(FT(0))),
-        bottom = Operators.SetValue(C3(FT(0))),
-    )
-
     ### AMD ###
 
     (; ᶜu, ᶠu³) = p.precomputed
@@ -296,10 +281,8 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
     ## Horizontal momentum tendency
     ᶠρ = @. lazy(ᶠinterp(Y.c.ρ))
     @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(ᶠρ * ᶠτ_amd) / Y.c.ρ)
-    ## Apply boundary condition for momentum flux
-    @. Yₜ.c.uₕ -= ᶜdivᵥ_uₕ(-(FT(0) * ᶠgradᵥ(Y.c.uₕ))) / Y.c.ρ
     ## Vertical momentum tendency
-    @. Yₜ.f.u₃ -= C3(ᶠdivᵥ(Y.c.ρ * ᶜτ_amd) / ᶠρ)
+    @. Yₜ.f.u₃ -= C3(ᶠdiffdivᵥ_u₃(Y.c.ρ * ᶜτ_amd) / ᶠρ)
 
     ## Total energy tendency
     (; ᶜh_tot) = p.precomputed
@@ -316,14 +299,11 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
         ) /
         max(eps(FT), norm_sqr(∇h_tot)),
     )
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(-(ᶠρ * ᶠD_amd * ᶠgradᵥ(ᶜh_tot)))
+    ᶠρD = @. lazy(ᶠρ * ᶠD_amd)
+    ᶜ∇ᵥρD∇h_totₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠρD, ᶜh_tot)
+    @. Yₜ.c.ρe_tot -= ᶜ∇ᵥρD∇h_totₜ
 
     ## Tracer diffusion and associated mass changes
-    ᶜdivᵥ_ρχ = Operators.DivergenceF2C(;
-        top = Operators.SetValue(C3(FT(0))),
-        bottom = Operators.SetValue(C3(FT(0))),
-    )
-
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
         ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
         ∇ᶜχ = @. lazy(Geometry.project(axis_uvw, ᶠgradᵥ_scalar(ᶜχ)))
@@ -338,8 +318,8 @@ function vertical_amd_tendency!(Yₜ, Y, p, t, les::AnisotropicMinimumDissipatio
             ) /
             max(eps(FT), norm_sqr(∇ᶜχ)),
         )
-        ᶜ∇ᵥρD∇χₜ =
-            @. lazy(ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_amd * ᶠgradᵥ(specific(ᶜρχ, Y.c.ρ)))))
+        ᶠρD_tracer = @. lazy(ᶠρ * ᶠD_amd)
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠρD_tracer, ᶜχ)
         @. ᶜρχₜ -= ᶜ∇ᵥρD∇χₜ
         # Rain and snow does not affect the mass
         if ρχ_name == @name(ρq_tot)

--- a/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
+++ b/src/parameterized_tendencies/les_sgs_models/smagorinsky_lilly.jl
@@ -3,7 +3,6 @@
 #####
 
 import ClimaCore.Fields as Fields
-import ClimaCore.Operators as Operators
 import ClimaCore: Geometry
 
 """
@@ -152,21 +151,11 @@ end
 
 function vertical_smagorinsky_lilly_tendency!(Yₜ, Y, p, t, model::SmagorinskyLilly)
     is_smagorinsky_vertical(model) || return nothing
-    FT = eltype(Y)
     (; ᶜS, ᶠS, ᶜνₜ_v) = p.precomputed
     (; ᶜtemp_UVWxUVW, ᶠtemp_UVWxUVW, ᶠtemp_scalar, ᶠtemp_scalar_2) = p.scratch
     Pr_t = CAP.Prandtl_number_0(CAP.turbconv_params(p.params))
     ᶜρ = Y.c.ρ
     ᶠρ = @. ᶠtemp_scalar = ᶠinterp(ᶜρ)
-
-    # Define operators
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
-    divᵥ_uₕ_bc = Operators.SetValue(C3(FT(0)) ⊗ C12(FT(0), FT(0)))
-    ᶜdivᵥ_uₕ = Operators.DivergenceF2C(; bottom = divᵥ_uₕ_bc, top = divᵥ_uₕ_bc)
-    divᵥ_bc = Operators.SetDivergence(FT(0))
-    ᶠdivᵥ = Operators.DivergenceC2F(; bottom = divᵥ_bc, top = divᵥ_bc)
-    divᵥ_ρχ_bc = Operators.SetValue(C3(FT(0)))
-    ᶜdivᵥ_ρχ = Operators.DivergenceF2C(; bottom = divᵥ_ρχ_bc, top = divᵥ_ρχ_bc)
 
     # Subgrid-scale momentum flux tensor, `τ = -2 νₜ ∘ S`
     ᶠνₜ_v = @. lazy(ᶠinterp(ᶜνₜ_v))
@@ -175,23 +164,23 @@ function vertical_smagorinsky_lilly_tendency!(Yₜ, Y, p, t, model::SmagorinskyL
 
     # Turbulent diffusivity
     ᶠD_smag = @. lazy(ᶠνₜ_v / Pr_t)
+    ᶠρD = @. lazy(ᶠρ * ᶠD_smag)
 
     # Apply to tendencies
     ## Horizontal momentum tendency
     @. Yₜ.c.uₕ -= C12(ᶜdivᵥ(ᶠρ * ᶠτ_smag) / ᶜρ)
-    ## Apply boundary condition for momentum flux
-    @. Yₜ.c.uₕ -= ᶜdivᵥ_uₕ(-(FT(0) * ᶠgradᵥ(Y.c.uₕ))) / ᶜρ
     ## Vertical momentum tendency
-    @. Yₜ.f.u₃ -= C3(ᶠdivᵥ(ᶜρ * ᶜτ_smag) / ᶠρ)
+    @. Yₜ.f.u₃ -= C3(ᶠdiffdivᵥ_u₃(ᶜρ * ᶜτ_smag) / ᶠρ)
 
     ## Total energy tendency
     (; ᶜh_tot) = p.precomputed
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_smag * ᶠgradᵥ(ᶜh_tot)))
+    ᶜ∇ᵥρD∇h_totₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠρD, ᶜh_tot)
+    @. Yₜ.c.ρe_tot -= ᶜ∇ᵥρD∇h_totₜ
 
     ## Tracer diffusion and associated mass changes
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
         ᶜχ = @. lazy(specific(ᶜρχ, ᶜρ))
-        ᶜ∇ᵥρD∇χₜ = @. lazy(ᶜdivᵥ_ρχ(-(ᶠρ * ᶠD_smag * ᶠgradᵥ(ᶜχ))))
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠρD, ᶜχ)
         @. ᶜρχₜ -= ᶜ∇ᵥρD∇χₜ
         # Rain and snow does not affect the mass
         if ρχ_name == @name(ρq_tot)

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -847,6 +847,32 @@ function ᶜmixing_length(Y, p, property::Val{P} = Val{:master}()) where {P}
 end
 
 """
+    ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ)
+
+Lazy vertical divergence of the diffusive scalar flux `F = -ᶠcoef ∇χ`, with
+zero-flux top and bottom boundaries.
+
+`ᶠcoef` must be a face field or a `lazy` broadcast, not a bare `Field * Field`
+product. Fold `ρ`, `K`, and any scaling factor into `ᶠcoef` in left-to-right order.
+"""
+ᶜdiffusive_flux_divergenceᵥ(ᶠcoef, ᶜχ) = @. lazy(ᶜdiffdivᵥ(-(ᶠcoef * ᶠgradᵥ(ᶜχ))))
+
+"""
+    ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice)
+
+Lazy face gradient of total enthalpy in dry-static-energy + water-enthalpy form,
+`∇s_d + Σ_μ (h_μ + Φ) ∇q_μ` for `μ ∈ {vap, liq, ice}`.
+
+Summands are combined in a fixed order: dry static energy, then vapor, liquid, ice.
+"""
+ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice) = @. lazy(
+    ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
+    ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_vap) +
+    ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_liq) +
+    ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) * ᶠgradᵥ(ᶜq_ice),
+)
+
+"""
     gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
 
 Calculates the gradient Richardson number (Ri).

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -3,7 +3,6 @@
 #####
 
 import ClimaCore.Geometry: ⊗
-import ClimaCore.Operators as Operators
 
 """
     vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, t)
@@ -94,7 +93,6 @@ function vertical_diffusion_boundary_layer_tendency!(
     α_vert_diff_microphysics = CAP.α_vert_diff_tracer(p.params)
     thermo_params = CAP.thermodynamics_params(p.params)
     (; ᶜu, ᶜp, ᶜT, ᶜq_liq, ᶜq_ice) = p.precomputed
-    ᶠgradᵥ = Operators.GradientC2F() # apply BCs to ᶜdivᵥ, which wraps ᶠgradᵥ
     ᶜK_h = p.scratch.ᶜtemp_scalar
     if vertical_diffusion isa DecayWithHeightDiffusion
         ᶜK_h .= ᶜcompute_eddy_diffusivity_coefficient(Y.c.ρ, vertical_diffusion)
@@ -125,27 +123,12 @@ function vertical_diffusion_boundary_layer_tendency!(
     # vertical diffusion factor α_vert_diff_tracer) to maintain exact energetic
     # consistency with the unscaled ρq_tot diffusion equation, preserve total
     # water invariance, and align with the implicit solver's Jacobian.
-    ᶜdivᵥ_ρe_tot = Operators.DivergenceF2C(
-        top = Operators.SetValue(C3(0)),
-        bottom = Operators.SetValue(C3(0)),
-    )
     (; ᶜΦ) = p.core
     (; ᶜq_tot_nonneg) = p.precomputed
     ᶜq_vap = @. lazy(TD.vapor_specific_humidity(ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice))
-    @. Yₜ.c.ρe_tot -= ᶜdivᵥ_ρe_tot(
-        -(
-            ᶠinterp(Y.c.ρ) / ᶠinterp(1 / max(ᶜK_h, ϵK)) *
-            (
-                ᶠgradᵥ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)) +
-                ᶠinterp(TD.enthalpy_vapor(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_vap) +
-                ᶠinterp(TD.enthalpy_liquid(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_liq) +
-                ᶠinterp(TD.enthalpy_ice(thermo_params, ᶜT) + ᶜΦ) *
-                ᶠgradᵥ(ᶜq_ice)
-            )
-        ),
-    )
+    ᶠgrad_h = ᶠtotal_enthalpy_gradientᵥ(thermo_params, ᶜT, ᶜΦ, ᶜq_vap, ᶜq_liq, ᶜq_ice)
+    @. Yₜ.c.ρe_tot -=
+        ᶜdiffdivᵥ(-(ᶠinterp(Y.c.ρ) / ᶠinterp(1 / max(ᶜK_h, ϵK)) * ᶠgrad_h))
 
     ᶜρχₜ_diffusion = p.scratch.ᶜtemp_scalar_2
     ᶜK_h_scaled = p.scratch.ᶜtemp_scalar_3
@@ -159,17 +142,10 @@ function vertical_diffusion_boundary_layer_tendency!(
         else
             @. ᶜK_h_scaled = ᶜK_h
         end
-        ᶜdivᵥ_ρχ = Operators.DivergenceF2C(
-            top = Operators.SetValue(C3(0)),
-            bottom = Operators.SetValue(C3(0)),
-        )
-        @. ᶜρχₜ_diffusion = ᶜdivᵥ_ρχ(
-            -(
-                ᶠinterp(Y.c.ρ) /
-                ᶠinterp(1 / max(ᶜK_h_scaled, ϵK)) *
-                ᶠgradᵥ(specific(ᶜρχ, Y.c.ρ))
-            ),
-        )
+        ᶠρK = @. lazy(ᶠinterp(Y.c.ρ) / ᶠinterp(1 / max(ᶜK_h_scaled, ϵK)))
+        ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+        ᶜ∇ᵥρD∇χₜ = ᶜdiffusive_flux_divergenceᵥ(ᶠρK, ᶜχ)
+        @. ᶜρχₜ_diffusion = ᶜ∇ᵥρD∇χₜ
         @. ᶜρχₜ -= ᶜρχₜ_diffusion
         # Only add contribution from total water diffusion to mass tendency
         # (exclude contributions from diffusion of condensate, precipitation)

--- a/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
+++ b/src/prognostic_equations/vertical_diffusion_boundary_layer.jl
@@ -134,10 +134,7 @@ function vertical_diffusion_boundary_layer_tendency!(
     ᶜK_h_scaled = p.scratch.ᶜtemp_scalar_3
 
     foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
-        if ρχ_name in (
-            @name(ρq_lcl), @name(ρq_icl), @name(ρq_rai),
-            @name(ρq_sno), @name(ρn_lcl), @name(ρn_rai)
-        )
+        if ρχ_name in gs_sedimenting_tracer_candidates
             @. ᶜK_h_scaled = α_vert_diff_microphysics * ᶜK_h
         else
             @. ᶜK_h_scaled = ᶜK_h

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -40,6 +40,18 @@ const ᶜadvdivᵥ = Operators.DivergenceF2C(
 # Precipitation has no flux at the top, but it has free outflow at the bottom.
 const ᶜprecipdivᵥ = Operators.DivergenceF2C(top = Operators.SetValue(CT3(0)))
 
+# Diffusive scalar fluxes vanish through the top and bottom cell faces.
+const ᶜdiffdivᵥ = Operators.DivergenceF2C(
+    bottom = Operators.SetValue(C3(0)),
+    top = Operators.SetValue(C3(0)),
+)
+
+# Vertical-momentum (u₃) diffusive flux vanishes through the top and bottom faces.
+const ᶠdiffdivᵥ_u₃ = Operators.DivergenceC2F(
+    bottom = Operators.SetDivergence(0),
+    top = Operators.SetDivergence(0),
+)
+
 const ᶠleft_bias = Operators.LeftBiasedC2F()
 const ᶠright_bias = Operators.RightBiasedC2F() # for free outflow in ᶜprecipdivᵥ
 const ᶜleft_bias = Operators.LeftBiasedF2C()

--- a/test/prognostic_equations/vertical_diffusion_tests.jl
+++ b/test/prognostic_equations/vertical_diffusion_tests.jl
@@ -1,0 +1,77 @@
+# Sedimenting tracers in `gs_sedimenting_tracer_candidates` (including P3
+# `ρn_ice`/`ρq_rim`/`ρb_rim`) receive the `α_vert_diff_tracer`-scaled diffusivity;
+# passive tracers keep the unscaled diffusivity.
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaAtmos.Parameters as CAP
+import ClimaParams as CP
+import ClimaCore: Fields, Geometry
+
+include("../test_helpers.jl")
+
+@testset "Vertical diffusion tracer diffusivity scaling" begin
+    FT = Float64
+    α = FT(0.4)
+    override_file = Dict(
+        "tracer_vertical_diffusion_factor" => Dict("value" => α, "type" => "float"),
+    )
+    params = CA.ClimaAtmosParameters(CP.create_toml_dict(FT; override_file))
+    @test CAP.α_vert_diff_tracer(params) == α
+
+    (; cent_space) = get_cartesian_spaces(; FT)
+    coords = Fields.coordinate_field(cent_space)
+    ᶜz = coords.z
+
+    tracer_names = (:ρq_tot, :ρq_rai, :ρn_ice, :ρq_rim, :ρb_rim, :ρq_gas_A)
+    NT = NamedTuple{
+        (:ρ, :ρe_tot, tracer_names...),
+        NTuple{2 + length(tracer_names), FT},
+    }
+    Yc = similar(coords, NT)
+    @. Yc.ρ = FT(1.2)
+    @. Yc.ρe_tot = Yc.ρ * FT(2.5e5)
+    @. Yc.ρq_tot = Yc.ρ * FT(1e-2)
+    ᶜρχ = @. Yc.ρ * cos(ᶜz)
+    @. Yc.ρq_rai = ᶜρχ
+    @. Yc.ρn_ice = ᶜρχ
+    @. Yc.ρq_rim = ᶜρχ
+    @. Yc.ρb_rim = ᶜρχ
+    @. Yc.ρq_gas_A = ᶜρχ
+    Y = Fields.FieldVector(; c = Yc)
+
+    ᶜu = @. Geometry.UVWVector(zero(ᶜz), zero(ᶜz), zero(ᶜz))
+    ᶜp = @. FT(1e5) - FT(1e3) * ᶜz
+    ᶜT = @. FT(280) - FT(20) * (ᶜz / FT(π))
+    ᶜq_liq = @. FT(1e-4) + zero(ᶜz)
+    ᶜq_ice = @. FT(1e-5) + zero(ᶜz)
+    ᶜq_tot_nonneg = @. FT(1e-2) + zero(ᶜz)
+    p = (;
+        atmos = (;
+            vertical_diffusion = CA.DecayWithHeightDiffusion{FT}(;
+                disable_momentum_vertical_diffusion = true,
+                H = FT(1),
+                D₀ = FT(1),
+            ),
+        ),
+        params,
+        precomputed = (; ᶜu, ᶜp, ᶜT, ᶜq_liq, ᶜq_ice, ᶜq_tot_nonneg),
+        core = (; ᶜΦ = (@. CAP.grav(params) * ᶜz)),
+        scratch = (;
+            ᶜtemp_scalar = similar(ᶜz),
+            ᶜtemp_scalar_2 = similar(ᶜz),
+            ᶜtemp_scalar_3 = similar(ᶜz),
+        ),
+    )
+
+    Yₜ = Fields.FieldVector(; c = zero(Yc))
+    CA.vertical_diffusion_boundary_layer_tendency!(Yₜ, Y, p, FT(0))
+
+    @test maximum(abs, parent(Yₜ.c.ρq_rai)) > 0
+    @test parent(Yₜ.c.ρn_ice) == parent(Yₜ.c.ρq_rai)
+    @test parent(Yₜ.c.ρq_rim) == parent(Yₜ.c.ρq_rai)
+    @test parent(Yₜ.c.ρb_rim) == parent(Yₜ.c.ρq_rai)
+    @test parent(Yₜ.c.ρn_ice) ≈ α .* parent(Yₜ.c.ρq_gas_A)
+    @test parent(Yₜ.c.ρq_gas_A) != parent(Yₜ.c.ρn_ice)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,7 @@ if TEST_GROUP in ("dynamics", "all")
     @safetestset "Tendency computations" begin @time include("prognostic_equations/tendency_tests.jl") end
     @safetestset "Tracer/mass transport consistency" begin @time include("prognostic_equations/tracer_mass_consistency_tests.jl") end
     @safetestset "Post-Newton implicit-advection correction" begin @time include("prognostic_equations/correct_implicit_advection_tests.jl") end
+    @safetestset "Vertical diffusion tracer scaling" begin @time include("prognostic_equations/vertical_diffusion_tests.jl") end
     @safetestset "Vertical water borrowing limiter" begin @time include("prognostic_equations/vertical_water_borrowing_tests.jl") end
     @safetestset "Enforce physical constraints" begin @time include("prognostic_equations/enforce_physical_constraints_tests.jl") end
     @safetestset "Eddy diffusion closures" begin @time include("prognostic_equations/eddy_diffusion_closures_tests.jl") end


### PR DESCRIPTION
Consolidate the per-file vertical diffusive-flux implementations into a shared set of zero-flux boundary-condition operators and lazy flux helpers, and route the three vertical diffusion closures through them.

Two zero-flux boundary-condition operators are added to the abbreviations: `ᶜdiffdivᵥ` for the scalar-flux divergence (matching the `ᶠgradᵥ` output) and `ᶠdiffdivᵥ_u₃` for the vertical-momentum divergence, each with a zero top and bottom boundary. Two lazy flux helpers are added to the eddy-diffusion closures: `ᶜdiffusive_flux_divergenceᵥ` for the divergence of a single diffusive scalar flux `-∇·(ρD ∇χ)`, and `ᶠtotal_enthalpy_gradientᵥ` for the dry-static-energy + water-enthalpy gradient.

Smagorinsky-Lilly, anisotropic minimum dissipation (AMD), and the boundary-layer vertical diffusion now build their scalar, energy, and vertical-momentum tendencies from these shared operators and helpers.

The momentum-flux boundary-correction term is removed from Smagorinsky-Lilly and AMD. It is the divergence of a flux with a zero coefficient and a zero boundary value, so it evaluates to zero identically; the surface momentum flux is applied by `surface_flux_tendency!`.

The one behavioral change is the tracer-scaling selection in the boundary-layer vertical diffusion. The tracers that receive the `α_vert_diff_tracer` eddy-diffusivity scaling are now selected from the shared `gs_sedimenting_tracer_candidates` list instead of a hardcoded tuple of species. The previous tuple omitted the P3 sedimenting tracers `ρn_ice`, `ρq_rim`, and `ρb_rim`, which were diffused with the unscaled `K_h`; they now receive the scaled diffusivity, so the tracer diffusivity scaling is consistent across the boundary-layer diffusion, the EDMFX SGS flux, the EDMFX updraft vertical diffusion, and the implicit Jacobian, which already use that list.
