### PR TITLE
Add a temporary lateral coeff for sedimentation

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-388
+389
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+389
+- Add a temporary parameter for lateral sedimentation mixing
+
 388
 - Unify SGS vertical diffusion with grid mean. Each PrognosticEDMFX
   subdomain inherits the grid-mean specific tendency for mseⱼ, q_totⱼ,

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -65,6 +65,8 @@ Base.@kwdef struct TurbulenceConvectionParameters{FT, VFT1, VFT2, VTF3} <: ATCP
     cloud_fraction_floor_release_abs_margin::FT
     cloud_fraction_floor_release_sharpness::FT
     cloud_fraction_floor_residual::FT
+    # Scaling coefficient for the lateral correction in updraft sedimentation
+    sedimentation_lateral_coeff::FT
     interface_entr_efficiency::FT
     # Surface mass flux closure (`set_edmfx_surface_conditions!`).
     sfc_mass_flux_ustar_coeff::FT

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -382,6 +382,9 @@ function TurbulenceConvectionParameters(
         cloud_fraction_floor_release_abs_margin = FT(1),
         cloud_fraction_floor_release_sharpness = FT(1),
         cloud_fraction_floor_residual = FT(0),
+        # Lateral correction scaling for updraft sedimentation
+        # (see `updraft_sedimentation!`). 1.0 = full correction, 0.0 = disabled.
+        sedimentation_lateral_coeff = FT(0),
     )
     release_present = filter(collect(keys(release_defaults))) do name
         haskey(toml_dict.data, string(name))

--- a/src/prognostic_equations/advection.jl
+++ b/src/prognostic_equations/advection.jl
@@ -339,6 +339,7 @@ function edmfx_sgs_vertical_advection_tendency!(
     (; ᶜgradᵥ_ᶠΦ) = p.core
 
     FT = eltype(p.params)
+    α_lat = CAP.sedimentation_lateral_coeff(p.params)
     ᶠJ = Fields.local_geometry_field(axes(Y.f)).J
 
     for j in 1:n
@@ -433,6 +434,7 @@ function edmfx_sgs_vertical_advection_tendency!(
                     ᶜqʲ,
                     ᶠJ,
                     ᶜρ⁰w⁰χ⁰,
+                    α_lat,
                 )
                 @. ᶜqʲₜ += ᶜinv_ρ̂ * vtt
                 @. Yₜ.c.sgsʲs.:($$j).q_tot += ᶜinv_ρ̂ * vtt
@@ -485,6 +487,7 @@ function edmfx_sgs_vertical_advection_tendency!(
                     ᶜχʲ,
                     ᶠJ,
                     ᶜρ⁰w⁰χ⁰,
+                    α_lat,
                 )
                 @. ᶜχʲₜ += ᶜinv_ρ̂ * vtt
             end
@@ -493,7 +496,7 @@ function edmfx_sgs_vertical_advection_tendency!(
 end
 
 """
-    updraft_sedimentation!(vtt, p, ᶜρ, ᶜw, ᶜa, ᶜχ, ᶠJ, ᶜρ⁰w⁰χ⁰)
+    updraft_sedimentation!(vtt, p, ᶜρ, ᶜw, ᶜa, ᶜχ, ᶠJ, ᶜρ⁰w⁰χ⁰, α_lat)
 
 Compute the sedimentation tendency of tracer `χ` within an updraft, including
 lateral transfer (detrainment and entrainment) across tilted updraft boundaries.
@@ -518,7 +521,7 @@ The combined tendency is:
 
 ```math
 \\text{tend} = a \\cdot \\partial_z(\\rho^{(1)} w^{(1)} \\chi^{(1)})
-            + \\min(\\partial_z a,\\, 0) \\cdot
+            + \\alpha_{lat} \\cdot \\min(\\partial_z a,\\, 0) \\cdot
               (\\rho^{(1)} w^{(1)} \\chi^{(1)} - \\rho^{(0)} w^{(0)} \\chi^{(0)})
 ```
 
@@ -536,6 +539,7 @@ flux, no lateral mixing occurs.
   - `ᶜχ`: updraft tracer mixing ratio
   - `ᶠJ`: face Jacobian (grid geometry)
   - `ᶜρ⁰w⁰χ⁰`: environment sedimentation flux density (ρ⁰ · w⁰ · χ⁰)
+  - `α_lat`: lateral correction scaling (0 = disabled, 1 = full)
 
 `vtt` gets filled with tracer tendency due to sedimentation and lateral transfer.
 """
@@ -548,6 +552,7 @@ function updraft_sedimentation!(
     ᶜχ,
     ᶠJ,
     ᶜρ⁰w⁰χ⁰,
+    α_lat,
 )
     ᶜJ = Fields.local_geometry_field(axes(ᶜρ)).J
     # use output as a scratch field
@@ -555,10 +560,13 @@ function updraft_sedimentation!(
     @. ∂a∂z = ᶜprecipdivᵥ(ᶠinterp(ᶜJ) / ᶠJ * ᶠright_bias(Geometry.WVector(ᶜa)))
     ᶠρ = @. p.scratch.ᶠtemp_scalar = ᶠinterp(ᶜρ * ᶜJ) / ᶠJ
     ᶠwχ = @. p.scratch.ᶠtemp_scalar_2 = ᶠright_bias(-(ᶜw) * ᶜχ)
+    ᶠwaχ = @. p.scratch.ᶠtemp_scalar_3 = ᶠright_bias(-(ᶜw) * ᶜa * ᶜχ)
     # Base: within-updraft flux convergence a · ∂_z(ρ w χ)
-    # Entrainment correction: min(∂a/∂z, 0) · (ρ¹w¹χ¹ − ρ⁰w⁰χ⁰)
-    @. vtt =
-        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwχ))) +
-        min(∂a∂z, 0) * (ᶜρ * ᶜw * ᶜχ - ᶜρ⁰w⁰χ⁰)
+    # Lateral correction: α_lat · min(∂a/∂z, 0) · ρ⁰w⁰χ⁰
+    @. vtt = ifelse(
+        ∂a∂z < 0,
+        -(ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwaχ)) - α_lat * ∂a∂z * ᶜρ⁰w⁰χ⁰),
+        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwχ))),
+    )
     return
 end

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -1119,6 +1119,7 @@ function update_sgs_advection_jacobian!(matrix, Y, p, dtγ)
     p.atmos.turbconv_model isa PrognosticEDMFX || return nothing
     (; ᶜρʲs, ᶠu³ʲs) = p.precomputed
     FT = Spaces.undertype(axes(Y.c))
+    α_lat = CAP.sedimentation_lateral_coeff(p.params)
     ᶜJ = Fields.local_geometry_field(Y.c).J
     ᶠJ = Fields.local_geometry_field(Y.f).J
     (; ᶠsed_tracer_advection, ᶜtridiagonal_matrix_scalar) = p.scratch
@@ -1200,23 +1201,26 @@ function update_sgs_advection_jacobian!(matrix, Y, p, dtγ)
 
             # sedimentation
             # Base: a·∂_z(ρwχ) — always the same regardless of ∂a/∂z sign
-            # Correction: min(∂a/∂z, 0)·(ρ¹w¹χ¹ − ρ⁰w⁰χ⁰)
+            # Correction when ∂a/∂z < 0 :
+            #   α_lat · ∂a/∂z · (ρ¹w¹χ¹ − ρ⁰w⁰χ⁰)
             #   ρ⁰w⁰χ⁰ = (w_GS·ρχ_GS − ρa¹·w¹·χ¹)/(1−a), so
             #   ∂(ρ⁰w⁰χ⁰)/∂χʲ = −ρa¹·w¹/(1−a) and
-            #   ∂/∂χʲ of correction = min(∂a/∂z, 0)·ρ¹w¹/(1−a)
+            #   ∂/∂χʲ of correction = α_lat · ∂a/∂z · ρ¹w¹/(1−a)
             @. ᶠsed_tracer_advection =
                 DiagonalMatrixRow(ᶠinterp(ᶜρʲs.:(1) * ᶜJ) / ᶠJ) ⋅
                 ᶠright_bias_matrix() ⋅
                 DiagonalMatrixRow(-Geometry.WVector(ᶜwʲ))
             @. ᶜtridiagonal_matrix_scalar =
-                dtγ * (
-                    -DiagonalMatrixRow(ᶜa) ⋅ ᶜprecipdivᵥ_matrix() ⋅
-                    ᶠsed_tracer_advection +
+                dtγ * ifelse(ᶜ∂a∂z < 0,
+                    -(ᶜprecipdivᵥ_matrix()) ⋅ ᶠsed_tracer_advection *
+                    DiagonalMatrixRow(ᶜa) +
                     DiagonalMatrixRow(
-                        min(ᶜ∂a∂z, zero(ᶜ∂a∂z)) * ᶜρʲs.:(1) * ᶜwʲ /
-                        max(1 - ᶜa, eps(eltype(ᶜa))),
-                    )
+                        α_lat * ᶜ∂a∂z * ᶜρʲs.:(1) * ᶜwʲ / max(1 - ᶜa, eps(eltype(ᶜa))),
+                    ),
+                    -DiagonalMatrixRow(ᶜa) ⋅ ᶜprecipdivᵥ_matrix() ⋅ ᶠsed_tracer_advection,
                 )
+            # sedimentation
+            # (pull out common subexpression for performance)
 
             @. ∂ᶜχʲ_err_∂ᶜχʲ +=
                 DiagonalMatrixRow(ᶜinv_ρ̂) ⋅ ᶜtridiagonal_matrix_scalar


### PR DESCRIPTION
To compare with what we had a week ago:

Old sedimentation term:

```
    @. vtt = ifelse(
        ∂a∂z < 0,
        -(ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwaχ))),
        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwχ))),
    )
```

new sedimentation term:

```
    @. vtt = ifelse(
        ∂a∂z < 0,
        -(ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwaχ)) - α_lat * ∂a∂z * ᶜρ⁰w⁰χ⁰),
        -(ᶜa * ᶜprecipdivᵥ(ᶠρ * Geometry.WVector(ᶠwχ))),
    )
```

Old Jacobian term:

```
@. ᶜtridiagonal_matrix_scalar = dtγ * ifelse(ᶜ∂a∂z < 0,
     -(ᶜprecipdivᵥ_matrix()) ⋅ ᶠsed_tracer_advection * DiagonalMatrixRow(ᶜa),
      -DiagonalMatrixRow(ᶜa) ⋅ ᶜprecipdivᵥ_matrix() ⋅ ᶠsed_tracer_advection,
 )
```

new Jacobian term:

```
@. ᶜtridiagonal_matrix_scalar = dtγ * ifelse(ᶜ∂a∂z < 0,
    -(ᶜprecipdivᵥ_matrix()) ⋅ ᶠsed_tracer_advection * DiagonalMatrixRow(ᶜa) +
        DiagonalMatrixRow(α_lat * ᶜ∂a∂z * ᶜρʲs.:(1) * ᶜwʲ / max(1 - ᶜa, eps(eltype(ᶜa)))),
    -DiagonalMatrixRow(ᶜa) ⋅ ᶜprecipdivᵥ_matrix() ⋅ ᶠsed_tracer_advection,
)
````

And I'm setting `α_lat = 0` for now for testing and to recover nightly amip