### PR TITLE
Make topography_damping_factor config default a float.

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -51,7 +51,7 @@ topo_smoothing:
   value: false
 topography_damping_factor:
   help: "Factor by which smallest resolved length-scale is to be damped"
-  value: 5
+  value: 5.0
 # ODE
 use_newton_rtol:
   help: "Whether to check if the current iteration of Newton's method has an error within a relative tolerance, instead of always taking the maximum number of iterations (only for ClimaTimeSteppers.jl)"


### PR DESCRIPTION
The config loader pins every override to the type of the default, so passing float values (eg from the Coupler) results in an `InexactError`.  This changes the expected type to float, allowing for fractional topography_damping_factors. 