### PR TITLE
no sponge on grid-mean micro tracers

### DIFF
--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -164,27 +164,7 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
         rst_ρtke = rayleigh_sponge_tendency_tracer(Y.c.ρtke, rayleigh_sponge)
         @. Yₜ.c.ρtke += rst_ρtke
     end
-    # TODO: This damps ρq_lcl/ρq_icl/ρq_rai/ρq_sno toward zero with no
-    # counterpart in ρq_tot, ρ, or ρe_tot, so it implicitly converts
-    # condensate to vapor without accounting for the associated latent
-    # heat, which can generate spurious heating/cooling and supersaturation
-    # in the sponge layer. Either remove this once it's confirmed unneeded
-    # (e.g. after the top-boundary flux fixes), or make it mass- and
-    # energy-consistent by applying the same sink to ρq_tot, ρ, and ρe_tot.
-    if microphysics_model isa NonEquilibriumMicrophysics1M
-        grid_mean_micro_species = (
-            @name(c.ρq_lcl),
-            @name(c.ρq_icl),
-            @name(c.ρq_rai),
-            @name(c.ρq_sno),
-        )
-        MatrixFields.unrolled_foreach(grid_mean_micro_species) do ρq_name
-            ᶜρq = MatrixFields.get_field(Y, ρq_name)
-            ᶜρqₜ = MatrixFields.get_field(Yₜ, ρq_name)
-            rst_ρq = rayleigh_sponge_tendency_tracer(ᶜρq, rayleigh_sponge)
-            @. ᶜρqₜ += rst_ρq
-        end
-    end
+
     if turbconv_model isa PrognosticEDMFX
         ᶜmse = @. lazy(ᶜh_tot - ᶜK)
         ᶜq_tot = @. lazy(specific(Y.c.ρq_tot, Y.c.ρ))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I kept the sponge for updraft because it may be useful for passive tracers. It shouldn't have an effect on microphysics tracers.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
