### PR TITLE
Bump to v0.42.1 

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -383,7 +383,7 @@ version = "0.5.22"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.42.0"
+version = "0.42.1"
 
     [deps.ClimaAtmos.extensions]
     ClimaAtmosMusica = "Musica"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,12 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+
+0.42.1
+-------
+- [#4693](https://github.com/CliMA/ClimaAtmos.jl/pull/4693) ![][badge-🔥behavioralΔ] Mix the sedimentation flux across subdomains under `PrognosticEDMFX`. The lateral transfer of each sedimenting updraft tracer across tilted updraft boundaries now includes both detrainment (where the updraft narrows with height) and entrainment of the environment sedimentation flux (where it widens), with the environment flux density `ρ⁰w⁰χ⁰` reconstructed from the grid-mean flux minus the updraft contribution. Applied to the condensate/precipitation masses and their number concentrations, with matching implicit-Jacobian updates.
 - [#4699](https://github.com/CliMA/ClimaAtmos.jl/pull/4699) ![][badge-🔥behavioralΔ] Select the tracers that receive the `α_vert_diff_tracer` eddy-diffusivity scaling in the boundary-layer vertical diffusion from the shared `gs_sedimenting_tracer_candidates` list instead of a hardcoded tuple of species. The tracer diffusivity scaling is now consistent across the boundary-layer diffusion, the EDMFX SGS flux, the EDMFX updraft vertical diffusion, and the implicit Jacobian.
+- [#4703](https://github.com/CliMA/ClimaAtmos.jl/pull/4703) ![][badge-🔥behavioralΔ] Unify SGS hyperdiffusion with the grid mean: each `PrognosticEDMFX` subdomain inherits the grid-mean specific tendency (uniform hyperdiffusion within the grid box). The total-enthalpy hyperdiffusive flux is split into dry-static-energy and water-species contributions so that dry-air enthalpy is no longer diffused along with water enthalpy.
 
 0.42.0
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.42.0"
+version = "0.42.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Patch release. Move the pending NEWS entries under a 0.42.1 header (#4693, #4699, #4703) and bump the version in Project.toml and the .buildkite manifest.
