### PR TITLE
feat(perf): add draft timing harness

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -1067,7 +1067,7 @@ steps:
         retry: *retry_policy
         command: >
           cd perf/run-and-time &&
-          julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)' &&
+          julia --project -e 'using Pkg; Pkg.Registry.update(); Pkg.Pkg.instantiate(;verbose=true)' &&
           julia --color=yes --project ci_test_models.jl
         agents:
           slurm_mem: 20GB

--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -1054,6 +1054,17 @@ steps:
       #     slurm_gpus: 1
       #     slurm_mem: 20GB
 
+  - group: "Performance scripts"
+    steps:
+      - label: ":test_tube: Component models: Smoke test"
+        retry: *retry_policy
+        command: >
+          cd perf/run-and-time &&
+          julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)' &&
+          julia --color=yes --project ci_test_models.jl
+        agents:
+          slurm_mem: 20GB
+
   - group: "Timestep cost"
     steps:
       - label: ":alarm_clock: Timestep cost: Moist baroclinic wave"

--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -1061,6 +1061,17 @@ steps:
       #     slurm_gpus: 1
       #     slurm_mem: 20GB
 
+  - group: "Performance scripts"
+    steps:
+      - label: ":test_tube: Component models: Smoke test"
+        retry: *retry_policy
+        command: >
+          cd perf/run-and-time &&
+          julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)' &&
+          julia --color=yes --project ci_test_models.jl
+        agents:
+          slurm_mem: 20GB
+
   - group: "Timestep cost"
     steps:
       - label: ":alarm_clock: Timestep cost: Moist baroclinic wave"

--- a/perf/run-and-time/Project.toml
+++ b/perf/run-and-time/Project.toml
@@ -3,6 +3,7 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaAtmos = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [sources]

--- a/perf/run-and-time/Project.toml
+++ b/perf/run-and-time/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ClimaAtmos = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
+ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[sources]
+ClimaAtmos = {path = "../.."}

--- a/perf/run-and-time/README.md
+++ b/perf/run-and-time/README.md
@@ -1,0 +1,56 @@
+# Compenent profiling
+
+This directory contains the  GPU test and profiling harnesses are run from this directory. Instantiate
+the local environment once, then invoke a harness with the model file to run:
+
+```sh
+export CLIMACOMMS_DEVICE=CUDA
+julia --project -e 'using Pkg; Pkg.instantiate()'
+julia --project HARNESS_SCRIPT.jl models/MODEL.jl
+```
+
+To perform fast iteration make sure you have `Revise.jl` installed in the base
+environment and use `-i` when running the script to enter the REPL after. Then
+the same model can be re-run using:
+```julia
+include("HARNESS_SCRIPT.jl")
+```
+
+## Harness scripts
+
+- `timer_harness.jl` uses BenchmarkTools to measure average GPU execution time
+  (as well as setup time and warmup/compilation time).
+
+- `quickprof_harness.jl` uses CUDA.jl profiling and prints a summary of the
+  measurements for each kernel:
+
+  ```sh
+  julia --project quickprof_harness.jl models/hyperdiff_tendency.jl
+  ```
+
+- `prof_harness.jl` should be used to run the profiling with Nsight Compute or
+  Nsight Systems.
+
+  ```sh
+  ncu -o output.ncu-rep --import-source 1 --profile-from-start=off --set=full \
+    julia --project prof_harness.jl models/hyperdiff_tendency.jl
+  ```
+
+  We also need to make sure that nsys/ncu is useing the same CUDA version as
+  Julia. To change the version used by julia run, e.g.:
+  ```
+  julia --project -e 'using CUDA; CUDA.set_runtime_version!(v"12.2")'
+  ```
+
+## Models
+
+The files containing the specific components to be tested are in `models/`:
+- `hyperdiff_tendency.jl`
+- `implicit_tendency.jl`
+- `set_cloud_frac.jl`
+- `set_CM_cache.jl`
+- `sgs.jl`
+
+These define two functions that are used by the harness scripts:
+- `case_setup()` to setup the model state needed for the component.
+- `case_run(state)` to execute the component that is to be profiled.

--- a/perf/run-and-time/README.md
+++ b/perf/run-and-time/README.md
@@ -1,0 +1,64 @@
+# Compenent profiling
+
+This directory contains the  GPU test and profiling harnesses are run from this directory. Instantiate
+the local environment once, then invoke a harness with the model file to run:
+
+```sh
+export CLIMACOMMS_DEVICE=CUDA
+julia --project -e 'using Pkg; Pkg.instantiate()'
+julia --project HARNESS_SCRIPT.jl models/MODEL.jl
+```
+
+To perform fast iteration make sure you have `Revise.jl` installed in the base
+environment and use `-i` when running the script to enter the REPL after. Then
+the same model can be re-run using:
+```julia
+include("HARNESS_SCRIPT.jl")
+```
+
+## Harness scripts
+
+- `timer_harness.jl` uses BenchmarkTools to measure average GPU execution time
+  (as well as setup time and warmup/compilation time).
+
+- `quickprof_harness.jl` uses CUDA.jl profiling and prints a summary of the
+  measurements for each kernel:
+
+  ```sh
+  julia --project quickprof_harness.jl models/hyperdiff_tendency.jl
+  ```
+
+- `prof_harness.jl` should be used to run the profiling with Nsight Compute or
+  Nsight Systems.
+
+  Nsight Compute:
+  ```sh
+  ncu -o output.ncu-rep --import-source 1 --profile-from-start=off --set=full \
+    julia --project prof_harness.jl models/MODEL.jl
+  ```
+
+  Nsight Systems:
+  ```sh
+  nsys profile -o output.nsys-rep \
+    --capture-range=cudaProfilerApi --trace=nvtx,cuda,osrt --gpu-metrics-device=cuda-visible --cuda-memory-usage=true \
+    julia --project prof_harness.jl models/MODEL.jl
+  ```
+
+  We also need to make sure that nsys/ncu is useing the same CUDA version as
+  Julia. To change the version used by julia run, e.g.:
+  ```
+  julia --project -e 'using CUDA; CUDA.set_runtime_version!(v"12.2")'
+  ```
+
+## Models
+
+The files containing the specific components to be tested are in `models/`:
+- `hyperdiff_tendency.jl`
+- `implicit_tendency.jl`
+- `set_cloud_frac.jl`
+- `set_CM_cache.jl`
+- `sgs.jl`
+
+These define two functions that are used by the harness scripts:
+- `case_setup()` to setup the model state needed for the component.
+- `case_run(state)` to execute the component that is to be profiled.

--- a/perf/run-and-time/ci_test_models.jl
+++ b/perf/run-and-time/ci_test_models.jl
@@ -1,0 +1,39 @@
+#=
+This file is intended to be used as a smoke test in CI to verify that all
+reduced component models run correctly.
+=#
+using Logging
+
+# List of files to skipe
+case_files = Set([
+    "models/hyperdiff_tendency.jl",
+    "models/implicit_tendency.jl",
+    "models/set_cloud_frac.jl",
+    "models/set_CM_cache.jl",
+    "models/sgs.jl",
+    ])
+
+has_faliures = false
+
+
+for model in case_files
+    # It overrides defined `case_setup` and `case_run` functions
+    include(model)
+    print("$model : ")
+
+    # Do not print the log messages
+    with_logger(NullLogger()) do
+        try
+            s = case_setup()
+            case_run(s)
+            printstyled("OK - it runs\n"; color = :green, bold = true)
+        catch e
+            printstyled("$model : ERROR\n"; color = :red, bold = true)
+            print(" - $e\n")
+            has_faliures = true
+        end
+    end
+end
+
+exit_code = has_faliures ? 1 : 0
+exit(exit_code)

--- a/perf/run-and-time/ci_test_models.jl
+++ b/perf/run-and-time/ci_test_models.jl
@@ -11,7 +11,7 @@ case_files = Set([
     "models/set_cloud_frac.jl",
     "models/set_CM_cache.jl",
     "models/sgs.jl",
-    ])
+])
 
 has_faliures = false
 

--- a/perf/run-and-time/ci_test_models.jl
+++ b/perf/run-and-time/ci_test_models.jl
@@ -4,7 +4,6 @@ reduced component models run correctly.
 =#
 using Logging
 
-# List of files to skipe
 case_files = Set([
     "models/hyperdiff_tendency.jl",
     "models/implicit_tendency.jl",
@@ -30,7 +29,7 @@ for model in case_files
         catch e
             printstyled("$model : ERROR\n"; color = :red, bold = true)
             print(" - $e\n")
-            has_faliures = true
+            global has_faliures = true
         end
     end
 end

--- a/perf/run-and-time/ci_test_models.jl
+++ b/perf/run-and-time/ci_test_models.jl
@@ -1,0 +1,39 @@
+#=
+This file is intended to be used as a smoke test in CI to verify that all
+reduced component models run correctly.
+=#
+using Logging
+
+# List of files to skipe
+case_files = Set([
+    "models/hyperdiff_tendency.jl",
+    "models/implicit_tendency.jl",
+    "models/set_cloud_frac.jl",
+    "models/set_CM_cache.jl",
+    "models/sgs.jl",
+])
+
+has_faliures = false
+
+
+for model in case_files
+    # It overrides defined `case_setup` and `case_run` functions
+    include(model)
+    print("$model : ")
+
+    # Do not print the log messages
+    with_logger(NullLogger()) do
+        try
+            s = case_setup()
+            case_run(s)
+            printstyled("OK - it runs\n"; color = :green, bold = true)
+        catch e
+            printstyled("$model : ERROR\n"; color = :red, bold = true)
+            print(" - $e\n")
+            has_faliures = true
+        end
+    end
+end
+
+exit_code = has_faliures ? 1 : 0
+exit(exit_code)

--- a/perf/run-and-time/models/atmos_config.jl
+++ b/perf/run-and-time/models/atmos_config.jl
@@ -1,0 +1,24 @@
+#=
+This file is intended to be included by all small components models.
+
+It is supposed to be a 'single source of truth' with regards to the base
+ClimaAtmos configuration we  are using.
+=#
+
+import ClimaAtmos as CA
+
+
+function get_base_atmos_config()
+    config_path = "config"
+    config_file = [
+        joinpath(pkgdir(CA), config_path, "common_configs", "numerics_sphere_he16ze63.yml"),
+        joinpath(
+            pkgdir(CA),
+            config_path,
+            "longrun_configs",
+            "amip_target.yml",
+        ),
+    ]
+    config = CA.AtmosConfig(config_file; job_id = nothing)
+    return config
+end

--- a/perf/run-and-time/models/hyperdiff_tendency.jl
+++ b/perf/run-and-time/models/hyperdiff_tendency.jl
@@ -1,0 +1,119 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import Random
+Random.seed!(1234)
+
+# ---------------------------------------------------------------------------
+# Minimal setup to call `hyperdiffusion_tendency!`, exposed as the
+# `case_setup`/`case_run` functions expected by the timing harness.
+#
+# `hyperdiffusion_tendency!` only needs `Y` (state), `p` (cache), and `t`, so
+# we skip `CA.get_simulation` (integrator, Jacobian, callbacks, diagnostics,
+# output writers) entirely and build just `Y`/`p`/`t` — this mirrors the
+# `Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)` (see
+# src/simulation/AtmosSimulations.jl). Restart handling is skipped (this
+# config starts from an initial condition, not a restart file).
+#
+# `hyperdiffusion_tendency!` reads only `p.atmos.{hyperdiff, turbconv_model}`,
+# `p.core.ᶜΦ`, `p.precomputed.ᶜT`/`ᶜTʲs`, `p.hyperdiff.*`, and `p.scratch`. It
+# never reads the radiation, aerosol, trace-gas, gravity-wave, tracer, or
+# external-forcing parts of `p`. Those are also the *expensive* part of model
+# setup (RRTMGP compilation + lookup tables, ETOPO topography load + spectral
+# smoothing, aerosol/trace-gas data ingestion, Beres gravity-wave tables), so
+# we strip them from the config below *before* building anything.
+# `ClimaAtmosParameters`/`get_atmos` then never load their parameter sets,
+# `build_cache` constructs trivial stubs in their place, and
+# `set_precomputed_quantities!` skips their precomputed quantities.
+#
+# What is KEPT (because `hyperdiffusion_tendency!` dispatches on / reads it):
+#   hyperdiff = Hyperdiffusion and turbconv = prognostic_edmfx.
+# ---------------------------------------------------------------------------
+
+# Defines: get_base_atmos_config
+include("atmos_config.jl")
+
+"""
+    case_setup()
+
+Build the minimal `Y`/`p`/`t` needed to call `hyperdiffusion_tendency!` and
+return them (plus the tendency buffers) as a `NamedTuple` with fields `Y`,
+`Yₜ`, `Yₜ_lim`, `p`, `t`. Mirrors the `Y`/`p`/`t`-producing subset of
+`AtmosSimulation{FT}(...)`; skips the integrator, Jacobian, callbacks,
+diagnostics, and output writers.
+"""
+function case_setup()
+    config = get_base_atmos_config()
+
+    # Stub out the components `hyperdiffusion_tendency!` does not read.
+    # Mutating `parsed_args` here (before params/model/grid are built) means
+    # the un-needed parameter sets, data files, and caches are never
+    # constructed in the first place. None of these knobs affect which
+    # branches the tendency takes.
+    pa = config.parsed_args
+    pa["rad"] = nothing                        # no RRTMGP model / lookup tables
+    pa["aerosol_radiation"] = false
+    pa["prescribed_aerosols"] = String[]       # no aerosol data ingestion
+    pa["time_varying_trace_gases"] = String[]  # no trace-gas data ingestion
+    pa["insolation"] = "idealized"             # unused once `rad` is off
+    pa["non_orographic_gravity_wave"] = false  # no Beres source tables
+    pa["orographic_gravity_wave"] = nothing
+    pa["topography"] = "NoWarp"                # skip ETOPO load + spectral smoothing
+    pa["topo_smoothing"] = false
+
+    FT = eltype(config)
+
+    params = CA.ClimaAtmosParameters(config)
+    setup_type = CA.get_setup_type(pa, CA.CAP.thermodynamics_params(params))
+    model = CA.get_atmos(config, params; setup_type = setup_type)
+    grid = CA.get_grid(pa, params, config.comms_ctx)
+
+    # Time arguments (dt is what the cache reads via `p.dt`).
+    dt, t_start, t_end = CA.convert_time_args(
+        pa["dt"], pa["t_start"], pa["t_end"], CA.parse_date(pa["start_date"]),
+    )
+
+    # Build the state `Y` from the initial condition.
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(
+        setup_type, params, model, spaces.center_space, spaces.face_space,
+    )
+    CA.Setups.overwrite_initial_state!(setup_type, Y, params.thermodynamics_params)
+
+    # Build the cache `p`. `build_cache` also calls `set_precomputed_quantities!`,
+    # so the precomputed quantities the tendency reads are populated here. The
+    # aerosol / trace-gas tuples are now empty, so the tracer cache is a stub.
+    steady_state_velocity = CA.steady_state_velocity_from_config(config, params)
+    resolved_steady_state_velocity =
+        steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
+        steady_state_velocity
+    p = CA.build_cache(
+        Y,
+        model,
+        params,
+        dt,
+        CA.parse_date(pa["start_date"]),
+        Tuple(pa["prescribed_aerosols"]),
+        Tuple(pa["time_varying_trace_gases"]),
+        resolved_steady_state_velocity,
+        CA.vertical_water_borrowing_species_from_config(config),
+    )
+
+    t = t_start
+
+    Yₜ = similar(Y)
+    Yₜ_lim = similar(Y)
+
+    return (; Y, Yₜ, Yₜ_lim, p, t)
+end
+
+"""
+    case_run(state)
+
+Run `hyperdiffusion_tendency!` under measurement. May be called multiple
+times on the same state.
+"""
+function case_run(state)
+    CA.hyperdiffusion_tendency!(state.Yₜ, state.Yₜ_lim, state.Y, state.p, state.t)
+    return nothing
+end

--- a/perf/run-and-time/models/implicit_tendency.jl
+++ b/perf/run-and-time/models/implicit_tendency.jl
@@ -1,0 +1,120 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import Random
+Random.seed!(1234)
+
+# ---------------------------------------------------------------------------
+# Minimal setup to call `implicit_tendency!`, exposed as the
+# `case_setup`/`case_run` functions expected by the timing harness.
+#
+# `implicit_tendency!` only needs `Y` (state), `p` (cache), and `t`, so we
+# skip `CA.get_simulation` (integrator, Jacobian, callbacks, diagnostics,
+# output writers) entirely and build just `Y`/`p`/`t` — this mirrors the
+# `Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)` (see
+# src/simulation/AtmosSimulations.jl). Restart handling is skipped (this
+# config starts from an initial condition, not a restart file).
+#
+# Beyond that, `implicit_tendency!` exercises only the vertical-advection,
+# EDMFX, microphysics, implicit-diffusion, and Rayleigh-sponge code paths. A
+# call-tree trace confirms it never reads the radiation, aerosol, trace-gas,
+# gravity-wave, tracer, external-forcing, or hyperdiffusion parts of `p`.
+# Those are also the *expensive* part of model setup (RRTMGP compilation +
+# lookup tables, ETOPO topography load + spectral smoothing, aerosol/trace-gas
+# data ingestion, Beres gravity-wave tables), so we strip them from the config
+# below *before* building anything. `ClimaAtmosParameters`/`get_atmos` then
+# never load their parameter sets, `build_cache` constructs trivial stubs in
+# their place, and `set_precomputed_quantities!` skips their precomputed
+# quantities.
+#
+# What is KEPT (because `implicit_tendency!` dispatches on / reads it):
+#   turbconv = prognostic_edmfx, microphysics_model = 1M, implicit_diffusion,
+#   rayleigh_sponge, and DefaultMoninObukhov surface fluxes (needed for the
+#   implicit-diffusion path's diffusivities).
+# ---------------------------------------------------------------------------
+
+# Defines: get_base_atmos_config
+include("atmos_config.jl")
+
+"""
+    case_setup()
+
+Build the minimal `Y`/`p`/`t` needed to call `implicit_tendency!` and return
+them (plus the tendency buffer) as a `NamedTuple` with fields `Y`, `Yₜ`, `p`,
+`t`. Mirrors the `Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)`;
+skips the integrator, Jacobian, callbacks, diagnostics, and output writers.
+"""
+function case_setup()
+    config = get_base_atmos_config()
+
+    # Stub out the components `implicit_tendency!` does not read. Mutating
+    # `parsed_args` here (before params/model/grid are built) means the
+    # un-needed parameter sets, data files, and caches are never constructed in
+    # the first place. None of these knobs affect which branches
+    # `implicit_tendency!` takes.
+    pa = config.parsed_args
+    pa["rad"] = nothing                        # no RRTMGP model / lookup tables
+    pa["aerosol_radiation"] = false
+    pa["prescribed_aerosols"] = String[]       # no aerosol data ingestion
+    pa["time_varying_trace_gases"] = String[]  # no trace-gas data ingestion
+    pa["insolation"] = "idealized"             # unused once `rad` is off
+    pa["non_orographic_gravity_wave"] = false  # no Beres source tables
+    pa["orographic_gravity_wave"] = nothing
+    pa["topography"] = "NoWarp"                # skip ETOPO load + spectral smoothing
+    pa["topo_smoothing"] = false
+
+    FT = eltype(config)
+
+    params = CA.ClimaAtmosParameters(config)
+    setup_type = CA.get_setup_type(pa, CA.CAP.thermodynamics_params(params))
+    model = CA.get_atmos(config, params; setup_type = setup_type)
+    grid = CA.get_grid(pa, params, config.comms_ctx)
+
+    # Time arguments (dt is what the tendency actually reads via `p.dt`).
+    dt, t_start, t_end = CA.convert_time_args(
+        pa["dt"], pa["t_start"], pa["t_end"], CA.parse_date(pa["start_date"]),
+    )
+
+    # Build the state `Y` from the initial condition.
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(
+        setup_type, params, model, spaces.center_space, spaces.face_space,
+    )
+    CA.Setups.overwrite_initial_state!(setup_type, Y, params.thermodynamics_params)
+
+    # Build the cache `p`. `build_cache` also calls `set_precomputed_quantities!`,
+    # so the precomputed quantities the tendency reads are populated here. The
+    # aerosol / trace-gas tuples are now empty, so the tracer cache is a stub.
+    steady_state_velocity = CA.steady_state_velocity_from_config(config, params)
+    resolved_steady_state_velocity =
+        steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
+        steady_state_velocity
+    p = CA.build_cache(
+        Y,
+        model,
+        params,
+        dt,
+        CA.parse_date(pa["start_date"]),
+        Tuple(pa["prescribed_aerosols"]),
+        Tuple(pa["time_varying_trace_gases"]),
+        resolved_steady_state_velocity,
+        CA.vertical_water_borrowing_species_from_config(config),
+    )
+
+    t = t_start
+
+    Yₜ = similar(Y)
+
+    return (; Y, Yₜ, p, t)
+end
+
+"""
+    case_run(state)
+
+Run `implicit_tendency!` under measurement. May be called multiple times on
+the same state.
+"""
+function case_run(state)
+    CA.implicit_tendency!(state.Yₜ, state.Y, state.p, state.t)
+    return nothing
+end

--- a/perf/run-and-time/models/set_CM_cache.jl
+++ b/perf/run-and-time/models/set_CM_cache.jl
@@ -1,0 +1,123 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import Random
+Random.seed!(1234)
+
+# ---------------------------------------------------------------------------
+# Minimal setup to call `set_microphysics_tendency_cache!`, exposed as the
+# `case_setup`/`case_run` functions expected by the timing harness.
+#
+# It only needs `Y` (state) and `p` (cache), so we skip `CA.get_simulation`
+# (integrator, Jacobian, callbacks, diagnostics, output writers) entirely and
+# build just `Y`/`p`/`t` — this mirrors the `Y`/`p`/`t`-producing subset of
+# `AtmosSimulation{FT}(...)` (see src/simulation/AtmosSimulations.jl). Restart
+# handling is skipped (this config starts from an initial condition, not a
+# restart file).
+#
+# `set_microphysics_tendency_cache!` is one of the steps
+# `set_precomputed_quantities!` (invoked by `build_cache`) already runs, so
+# building the cache in `case_setup` exercises it once. It reads only the
+# thermodynamic / microphysics parts of `p.precomputed` and never reads the
+# radiation, aerosol, trace-gas, gravity-wave, tracer, or external-forcing
+# parts of `p`. Those are also the *expensive* part of model setup (RRTMGP
+# compilation + lookup tables, ETOPO topography load + spectral smoothing,
+# aerosol/trace-gas data ingestion, Beres gravity-wave tables), so we strip
+# them from the config below *before* building anything.
+# `ClimaAtmosParameters`/`get_atmos` then never load their parameter sets,
+# `build_cache` constructs trivial stubs in their place, and
+# `set_precomputed_quantities!` skips their precomputed quantities.
+#
+# What is KEPT (because it determines the microphysics-cache code path):
+#   microphysics_model = 1M and turbconv = prognostic_edmfx.
+# ---------------------------------------------------------------------------
+
+# Defines: get_base_atmos_config
+include("atmos_config.jl")
+
+"""
+    case_setup()
+
+Build the minimal `Y`/`p`/`t` needed to call
+`set_microphysics_tendency_cache!` and return them as a `NamedTuple` with
+fields `Y`, `p`, `t`. Mirrors the `Y`/`p`/`t`-producing subset of
+`AtmosSimulation{FT}(...)`; skips the integrator, Jacobian, callbacks,
+diagnostics, and output writers.
+"""
+function case_setup()
+    config = get_base_atmos_config()
+
+    # Stub out the components `set_microphysics_tendency_cache!` does not read.
+    # Mutating `parsed_args` here (before params/model/grid are built) means
+    # the un-needed parameter sets, data files, and caches are never
+    # constructed in the first place. None of these knobs affect which branch
+    # the routine takes.
+    pa = config.parsed_args
+    pa["rad"] = nothing                        # no RRTMGP model / lookup tables
+    pa["aerosol_radiation"] = false
+    pa["prescribed_aerosols"] = String[]       # no aerosol data ingestion
+    pa["time_varying_trace_gases"] = String[]  # no trace-gas data ingestion
+    pa["insolation"] = "idealized"             # unused once `rad` is off
+    pa["non_orographic_gravity_wave"] = false  # no Beres source tables
+    pa["orographic_gravity_wave"] = nothing
+    pa["topography"] = "NoWarp"                # skip ETOPO load + spectral smoothing
+    pa["topo_smoothing"] = false
+
+    FT = eltype(config)
+
+    params = CA.ClimaAtmosParameters(config)
+    setup_type = CA.get_setup_type(pa, CA.CAP.thermodynamics_params(params))
+    model = CA.get_atmos(config, params; setup_type = setup_type)
+    grid = CA.get_grid(pa, params, config.comms_ctx)
+
+    # Time arguments (dt is what the cache reads via `p.dt`).
+    dt, t_start, t_end = CA.convert_time_args(
+        pa["dt"], pa["t_start"], pa["t_end"], CA.parse_date(pa["start_date"]),
+    )
+
+    # Build the state `Y` from the initial condition.
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(
+        setup_type, params, model, spaces.center_space, spaces.face_space,
+    )
+    CA.Setups.overwrite_initial_state!(setup_type, Y, params.thermodynamics_params)
+
+    # Build the cache `p`. `build_cache` also calls `set_precomputed_quantities!`,
+    # so the precomputed quantities the routine reads are populated here. The
+    # aerosol / trace-gas tuples are now empty, so the tracer cache is a stub.
+    steady_state_velocity = CA.steady_state_velocity_from_config(config, params)
+    resolved_steady_state_velocity =
+        steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
+        steady_state_velocity
+    p = CA.build_cache(
+        Y,
+        model,
+        params,
+        dt,
+        CA.parse_date(pa["start_date"]),
+        Tuple(pa["prescribed_aerosols"]),
+        Tuple(pa["time_varying_trace_gases"]),
+        resolved_steady_state_velocity,
+        CA.vertical_water_borrowing_species_from_config(config),
+    )
+
+    t = t_start
+
+    return (; Y, p, t)
+end
+
+"""
+    case_run(state)
+
+Run `set_microphysics_tendency_cache!` under measurement. May be called
+multiple times on the same state.
+"""
+function case_run(state)
+    CA.set_microphysics_tendency_cache!(
+        state.Y,
+        state.p,
+        state.p.atmos.microphysics_model,
+        state.p.atmos.turbconv_model,
+    )
+    return nothing
+end

--- a/perf/run-and-time/models/set_cloud_frac.jl
+++ b/perf/run-and-time/models/set_cloud_frac.jl
@@ -1,0 +1,120 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import Random
+Random.seed!(1234)
+
+# ---------------------------------------------------------------------------
+# Minimal setup to call `set_cloud_fraction!`, exposed as the
+# `case_setup`/`case_run` functions expected by the timing harness.
+#
+# `set_cloud_fraction!` only needs `Y` (state) and `p` (cache), so we skip
+# `CA.get_simulation` (integrator, Jacobian, callbacks, diagnostics, output
+# writers) entirely and build just `Y`/`p`/`t` — this mirrors the
+# `Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)` (see
+# src/simulation/AtmosSimulations.jl). Restart handling is skipped (this
+# config starts from an initial condition, not a restart file).
+#
+# `set_cloud_fraction!` is one of the steps `set_precomputed_quantities!`
+# (invoked by `build_cache`) already runs, so building the cache in
+# `case_setup` exercises it once. It reads only the thermodynamic /
+# SGS-covariance parts of `p.precomputed` and never reads the radiation,
+# aerosol, trace-gas, gravity-wave, tracer, or external-forcing parts of `p`.
+# Those are also the *expensive* part of model setup (RRTMGP compilation +
+# lookup tables, ETOPO topography load + spectral smoothing, aerosol/trace-gas
+# data ingestion, Beres gravity-wave tables), so we strip them from the config
+# below *before* building anything. `ClimaAtmosParameters`/`get_atmos` then
+# never load their parameter sets, `build_cache` constructs trivial stubs in
+# their place, and `set_precomputed_quantities!` skips their precomputed
+# quantities.
+#
+# What is KEPT (because it determines the cloud-fraction code path):
+#   microphysics_model = 1M, cloud_model = QuadratureCloud, and
+#   turbconv = prognostic_edmfx.
+# ---------------------------------------------------------------------------
+
+# Defines: get_base_atmos_config
+include("atmos_config.jl")
+
+"""
+    case_setup()
+
+Build the minimal `Y`/`p`/`t` needed to call `set_cloud_fraction!` and return
+them as a `NamedTuple` with fields `Y`, `p`, `t`. Mirrors the
+`Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)`; skips the
+integrator, Jacobian, callbacks, diagnostics, and output writers.
+"""
+function case_setup()
+    config = get_base_atmos_config()
+
+    # Stub out the components `set_cloud_fraction!` does not read. Mutating
+    # `parsed_args` here (before params/model/grid are built) means the
+    # un-needed parameter sets, data files, and caches are never constructed in
+    # the first place. None of these knobs affect which branch cloud fraction
+    # takes.
+    pa = config.parsed_args
+    pa["rad"] = nothing                        # no RRTMGP model / lookup tables
+    pa["aerosol_radiation"] = false
+    pa["prescribed_aerosols"] = String[]       # no aerosol data ingestion
+    pa["time_varying_trace_gases"] = String[]  # no trace-gas data ingestion
+    pa["insolation"] = "idealized"             # unused once `rad` is off
+    pa["non_orographic_gravity_wave"] = false  # no Beres source tables
+    pa["orographic_gravity_wave"] = nothing
+    pa["topography"] = "NoWarp"                # skip ETOPO load + spectral smoothing
+    pa["topo_smoothing"] = false
+
+    FT = eltype(config)
+
+    params = CA.ClimaAtmosParameters(config)
+    setup_type = CA.get_setup_type(pa, CA.CAP.thermodynamics_params(params))
+    model = CA.get_atmos(config, params; setup_type = setup_type)
+    grid = CA.get_grid(pa, params, config.comms_ctx)
+
+    # Time arguments (dt is what the cache reads via `p.dt`).
+    dt, t_start, t_end = CA.convert_time_args(
+        pa["dt"], pa["t_start"], pa["t_end"], CA.parse_date(pa["start_date"]),
+    )
+
+    # Build the state `Y` from the initial condition.
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(
+        setup_type, params, model, spaces.center_space, spaces.face_space,
+    )
+    CA.Setups.overwrite_initial_state!(setup_type, Y, params.thermodynamics_params)
+
+    # Build the cache `p`. `build_cache` also calls `set_precomputed_quantities!`,
+    # so the precomputed quantities `set_cloud_fraction!` reads are populated
+    # here. The aerosol / trace-gas tuples are now empty, so the tracer cache
+    # is a stub.
+    steady_state_velocity = CA.steady_state_velocity_from_config(config, params)
+    resolved_steady_state_velocity =
+        steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
+        steady_state_velocity
+    p = CA.build_cache(
+        Y,
+        model,
+        params,
+        dt,
+        CA.parse_date(pa["start_date"]),
+        Tuple(pa["prescribed_aerosols"]),
+        Tuple(pa["time_varying_trace_gases"]),
+        resolved_steady_state_velocity,
+        CA.vertical_water_borrowing_species_from_config(config),
+    )
+
+    t = t_start
+
+    return (; Y, p, t)
+end
+
+"""
+    case_run(state)
+
+Run `set_cloud_fraction!` under measurement. May be called multiple times on
+the same state.
+"""
+function case_run(state)
+    (; cloud_model, microphysics_model) = state.p.atmos
+    CA.set_cloud_fraction!(state.Y, state.p, microphysics_model, cloud_model)
+    return nothing
+end

--- a/perf/run-and-time/models/sgs.jl
+++ b/perf/run-and-time/models/sgs.jl
@@ -1,0 +1,125 @@
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import Random
+Random.seed!(1234)
+
+# ---------------------------------------------------------------------------
+# Minimal setup to call `set_sgs_moments_and_cloud_fraction!`, exposed as the
+# `case_setup`/`case_run` functions expected by the timing harness.
+#
+# It only needs `Y` (state) and `p` (cache), so we skip `CA.get_simulation`
+# (integrator, Jacobian, callbacks, diagnostics, output writers) entirely and
+# build just `Y`/`p`/`t` — this mirrors the `Y`/`p`/`t`-producing subset of
+# `AtmosSimulation{FT}(...)` (see src/simulation/AtmosSimulations.jl). Restart
+# handling is skipped (this config starts from an initial condition, not a
+# restart file).
+#
+# `set_sgs_moments_and_cloud_fraction!` is one of the steps
+# `set_precomputed_quantities!` (invoked by `build_cache`) already runs, so
+# building the cache in `case_setup` exercises it once. It reads only the
+# thermodynamic / SGS-covariance parts of `p.precomputed`, and never reads
+# the radiation, aerosol, trace-gas, gravity-wave, tracer, or
+# external-forcing parts of `p`. Those are also the *expensive* part of model
+# setup (RRTMGP compilation + lookup tables, ETOPO topography load + spectral
+# smoothing, aerosol/trace-gas data ingestion, Beres gravity-wave tables), so
+# we strip them from the config below *before* building anything.
+# `ClimaAtmosParameters`/`get_atmos` then never load their parameter sets,
+# `build_cache` constructs trivial stubs in their place, and
+# `set_precomputed_quantities!` skips their precomputed quantities.
+#
+# What is KEPT (because it determines the SGS/cloud-fraction code path):
+#   microphysics_model = 1M, cloud_model = QuadratureCloud, and
+#   turbconv = prognostic_edmfx.
+# ---------------------------------------------------------------------------
+
+"""
+    case_setup()
+
+Build the minimal `Y`/`p`/`t` needed to call `set_sgs_moments_and_cloud_fraction!`
+and return them as a `NamedTuple` with fields `Y`, `p`, `t`. Mirrors the
+`Y`/`p`/`t`-producing subset of `AtmosSimulation{FT}(...)`; skips the
+integrator, Jacobian, callbacks, diagnostics, and output writers.
+"""
+function case_setup()
+    config_path = "config"
+
+    config_file = [
+        joinpath(pkgdir(CA), config_path, "common_configs", "numerics_sphere_he16ze63.yml"),
+        joinpath(
+            pkgdir(CA),
+            config_path,
+            "longrun_configs",
+            "amip_target.yml",
+        ),
+    ]
+    config = CA.AtmosConfig(config_file; job_id = nothing)
+
+    # Stub out the components `set_sgs_moments_and_cloud_fraction!` does not read.
+    # Mutating `parsed_args` here (before params/model/grid are built) means the
+    # un-needed parameter sets, data files, and caches are never constructed in
+    # the first place. None of these knobs affect which branch the routine takes.
+    pa = config.parsed_args
+    pa["rad"] = nothing                        # no RRTMGP model / lookup tables
+    pa["aerosol_radiation"] = false
+    pa["prescribed_aerosols"] = String[]       # no aerosol data ingestion
+    pa["time_varying_trace_gases"] = String[]  # no trace-gas data ingestion
+    pa["insolation"] = "idealized"             # unused once `rad` is off
+    pa["non_orographic_gravity_wave"] = false  # no Beres source tables
+    pa["orographic_gravity_wave"] = nothing
+    pa["topography"] = "NoWarp"                # skip ETOPO load + spectral smoothing
+    pa["topo_smoothing"] = false
+
+    FT = eltype(config)
+
+    params = CA.ClimaAtmosParameters(config)
+    setup_type = CA.get_setup_type(pa, CA.CAP.thermodynamics_params(params))
+    model = CA.get_atmos(config, params; setup_type = setup_type)
+    grid = CA.get_grid(pa, params, config.comms_ctx)
+
+    # Time arguments (dt is what the cache reads via `p.dt`).
+    dt, t_start, t_end = CA.convert_time_args(
+        pa["dt"], pa["t_start"], pa["t_end"], CA.parse_date(pa["start_date"]),
+    )
+
+    # Build the state `Y` from the initial condition.
+    spaces = CA.get_spaces(grid)
+    Y = CA.Setups.initial_state(
+        setup_type, params, model, spaces.center_space, spaces.face_space,
+    )
+    CA.Setups.overwrite_initial_state!(setup_type, Y, params.thermodynamics_params)
+
+    # Build the cache `p`. `build_cache` also calls `set_precomputed_quantities!`,
+    # so the precomputed quantities the routine reads are populated here. The
+    # aerosol / trace-gas tuples are now empty, so the tracer cache is a stub.
+    steady_state_velocity = CA.steady_state_velocity_from_config(config, params)
+    resolved_steady_state_velocity =
+        steady_state_velocity isa Function ? steady_state_velocity(Y, params) :
+        steady_state_velocity
+    p = CA.build_cache(
+        Y,
+        model,
+        params,
+        dt,
+        CA.parse_date(pa["start_date"]),
+        Tuple(pa["prescribed_aerosols"]),
+        Tuple(pa["time_varying_trace_gases"]),
+        resolved_steady_state_velocity,
+        CA.vertical_water_borrowing_species_from_config(config),
+    )
+
+    t = t_start
+
+    return (; Y, p, t)
+end
+
+"""
+    case_run(state)
+
+Run `set_sgs_moments_and_cloud_fraction!` under measurement. May be called
+multiple times on the same state.
+"""
+function case_run(state)
+    CA.set_sgs_moments_and_cloud_fraction!(state.Y, state.p)
+    return nothing
+end

--- a/perf/run-and-time/models/sgs.jl
+++ b/perf/run-and-time/models/sgs.jl
@@ -33,6 +33,9 @@ Random.seed!(1234)
 #   turbconv = prognostic_edmfx.
 # ---------------------------------------------------------------------------
 
+# Defines: get_base_atmos_config
+include("atmos_config.jl")
+
 """
     case_setup()
 
@@ -42,18 +45,7 @@ and return them as a `NamedTuple` with fields `Y`, `p`, `t`. Mirrors the
 integrator, Jacobian, callbacks, diagnostics, and output writers.
 """
 function case_setup()
-    config_path = "config"
-
-    config_file = [
-        joinpath(pkgdir(CA), config_path, "common_configs", "numerics_sphere_he16ze63.yml"),
-        joinpath(
-            pkgdir(CA),
-            config_path,
-            "longrun_configs",
-            "amip_target.yml",
-        ),
-    ]
-    config = CA.AtmosConfig(config_file; job_id = nothing)
+    config = get_base_atmos_config()
 
     # Stub out the components `set_sgs_moments_and_cloud_fraction!` does not read.
     # Mutating `parsed_args` here (before params/model/grid are built) means the

--- a/perf/run-and-time/prof_harness.jl
+++ b/perf/run-and-time/prof_harness.jl
@@ -1,5 +1,5 @@
 #=
-To run under NSightCompute: 
+To run under NSightCompute:
 ````
 ncu \
   -o output.ncu-rep \
@@ -21,7 +21,7 @@ nsys profile \
     julia --project ./prof_harness.jl <path-to-case-file>
 ```
 
-We also need to make sure that nsys/ncu is useing the same CUDA version as 
+We also need to make sure that nsys/ncu is useing the same CUDA version as
 Julia.
 
 To change the version used by julia run, e.g.:

--- a/perf/run-and-time/prof_harness.jl
+++ b/perf/run-and-time/prof_harness.jl
@@ -1,0 +1,81 @@
+#=
+To run under NSightCompute:
+````
+ncu \
+  -o output.ncu-rep \
+  --import-source 1 \
+  --profile-from-start=off \
+  --set=full \
+  julia --project ./prof_harness.jl <path-to-case-file>
+```
+
+To run with NSightSystems:
+```
+nsys profile \
+    --capture-range=cudaProfilerApi \
+    --kill=none \
+    --trace=nvtx,cuda,osrt \
+    --gpu-metrics-device=all \
+    --cuda-memory-usage=true \
+    --output=output.nsys-rep \
+    julia --project ./prof_harness.jl <path-to-case-file>
+```
+
+We also need to make sure that nsys/ncu is useing the same CUDA version as
+Julia.
+
+To change the version used by julia run, e.g.:
+```
+julia --project -e 'using CUDA; CUDA.set_runtime_version!(v"12.2")'
+```
+
+=#
+
+# Activate ClimaCore's kernel renaming feature, so kernels show up in
+# profiler output (nsys/ncu) with human-readable names constructed from
+# the stack trace (function name, file, and line).
+# Must be set before ClimaCore's CUDA extension (ClimaCoreCUDAExt) is loaded,
+# since the setting is read in its `__init__`.
+ENV["CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE"] = get(
+    ENV, "CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE", "true",
+)
+
+using CUDA
+
+
+if length(ARGS) != 1
+    error(
+        "You need to provide path to the 'case' file that defines 'case_setup' and 'case_run' functions.",
+    )
+end
+
+# Load the simulation file
+case_path = abspath(ARGS[1])
+
+#=
+The file getting include here needs to specify the 2 methods:
+    - `case_setup`: returns a 'state'
+    - `case_run(state)`: runs the functions we wish to measure
+=#
+include(case_path)
+
+isdefined(Main, :case_setup) ||
+    error("The required 'case_setup' function was not defined in the case file: $case_path")
+isdefined(Main, :case_run) ||
+    error("The required 'case_run' function was not defined in the case file: $case_path")
+
+
+
+setup_time = @elapsed s = case_setup()
+
+compile_time = @elapsed case_run(s)
+
+@info """Basic run statistics:
+    • Setup time: $setup_time [s]
+    • Warmup (compilation) time: $compile_time [s]
+"""
+
+# Profile the section with the CUDA's build-in profiler
+CUDA.@profile external=true begin
+    case_run(s)
+end

--- a/perf/run-and-time/prof_harness.jl
+++ b/perf/run-and-time/prof_harness.jl
@@ -1,0 +1,81 @@
+#=
+To run under NSightCompute: 
+````
+ncu \
+  -o output.ncu-rep \
+  --import-source 1 \
+  --profile-from-start=off \
+  --set=full \
+  julia --project ./prof_harness.jl <path-to-case-file>
+```
+
+To run with NSightSystems:
+```
+nsys profile \
+    --capture-range=cudaProfilerApi \
+    --kill=none \
+    --trace=nvtx,cuda,osrt \
+    --gpu-metrics-device=all \
+    --cuda-memory-usage=true \
+    --output=output.nsys-rep \
+    julia --project ./prof_harness.jl <path-to-case-file>
+```
+
+We also need to make sure that nsys/ncu is useing the same CUDA version as 
+Julia.
+
+To change the version used by julia run, e.g.:
+```
+julia --project -e 'using CUDA; CUDA.set_runtime_version!(v"12.2")'
+```
+
+=#
+
+# Activate ClimaCore's kernel renaming feature, so kernels show up in
+# profiler output (nsys/ncu) with human-readable names constructed from
+# the stack trace (function name, file, and line).
+# Must be set before ClimaCore's CUDA extension (ClimaCoreCUDAExt) is loaded,
+# since the setting is read in its `__init__`.
+ENV["CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE"] = get(
+    ENV, "CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE", "true",
+)
+
+using CUDA
+
+
+if length(ARGS) != 1
+    error(
+        "You need to provide path to the 'case' file that defines 'case_setup' and 'case_run' functions.",
+    )
+end
+
+# Load the simulation file
+case_path = abspath(ARGS[1])
+
+#=
+The file getting include here needs to specify the 2 methods:
+    - `case_setup`: returns a 'state'
+    - `case_run(state)`: runs the functions we wish to measure
+=#
+include(case_path)
+
+isdefined(Main, :case_setup) ||
+    error("The required 'case_setup' function was not defined in the case file: $case_path")
+isdefined(Main, :case_run) ||
+    error("The required 'case_run' function was not defined in the case file: $case_path")
+
+
+
+setup_time = @elapsed s = case_setup()
+
+compile_time = @elapsed case_run(s)
+
+@info """Basic run statistics:
+    • Setup time: $setup_time [s]
+    • Warmup (compilation) time: $compile_time [s]
+"""
+
+# Profile the section with the CUDA's build-in profiler
+CUDA.@profile external=true begin
+    case_run(s)
+end

--- a/perf/run-and-time/quickprof_harness.jl
+++ b/perf/run-and-time/quickprof_harness.jl
@@ -1,0 +1,148 @@
+#=
+run with: julia  --project ./quickprof_harness.jl <path-to-case-file>
+
+from the script directory.
+=#
+
+# Always try using Revise if available
+# It will allow to skip setup+compilation overhead when iterating on a function
+# using the harness to re-do measurements
+try
+    using Revise
+catch e
+    @warn "'Revise' module not available received: $e on import"
+end
+
+# Activate ClimaCore's kernel renaming feature, so kernels show up in
+# profiler output (nsys/ncu) with human-readable names constructed from
+# the stack trace (function name, file, and line).
+# Must be set before ClimaCore's CUDA extension (ClimaCoreCUDAExt) is loaded,
+# since the setting is read in its `__init__`.
+ENV["CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE"] = get(
+    ENV, "CLIMA_NAME_CUDA_KERNELS_FROM_STACK_TRACE", "true",
+)
+
+using CUDA
+using DataFrames
+
+
+if length(ARGS) != 1
+    error(
+        "You need to provide path to the 'case' file that defines 'case_setup' and 'case_run' functions.",
+    )
+end
+
+# Load the simulation file
+case_path = abspath(ARGS[1])
+
+#=
+The file getting include here needs to specify the 2 methods:
+    - `case_setup`: returns a 'state'
+    - `case_run(state)`: runs the functions we wish to measure
+=#
+include(case_path)
+
+isdefined(Main, :case_setup) ||
+    error("The required 'case_setup' function was not defined in the case file: $case_path")
+isdefined(Main, :case_run) ||
+    error("The required 'case_run' function was not defined in the case file: $case_path")
+
+
+
+function quick_profile()
+
+    setup_time = @elapsed s = case_setup()
+
+    compile_time = @elapsed case_run(s)
+
+    @info """Basic run statistics:
+        • Setup time: $setup_time [s]
+        • Warmup (compilation) time: $compile_time [s]
+    """
+
+    # Profile the section with the CUDA's build-in profiler
+    profile_data = CUDA.@profile begin
+        case_run(s)
+    end
+
+    # We want to avoid truncating the data both in interactive and script use
+    # Hence we call shows below with explicit IOContext
+    io = IOContext(
+        stdout,
+        :limit => false,
+        :displaysize => displaysize(stdout),
+        :color => get(stdout, :color, false),
+    )
+
+    show(io, profile_data)
+    summary = get_kernel_data(profile_data)
+
+    show(io, summary;
+        truncate = 0,
+        allcols = true,
+        allrows = true,
+        summary = false,
+        eltypes = false,
+    )
+
+    return (profile_data, summary)
+end
+
+cudim_to_tuple(grid::CUDA.CuDim3) = map(Int64, (grid.x, grid.y, grid.z))
+cudim_to_tuple(::Missing) = missing
+
+
+"""
+    get_kernel_data(profile_data)
+
+Identify unique kernels and generate DataFrame summary with launch statistics
+and compile parameters (e.g. register usage).
+
+Here we are relying on the internal representation of the profile data
+This is not Public CUDA API and is unstable. Developed on CUDA.jl 5.11.3
+It is possible for it to break on any major, minor (or even patch) version
+"""
+function get_kernel_data(profile_data)
+    device_data = DataFrame(profile_data.device)
+
+    transform!(device_data, [:stop, :start] => ByRow(-) => :duration)
+    transform!(device_data, :grid => ByRow(cudim_to_tuple) => :grid)
+    transform!(device_data, :block => ByRow(cudim_to_tuple) => :block)
+
+    transform!(
+        device_data,
+        :shared_mem => ByRow(x -> x === missing ? missing : x.dynamic) => :dynamic_shmem,
+    )
+    transform!(
+        device_data,
+        :shared_mem => ByRow(x -> x === missing ? missing : x.static) => :static_shmem,
+    )
+    transform!(
+        device_data,
+        :local_mem => ByRow(x -> x === missing ? missing : x.thread) => :local_mem,
+    )
+
+    # Group by duplicates
+    # We assume the kernel is the same if it has all the same:
+    kernel_traits =
+        [:name, :grid, :block, :dynamic_shmem, :static_shmem, :local_mem, :registers]
+    groups = groupby(
+        device_data,
+        kernel_traits,
+    )
+
+    # Reduce each group to one row of summary statistics.
+    # duration is in seconds (CUDA.jl stores start/stop as Float64 seconds).
+    summary = combine(groups) do subdf
+        durs = subdf.duration
+        n = length(durs)
+        (
+            n_launches = n,
+        )
+    end
+
+    return summary
+end
+
+
+(data, kernel_summary) = quick_profile()

--- a/perf/run-and-time/timer_harness.jl
+++ b/perf/run-and-time/timer_harness.jl
@@ -1,7 +1,7 @@
 #=
-run with: julia  --project=.buildkite perf/run-and-time/timer_harness.jl <path-to-case-file>
+run with: julia  --project ./timer_harness.jl <path-to-case-file>
 
-from the root of the repository.
+from the script directory.
 =#
 
 # Always try using Revise if available

--- a/perf/run-and-time/timer_harness.jl
+++ b/perf/run-and-time/timer_harness.jl
@@ -1,0 +1,62 @@
+#=
+run with: julia  --project=.buildkite perf/run-and-time/timer_harness.jl <path-to-case-file>
+
+from the root of the repository.
+=#
+
+# Always try using Revise if available
+# It will allow to skip setup+compilation overhead when iterating on a function
+# using the harness to re-do measurements
+try
+    using Revise
+catch e
+    @warn "'Revise' module not available received: $e on import"
+end
+
+using CUDA
+using BenchmarkTools
+using ClimaComms
+
+
+if length(ARGS) != 1
+    error(
+        "You need to provide path to the 'case' file that defines 'case_setup' and 'case_run' functions.",
+    )
+end
+
+# Load the simulation file
+case_path = abspath(ARGS[1])
+
+#=
+The file getting include here needs to specify the 2 methods:
+    - `case_setup`: returns a 'state'
+    - `case_run(state)`: runs the functions we wish to measure
+=#
+include(case_path)
+
+isdefined(Main, :case_setup) ||
+    error("The required 'case_setup' function was not defined in the case file: $case_path")
+isdefined(Main, :case_run) ||
+    error("The required 'case_run' function was not defined in the case file: $case_path")
+
+
+function basic_timers()
+    setup_time = @elapsed s = case_setup()
+
+    compile_time = @elapsed case_run(s)
+
+    benchmark = BenchmarkTools.@benchmark CUDA.@sync begin
+        case_run($s)
+    end
+
+    display(benchmark)
+    @info """Basic run statistics:
+        • Setup time: $setup_time [s]
+        • Warmup (compilation) time: $compile_time [s]
+        • Mean GPU time: $(mean(benchmark.times * 1e-6)) [μs]
+    """
+    return benchmark
+end
+
+# Run the timers by default
+basic_timers()

--- a/perf/run-and-time/timer_harness.jl
+++ b/perf/run-and-time/timer_harness.jl
@@ -53,7 +53,7 @@ function basic_timers()
     @info """Basic run statistics:
         • Setup time: $setup_time [s]
         • Warmup (compilation) time: $compile_time [s]
-        • Mean GPU time: $(mean(benchmark.times * 1e-6)) [μs]
+        • Mean GPU time: $(mean(benchmark.times * 1e-3)) [ms]
     """
     return benchmark
 end


### PR DESCRIPTION
## Purpose 

Propose a draft of architecture for modular way to collect performance metrics for isolated parts of the code.

## TODO

- [x] Move other components (cases) from the [tr/perf-scripts](https://github.com/CliMA/ClimaAtmos.jl/tree/tr/perf-scripts/run-and-time) branch over. At the moment only `sgs` is present.
- [x] Add documentation 
- [x] Add a smoke test in CI to verify it runs

## Content

@dennisYatunin  @imreddyTeja 
This in preparation for the following task of trying to isolate pieces of the ClimaAtmos functionality and iterate on them to find performance opportunities.  

The problem that we want to address is that we expect to have many cases representing different pieces of ClimaAtmos as well as different metrics we would wish to collect. Furthermore, we wish to avoid duplication (i.e. copy and paste) of the code to collect metrics of interest into the scripts. 

To solve this we can decouple the code that does the collection from the code that contains instructions on how to setup the case and run a piece of code we wish to measure.  

In the `models` directory we collect julia source files that need to define two functions `case_setup` and `case_run`. First one produces some "state" representing the case. `case_run` executes the function we wish to measure. 

The `*_harness.jl` files are envisioned to 'dynamically load' the case via `include` and then apply the measurements.   

At the moment the `timer_harness.jl` is the bare-bones example of just collecting runtime information. If we are happy with the setup we can add extra harnesses to do the profiling with `nsys` or `ncu`.

----
- [x] I have read and checked the items on the review checklist.
