### PR TITLE
Use full 3D pressure by default for WeatherModel IC.

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -206,6 +206,9 @@ start_date:
 era5_initial_condition_dir:
   help: "Directory containing ERA5 initial condition files. Filenames inferred from start_date [none (default)]. Generated with `https://github.com/CliMA/WeatherQuest`."
   value: ~
+era5_ic_full_pressure:
+  help: "For `WeatherModel` initial conditions, read 3D pressure (`p_3d`) from the ERA5 file instead of integrating hydrostatically from surface pressure [`false` (default), `true`]"
+  value: false
 test_dycore_consistency:
   help: "Test dycore consistency [`false` (default), `true`]"
   value: false

--- a/config/model_configs/sphere_beres_verification.yml
+++ b/config/model_configs/sphere_beres_verification.yml
@@ -25,7 +25,7 @@ microphysics_model: "0M"
 non_orographic_gravity_wave: true
 nogw_beres_source: true
 nogw_beres_detailed_diagnostics: true
-dt_nogw: "400secs"
+dt_nogw: "350secs"
 t_end: "7days"
 dt_save_state_to_disk: "Inf"
 toml: [toml/prognostic_edmfx.toml, toml/nogw_verification_grid.toml]

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -184,10 +184,11 @@ values map to same-named types in `Setups`:
     `"DYCOMS_RF02"`, `"TRMM_LBA"`, `"Larcform1"`, `"GABLS"`, `"ISDAC"`, which read
     `prognostic_tke` (and, for ISDAC, `perturb_initstate`).
   - RCEMIP II: `"RCEMIPIIProfile_295"`, `"RCEMIPIIProfile_300"`, `"RCEMIPIIProfile_305"`.
-  - File- and reanalysis-driven: `"GCM"` (`external_forcing_file` plus `cfsite_number`),
+  - File and reanalysis-driven: `"GCM"` (`external_forcing_file` plus `cfsite_number`),
     `"ARMVARANAL"` (an ARM VARANAL file, converted to the ClimaColumn schema),
     `"ForcingFromFile"` (a ClimaColumn file), `"ReanalysisTimeVarying"` (an ERA5 file for
-    the site, generated when missing or stale), `"WeatherModel"`, and `"AMIPFromERA5"`.
+    the site, generated when missing or stale), `"WeatherModel"` (reads
+    `era5_initial_condition_dir` and `era5_ic_full_pressure`), and `"AMIPFromERA5"`.
 
 A value that names an existing file is read as a `Setups.MoistFromFile` initial state.
 Anything else raises an error.
@@ -284,7 +285,8 @@ function get_setup_type(parsed_args, thermo_params)
     elseif ic_name == "WeatherModel"
         return Setups.WeatherModel(
             parsed_args["start_date"],
-            parsed_args["era5_initial_condition_dir"],
+            parsed_args["era5_initial_condition_dir"];
+            use_full_pressure = parsed_args["era5_ic_full_pressure"],
         )
     elseif ic_name == "AMIPFromERA5"
         return Setups.AMIPFromERA5(parsed_args["start_date"])

--- a/src/setups/WeatherModel.jl
+++ b/src/setups/WeatherModel.jl
@@ -12,7 +12,7 @@ full prognostic state with ERA5 data obtained via `weather_model_data_path`.
   - `era5_initial_condition_dir`: Optional directory with pre-processed ERA5 files.
     When `nothing`, uses the `wxquest_initial_conditions` ClimaArtifact.
   - `use_full_pressure`: If `true`, attempt to read 3D pressure from the file
-    rather than computing it hydrostatically. Defaults to `false`.
+    rather than computing it hydrostatically. Defaults to `true`.
 
 The optional ERA5 initial condition directory is stored in `_ERA5_IC_DIR` to avoid GPU
 allocation issues with strings. When `nothing`, uses the `weather_model_ic` ClimaArtifact.
@@ -27,7 +27,7 @@ const _ERA5_IC_DIR = Ref{Any}(nothing)
 function WeatherModel(
     start_date::String,
     era5_initial_condition_dir = nothing;
-    use_full_pressure::Bool = false,
+    use_full_pressure::Bool = true,
 )
     _ERA5_IC_DIR[] = era5_initial_condition_dir
     return WeatherModel(
@@ -93,6 +93,7 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
         haskey(ds, "p_3d")
     end
     ᶠp = if use_p3d
+        @info "Using full 3D pressure from file variable `p_3d` (use_full_pressure=true)"
         SpaceVaryingInputs.SpaceVaryingInput(
             file_path, "p_3d", face_space; svi_kwargs...,
         )

--- a/src/setups/WeatherModel.jl
+++ b/src/setups/WeatherModel.jl
@@ -102,6 +102,7 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
         haskey(ds, "p_3d")
     end
     ᶠp = if use_p3d
+        @info "Using full 3D pressure from file variable `p_3d` (use_full_pressure=true)"
         SpaceVaryingInputs.SpaceVaryingInput(
             file_path, "p_3d", face_space; svi_kwargs...,
         )


### PR DESCRIPTION
Use full 3D pressure field for initialization from ERA5 by default. In place of hydrostatic integration from surface pressure. 
