### PR TITLE
Move 1M options into AtmosModel

### DIFF
--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -11,7 +11,11 @@ function get_microphysics_model(parsed_args, params = nothing)
     elseif model_name == "1M"
         n_substeps = parsed_args["microphysics_n_substeps"]
         n_substeps_quad = parsed_args["microphysics_n_substeps_quadrature"]
-        NonEquilibriumMicrophysics1M(; n_substeps, n_substeps_quad)
+        NonEquilibriumMicrophysics1M(;
+            n_substeps,
+            n_substeps_quad,
+            get_microphysics_1m_options(parsed_args)...,
+        )
     elseif model_name == "2M"
         NonEquilibriumMicrophysics2M()
     elseif model_name == "2MP3"
@@ -27,11 +31,12 @@ end
     get_microphysics_1m_options(parsed_args)
 
 Parse the YAML config keys for 1-moment microphysics process options and
-return a `NamedTuple` of keyword arguments for `CMP.Microphysics1MParams`.
+return a `NamedTuple` of keyword arguments for
+[`NonEquilibriumMicrophysics1M`](@ref).
 
-Each YAML key maps to one field of `get_microphysics_1m_options`, selecting the
-process option type that controls dispatch inside `bulk_microphysics_tendencies`.
-Setting a YAML value to `~` (null) disables the process (`nothing`).
+Each YAML key maps to one process, selecting the option type that controls
+dispatch inside `bulk_microphysics_tendencies`. Setting a YAML value to `~`
+(null) disables the process (`nothing`).
 """
 function get_microphysics_1m_options(parsed_args)
     CMP = CM.Parameters

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -12,7 +12,7 @@ Accepted values:
   - `"dry"`: `DryModel`, no water in the model.
   - `"0M"`: `EquilibriumMicrophysics0M`, instantaneous removal of supersaturation.
   - `"1M"`: `NonEquilibriumMicrophysics1M`, built from the config keys parsed by
-    [`get_microphysics_1m_options`](@ref).
+    `get_microphysics_1m_options`.
   - `"2M"`: `NonEquilibriumMicrophysics2M`.
   - `"2MP3"`: `NonEquilibriumMicrophysics2MP3`.
 

--- a/src/config/model_getters.jl
+++ b/src/config/model_getters.jl
@@ -11,9 +11,8 @@ Accepted values:
 
   - `"dry"`: `DryModel`, no water in the model.
   - `"0M"`: `EquilibriumMicrophysics0M`, instantaneous removal of supersaturation.
-  - `"1M"`: `NonEquilibriumMicrophysics1M`, built with `n_substeps` from
-    `microphysics_n_substeps` and `n_substeps_quad` from
-    `microphysics_n_substeps_quadrature`.
+  - `"1M"`: `NonEquilibriumMicrophysics1M`, built from the config keys parsed by
+    [`get_microphysics_1m_options`](@ref).
   - `"2M"`: `NonEquilibriumMicrophysics2M`.
   - `"2MP3"`: `NonEquilibriumMicrophysics2MP3`.
 
@@ -27,9 +26,7 @@ function get_microphysics_model(parsed_args, params = nothing)
     elseif model_name == "0M"
         EquilibriumMicrophysics0M()
     elseif model_name == "1M"
-        n_substeps = parsed_args["microphysics_n_substeps"]
-        n_substeps_quad = parsed_args["microphysics_n_substeps_quadrature"]
-        NonEquilibriumMicrophysics1M(; n_substeps, n_substeps_quad)
+        NonEquilibriumMicrophysics1M(; get_microphysics_1m_options(parsed_args)...)
     elseif model_name == "2M"
         NonEquilibriumMicrophysics2M()
     elseif model_name == "2MP3"
@@ -44,10 +41,13 @@ end
 """
     get_microphysics_1m_options(parsed_args)
 
-Parse the config keys for 1-moment microphysics processes into a `NamedTuple` of
-keyword arguments for `CM.Parameters.Microphysics1MParams`.
+Parse the config keys for 1-moment microphysics into a `NamedTuple` of keyword
+arguments for [`NonEquilibriumMicrophysics1M`](@ref).
 
-Each key selects the process-option type that controls dispatch inside
+The substep counts come from `microphysics_n_substeps` (`n_substeps`) and
+`microphysics_n_substeps_quadrature` (`n_substeps_quad`).
+
+The remaining keys select the process-option type that controls dispatch inside
 `bulk_microphysics_tendencies`; a value of `~` (null) disables the process (`nothing`).
 Values are looked up with `parse_option`, so an unknown string raises an error listing
 the valid choices. Each option string names the `CM.Parameters` type it maps to:
@@ -68,6 +68,9 @@ the valid choices. Each option string names the `CM.Parameters` type it maps to:
 """
 function get_microphysics_1m_options(parsed_args)
     CMP = CM.Parameters
+
+    n_substeps = parsed_args["microphysics_n_substeps"]
+    n_substeps_quad = parsed_args["microphysics_n_substeps_quadrature"]
 
     cloud_liquid_formation = parse_option(
         parsed_args["cloud_liquid_formation"],
@@ -171,6 +174,8 @@ function get_microphysics_1m_options(parsed_args)
     )
 
     return (;
+        n_substeps,
+        n_substeps_quad,
         cloud_liquid_formation,
         cloud_ice_formation,
         cloud_ice_melt,

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -15,7 +15,6 @@ function ClimaAtmosParameters(config::AtmosConfig)
     return ClimaAtmosParameters(
         config.toml_dict;
         microphysics_model = get_microphysics_model(pa),
-        microphysics_1m_options = get_microphysics_1m_options(pa),
         has_non_orographic_gw = get(pa, "non_orographic_gravity_wave", false) != false,
         has_orographic_gw =
         !isnothing(get(pa, "orographic_gravity_wave", nothing)),
@@ -62,10 +61,9 @@ function get_atmos(config::AtmosConfig, params; setup_type = nothing)
     @assert !@any_reltype(atmos, (UnionAll, DataType))
 
     @info "AtmosModel: \n$(summary(atmos))"
-    if !isnothing(params.microphysics_1m_params)
-        microphysics_model = atmos.water.microphysics_model
-        options = params.microphysics_1m_params.processes
-        @info "Microphysics settings: $(sprint(summary_microphysics, microphysics_model, options))"
+    microphysics_model = atmos.water.microphysics_model
+    if microphysics_model isa NonEquilibriumMicrophysics1M
+        @info "Microphysics settings: $(sprint(summary_microphysics, microphysics_model))"
     end
     return atmos
 end

--- a/src/config/type_getters.jl
+++ b/src/config/type_getters.jl
@@ -16,7 +16,6 @@ function ClimaAtmosParameters(config::AtmosConfig)
     return ClimaAtmosParameters(
         config.toml_dict;
         microphysics_model = get_microphysics_model(pa),
-        microphysics_1m_options = get_microphysics_1m_options(pa),
         has_non_orographic_gw = get(pa, "non_orographic_gravity_wave", false) != false,
         has_orographic_gw =
         !isnothing(get(pa, "orographic_gravity_wave", nothing)),
@@ -77,10 +76,9 @@ function get_atmos(config::AtmosConfig, params; setup_type = nothing)
     @assert !@any_reltype(atmos, (UnionAll, DataType))
 
     @info "AtmosModel: \n$(summary(atmos))"
-    if !isnothing(params.microphysics_1m_params)
-        microphysics_model = atmos.water.microphysics_model
-        options = params.microphysics_1m_params.processes
-        @info "Microphysics settings: $(sprint(summary_microphysics, microphysics_model, options))"
+    microphysics_model = atmos.water.microphysics_model
+    if microphysics_model isa NonEquilibriumMicrophysics1M
+        @info "Microphysics settings: $(sprint(summary_microphysics, microphysics_model))"
     end
     return atmos
 end

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -8,9 +8,8 @@ import CloudMicrophysics as CM
 import StaticArrays as SA
 
 """
-    ClimaAtmosParameters(FT::AbstractFloat)
+    ClimaAtmosParameters(FT::AbstractFloat; kwargs...)
     ClimaAtmosParameters(toml_dict; microphysics_model = nothing,
-                                    microphysics_1m_options = (;),
                                     has_non_orographic_gw = false,
                                     has_orographic_gw = false,
                                     has_beres_source = false)
@@ -22,13 +21,12 @@ relevant to that model are loaded; the rest are stored as `nothing` to save
 memory. Likewise the gravity-wave parameter sets are loaded only when their
 corresponding flag is `true`.
 """
-ClimaAtmosParameters(::Type{FT}) where {FT <: AbstractFloat} =
-    ClimaAtmosParameters(CP.create_toml_dict(FT))
+ClimaAtmosParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    ClimaAtmosParameters(CP.create_toml_dict(FT); kwargs...)
 
 function ClimaAtmosParameters(
     toml_dict::TD;
     microphysics_model = nothing,
-    microphysics_1m_options = (;),
     has_non_orographic_gw::Bool = false,
     has_orographic_gw::Bool = false,
     has_beres_source::Bool = false,
@@ -61,8 +59,10 @@ function ClimaAtmosParameters(
     MPC = typeof(microphysics_cloud_params)
 
     microphysics_0m_params = CM.Parameters.Microphysics0MParams(toml_dict)
-    microphysics_1m_params =
-        microphys_1m_parameters(toml_dict; microphysics_1m_options...)
+    microphysics_1m_params = microphys_1m_parameters(
+        toml_dict;
+        microphysics_1m_options(microphysics_model)...,
+    )
     microphysics_2m_params = microphys_2m_parameters(toml_dict)
     microphysics_2mp3_params = get_microphysics_2m_p3_parameters(toml_dict)
 
@@ -199,6 +199,22 @@ cloud_parameters(toml_dict::CP.ParamDict) = (;
     aml = aerosol_ml_parameters(toml_dict),
     activation = CM.Parameters.AerosolActivationParameters(toml_dict),
 )
+
+"""
+    microphysics_1m_options(microphysics_model)
+
+The per-process option selections to build `CMP.Microphysics1MParams` with, as
+keyword arguments.
+"""
+microphysics_1m_options(_) = (;)
+function microphysics_1m_options(
+    microphysics_model::NonEquilibriumMicrophysics1M,
+)
+    processes = microphysics_model.processes
+    return (;
+        (pn => getproperty(processes, pn) for pn in propertynames(processes))...
+    )
+end
 
 microphys_1m_parameters(
     ::Type{FT};

--- a/src/parameters/create_parameters.jl
+++ b/src/parameters/create_parameters.jl
@@ -12,7 +12,6 @@ import StaticArrays as SA
     ClimaAtmosParameters(
         toml_dict;
         microphysics_model = nothing,
-        microphysics_1m_options = (;),
         has_non_orographic_gw = false,
         has_orographic_gw = false,
         has_beres_source = false,
@@ -42,8 +41,6 @@ set is loaded only when its flag is `true`. Passing `microphysics_model = nothin
 
   - `microphysics_model = nothing`: Microphysics model; selects which
     microphysics parameter sets to keep. `nothing` keeps all of them.
-  - `microphysics_1m_options = (;)`: Extra keyword arguments forwarded to
-    `CloudMicrophysics.Parameters.Microphysics1MParams`.
   - `has_non_orographic_gw = false`: Load the non-orographic gravity-wave
     parameters.
   - `has_orographic_gw = false`: Load the orographic gravity-wave parameters.
@@ -60,13 +57,12 @@ import ClimaAtmos as CA
 params = CA.ClimaAtmosParameters(Float64)
 ```
 """
-ClimaAtmosParameters(::Type{FT}) where {FT <: AbstractFloat} =
-    ClimaAtmosParameters(CP.create_toml_dict(FT))
+ClimaAtmosParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    ClimaAtmosParameters(CP.create_toml_dict(FT); kwargs...)
 
 function ClimaAtmosParameters(
     toml_dict::TD;
     microphysics_model = nothing,
-    microphysics_1m_options = (;),
     has_non_orographic_gw::Bool = false,
     has_orographic_gw::Bool = false,
     has_beres_source::Bool = false,
@@ -99,8 +95,10 @@ function ClimaAtmosParameters(
     MPC = typeof(microphysics_cloud_params)
 
     microphysics_0m_params = CM.Parameters.Microphysics0MParams(toml_dict)
-    microphysics_1m_params =
-        microphys_1m_parameters(toml_dict; microphysics_1m_options...)
+    microphysics_1m_params = microphys_1m_parameters(
+        toml_dict;
+        microphysics_1m_options(microphysics_model)...,
+    )
     microphysics_2m_params = microphys_2m_parameters(toml_dict)
     microphysics_2mp3_params = get_microphysics_2m_p3_parameters(toml_dict)
 
@@ -263,6 +261,22 @@ cloud_parameters(toml_dict::CP.ParamDict) = (;
     aml = aerosol_ml_parameters(toml_dict),
     activation = CM.Parameters.AerosolActivationParameters(toml_dict),
 )
+
+"""
+    microphysics_1m_options(microphysics_model)
+
+The per-process option selections to build `CMP.Microphysics1MParams` with, as
+keyword arguments.
+"""
+microphysics_1m_options(_) = (;)
+function microphysics_1m_options(
+    microphysics_model::NonEquilibriumMicrophysics1M,
+)
+    processes = microphysics_model.processes
+    return (;
+        (pn => getproperty(processes, pn) for pn in propertynames(processes))...
+    )
+end
 
 """
     microphys_1m_parameters(FT; options_kwargs...)

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -168,7 +168,9 @@ Construct an atmospheric simulation with floating-point type `FT` (default: Floa
 ### Model and domain
 
   - `model::AtmosModel = AtmosModel()`: Physics and parameterization configuration.
-  - `params::ClimaAtmosParameters = ClimaAtmosParameters(FT)`: Physical parameters.
+  - `params::ClimaAtmosParameters`: Physical parameters. By default, built from
+    `model`, so only the parameters the model needs are loaded and the
+    microphysics process options set on the model take effect.
   - `grid::AbstractGrid = SphereGrid(FT; ...)`: Computational grid.
     Use [`ColumnGrid`](@ref), [`BoxGrid`](@ref), [`PlaneGrid`](@ref), or [`SphereGrid`](@ref).
   - `setup = Setups.DecayingProfile(; perturb=true, params)`: Setup defining the
@@ -236,7 +238,10 @@ simulation = CA.AtmosSimulation{Float64}(;
 """
 function AtmosSimulation{FT}(;
     model = AtmosModel(),
-    params::Parameters.ClimaAtmosParameters = ClimaAtmosParameters(FT),
+    params::Parameters.ClimaAtmosParameters = ClimaAtmosParameters(
+        FT;
+        microphysics_model = model.microphysics_model,
+    ),
     context::ClimaComms.AbstractCommsContext = ClimaComms.context(),
     grid::Grids.AbstractGrid = SphereGrid(FT; radius = CAP.planet_radius(params), context),
     setup = Setups.DecayingProfile(; perturb = true, params),

--- a/src/simulation/AtmosSimulations.jl
+++ b/src/simulation/AtmosSimulations.jl
@@ -235,7 +235,10 @@ entry point for simulations written as scripts; configuration-driven runs go thr
 # Keyword Arguments
 
   - `model = AtmosModel()`: Physics and parameterization configuration.
-  - `params = ClimaAtmosParameters(FT)`: Physical parameters.
+  - `params = ClimaAtmosParameters(FT; microphysics_model = model.microphysics_model)`:
+    Physical parameters. Built from `model` by default, so only the parameter sets
+    the model needs are loaded and the microphysics process options set on the
+    model take effect.
   - `context = ClimaComms.context()`: Communications context (device and MPI).
   - `grid = SphereGrid(FT; radius = CAP.planet_radius(params), context)`: Computational
     grid. Use [`ColumnGrid`](@ref), [`BoxGrid`](@ref), [`PlaneGrid`](@ref), or
@@ -306,7 +309,9 @@ simulation = CA.AtmosSimulation{Float64}(;
 """
 function AtmosSimulation{FT}(;
     model = AtmosModel(),
-    params::Parameters.ClimaAtmosParameters = ClimaAtmosParameters(FT),
+    params::Parameters.ClimaAtmosParameters = ClimaAtmosParameters(
+        FT; model.microphysics_model,
+    ),
     context::ClimaComms.AbstractCommsContext = ClimaComms.context(),
     grid::Grids.AbstractGrid = SphereGrid(FT; radius = CAP.planet_radius(params), context),
     setup = Setups.DecayingProfile(; perturb = true, params),

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,16 +6,49 @@ import Dates
 import ClimaParams as CP
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import LazyArtifacts
+import CloudMicrophysics.Parameters as CMP
 
 abstract type AbstractMicrophysicsModel end
 
 struct DryModel <: AbstractMicrophysicsModel end
 struct EquilibriumMicrophysics0M <: AbstractMicrophysicsModel end
-struct NonEquilibriumMicrophysics1M <: AbstractMicrophysicsModel
+
+"""
+    NonEquilibriumMicrophysics1M(; n_substeps = 1, n_substeps_quad = 1,
+                                   process_options...)
+
+1-moment bulk microphysics with prognostic cloud liquid, cloud ice, rain, and
+snow.
+
+`n_substeps` and `n_substeps_quad` set how many substeps the bulk tendencies are
+time-averaged over, without and with SGS quadrature respectively.
+
+```julia
+import ClimaAtmos as CA
+import CloudMicrophysics.Parameters as CMP
+
+microphysics_model = CA.NonEquilibriumMicrophysics1M(;
+    n_substeps = 3,
+    rain_autoconversion = CMP.PrescribedNd(),
+    cloud_ice_formation = CMP.TemperatureDependent(),
+    rain_snow_accretion = nothing,
+)
+```
+
+See `CMP.Microphysics1MOptions` for the full list of processes and their
+available variants.
+"""
+struct NonEquilibriumMicrophysics1M{OPT} <: AbstractMicrophysicsModel
     n_substeps::Int  # number of microphysics substeps
     n_substeps_quad::Int  # number of microphysics substeps with sgs quadrature
-    function NonEquilibriumMicrophysics1M(; n_substeps = 1, n_substeps_quad = 1)
-        return new(n_substeps, n_substeps_quad)
+    processes::OPT  # per-process variant selection (CMP.Microphysics1MOptions)
+    function NonEquilibriumMicrophysics1M(;
+        n_substeps = 1,
+        n_substeps_quad = 1,
+        process_options...,
+    )
+        processes = CMP.Microphysics1MOptions(; process_options...)
+        return new{typeof(processes)}(n_substeps, n_substeps_quad, processes)
     end
 end
 struct NonEquilibriumMicrophysics2M <: AbstractMicrophysicsModel end

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,8 +50,8 @@ struct EquilibriumMicrophysics0M <: AbstractMicrophysicsModel end
 
 """
     NonEquilibriumMicrophysics1M(;
-        n_substeps = 1,
-        n_substeps_quad = 1,
+        n_substeps = 3,
+        n_substeps_quad = 2,
         process_options...,
     )
 
@@ -69,13 +69,13 @@ collected into a `CMP.Microphysics1MOptions`, which documents the full list of
 processes and their available variants. Passing `nothing` for a process disables
 it.
 
-Any process that is not passed keeps the `CMP.Microphysics1MOptions` default, so
+Any process that is not passed keeps its default, so
 `NonEquilibriumMicrophysics1M()` turns every process on with these variants:
 
 | Process                         | Default variant              |
 |:------------------------------- |:---------------------------- |
 | `cloud_liquid_formation`        | `CloudLiquidFormation()`     |
-| `cloud_ice_formation`           | `ConstantTimescale()`        |
+| `cloud_ice_formation`           | `TemperatureDependent()`     |
 | `cloud_ice_melt`                | `CloudIceMelt()`             |
 | `rain_autoconversion`           | `Kessler1M()`                |
 | `snow_autoconversion`           | `NoSupersaturation()`        |
@@ -88,10 +88,10 @@ Any process that is not passed keeps the `CMP.Microphysics1MOptions` default, so
 | `cloud_ice_snow_accretion`      | `CloudIceSnowAccretion()`    |
 | `rain_snow_accretion`           | `RainSnowAccretion()`        |
 
-Configuration-driven runs set every process explicitly from the config keys in
-`default_config.yml` (see [`get_microphysics_1m_options`](@ref)), which currently
-differ from the defaults above in one place: `cloud_ice_formation` defaults to
-`TemperatureDependent` there.
+These match the defaults of the corresponding config keys, so a model built here
+and one built from an unmodified configuration file agree (see
+[`get_microphysics_1m_options`](@ref)). All variants except
+`cloud_ice_formation` are also the `CMP.Microphysics1MOptions` defaults.
 
 # Fields
 
@@ -108,11 +108,10 @@ import ClimaAtmos as CA
 import CloudMicrophysics.Parameters as CMP
 
 model = CA.NonEquilibriumMicrophysics1M(;
-    n_substeps = 3,
-    n_substeps_quad = 2,
+    n_substeps = 1,
     rain_autoconversion = CMP.PrescribedNd(),
-    cloud_ice_formation = CMP.TemperatureDependent(),
-    rain_snow_accretion = nothing,
+    cloud_ice_formation = CMP.ConstantTimescale(),
+    rain_snow_accretion = nothing,  # process off
 )
 ```
 """
@@ -121,11 +120,16 @@ struct NonEquilibriumMicrophysics1M{OPT} <: AbstractMicrophysicsModel
     n_substeps_quad::Int  # number of microphysics substeps with sgs quadrature
     processes::OPT  # per-process variant selection (CMP.Microphysics1MOptions)
     function NonEquilibriumMicrophysics1M(;
-        n_substeps = 1,
-        n_substeps_quad = 1,
+        n_substeps = 3,
+        n_substeps_quad = 2,
         process_options...,
     )
-        processes = CMP.Microphysics1MOptions(; process_options...)
+        # `cloud_ice_formation` overrides the CloudMicrophysics default
+        # (`ConstantTimescale`) so that these defaults match `default_config.yml`
+        processes = CMP.Microphysics1MOptions(;
+            cloud_ice_formation = CMP.TemperatureDependent(),
+            process_options...,
+        )
         return new{typeof(processes)}(n_substeps, n_substeps_quad, processes)
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -90,8 +90,8 @@ Any process that is not passed keeps its default, so
 
 These match the defaults of the corresponding config keys, so a model built here
 and one built from an unmodified configuration file agree (see
-[`get_microphysics_1m_options`](@ref)). All variants except
-`cloud_ice_formation` are also the `CMP.Microphysics1MOptions` defaults.
+`get_microphysics_1m_options`). All variants except `cloud_ice_formation` are
+also the `CMP.Microphysics1MOptions` defaults.
 
 # Fields
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,6 +6,7 @@ import Dates
 import ClimaParams as CP
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import LazyArtifacts
+import CloudMicrophysics.Parameters as CMP
 
 """
     AbstractMicrophysicsModel
@@ -48,7 +49,11 @@ Selected by `microphysics_model: "0M"`. Requires `use_sgs_quadrature: true`.
 struct EquilibriumMicrophysics0M <: AbstractMicrophysicsModel end
 
 """
-    NonEquilibriumMicrophysics1M(; n_substeps = 1, n_substeps_quad = 1)
+    NonEquilibriumMicrophysics1M(;
+        n_substeps = 1,
+        n_substeps_quad = 1,
+        process_options...,
+    )
 
 Non-equilibrium 1-moment microphysics with prognostic cloud and precipitation mass.
 
@@ -59,24 +64,69 @@ The substep counts are handed to CloudMicrophysics' averaged tendency
 evaluation, which subdivides the dynamics step into substeps and returns the
 time-averaged rates; this keeps the explicit sources stable at large `dt`.
 
+`process_options` selects the variant used for each individual process; they are
+collected into a `CMP.Microphysics1MOptions`, which documents the full list of
+processes and their available variants. Passing `nothing` for a process disables
+it.
+
+Any process that is not passed keeps the `CMP.Microphysics1MOptions` default, so
+`NonEquilibriumMicrophysics1M()` turns every process on with these variants:
+
+| Process                         | Default variant              |
+|:------------------------------- |:---------------------------- |
+| `cloud_liquid_formation`        | `CloudLiquidFormation()`     |
+| `cloud_ice_formation`           | `ConstantTimescale()`        |
+| `cloud_ice_melt`                | `CloudIceMelt()`             |
+| `rain_autoconversion`           | `Kessler1M()`                |
+| `snow_autoconversion`           | `NoSupersaturation()`        |
+| `rain_condensation_evaporation` | `RainEvaporation()`          |
+| `snow_deposition_sublimation`   | `DepositionAndSublimation()` |
+| `snow_melt`                     | `SnowMelt()`                 |
+| `cloud_liquid_rain_accretion`   | `CloudLiquidRainAccretion()` |
+| `cloud_liquid_snow_accretion`   | `CloudLiquidSnowAccretion()` |
+| `cloud_ice_rain_accretion`      | `CloudIceRainAccretion()`    |
+| `cloud_ice_snow_accretion`      | `CloudIceSnowAccretion()`    |
+| `rain_snow_accretion`           | `RainSnowAccretion()`        |
+
+Configuration-driven runs set every process explicitly from the config keys in
+`default_config.yml` (see [`get_microphysics_1m_options`](@ref)), which currently
+differ from the defaults above in one place: `cloud_ice_formation` defaults to
+`TemperatureDependent` there.
+
 # Fields
 
   - `n_substeps`: Number of substeps used when the tendencies are evaluated at
     grid-mean conditions (no SGS quadrature) [-].
   - `n_substeps_quad`: Number of substeps used when the tendencies are integrated
     over the SGS quadrature [-].
+  - `processes`: Per-process variant selection, a `CMP.Microphysics1MOptions`.
 
 # Examples
 
 ```julia
-model = ClimaAtmos.NonEquilibriumMicrophysics1M(; n_substeps = 3, n_substeps_quad = 2)
+import ClimaAtmos as CA
+import CloudMicrophysics.Parameters as CMP
+
+model = CA.NonEquilibriumMicrophysics1M(;
+    n_substeps = 3,
+    n_substeps_quad = 2,
+    rain_autoconversion = CMP.PrescribedNd(),
+    cloud_ice_formation = CMP.TemperatureDependent(),
+    rain_snow_accretion = nothing,
+)
 ```
 """
-struct NonEquilibriumMicrophysics1M <: AbstractMicrophysicsModel
+struct NonEquilibriumMicrophysics1M{OPT} <: AbstractMicrophysicsModel
     n_substeps::Int  # number of microphysics substeps
     n_substeps_quad::Int  # number of microphysics substeps with sgs quadrature
-    function NonEquilibriumMicrophysics1M(; n_substeps = 1, n_substeps_quad = 1)
-        return new(n_substeps, n_substeps_quad)
+    processes::OPT  # per-process variant selection (CMP.Microphysics1MOptions)
+    function NonEquilibriumMicrophysics1M(;
+        n_substeps = 1,
+        n_substeps_quad = 1,
+        process_options...,
+    )
+        processes = CMP.Microphysics1MOptions(; process_options...)
+        return new{typeof(processes)}(n_substeps, n_substeps_quad, processes)
     end
 end
 

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -242,6 +242,9 @@ function Base.summary(io::IO, numerics::AtmosNumerics)
     end
 end
 
+summary_type(prop) = typeof(prop)
+summary_type(::NonEquilibriumMicrophysics1M) = NonEquilibriumMicrophysics1M
+
 function Base.summary(io::IO, atmos::AtmosModel)
     pns = string.(propertynames(atmos))
     buf = maximum(length.(pns))
@@ -265,7 +268,7 @@ function Base.summary(io::IO, atmos::AtmosModel)
             '`',
             "::",
             '`',
-            typeof(prop),
+            summary_type(prop),
             '`',
             '\n',
         )
@@ -274,36 +277,32 @@ function Base.summary(io::IO, atmos::AtmosModel)
 end
 
 """
-    summary_microphysics(io::IO, microphysics_model, options)
+    summary_microphysics(io::IO, microphysics_model::NonEquilibriumMicrophysics1M)
 
-Print to `io` the microphysics settings that `summary(::AtmosModel)` does not
-surface.
-
-Two kinds of setting are hidden from the type-based summary: the substep counts
-of `NonEquilibriumMicrophysics1M`, which are struct fields rather than type
-parameters, and the per-process option selections, which live in the parameter
-set rather than in the `AtmosModel`.
+Print to `io` the 1-moment microphysics settings that `summary(::AtmosModel)`
+does not surface, because they are struct fields hidden by `typeof`: the substep
+counts and the per-process option selections (e.g. which autoconversion or
+accretion scheme is active, or `disabled` when the option is `nothing`).
 
 # Arguments
 
   - `io`: Stream to print to.
-  - `microphysics_model`: Microphysics model; substep counts are printed only for
-    `NonEquilibriumMicrophysics1M`.
-  - `options`: Per-process microphysics options; each is printed as the name of
-    its type, or as `disabled` when it is `nothing`.
+  - `microphysics_model`: Microphysics model whose substep counts and
+    per-process options are printed.
 """
-function summary_microphysics(io::IO, microphysics_model, options)
+function summary_microphysics(
+    io::IO,
+    microphysics_model::NonEquilibriumMicrophysics1M,
+)
+    options = microphysics_model.processes
     keys = collect(string.(propertynames(options)))
-    is_1m = microphysics_model isa NonEquilibriumMicrophysics1M
-    is_1m && append!(keys, ("n_substeps", "n_substeps_quad"))
+    append!(keys, ("n_substeps", "n_substeps_quad"))
     buf = maximum(length, keys)
     print(io, '\n')
     pad(k) = repeat(" ", buf - length(k) + 2)
     line(k, v) = print(io, "  ", pad(k), '`', k, '`', "::", '`', v, '`', '\n')
-    if is_1m
-        line("n_substeps", microphysics_model.n_substeps)
-        line("n_substeps_quad", microphysics_model.n_substeps_quad)
-    end
+    line("n_substeps", microphysics_model.n_substeps)
+    line("n_substeps_quad", microphysics_model.n_substeps_quad)
     for pn in propertynames(options)
         opt = getproperty(options, pn)
         label = isnothing(opt) ? "disabled" : string(nameof(typeof(opt)))

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -229,6 +229,9 @@ function Base.summary(io::IO, numerics::AtmosNumerics)
     end
 end
 
+summary_type(prop) = typeof(prop)
+summary_type(::NonEquilibriumMicrophysics1M) = NonEquilibriumMicrophysics1M
+
 function Base.summary(io::IO, atmos::AtmosModel)
     pns = string.(propertynames(atmos))
     buf = maximum(length.(pns))
@@ -252,7 +255,7 @@ function Base.summary(io::IO, atmos::AtmosModel)
             '`',
             "::",
             '`',
-            typeof(prop),
+            summary_type(prop),
             '`',
             '\n',
         )
@@ -261,26 +264,26 @@ function Base.summary(io::IO, atmos::AtmosModel)
 end
 
 """
-    summary_microphysics(io::IO, microphysics_model, options)
+    summary_microphysics(io::IO, microphysics_model::NonEquilibriumMicrophysics1M)
 
-Print the microphysics settings that `summary(::AtmosModel)` does not surface:
-the substep counts of `NonEquilibriumMicrophysics1M` (struct fields, hidden by
-`typeof`) and the per-process option selections (e.g. which autoconversion or
-accretion scheme is active, or `disabled` when the option is `nothing`). The
-process options live in the parameter set, not in the `AtmosModel`.
+Print the 1-moment microphysics settings that `summary(::AtmosModel)` does not
+surface, because they are struct fields hidden by `typeof`: the substep counts
+and the per-process option selections (e.g. which autoconversion or accretion
+scheme is active, or `disabled` when the option is `nothing`).
 """
-function summary_microphysics(io::IO, microphysics_model, options)
+function summary_microphysics(
+    io::IO,
+    microphysics_model::NonEquilibriumMicrophysics1M,
+)
+    options = microphysics_model.processes
     keys = collect(string.(propertynames(options)))
-    is_1m = microphysics_model isa NonEquilibriumMicrophysics1M
-    is_1m && append!(keys, ("n_substeps", "n_substeps_quad"))
+    append!(keys, ("n_substeps", "n_substeps_quad"))
     buf = maximum(length, keys)
     print(io, '\n')
     pad(k) = repeat(" ", buf - length(k) + 2)
     line(k, v) = print(io, "  ", pad(k), '`', k, '`', "::", '`', v, '`', '\n')
-    if is_1m
-        line("n_substeps", microphysics_model.n_substeps)
-        line("n_substeps_quad", microphysics_model.n_substeps_quad)
-    end
+    line("n_substeps", microphysics_model.n_substeps)
+    line("n_substeps_quad", microphysics_model.n_substeps_quad)
     for pn in propertynames(options)
         opt = getproperty(options, pn)
         label = isnothing(opt) ? "disabled" : string(nameof(typeof(opt)))

--- a/test/parameter_tests.jl
+++ b/test/parameter_tests.jl
@@ -26,6 +26,47 @@ import Thermodynamics as TD
     end
 end
 
+@testset "1-moment microphysics process options" begin
+    CMP = CAP.CM.Parameters
+
+    # Defaults come from CloudMicrophysics
+    defaults = CA.NonEquilibriumMicrophysics1M()
+    @test defaults.processes.rain_autoconversion isa CMP.Kessler1M
+    # Unknown process names are rejected where they are written
+    @test_throws Exception CA.NonEquilibriumMicrophysics1M(; not_a_process = 1)
+
+    # Options set on the model select the parameters loaded for it
+    model = CA.NonEquilibriumMicrophysics1M(;
+        n_substeps = 3,
+        rain_autoconversion = CMP.PrescribedNd(),
+        cloud_ice_formation = CMP.TemperatureDependent(),
+        rain_snow_accretion = nothing,
+    )
+    @test model.n_substeps == 3
+    params = CA.ClimaAtmosParameters(Float64; microphysics_model = model)
+    processes = params.microphysics_1m_params.processes
+    @test processes.rain_autoconversion isa CMP.PrescribedNd
+    @test processes.cloud_ice_formation isa CMP.TemperatureDependent
+    @test isnothing(processes.rain_snow_accretion)
+    @test isnothing(
+        params.microphysics_1m_params.process_params.rain_snow_accretion,
+    )
+
+    # The YAML keys reach the same place
+    config = CA.AtmosConfig(
+        Dict(
+            "microphysics_model" => "1M",
+            "rain_autoconversion" => "PrescribedNd",
+            "rain_snow_accretion" => nothing,
+        ),
+        job_id = "parameter_test_1m_options",
+    )
+    yaml_processes =
+        CA.ClimaAtmosParameters(config).microphysics_1m_params.processes
+    @test yaml_processes.rain_autoconversion isa CMP.PrescribedNd
+    @test isnothing(yaml_processes.rain_snow_accretion)
+end
+
 @testset "TKE dissipation coefficient derived from Ri_crit" begin
     for FT in (Float32, Float64)
         params = CA.ClimaAtmosParameters(FT)

--- a/test/parameter_tests.jl
+++ b/test/parameter_tests.jl
@@ -29,11 +29,20 @@ end
 @testset "1-moment microphysics process options" begin
     CMP = CAP.CM.Parameters
 
-    # Defaults come from CloudMicrophysics
+    # Defaults come from CloudMicrophysics, except where `default_config.yml`
+    # picks another variant
     defaults = CA.NonEquilibriumMicrophysics1M()
     @test defaults.processes.rain_autoconversion isa CMP.Kessler1M
+    @test defaults.processes.cloud_ice_formation isa CMP.TemperatureDependent
     # Unknown process names are rejected where they are written
     @test_throws Exception CA.NonEquilibriumMicrophysics1M(; not_a_process = 1)
+
+    # Building the model directly and from an unmodified config agree
+    default_config = CA.AtmosConfig(
+        Dict("microphysics_model" => "1M"),
+        job_id = "parameter_test_1m_defaults",
+    )
+    @test CA.get_microphysics_model(default_config.parsed_args) == defaults
 
     # Options set on the model select the parameters loaded for it
     model = CA.NonEquilibriumMicrophysics1M(;


### PR DESCRIPTION
This PR moves the CloudMicrophysics 1M process options into NonEquilibriumMicrophysics1M within AtmosModel. This enables direct use of these options in ClimaAtmos run scripts:

```julia
import ClimaAtmos as CA

microphysics_model = CA.NonEquilibriumMicrophysics1M(;
    n_substeps = 3,
    n_substeps_quad = 2,
    rain_autoconversion = CA.CMP.PrescribedNd(),        # instead of Kessler1M()
    cloud_ice_formation = CA.CMP.TemperatureDependent(), # instead of ConstantTimescale()
    snow_autoconversion = CA.CMP.WithSupersaturation(),
    rain_snow_accretion = nothing,                    # process off
)

simulation = CA.Presets.aquaplanet(
    Float64;
    model = CA.Presets.nonequil_moist_1m(; microphysics_model),
    t_end = 86400,
)
CA.solve_atmos!(simulation)
```