### PR TITLE
fix(radiation): make the TRMM_LBA radiation GPU-compatible

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -494,6 +494,15 @@ steps:
         agents:
           slurm_gpus: 1
 
+      - label: ":crown: TRMM_LBA radiation is GPU-compatible"
+        retry: *retry_policy
+        command: >
+          julia --color=yes --project=.buildkite test/gpu_radiation.jl
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus: 1
+
   - group: "Conservation Tests"
     steps:
       - label: ":computer: Conservation tests: Dry baroclinic wave, no sources"

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -492,7 +492,7 @@ function get_radiation_mode(parsed_args, ::Type{FT}; setup_type = nothing) where
     elseif radiation_name == "DYCOMS"
         RadiationDYCOMS{FT}()
     elseif radiation_name == "TRMM_LBA"
-        RadiationTRMM_LBA(FT)
+        RadiationTRMM_LBA()
     elseif radiation_name == "ISDAC"
         RadiationISDAC{FT}()
     elseif isnothing(radiation_name)

--- a/src/parameterized_tendencies/radiation/radiation.jl
+++ b/src/parameterized_tendencies/radiation/radiation.jl
@@ -18,6 +18,9 @@ import ClimaUtilities.TimeVaryingInputs:
     LinearInterpolation
 
 import Interpolations as Intp
+import StaticArrays as SA
+import ClimaInterpolations.Interpolation1D as CI1D
+import AtmosphericProfilesLibrary as APL
 using Statistics: mean
 
 radiation_model_cache(Y, atmos::AtmosModel, args...) =
@@ -521,26 +524,58 @@ end
 ##### TRMM_LBA radiation
 #####
 
+# Height grid of the AtmosphericProfilesLibrary TRMM_LBA radiative-cooling
+# table, read from the underlying interpolant.
+function trmm_lba_radiation_z_knots(rad_profile)
+    z_grid = getfield(getfield(getfield(rad_profile, :prof), :itp), :knots)[2]
+    return SA.SVector{length(z_grid)}(z_grid)
+end
+
 function radiation_model_cache(Y, radiation_mode::RadiationTRMM_LBA)
     FT = Spaces.undertype(axes(Y.c))
+    rad_profile = APL.TRMM_LBA_radiation(FT)
     return (;
         ᶜdTdt_rad = similar(Y.c, FT),
+        rad_profile,
+        z_knots = trmm_lba_radiation_z_knots(rad_profile),
         net_energy_flux_toa = [Geometry.WVector(FT(0))],
         net_energy_flux_sfc = [Geometry.WVector(FT(0))],
     )
 end
 
-function radiation_tendency!(Yₜ, Y, p, t, radiation_mode::RadiationTRMM_LBA)
+"""
+    set_trmm_lba_dTdt_rad!(ᶜdTdt_rad, rad_profile, z_knots, t)
+
+Set `ᶜdTdt_rad` to the TRMM_LBA radiative cooling `rad_profile(t, z)`.
+`rad_profile` interpolates in time and height and is host-resident. On a host
+space it is broadcast directly. On a device space its time coordinate is
+resolved on the host into the `SVector` height profile at `t`, which is then
+interpolated in height on the device.
+"""
+function set_trmm_lba_dTdt_rad!(ᶜdTdt_rad, rad_profile, z_knots, t)
+    ᶜz = Fields.coordinate_field(axes(ᶜdTdt_rad)).z
+    if ClimaComms.device(ᶜdTdt_rad) isa ClimaComms.AbstractCPUDevice
+        @. ᶜdTdt_rad = rad_profile(t, ᶜz)
+    else
+        dTdt_at_t = map(z -> rad_profile(t, z), z_knots)
+        z_profile = CI1D.Interpolate1D(
+            z_knots, dTdt_at_t;
+            interpolationorder = CI1D.Linear(),
+            extrapolationorder = CI1D.Flat(),
+        )
+        @. ᶜdTdt_rad = z_profile(ᶜz)
+    end
+    return nothing
+end
+
+function radiation_tendency!(Yₜ, Y, p, t, ::RadiationTRMM_LBA)
     FT = Spaces.undertype(axes(Y.c))
     (; params) = p
-    # TODO: get working (need to add cache / function)
-    rad = radiation_mode.rad_profile
     thermo_params = CAP.thermodynamics_params(params)
-    ᶜdTdt_rad = p.radiation.ᶜdTdt_rad
+    (; ᶜdTdt_rad, rad_profile, z_knots) = p.radiation
     ᶜρ = Y.c.ρ
     (; ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
-    zc = Fields.coordinate_field(axes(ᶜρ)).z
-    @. ᶜdTdt_rad = rad(FT(t), zc)
+    set_trmm_lba_dTdt_rad!(ᶜdTdt_rad, rad_profile, z_knots, FT(t))
     @. Yₜ.c.ρe_tot +=
         ᶜρ * TD.cv_m(thermo_params, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) * ᶜdTdt_rad
     return nothing

--- a/src/setups/TRMM_LBA.jl
+++ b/src/setups/TRMM_LBA.jl
@@ -88,4 +88,4 @@ function surface_condition(::TRMM_LBA, params)
     )
 end
 
-radiation_model(::TRMM_LBA, ::Type{FT}) where {FT} = RadiationTRMM_LBA(FT)
+radiation_model(::TRMM_LBA, ::Type{FT}) where {FT} = RadiationTRMM_LBA()

--- a/src/types.jl
+++ b/src/types.jl
@@ -739,15 +739,7 @@ end
     κ::FT = 170  # m²/kg
 end
 
-import AtmosphericProfilesLibrary as APL
-
-struct RadiationTRMM_LBA{R}
-    rad_profile::R
-    function RadiationTRMM_LBA(::Type{FT}) where {FT}
-        rad_profile = APL.TRMM_LBA_radiation(FT)
-        return new{typeof(rad_profile)}(rad_profile)
-    end
-end
+struct RadiationTRMM_LBA end
 
 abstract type PrescribedFlow{FT} end
 

--- a/test/gpu_radiation.jl
+++ b/test/gpu_radiation.jl
@@ -1,0 +1,37 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaCore: CommonSpaces, Fields, Grids, Spaces
+
+column_space(FT, device) = CommonSpaces.ColumnSpace(
+    FT;
+    z_min = 0, z_max = 16400, z_elem = 82,
+    device, staggering = Grids.CellCenter(),
+)
+
+# `RadiationTRMM_LBA` must stay an isbits marker: it lives in the AtmosModel,
+# which is captured whole into device kernels (e.g. the surface-conditions
+# update), so a non-isbits field there breaks any GPU run. See PR #4664 and the
+# TRMM radiation follow-up.
+device = ClimaComms.device()
+@testset "TRMM_LBA radiation on $(nameof(typeof(device)))" begin
+    @test isbits(CA.RadiationTRMM_LBA())
+
+    @testset "$FT" for FT in (Float64, Float32)
+        rad_profile = CA.Setups.APL.TRMM_LBA_radiation(FT)
+        z_knots = CA.trmm_lba_radiation_z_knots(rad_profile)
+        space = column_space(FT, device)
+        ᶜz = Fields.coordinate_field(space).z
+        ᶜdTdt_rad = Fields.Field(FT, space)
+        for t in (FT(0), FT(1000), FT(5000))
+            CA.set_trmm_lba_dTdt_rad!(ᶜdTdt_rad, rad_profile, z_knots, t)
+            @test parent(ᶜdTdt_rad) isa ClimaComms.array_type(device)
+            dev_vals = Array(parent(ᶜdTdt_rad))
+            @test all(isfinite, dev_vals)
+            # The device path resolves time on the host and interpolates height
+            # on the device; it must reproduce the host bilinear evaluation.
+            @test dev_vals ≈ rad_profile.(t, Array(parent(ᶜz)))
+        end
+    end
+end


### PR DESCRIPTION
Follow-up to #4664: makes the `TRMM_LBA` radiation GPU-compatible, so a full `TRMM_LBA` simulation runs on a GPU space.

`APL.TRMM_LBA_radiation` is a 2D (time × height) `Interpolations.jl` interpolant that is not isbits. It was held by `RadiationTRMM_LBA`, which lives in the `AtmosModel`, and the `AtmosModel` is captured whole into device kernels (for example `update_surface_conditions!`), so a `TRMM_LBA` run crashed at initialization on a GPU space with a non-isbits kernel argument.

`RadiationTRMM_LBA` becomes an isbits marker and the profile moves into the radiation cache. The radiative-cooling tendency resolves the time coordinate on the host into the height profile at `t`, then interpolates in height on the device with a `ClimaInterpolations.Interpolation1D.Interpolate1D` over `SVector` knots. Only the small height-profile `SVector`, not the full 36 × 33 table, enters the kernel, so the kernel-parameter footprint stays small and portable across GPUs. 

On CPUs, we profile is broadcast directly, so there's no changes to reproducibility tests.


Similar cases not addressed here: `ARMVARANAL` has the same `TimeZProfile`, plus a separate host scalar loop over `parent(z)` in `update_varanal_forcing_fields!`.