### PR TITLE
Use non-constant rain sedimentation velocity

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -343,13 +343,20 @@ steps:
       - label: ":chart_with_upwards_trend: SCM intercomparison plots"
         retry: *retry_policy
         depends_on:
-          - prognostic_edmfx_soares_column
-          - prognostic_edmfx_gabls_column
-          - prognostic_edmfx_bomex_column
-          - prognostic_edmfx_dycoms_rf01_column
-          - prognostic_edmfx_dycoms_rf02_column
-          - prognostic_edmfx_rico_column
-          - prognostic_edmfx_trmm_column
+          - step: prognostic_edmfx_soares_column
+            allow_failure: true
+          - step: prognostic_edmfx_gabls_column
+            allow_failure: true
+          - step: prognostic_edmfx_bomex_column
+            allow_failure: true
+          - step: prognostic_edmfx_dycoms_rf01_column
+            allow_failure: true
+          - step: prognostic_edmfx_dycoms_rf02_column
+            allow_failure: true
+          - step: prognostic_edmfx_rico_column
+            allow_failure: true
+          - step: prognostic_edmfx_trmm_column
+            allow_failure: true
         command: |
           for JOB in \
             prognostic_edmfx_soares_column \

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaAtmos.jl Release Notes
 
 main
 ----
+- [#4744](https://github.com/CliMA/ClimaAtmos.jl/pull/4744) ![][badge-🔥behavioralΔ] Make rain sediment with non-constant velocity
+
 0.42.4
 -------
 - [#4750](https://github.com/CliMA/ClimaAtmos.jl/pull/4750) ![][badge-✨feature/enhancement] Add the diagnostics `ssatl` and `ssati` (water-vapor supersaturation with respect to liquid and to ice), available for any moist microphysics model.

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -263,8 +263,17 @@ microphysics_n_substeps:
 microphysics_n_substeps_quadrature:
   help: "Number of susbteps for time averaging bulk microphysics tendencies with subgrid-scale quadrature. Default: 2"
   value: 2
-fixed_terminal_velocity:
-  help: "Use fixed terminal velocities for microphysics tracers [`true` (default), `false`]"
+fixed_terminal_velocity_liquid:
+  help: "Use fixed terminal velocity for cloud liquid sedimentation [`true` (default), `false`]"
+  value: true
+fixed_terminal_velocity_ice:
+  help: "Use fixed terminal velocity for cloud ice sedimentation [`true` (default), `false`]"
+  value: true
+fixed_terminal_velocity_rain:
+  help: "Use fixed terminal velocity for rain sedimentation [`true`, `false` (default)]"
+  value: false
+fixed_terminal_velocity_snow:
+  help: "Use fixed terminal velocity for snow sedimentation [`true` (default), `false`]"
   value: true
 cloud_liquid_formation:
   help: "Cloud liquid formation option for 1M microphysics [`CloudLiquidFormation` (default), ~]"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -67,7 +67,7 @@ use_dynamic_krylov_rtol:
   value: false
 max_newton_iters_ode:
   help: "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)."
-  value: 3
+  value: 1
 ode_algo:
   help: "ODE algorithm [`ARS343` (default), `SSP333`, `IMKG343a`, etc.]"
   value: "ARS343"

--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -67,7 +67,7 @@ use_dynamic_krylov_rtol:
   value: false
 max_newton_iters_ode:
   help: "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)."
-  value: 1
+  value: 3
 ode_algo:
   help: "ODE algorithm [`ARS343` (default), `SSP333`, `IMKG343a`, etc.]"
   value: "ARS343"
@@ -263,8 +263,17 @@ microphysics_n_substeps:
 microphysics_n_substeps_quadrature:
   help: "Number of susbteps for time averaging bulk microphysics tendencies with subgrid-scale quadrature. Default: 2"
   value: 2
-fixed_terminal_velocity:
-  help: "Use fixed terminal velocities for microphysics tracers [`true` (default), `false`]"
+fixed_terminal_velocity_liquid:
+  help: "Use fixed terminal velocity for cloud liquid sedimentation [`true` (default), `false`]"
+  value: true
+fixed_terminal_velocity_ice:
+  help: "Use fixed terminal velocity for cloud ice sedimentation [`true` (default), `false`]"
+  value: true
+fixed_terminal_velocity_rain:
+  help: "Use fixed terminal velocity for rain sedimentation [`true` (default), `false`]"
+  value: false
+fixed_terminal_velocity_snow:
+  help: "Use fixed terminal velocity for snow sedimentation [`true` (default), `false`]"
   value: true
 cloud_liquid_formation:
   help: "Cloud liquid formation option for 1M microphysics [`CloudLiquidFormation` (default), ~]"

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-397
+398
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+398
+- Make rain sediment with non-constant velocity
+
 397
 - Change default ice formation to temperature dependent
 

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -710,11 +710,15 @@ function update_implicit_microphysics_cache!(
     if p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity
         (; ᶜwᵣ) = p.precomputed
         cmp = CAP.microphysics_1m_params(p.params)
-        @. ᶜwᵣ = CM1.terminal_velocity(
-            cmp.precip.rain,
-            cmp.terminal_velocity.rain,
-            Y.c.ρ,
-            max(zero(Y.c.ρ), specific(Y.c.ρq_rai, Y.c.ρ)),
+        @. ᶜwᵣ = clamp(
+            CM1.terminal_velocity(
+                cmp.precip.rain,
+                cmp.terminal_velocity.rain,
+                Y.c.ρ,
+                max(zero(Y.c.ρ), specific(Y.c.ρq_rai, Y.c.ρ)),
+            ),
+            typeof(Y.c.ρ)(1e-3),
+            typeof(Y.c.ρ)(3),
         )
     end
     set_precipitation_surface_fluxes!(Y, p, mm)

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -108,10 +108,11 @@ function set_precipitation_velocities!(
 )
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ, ᶜT, ᶜu) = p.precomputed
     (; ᶜΦ) = p.core
-    (; terminal_velocity_mode) = p.atmos
-    cmc = CAP.microphysics_cloud_params(p.params)
-    cmp = CAP.microphysics_1m_params(p.params)
-    thp = CAP.thermodynamics_params(p.params)
+    atmos = p.atmos
+    params = p.params
+    cmc = CAP.microphysics_cloud_params(params)
+    cmp = CAP.microphysics_1m_params(params)
+    thp = CAP.thermodynamics_params(params)
 
     # scratch for adding energy fluxes over subdomains
     ᶜρwₕhₜ = p.scratch.ᶜtemp_scalar
@@ -119,8 +120,9 @@ function set_precipitation_velocities!(
 
     terminal_velocity_function(name, ρ, q) = terminal_velocity(
         microphysics_model,
-        terminal_velocity_mode,
+        velocity_mode(atmos, name),
         name,
+        params,
         cmc,
         cmp,
         ρ,
@@ -167,11 +169,12 @@ function set_precipitation_velocities!(
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ) = p.precomputed
     (; ᶜwₗʲs, ᶜwᵢʲs, ᶜwᵣʲs, ᶜwₛʲs, ᶜTʲs, ᶜρʲs) = p.precomputed
     (; ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
-    (; terminal_velocity_mode) = p.atmos
+    atmos = p.atmos
+    params = p.params
 
-    cmc = CAP.microphysics_cloud_params(p.params)
-    cmp = CAP.microphysics_1m_params(p.params)
-    thp = CAP.thermodynamics_params(p.params)
+    cmc = CAP.microphysics_cloud_params(params)
+    cmp = CAP.microphysics_1m_params(params)
+    thp = CAP.thermodynamics_params(params)
 
     ᶜρ⁰ = @. lazy(
         TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰),
@@ -196,8 +199,9 @@ function set_precipitation_velocities!(
 
     terminal_velocity_function(name, ρ, q) = terminal_velocity(
         microphysics_model,
-        terminal_velocity_mode,
+        velocity_mode(atmos, name),
         name,
+        params,
         cmc,
         cmp,
         ρ,
@@ -243,8 +247,9 @@ function set_precipitation_velocities!(
         # average
         @. ᶜw = gs_terminal_velocity(
             microphysics_model,
-            terminal_velocity_mode,
+            velocity_mode(atmos, χ_name),
             χ_name,
+            params,
             ᶜw,
             ᶜρχ,
         )
@@ -718,6 +723,27 @@ function update_implicit_microphysics_cache!(
         ρdq_tot_dtʲ = @. lazy(Y.c.sgsʲs.:($$j).ρa * ᶜmp_tendencyʲs.:($$j).dq_tot_dt)
         @. ᶜρ_dq_tot_dt += ρdq_tot_dtʲ
         @. ᶜρ_de_tot_dt += ρdq_tot_dtʲ * ᶜmp_tendencyʲs.:($$j).e_tot_hlpr
+    end
+    set_precipitation_surface_fluxes!(Y, p, mm)
+    return nothing
+end
+
+function update_implicit_microphysics_cache!(
+    Y,
+    p,
+    mm::NonEquilibriumMicrophysics1M,
+    tm,
+)
+    # Recompute the sedimentation velocities from the current implicit-solver state.
+    # This is expecially important for PrognosticEDMFX `ᶜwᵣʲs`.
+    # Leaving updraft velocities at their explicit-stage values treats the
+    # nonlinear part of the sedimentation flux explicitly.
+    # No number of Newton iterations can correct a field that nothing updates.
+    if p.atmos.terminal_velocity_liquid isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_ice isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_snow isa DiagnosticTerminalVelocity
+        set_precipitation_velocities!(Y, p, mm, tm)
     end
     set_precipitation_surface_fluxes!(Y, p, mm)
     return nothing

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -700,27 +700,18 @@ function update_implicit_microphysics_cache!(
     Y,
     p,
     mm::NonEquilibriumMicrophysics1M,
-    _,
+    tm,
 )
-    # Recompute rain terminal velocity from the current Newton iterate when
-    # using diagnostic (state-dependent) rain sedimentation velocity.  The
-    # Jacobian still treats wᵣ as locally constant (lagged-coefficient
-    # approximation), but using the current value rather than the stale
-    # explicit-stage value improves implicit-solve accuracy.
-    if p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity
-        (; ᶜwᵣ) = p.precomputed
-        cmp = CAP.microphysics_1m_params(p.params)
-        FT = eltype(Y.c.ρ)
-        @. ᶜwᵣ = clamp(
-            CM1.terminal_velocity(
-                cmp.precip.rain,
-                cmp.terminal_velocity.rain,
-                Y.c.ρ,
-                max(zero(Y.c.ρ), specific(Y.c.ρq_rai, Y.c.ρ)),
-            ),
-            FT(1e-3),
-            FT(3),
-        )
+    # Recompute the sedimentation velocities from the current implicit-solver state.
+    # This is expecially important for PrognosticEDMFX `ᶜwᵣʲs`.
+    # Leaving updraft velocities at their explicit-stage values treats the
+    # nonlinear part of the sedimentation flux explicitly.
+    # No number of Newton iterations can correct a field that nothing updates.
+    if p.atmos.terminal_velocity_liquid isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_ice isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity ||
+       p.atmos.terminal_velocity_snow isa DiagnosticTerminalVelocity
+        set_precipitation_velocities!(Y, p, mm, tm)
     end
     set_precipitation_surface_fluxes!(Y, p, mm)
     return nothing

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -84,10 +84,11 @@ function set_precipitation_velocities!(
 )
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ, ᶜT, ᶜu) = p.precomputed
     (; ᶜΦ) = p.core
-    (; terminal_velocity_mode) = p.atmos
-    cmc = CAP.microphysics_cloud_params(p.params)
-    cmp = CAP.microphysics_1m_params(p.params)
-    thp = CAP.thermodynamics_params(p.params)
+    atmos = p.atmos
+    params = p.params
+    cmc = CAP.microphysics_cloud_params(params)
+    cmp = CAP.microphysics_1m_params(params)
+    thp = CAP.thermodynamics_params(params)
 
     # scratch for adding energy fluxes over subdomains
     ᶜρwₕhₜ = p.scratch.ᶜtemp_scalar
@@ -95,8 +96,9 @@ function set_precipitation_velocities!(
 
     terminal_velocity_function(name, ρ, q) = terminal_velocity(
         microphysics_model,
-        terminal_velocity_mode,
+        velocity_mode(atmos, name),
         name,
+        params,
         cmc,
         cmp,
         ρ,
@@ -143,11 +145,12 @@ function set_precipitation_velocities!(
     (; ᶜwₗ, ᶜwᵢ, ᶜwᵣ, ᶜwₛ, ᶜwₜqₜ, ᶜwₕhₜ) = p.precomputed
     (; ᶜwₗʲs, ᶜwᵢʲs, ᶜwᵣʲs, ᶜwₛʲs, ᶜTʲs, ᶜρʲs) = p.precomputed
     (; ᶜT⁰, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰) = p.precomputed
-    (; terminal_velocity_mode) = p.atmos
+    atmos = p.atmos
+    params = p.params
 
-    cmc = CAP.microphysics_cloud_params(p.params)
-    cmp = CAP.microphysics_1m_params(p.params)
-    thp = CAP.thermodynamics_params(p.params)
+    cmc = CAP.microphysics_cloud_params(params)
+    cmp = CAP.microphysics_1m_params(params)
+    thp = CAP.thermodynamics_params(params)
 
     ᶜρ⁰ = @. lazy(
         TD.air_density(thp, ᶜT⁰, ᶜp, ᶜq_tot_nonneg⁰, ᶜq_liq⁰, ᶜq_ice⁰),
@@ -172,8 +175,9 @@ function set_precipitation_velocities!(
 
     terminal_velocity_function(name, ρ, q) = terminal_velocity(
         microphysics_model,
-        terminal_velocity_mode,
+        velocity_mode(atmos, name),
         name,
+        params,
         cmc,
         cmp,
         ρ,
@@ -219,8 +223,9 @@ function set_precipitation_velocities!(
         # average
         @. ᶜw = gs_terminal_velocity(
             microphysics_model,
-            terminal_velocity_mode,
+            velocity_mode(atmos, χ_name),
             χ_name,
+            params,
             ᶜw,
             ᶜρχ,
         )
@@ -686,6 +691,31 @@ function update_implicit_microphysics_cache!(
         ρdq_tot_dtʲ = @. lazy(Y.c.sgsʲs.:($$j).ρa * ᶜmp_tendencyʲs.:($$j).dq_tot_dt)
         @. ᶜρ_dq_tot_dt += ρdq_tot_dtʲ
         @. ᶜρ_de_tot_dt += ρdq_tot_dtʲ * ᶜmp_tendencyʲs.:($$j).e_tot_hlpr
+    end
+    set_precipitation_surface_fluxes!(Y, p, mm)
+    return nothing
+end
+
+function update_implicit_microphysics_cache!(
+    Y,
+    p,
+    mm::NonEquilibriumMicrophysics1M,
+    _,
+)
+    # Recompute rain terminal velocity from the current Newton iterate when
+    # using diagnostic (state-dependent) rain sedimentation velocity.  The
+    # Jacobian still treats wᵣ as locally constant (lagged-coefficient
+    # approximation), but using the current value rather than the stale
+    # explicit-stage value improves implicit-solve accuracy.
+    if p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity
+        (; ᶜwᵣ) = p.precomputed
+        cmp = CAP.microphysics_1m_params(p.params)
+        @. ᶜwᵣ = CM1.terminal_velocity(
+            cmp.precip.rain,
+            cmp.terminal_velocity.rain,
+            Y.c.ρ,
+            max(zero(Y.c.ρ), specific(Y.c.ρq_rai, Y.c.ρ)),
+        )
     end
     set_precipitation_surface_fluxes!(Y, p, mm)
     return nothing

--- a/src/cache/microphysics_cache.jl
+++ b/src/cache/microphysics_cache.jl
@@ -710,6 +710,7 @@ function update_implicit_microphysics_cache!(
     if p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity
         (; ᶜwᵣ) = p.precomputed
         cmp = CAP.microphysics_1m_params(p.params)
+        FT = eltype(Y.c.ρ)
         @. ᶜwᵣ = clamp(
             CM1.terminal_velocity(
                 cmp.precip.rain,
@@ -717,8 +718,8 @@ function update_implicit_microphysics_cache!(
                 Y.c.ρ,
                 max(zero(Y.c.ρ), specific(Y.c.ρq_rai, Y.c.ρ)),
             ),
-            typeof(Y.c.ρ)(1e-3),
-            typeof(Y.c.ρ)(3),
+            FT(1e-3),
+            FT(3),
         )
     end
     set_precipitation_surface_fluxes!(Y, p, mm)

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -835,14 +835,18 @@ function AtmosWater(config::AtmosConfig, params, ::Type{FT}) where {FT}
 
     cloud_model = get_cloud_model(pa, params)
 
-    terminal_velocity_mode =
-        pa["fixed_terminal_velocity"] ?
-        FixedTerminalVelocity{FT}(
-            CAP.fixed_cloud_liquid_terminal_velocity(params),
-            CAP.fixed_cloud_ice_terminal_velocity(params),
-            CAP.fixed_rain_terminal_velocity(params),
-            CAP.fixed_snow_terminal_velocity(params),
-        ) : DiagnosticTerminalVelocity()
+    terminal_velocity_liquid =
+        pa["fixed_terminal_velocity_liquid"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_ice =
+        pa["fixed_terminal_velocity_ice"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_rain =
+        pa["fixed_terminal_velocity_rain"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_snow =
+        pa["fixed_terminal_velocity_snow"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
 
     implicit_microphysics = pa["implicit_microphysics"]
 
@@ -853,7 +857,10 @@ function AtmosWater(config::AtmosConfig, params, ::Type{FT}) where {FT}
                                              Explicit(),
         tracer_nonnegativity_method = get_tracer_nonnegativity_method(pa),
         sgs_quadrature,
-        terminal_velocity_mode,
+        terminal_velocity_liquid,
+        terminal_velocity_ice,
+        terminal_velocity_rain,
+        terminal_velocity_snow,
     )
 end
 

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -1142,14 +1142,18 @@ function AtmosWater(config::AtmosConfig, params, ::Type{FT}) where {FT}
 
     cloud_model = get_cloud_model(pa, params)
 
-    terminal_velocity_mode =
-        pa["fixed_terminal_velocity"] ?
-        FixedTerminalVelocity{FT}(
-            CAP.fixed_cloud_liquid_terminal_velocity(params),
-            CAP.fixed_cloud_ice_terminal_velocity(params),
-            CAP.fixed_rain_terminal_velocity(params),
-            CAP.fixed_snow_terminal_velocity(params),
-        ) : DiagnosticTerminalVelocity()
+    terminal_velocity_liquid =
+        pa["fixed_terminal_velocity_liquid"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_ice =
+        pa["fixed_terminal_velocity_ice"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_rain =
+        pa["fixed_terminal_velocity_rain"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
+    terminal_velocity_snow =
+        pa["fixed_terminal_velocity_snow"] ?
+        FixedTerminalVelocity() : DiagnosticTerminalVelocity()
 
     implicit_microphysics = pa["implicit_microphysics"]
 
@@ -1160,7 +1164,10 @@ function AtmosWater(config::AtmosConfig, params, ::Type{FT}) where {FT}
                                              Explicit(),
         tracer_nonnegativity_method = get_tracer_nonnegativity_method(pa),
         sgs_quadrature,
-        terminal_velocity_mode,
+        terminal_velocity_liquid,
+        terminal_velocity_ice,
+        terminal_velocity_rain,
+        terminal_velocity_snow,
     )
 end
 

--- a/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
+++ b/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
@@ -81,11 +81,7 @@ terminal_velocity(
     cmp,
     ρ,
     q,
-) = clamp(
-    CM1.terminal_velocity(cmp.precip.rain, cmp.terminal_velocity.rain, ρ, q),
-    typeof(q)(1e-3),
-    typeof(q)(3),
-)
+) = CM1.terminal_velocity(cmp.precip.rain, cmp.terminal_velocity.rain, ρ, q)
 
 # Snow, 1M
 terminal_velocity(

--- a/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
+++ b/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
@@ -81,7 +81,11 @@ terminal_velocity(
     cmp,
     ρ,
     q,
-) = CM1.terminal_velocity(cmp.precip.rain, cmp.terminal_velocity.rain, ρ, q)
+) = clamp(
+    CM1.terminal_velocity(cmp.precip.rain, cmp.terminal_velocity.rain, ρ, q),
+    typeof(q)(1e-3),
+    typeof(q)(3),
+)
 
 # Snow, 1M
 terminal_velocity(

--- a/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
+++ b/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
@@ -27,22 +27,29 @@ idealized tests where the sedimentation rate is to be controlled directly.
 
 Sign convention: the stored values are downward fall speeds and must be
 non-negative.
-
-# Fields
-
-  - `liquid`: Cloud liquid fall speed [m/s].
-  - `ice`: Cloud ice fall speed [m/s].
-  - `rain`: Rain fall speed [m/s].
-  - `snow`: Snow fall speed [m/s].
 """
-struct FixedTerminalVelocity{FT} <: AbstractTerminalVelocityMode
-    liquid::FT
-    ice::FT
-    rain::FT
-    snow::FT
-    #TODO fixed-velocity sedimentation of 2M/P3 tracers not implemented
-end
+struct FixedTerminalVelocity <: AbstractTerminalVelocityMode end
+#TODO fixed-velocity sedimentation of 2M/P3 tracers not implemented
 Base.broadcastable(x::AbstractTerminalVelocityMode) = tuple(x)
+
+"""
+    velocity_mode(atmos, name)
+
+Select the per-species terminal velocity mode from `atmos` based on the tracer
+`name` (a `MatrixFields.FieldName`).
+
+Each hydrometeor species has its own toggle in `AtmosWater`, so e.g. rain can
+use `DiagnosticTerminalVelocity` while the others remain
+`FixedTerminalVelocity`.
+"""
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_lcl,)}) =
+    atmos.terminal_velocity_liquid
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_icl,)}) =
+    atmos.terminal_velocity_ice
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_rai,)}) =
+    atmos.terminal_velocity_rain
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_sno,)}) =
+    atmos.terminal_velocity_snow
 
 # Liquid, 1M
 """
@@ -73,15 +80,17 @@ Terminal velocity [m/s], positive downward.
 """
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_lcl,)},
+    params,
     args...,
-) = mode.liquid
+) = CAP.fixed_cloud_liquid_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_lcl,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -91,15 +100,17 @@ terminal_velocity(
 # Ice, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_icl,)},
+    params,
     args...,
-) = mode.ice
+) = CAP.fixed_cloud_ice_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_icl,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -109,33 +120,46 @@ terminal_velocity(
 # Rain, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_rai,)},
+    params,
     args...,
-) = mode.rain
+) = CAP.fixed_rain_terminal_velocity(params)
 
+# The 1M terminal velocity varies as q^(1/8), so ∂w/∂q ∝ q^(-7/8).
+# As q goes to 0, it creates a large error.
+# Evaluating w at max(q, RAIN_Q_FLOOR) makes ∂w/∂q zero, and removes the issue.
+# 1e-8 corresponds to a minimum fall speed of ~0.8 m/s.
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_rai,)},
+    params,
     cmc,
     cmp,
     ρ,
-    q,
-) = CM1.terminal_velocity(cmp.precip.rain, cmp.terminal_velocity.rain, ρ, q)
+    q::FT,
+) where {FT} = CM1.terminal_velocity(
+    cmp.precip.rain,
+    cmp.terminal_velocity.rain,
+    ρ,
+    max(q, FT(1e-8)),
+)
 
 # Snow, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_sno,)},
+    params,
     args...,
-) = mode.snow
+) = CAP.fixed_snow_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_sno,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -144,7 +168,7 @@ terminal_velocity(
 
 """
     gs_terminal_velocity(
-        ::NonEquilibriumMicrophysics1M, tv_mode, var_name, ρwχ, ρχ,
+        ::NonEquilibriumMicrophysics1M, tv_mode, var_name, params, ρwχ, ρχ,
     )
 
 Return the grid-scale terminal velocity of a 1-moment species from subdomain fluxes.
@@ -160,6 +184,7 @@ zero, keeping the grid-scale value bracketed by the subdomain velocities.
 
   - `tv_mode`: Terminal velocity mode, dispatched on.
   - `var_name`: `MatrixFields.FieldName` naming the species.
+  - `params`: Cloud microphysics parameters
   - `ρwχ`: Area-weighted sum of subdomain sedimentation fluxes [kg/m²/s].
   - `ρχ`: Area-weighted sum of subdomain species masses [kg/m³].
 
@@ -173,13 +198,15 @@ gs_terminal_velocity(
     cm_1m::NonEquilibriumMicrophysics1M,
     tv_mode::FixedTerminalVelocity,
     var_name,
+    params,
     args...,
-) = terminal_velocity(cm_1m, tv_mode, var_name, args...)
+) = terminal_velocity(cm_1m, tv_mode, var_name, params)
 
 gs_terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     var_name,
+    params,
     ρwχ,
     ρχ::FT,
 ) where {FT} = ifelse(ρχ > ϵ_numerics(FT), max(ρwχ / ρχ, zero(ρχ)), zero(ρχ))

--- a/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
+++ b/src/parameterized_tendencies/microphysics/terminal_velocity_utils.jl
@@ -1,26 +1,42 @@
 abstract type AbstractTerminalVelocityMode end
 struct DiagnosticTerminalVelocity <: AbstractTerminalVelocityMode end
-struct FixedTerminalVelocity{FT} <: AbstractTerminalVelocityMode
-    liquid::FT
-    ice::FT
-    rain::FT
-    snow::FT
-    #TODO fixed-velocity sedimentation of 2M/P3 tracers not implemented
-end
+struct FixedTerminalVelocity <: AbstractTerminalVelocityMode end
+#TODO fixed-velocity sedimentation of 2M/P3 tracers not implemented
 Base.broadcastable(x::AbstractTerminalVelocityMode) = tuple(x)
+
+"""
+    velocity_mode(atmos, name)
+
+Select the per-species terminal velocity mode from `atmos` based on the tracer
+`name` (a `MatrixFields.FieldName`).
+
+Each hydrometeor species has its own toggle in `AtmosWater`, so e.g. rain can
+use `DiagnosticTerminalVelocity` while the others remain
+`FixedTerminalVelocity`.
+"""
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_lcl,)}) =
+    atmos.terminal_velocity_liquid
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_icl,)}) =
+    atmos.terminal_velocity_ice
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_rai,)}) =
+    atmos.terminal_velocity_rain
+velocity_mode(atmos, ::MatrixFields.FieldName{(:q_sno,)}) =
+    atmos.terminal_velocity_snow
 
 # Liquid, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_lcl,)},
+    params,
     args...,
-) = mode.liquid
+) = CAP.fixed_cloud_liquid_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_lcl,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -30,15 +46,17 @@ terminal_velocity(
 # Ice, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_icl,)},
+    params,
     args...,
-) = mode.ice
+) = CAP.fixed_cloud_ice_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_icl,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -48,15 +66,17 @@ terminal_velocity(
 # Rain, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_rai,)},
+    params,
     args...,
-) = mode.rain
+) = CAP.fixed_rain_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_rai,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -66,15 +86,17 @@ terminal_velocity(
 # Snow, 1M
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
-    mode::FixedTerminalVelocity,
+    ::FixedTerminalVelocity,
     ::MatrixFields.FieldName{(:q_sno,)},
+    params,
     args...,
-) = mode.snow
+) = CAP.fixed_snow_terminal_velocity(params)
 
 terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     ::MatrixFields.FieldName{(:q_sno,)},
+    params,
     cmc,
     cmp,
     ρ,
@@ -86,13 +108,15 @@ terminal_velocity(
         ::NonEquilibriumMicrophysics1M,
         ::AbstractTerminalVelocityMode,
         var_name,
+        params,
         ρwχ,
-        ρχ::FT,
+        ρχ,
     )
 
 Return the grid-scale terminal velocity.
 
-  - For `FixedTerminalVelocity`, returns the prescribed constant value.
+  - For `FixedTerminalVelocity`, returns the prescribed constant value
+    from `params`.
   - For `DiagnosticTerminalVelocity`, returns the mass-weighted velocity
     `ρwχ / ρχ`.
 
@@ -103,13 +127,15 @@ gs_terminal_velocity(
     cm_1m::NonEquilibriumMicrophysics1M,
     tv_mode::FixedTerminalVelocity,
     var_name,
+    params,
     args...,
-) = terminal_velocity(cm_1m, tv_mode, var_name, args...)
+) = terminal_velocity(cm_1m, tv_mode, var_name, params)
 
 gs_terminal_velocity(
     ::NonEquilibriumMicrophysics1M,
     ::DiagnosticTerminalVelocity,
     var_name,
+    params,
     ρwχ,
     ρχ::FT,
 ) where {FT} = ifelse(ρχ > ϵ_numerics(FT), max(ρwχ / ρχ, zero(ρχ)), zero(ρχ))

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -537,7 +537,7 @@ function TurbulenceConvectionParameters(
         cloud_fraction_floor_residual = FT(0),
         # Lateral correction scaling for updraft sedimentation
         # (see `updraft_sedimentation!`). 1.0 = full correction, 0.0 = disabled.
-        sedimentation_lateral_coeff = FT(0),
+        sedimentation_lateral_coeff = FT(1), # Testing if stable now. To be removed, if yes.
     )
     release_present = filter(collect(keys(release_defaults))) do name
         haskey(toml_dict.data, string(name))

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -709,6 +709,8 @@ function update_advection_jacobian!(matrix, Y, p, dtγ, topography_flag)
     return nothing
 end
 
+#=
+TODO - remove if not needed
 """
     jacobian_sedimentation_velocity(p, wₚ_name, ρχₚ_name)
 
@@ -735,6 +737,7 @@ precomputed velocity field unchanged.
     end
     return MatrixFields.get_field(p.precomputed, wₚ_name)
 end
+=#
 
 """
     update_sedimentation_jacobian!(matrix, Y, p, dtγ)
@@ -775,7 +778,10 @@ function update_sedimentation_jacobian!(matrix, Y, p, dtγ)
         ρχₚ_state_name = center_state_name(ρχₚ_name)
 
         ∂ᶜρχₚ_err_∂ᶜρχₚ = matrix[ρχₚ_state_name, ρχₚ_state_name]
-        ᶜwₚ = jacobian_sedimentation_velocity(p, wₚ_name, ρχₚ_name)
+        # TODO - remove if not needed
+        #ᶜwₚ = jacobian_sedimentation_velocity(p, wₚ_name, ρχₚ_name)
+        ᶜwₚ = MatrixFields.get_field(p.precomputed, wₚ_name)
+
         # TODO: come up with read-able names for the intermediate computations...
         @. p.scratch.ᶠband_matrix_wvec =
             ᶠright_bias_matrix() ⋅

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -710,6 +710,33 @@ function update_advection_jacobian!(matrix, Y, p, dtγ, topography_flag)
 end
 
 """
+    jacobian_sedimentation_velocity(p, wₚ_name, ρχₚ_name)
+
+Return the sedimentation velocity to use in the Jacobian for tracer `ρχₚ_name`.
+
+For rain with `DiagnosticTerminalVelocity`, returns the fixed constant velocity
+from the parameter set instead of the state-dependent precomputed field.  This
+stabilises the implicit solve by giving the preconditioner a smooth, constant
+advection speed while the tendency still sees the correct diagnostic velocity.
+
+For all other tracers (or when rain uses `FixedTerminalVelocity`), returns the
+precomputed velocity field unchanged.
+"""
+@inline jacobian_sedimentation_velocity(p, wₚ_name, _ρχₚ_name) =
+    MatrixFields.get_field(p.precomputed, wₚ_name)
+
+@inline function jacobian_sedimentation_velocity(
+    p,
+    wₚ_name,
+    ::MatrixFields.FieldName{(:ρq_rai,)},
+)
+    if p.atmos.terminal_velocity_rain isa DiagnosticTerminalVelocity
+        return CAP.fixed_rain_terminal_velocity(p.params)
+    end
+    return MatrixFields.get_field(p.precomputed, wₚ_name)
+end
+
+"""
     update_sedimentation_jacobian!(matrix, Y, p, dtγ)
 
 Updates the Jacobian blocks for implicit sedimentation of condensate tracers,
@@ -748,7 +775,7 @@ function update_sedimentation_jacobian!(matrix, Y, p, dtγ)
         ρχₚ_state_name = center_state_name(ρχₚ_name)
 
         ∂ᶜρχₚ_err_∂ᶜρχₚ = matrix[ρχₚ_state_name, ρχₚ_state_name]
-        ᶜwₚ = MatrixFields.get_field(p.precomputed, wₚ_name)
+        ᶜwₚ = jacobian_sedimentation_velocity(p, wₚ_name, ρχₚ_name)
         # TODO: come up with read-able names for the intermediate computations...
         @. p.scratch.ᶠband_matrix_wvec =
             ᶠright_bias_matrix() ⋅

--- a/src/types.jl
+++ b/src/types.jl
@@ -947,13 +947,16 @@ end
 
 Groups moisture and microphysics-related models and types.
 """
-@kwdef struct AtmosWater{MM, CM, MTTS, TNM, SQ, TVM}
+@kwdef struct AtmosWater{MM, CM, MTTS, TNM, SQ, TVL, TVI, TVR, TVS}
     microphysics_model::MM = DryModel()
     cloud_model::CM = QuadratureCloud()
     microphysics_tendency_timestepping::MTTS = nothing
     tracer_nonnegativity_method::TNM = nothing
     sgs_quadrature::SQ = nothing
-    terminal_velocity_mode::TVM = DiagnosticTerminalVelocity()
+    terminal_velocity_liquid::TVL = FixedTerminalVelocity()
+    terminal_velocity_ice::TVI = FixedTerminalVelocity()
+    terminal_velocity_rain::TVR = FixedTerminalVelocity()
+    terminal_velocity_snow::TVS = FixedTerminalVelocity()
 end
 
 """
@@ -1199,7 +1202,10 @@ The default AtmosModel provides:
   - `cloud_model`: GridScaleCloud(), QuadratureCloud()
   - `microphysics_tendency_timestepping`: Explicit(), Implicit()
   - `sgs_quadrature`: nothing or SGSQuadrature (subgrid-scale quadrature for microphysics tendencies)
-  - `terminal_velocity_mode`: FixedTerminalVelocity or DiagnosticTerminalVelocity
+  - `terminal_velocity_liquid`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+  - `terminal_velocity_ice`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+  - `terminal_velocity_rain`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+  - `terminal_velocity_snow`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
 
 ## SCMSetup (Single-Column Model & LES specific - accessed via model.subsidence, model.external_forcing, etc.)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -2193,13 +2193,16 @@ water = ClimaAtmos.AtmosWater(;
 )
 ```
 """
-@kwdef struct AtmosWater{MM, CM, MTTS, TNM, SQ, TVM}
+@kwdef struct AtmosWater{MM, CM, MTTS, TNM, SQ, TVL, TVI, TVR, TVS}
     microphysics_model::MM = DryModel()
     cloud_model::CM = QuadratureCloud()
     microphysics_tendency_timestepping::MTTS = nothing
     tracer_nonnegativity_method::TNM = nothing
     sgs_quadrature::SQ = nothing
-    terminal_velocity_mode::TVM = DiagnosticTerminalVelocity()
+    terminal_velocity_liquid::TVL = FixedTerminalVelocity()
+    terminal_velocity_ice::TVI = FixedTerminalVelocity()
+    terminal_velocity_rain::TVR = DiagnosticTerminalVelocity()
+    terminal_velocity_snow::TVS = FixedTerminalVelocity()
 end
 
 """
@@ -2587,6 +2590,90 @@ model = AtmosModel(;
     radiation_mode = RRTMGPI.AllSkyRadiation(),
 )
 ```
+
+# Default Configuration
+
+The default AtmosModel provides:
+
+  - **Dry atmosphere**: DryModel()
+  - **Basic surface**: AnalyticTemperature (zonally-symmetric SST) with default exchange coefficients
+  - **Cloud model**: QuadratureCloud() with SGS quadrature
+  - **Idealized insolation**: IdealizedInsolation()
+  - **Conservative numerics**: First-order upwinding with Explicit() timestepping
+  - **No advanced physics**: No radiation, turbulence, or forcing by default
+
+# Available Structs
+
+## AtmosWater
+
+  - `microphysics_model`: DryModel(), EquilibriumMicrophysics0M(), NonEquilibriumMicrophysics1M(), NonEquilibriumMicrophysics2M(), NonEquilibriumMicrophysics2MP3()
+  - `cloud_model`: GridScaleCloud(), QuadratureCloud()
+  - `microphysics_tendency_timestepping`: Explicit(), Implicit()
+  - `sgs_quadrature`: nothing or SGSQuadrature (subgrid-scale quadrature for microphysics tendencies)
+  - `terminal_velocity_liquid`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+  - `terminal_velocity_ice`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+  - `terminal_velocity_rain`: FixedTerminalVelocity or DiagnosticTerminalVelocity (default)
+  - `terminal_velocity_snow`: FixedTerminalVelocity (default) or DiagnosticTerminalVelocity
+
+## SCMSetup (Single-Column Model & LES specific - accessed via model.subsidence, model.external_forcing, etc.)
+
+Internal testing and calibration components for single-column setups:
+
+  - `subsidence`: nothing or Bomex_subsidence, Rico_subsidence, DYCOMS_subsidence, etc
+  - `external_forcing`: nothing or external forcing objects (GCMForcing, ExternalDrivenTVForcing, ISDACForcing)
+  - `ls_adv`: nothing or LargeScaleAdvection()
+  - `advection_test`: Bool
+  - `scm_coriolis`: nothing or NamedTuple `(; prof_ug, prof_vg, coriolis_param)`
+
+## AtmosRadiation
+
+  - `radiation_mode`: Radiation and atmospheric forcing modes
+
+      + Global radiation: RRTMGPI.ClearSkyRadiation(), RRTMGPI.AllSkyRadiation()
+      + Atmospheric forcing: HeldSuarezForcing() (for idealized dynamics)
+      + SCM-specific: RadiationDYCOMS(), RadiationISDAC(), RadiationTRMM_LBA()
+
+  - `insolation`: IdealizedInsolation(), TimeVaryingInsolation(), etc.
+
+## AtmosTurbconv
+
+  - `edmfx_model`: EDMFXModel()
+  - `turbconv_model`: nothing, PrognosticEDMFX(), EDOnlyEDMFX()
+  - `smagorinsky_lilly`: nothing or SmagorinskyLilly()
+  - `amd_les`: nothing or AnisotropicMinimumDissipation()
+  - `constant_horizontal_diffusion`: nothing or ConstantHorizontalDiffusion()
+
+## AtmosGravityWave
+
+  - `non_orographic_gravity_wave`: nothing or NonOrographicGravityWave()
+  - `orographic_gravity_wave`: nothing or OrographicGravityWave()
+
+## AtmosSponge
+
+  - `viscous_sponge`: nothing or ViscousSponge()
+  - `rayleigh_sponge`: nothing or RayleighSponge()
+
+## AtmosSurface
+
+  - `flux_scheme`: SurfaceConditions.MoninObukhov, SurfaceConditions.ExchangeCoefficients, or a default marker (DefaultMoninObukhov/DefaultExchangeCoefficients), or `nothing` to disable.
+  - `temperature`: SurfaceConditions.AnalyticTemperature, ExternalTemperature, SlabOceanTemperature, or CoupledTemperature.
+  - `boundary_overrides`: SurfaceConditions.SurfaceBoundaryOverrides
+  - `surface_albedo`: ConstantAlbedo(), RegressionFunctionAlbedo(), CouplerAlbedo()
+
+## AtmosNumerics    # Create grouped structs - use provided complete objects or create from individual fields
+
+  - `energy_q_tot_upwinding`, `tracer_upwinding`, `edmfx_mse_q_tot_upwinding`, `edmfx_sgsflux_upwinding`, `edmfx_tracer_upwinding`: Val() upwinding schemes
+  - `test_dycore_consistency`: nothing or TestDycoreConsistency() for debugging
+  - `limiter`: nothing or QuasiMonotoneLimiter()
+  - `vertical_water_borrowing_species`: internal value `nothing` (apply to all tracers; config default is `~`), empty tuple (apply to none; config `[]`), or Tuple{Symbol, ...} from config string/list (e.g. `["ρq_tot"]`) to apply only to those tracers. See config `vertical_water_borrowing_species` in default_config.yml for YAML options.
+    (Note: The vertical water borrowing limiter is created in the cache based on `AtmosWaterModel.tracer_nonnegativity_method`)
+  - `diff_mode`: Explicit(), Implicit() timestepping mode for diffusion
+  - `hyperdiff`: nothing or Hyperdiffusion()
+
+## Top-level Options
+
+  - `vertical_diffusion`: nothing, VerticalDiffusion(), DecayWithHeightDiffusion()
+  - `disable_surface_flux_tendency`: Bool
 """
 function AtmosModel(; kwargs...)
     group_kwargs, atmos_model_kwargs = _partition_atmos_model_kwargs(kwargs)


### PR DESCRIPTION
This PR makes the model use non-constant rain sedimentation velocity by default. There is an assumed minimum velocity of about 0.8 m/s to allow for stable computation with 1 Newton iteration. 

In the same PR I also switch on the lateral mixing of precipitation in the updrafts where area fraction decreases with height.
