### PR TITLE
Identify merged PR via gh for fast-forward/rebase merges

### DIFF
--- a/reproducibility_tests/publish_reference.jl
+++ b/reproducibility_tests/publish_reference.jl
@@ -14,11 +14,14 @@ isempty(merge_commit) &&
 
 # Fail loudly rather than silently skipping: on `main` the merged PR must be
 # identifiable, else no reference is ever published and the failure is invisible.
+# `discover_pr_number` already tries the `gh search prs` fallback, so `nothing`
+# here means even GitHub has no PR for this commit.
 pr_number = discover_pr_number()
 isnothing(pr_number) && error(
     "Repro: could not determine the merged PR for $merge_commit; no reference " *
-    "published. Expected BUILDKITE_PULL_REQUEST, a gh-readonly-queue branch, or " *
-    "a GitHub merge/squash commit message.",
+    "published. Tried BUILDKITE_PULL_REQUEST, a gh-readonly-queue branch, the " *
+    "commit message, and a `gh search prs` lookup (needs an authenticated `gh` " *
+    "on the agent).",
 )
 
 commit = get_commit_sha(; commit = merge_commit)

--- a/reproducibility_tests/reproducibility_utils.jl
+++ b/reproducibility_tests/reproducibility_utils.jl
@@ -626,10 +626,30 @@ function publish_staged_reference(
 end
 
 """
+    github_pr_for_commit(commit)
+
+Ask GitHub, via the `gh` CLI, which pull request `commit` belongs to; return its
+number or `nothing`. Resolves commits that carry no PR marker in their message --
+e.g. a fast-forwarded or rebased PR merge, where `(#<n>)` is absent. Returns
+`nothing` if `gh` is missing, unauthenticated, offline, or no PR matches, so
+callers fall back cleanly.
+"""
+function github_pr_for_commit(commit)
+    isempty(commit) && return nothing
+    out = try
+        readchomp(`gh search prs $commit --json number --jq ".[0].number"`)
+    catch
+        return nothing
+    end
+    return tryparse(Int, out)
+end
+
+"""
     discover_pr_number(;
         pull_request = get(ENV, "BUILDKITE_PULL_REQUEST", "false"),
         branch = get(ENV, "BUILDKITE_BRANCH", ""),
         message = get(ENV, "BUILDKITE_MESSAGE", ""),
+        commit = get(ENV, "BUILDKITE_COMMIT", ""),
     )
 
 Return the pull request number associated with the current build, or `nothing`
@@ -649,11 +669,16 @@ Tries, in order:
     commit but not an ordinary PR-branch commit, so it cannot mis-identify the PR
     on a PR build (which would clobber another PR's staging) or pick up an issue
     reference in the title.
+ 4. `commit` — last resort: ask GitHub which PR the commit belongs to, via
+    `github_pr_for_commit` (`gh search prs`). Catches merges that leave no PR
+    marker in the message (a fast-forwarded or rebased PR merge). Needs `gh`;
+    returns `nothing` if it is unavailable.
 """
 function discover_pr_number(;
     pull_request = get(ENV, "BUILDKITE_PULL_REQUEST", "false"),
     branch = get(ENV, "BUILDKITE_BRANCH", ""),
     message = get(ENV, "BUILDKITE_MESSAGE", ""),
+    commit = get(ENV, "BUILDKITE_COMMIT", ""),
 )
     if !(pull_request in ("false", ""))
         n = tryparse(Int, pull_request)
@@ -667,7 +692,7 @@ function discover_pr_number(;
         m = match(re, message)
         !isnothing(m) && return parse(Int, m.captures[1])
     end
-    return nothing
+    return github_pr_for_commit(commit)
 end
 
 """

--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -1000,17 +1000,24 @@ end
 end
 
 @testset "Reproducibility infrastructure: discover_pr_number" begin
-    # `branch` is pinned on every call so the CI environment's BUILDKITE_BRANCH
-    # (a gh-readonly-queue branch in the merge queue) can't leak in and win the
-    # branch-parse step ahead of the case under test.
+    # `branch` and `commit` are pinned on every call so the CI environment's
+    # BUILDKITE_BRANCH (a gh-readonly-queue branch in the merge queue) and
+    # BUILDKITE_COMMIT can't leak in: the former would win the branch-parse step
+    # ahead of the case under test, and the latter would reach the `gh search
+    # prs` fallback and hit the network.
     # 1. BUILDKITE_PULL_REQUEST (a real PR build)
-    @test discover_pr_number(; pull_request = "123", branch = "", message = "") ==
-          123
+    @test discover_pr_number(;
+        pull_request = "123",
+        branch = "",
+        message = "",
+        commit = "",
+    ) == 123
     # 2. Parsed from a merge-queue branch (gh-readonly-queue/main/pr-<n>-<sha>)
     @test discover_pr_number(;
         pull_request = "false",
         branch = "gh-readonly-queue/main/pr-42-0a1b2c3",
         message = "",
+        commit = "",
     ) == 42
     # A non-merge-queue branch that merely contains "pr-<n>" is NOT matched
     @test isnothing(
@@ -1018,6 +1025,7 @@ end
             pull_request = "false",
             branch = "fix-pr-9-bug",
             message = "",
+            commit = "",
         ),
     )
     # A gh-readonly-queue branch without a pr-<n> yields nothing (not `false`)
@@ -1026,6 +1034,7 @@ end
             pull_request = "false",
             branch = "gh-readonly-queue/main/deadbeef",
             message = "",
+            commit = "",
         ),
     )
     # 3. Parsed from a squash or merge commit message
@@ -1033,17 +1042,20 @@ end
         pull_request = "false",
         branch = "",
         message = "Some squashed change (#456)",
+        commit = "",
     ) == 456
     @test discover_pr_number(;
         pull_request = "false",
         branch = "",
         message = "Merge pull request #789 from foo/bar",
+        commit = "",
     ) == 789
     # A leading issue reference does NOT win over the trailing squash PR number
     @test discover_pr_number(;
         pull_request = "false",
         branch = "",
         message = "Fix #100 regression (#4652)",
+        commit = "",
     ) == 4652
     # An ordinary PR-branch commit (no canonical merge/squash form) is NOT
     # matched, so staging can never be keyed to (and clobber) an unrelated PR
@@ -1052,16 +1064,20 @@ end
             pull_request = "false",
             branch = "",
             message = "address review from #123",
+            commit = "",
         ),
     )
-    # No usable signal
+    # No usable signal, and no commit, so the `gh` fallback is skipped
     @test isnothing(
         discover_pr_number(;
             pull_request = "false",
             branch = "",
             message = "no pr number here",
+            commit = "",
         ),
     )
+    # The `gh` fallback is a no-op without a commit (guards before shelling out)
+    @test isnothing(github_pr_for_commit(""))
 end
 
 @testset "Reproducibility infrastructure: commit_sha_from_dir" begin


### PR DESCRIPTION
`discover_pr_number` only checked Buildkite env vars and the commit message, so a fast-forwarded or rebased PR merge couldn't be identified. This PR adds `github_pr_for_commit`, a fallback to `discover_pr_number` that attempts to identify a merged PR via the commit hash. 

Note: This relies on having the `gh` CLI installed with a fine-grained personal access token that never expires and can only read PRs and metadata.