### PR TITLE
Add downstream test hook to buildkite

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -9,7 +9,8 @@ env:
   SLURM_KILL_BAD_EXIT: 1
   JULIA_NVTX_CALLBACKS: gc
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100
-  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/depot:${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/shared"
+  # Shared layer hard-coded to climaatmos-ci: see the note in pipeline.yml.
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/depot:${BUILDKITE_BUILD_PATH}/climaatmos-ci/depot/shared"
   COMMON_CONFIG_PATH: "config/common_configs"
   CONFIG_PATH: "config/model_configs"
   GPU_CONFIG_PATH: "config/gpu_configs"
@@ -29,6 +30,52 @@ steps:
       - echo $$JULIA_DEPOT_PATH
       - echo "--- Instantiate .buildkite"
       - julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true, update_registry=false); Pkg.precompile(;strict=true); Pkg.status()'
+      # Downstream test hook: upstream packages (e.g. ClimaCore) trigger this
+      # pipeline with UPSTREAM_PACKAGES set to test themselves against
+      # ClimaAtmos CI. Space-separated entries, one per package
+      # (same convention as ClimaCoupler's nightly pipeline, see
+      # https://github.com/CliMA/ClimaCoupler.jl/blob/d8b5434/.buildkite/nightly/pipeline.yml#L12-L19):
+      #     Package        -> use the main branch
+      #     Package@1.2.3  -> use a registered version
+      #     Package#rev    -> use a branch or commit
+      # The tested packages are dropped from [compat] in both the base and the
+      # .buildkite projects, so unreleased upstream version bumps still
+      # resolve. Compat bounds from other registered dependencies still apply;
+      # the resolver enforces those regardless. For example, a breaking
+      # ClimaCore release fails to resolve until ClimaDiagnostics is compatible with it.
+      # The modified projects, manifest, and depot persist for all later steps.
+      - |
+        if [ -n "$${UPSTREAM_PACKAGES:-}" ]; then
+          echo "--- Downstream test: using $${UPSTREAM_PACKAGES}"
+          julia --project=.buildkite -e '
+            using Pkg
+            entries = split(ENV["UPSTREAM_PACKAGES"])
+            upstream = String[first(split(entry, r"[@#]")) for entry in entries]
+            for project in (".", ".buildkite")
+                Pkg.activate(project)
+                deps = Pkg.project().dependencies
+                # Pkg.compat throws for packages that are not deps of the
+                # active project (the upstream sets differ per project).
+                for name in filter(name -> haskey(deps, name), upstream)
+                    @info "Downstream test: removing [compat] entry" project name
+                    Pkg.compat(name, nothing)
+                end
+            end
+            Pkg.activate(".buildkite")
+            Pkg.add(map(entries) do entry
+                if occursin("@", entry)
+                    name, version = String.(split(entry, "@"))
+                    Pkg.PackageSpec(; name, version)
+                elseif occursin("#", entry)
+                    name, rev = String.(split(entry, "#"))
+                    Pkg.PackageSpec(; name, rev)
+                else
+                    Pkg.PackageSpec(; name = entry, rev = "main")
+                end
+            end)
+            Pkg.precompile(; strict = true)
+            Pkg.status()'
+        fi
 
     agents:
       slurm_cpus_per_task: 8
@@ -1312,5 +1359,8 @@ steps:
   - wait
 
   - label: ":robot_face: Stage reproducibility results"
+    # Downstream (UPSTREAM_PACKAGES) builds test an upstream branch, not a
+    # ClimaAtmos PR: never stage their results for publishing.
+    if: 'build.env("UPSTREAM_PACKAGES") == null'
     retry: *retry_policy
     command: "julia --color=yes --project=.buildkite reproducibility_tests/stage_output.jl"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,16 @@
 #         (merge-queue fast path, see .buildkite/should_skip_merge_queue.sh), or
 #       * uploads the full CI pipeline (.buildkite/full_pipeline.yml).
 #
+# Downstream builds: upstream packages (e.g. ClimaCore) trigger this pipeline
+# with the UPSTREAM_PACKAGES env var set to test their branch against ClimaAtmos
+# CI (see the "Downstream test hook" in full_pipeline.yml for the entry format).
+# Such builds run on `main` but must behave like PR builds (run the full
+# pipeline) and must not touch the reproducibility reference store; hence the
+# UPSTREAM_PACKAGES guards on the conditions below and in full_pipeline.yml.
+#
+# UPSTREAM_PACKAGES can also be set by hand in the Buildkite UI to test any ClimaAtmos
+# branch against specific upstream versions, e.g. when debugging an unreleased breaking change.
+#
 # Keeping the full pipeline out of the initially-loaded steps is what lets the
 # decider suppress it: a merge-queue build must still report success for the
 # queue to merge, but it does not have to re-run work the PR already did.
@@ -23,7 +33,12 @@ env:
   SLURM_KILL_BAD_EXIT: 1
   JULIA_NVTX_CALLBACKS: gc
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100
-  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/depot:${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/shared"
+  # The read-only shared layer is hard-coded to climaatmos-ci (matching
+  # SHARED_DEPOT_ROOT in depot_pipeline.yml, which seeds it) so that other
+  # pipelines running this yml (e.g. climaatmos-downstream) reuse the warm
+  # depot instead of cold-starting. The writable layer stays slug-keyed, so
+  # pipelines never write into each other's depots.
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/depot:${BUILDKITE_BUILD_PATH}/climaatmos-ci/depot/shared"
   COMMON_CONFIG_PATH: "config/common_configs"
   CONFIG_PATH: "config/model_configs"
   GPU_CONFIG_PATH: "config/gpu_configs"
@@ -32,7 +47,7 @@ env:
 
 steps:
   - label: ":robot_face: Move reproducibility results to reference store"
-    if: 'build.branch == "main"'
+    if: 'build.branch == "main" && build.env("UPSTREAM_PACKAGES") == null'
     retry: &retry_policy
       automatic:
         - exit_status: -1  # Retry on agent lost
@@ -46,7 +61,7 @@ steps:
       - "julia --color=yes --project=.buildkite reproducibility_tests/publish_reference.jl"
 
   - label: ":arrows_counterclockwise: Decide pipeline"
-    if: 'build.branch != "main"'
+    if: 'build.branch != "main" || build.env("UPSTREAM_PACKAGES") != null'
     retry: *retry_policy
     command:
       - ".buildkite/decide_pipeline.sh"


### PR DESCRIPTION

<!--- THESE LINES ARE COMMENTED -->
## Purpose 

When upstream packages have a gha downstream test for ClimaAtmos, they tend to be very flaky. Additionally, it is not easy to run downstream tests on a gpu. This allows upstream packages to run climaatmos buildkite ci using their branch of the upstream package.

## Content

Modify the pipeline to use a `UPSTREAM_PACKAGES` ENV var. If that var is set, it will drop the compats for the upstream pkg being tested, and then add the requested version/commit/branch. This should let upstream package use atmos buildkite ci as a downstream test.

This was mostly written by claude.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
