### PR TITLE
Next round of docs updates: Add and edit atmosphere core model docs

### DIFF
--- a/config/default_configs/default_config.yml
+++ b/config/default_configs/default_config.yml
@@ -127,7 +127,7 @@ prescribe_clouds_in_radiation:
   help: "Use prescribed clouds in radiation model. Clouds are read from ERA5 data and updated every time radiation is called. The year 2010 is used and continuously repeated. This mode only affect radiation and is only relevant for the RRTGMP mode. [`false` (default), `true`]"
   value: false
 insolation:
-  help: "Insolation used in radiation model [`idealized` (default), `timevarying`, `rcemipii`]"
+  help: "Insolation used in radiation model [`idealized` (default), `timevarying`, `rcemipii`, `gcmdriven`, `externaldriventv`, `larcform1`]"
   value: "idealized"
 add_isothermal_boundary_layer:
   help: "Add an isothermal boundary layer above the domain top for radiation [`false`, `true` (default)]"
@@ -228,7 +228,7 @@ surface_setup:
   help: "Surface flux scheme [`DefaultExchangeCoefficients` (default), `DefaultMoninObukhov`]"
   value: "DefaultExchangeCoefficients"
 initial_condition:
-  help: "Selects the simulation case/setup. Global/idealized options: `DryBaroclinicWave`, `MoistBaroclinicWave`, `ConstantBuoyancyFrequencyProfile`, `DecayingProfile` (default), `IsothermalProfile`, `Bomex`, `DryDensityCurrentProfile`, `RisingThermalBubbleProfile`, `ISDAC`, or a NetCDF file path (see docs). Externally-driven single-column cases: `GCM`, `ARMVARANAL`, `ColumnFromFile`, `ReanalysisTimeVarying`."
+  help: "Selects the simulation case/setup. Global/idealized options: `DryBaroclinicWave`, `MoistBaroclinicWave`, `ConstantBuoyancyFrequencyProfile`, `DecayingProfile` (default), `IsothermalProfile`, `Bomex`, `DryDensityCurrentProfile`, `RisingThermalBubbleProfile`, `ISDAC`, or a NetCDF file path (see docs). Externally-driven single-column cases: `GCM`, `ARMVARANAL`, `ForcingFromFile`, `ReanalysisTimeVarying`."
   value: "DecayingProfile"
 perturb_initstate:
   help: "Add a perturbation to the initial condition [`false`, `true` (default)]"
@@ -325,13 +325,13 @@ energy_q_tot_upwinding:
   help: "Energy upwinding mode [`none`, `first_order` , `third_order`, `vanleer_limiter` (default)]"
   value: vanleer_limiter
 orographic_gravity_wave:
-  help: "Orographic drag on horizontal mean flow [`nothing` (default), `gfdl_restart`, `raw_topo`]"
+  help: "Orographic drag on horizontal mean flow [`nothing` (default), `gfdl_restart`, `raw_topo`, `linear` (test path)]"
   value: ~
 non_orographic_gravity_wave:
   help: "Apply parameterization for convective gravity wave forcing on horizontal mean flow [`false` (default), `true`]"
   value: false
 nogw_beres_source:
-  help: "Use Beres (2004) convective source spectrum for tropical NOGW (requires EDMF) [`false` (default), `true`]"
+  help: "Use Beres (2004) convective source spectrum for tropical non-orographic gravity waves (requires the eddy-diffusivity mass-flux scheme) [`false` (default), `true`]"
   value: false
 nogw_beres_heating_latent:
   help: "Source the Beres in-cloud heating from the canonical transport-free latent-heat sum instead of the DSE flux-divergence Q1. Requires microphysics_model=1M and turbconv=prognostic_edmfx. [`false` (default), `true`]"
@@ -428,7 +428,7 @@ deep_atmosphere:
   help: "If true, use deep atmosphere equations and metric terms, otherwise assume columns are cylindrical (shallow atmosphere) [`true` (default), `false`]"
   value: true
 restart_file:
-  help: "Path to HDF5 file to use as simulation starting point. Note that the simulation can only be restarted in a reproducible way when `reproducible_restart` is true."
+  help: "Path to HDF5 file to use as simulation starting point. The simulation can only be restarted in a reproducible way when `reproducible_restart` is true."
   value: ~
 detect_restart_file:
   help: "When true, try finding a restart file and use it to restart the simulation. Only works with ActiveLink."
@@ -446,7 +446,7 @@ chemistry_model:
   help: "Chemistry model [`~` (default, no passive tracers), `passive` (enables passive tracer A)]"
   value: ~
 
-# EDMF configuration
+# Eddy-diffusivity mass-flux (EDMF) configuration
 turbconv:
   help: "Turbulence convection scheme [`nothing` (default), 'prognostic_edmfx']"
   value: ~
@@ -454,43 +454,43 @@ advection_test:
   help: "Switches off all grid-scale and subgrid-scale momentum tendencies [`false` (default), `true`]"
   value: false
 edmfx_scale_blending:
-  help: "Method for blending physical scales in EDMFX mixing length calculation. [`SmoothMinimum` (default), `HardMinimum`]"
+  help: "Method for blending physical scales in the eddy-diffusivity mass-flux mixing-length calculation. [`SmoothMinimum` (default), `HardMinimum`]"
   value: "SmoothMinimum"
 edmfx_filter:
-  help: "If set to true, it switches on the relaxation of negative velocity in EDMFX.  [`true`, `false` (default)]"
+  help: "If set to true, it switches on the relaxation of negative velocity in the eddy-diffusivity mass-flux scheme.  [`true`, `false` (default)]"
   value: false
 edmfx_nh_pressure:
-  help: "If set to true, it switches on EDMFX pressure drag closure.  For prognostic EDMF, this only controls the drag term in the pressure closure. The buoyancy term is always applied. [`true`, `false` (default)]"
+  help: "If set to true, it switches on the eddy-diffusivity mass-flux pressure drag closure.  For the prognostic scheme, this only controls the drag term in the pressure closure. The buoyancy term is always applied. [`true`, `false` (default)]"
   value: false
 edmfx_vertical_diffusion:
-  help: "If set to true, it switches on vertical diffusion of prognostic EDMFX updrafts. [`true`, `false` (default)]"
+  help: "If set to true, it switches on vertical diffusion of prognostic eddy-diffusivity mass-flux updrafts. [`true`, `false` (default)]"
   value: false
 edmfx_entr_model:
-  help: "EDMFX entrainment closure. Only consulted by `prognostic_edmfx`. [`Generalized` (default), `PiGroups`]"
+  help: "Eddy-diffusivity mass-flux entrainment closure. Only consulted by `prognostic_edmfx`. [`Generalized` (default), `PiGroups`]"
   value: "Generalized"
 edmfx_detr_model:
-  help: "EDMFX detrainment closure. Only consulted by `prognostic_edmfx`. This is a placeholder for new detrainment models. For now only supports `Generalized`. [`Generalized` (default)]"
+  help: "Eddy-diffusivity mass-flux detrainment closure. Only consulted by `prognostic_edmfx`. This is a placeholder for new detrainment models. For now only supports `Generalized`. [`Generalized` (default)]"
   value: "Generalized"
 edmfx_mse_q_tot_upwinding:
-  help: "EDMFX upwinding mode [`none`, `first_order` (default), `third_order`]"
+  help: "Eddy-diffusivity mass-flux upwinding mode [`none`, `first_order` (default), `third_order`]"
   value: first_order
 edmfx_tracer_upwinding:
-  help: "EDMFX tracer upwinding mode [`none`, `first_order` (default)]"
+  help: "Eddy-diffusivity mass-flux tracer upwinding mode [`none`, `first_order` (default)]"
   value: first_order
 edmfx_sgsflux_upwinding:
-  help: "EDMFX SGS mass flux upwinding mode [`none` (default), `first_order`, `third_order`]"
+  help: "Eddy-diffusivity mass-flux subgrid-scale mass flux upwinding mode [`none` (default), `first_order`, `third_order`]"
   value: none
 edmfx_sgs_mass_flux:
-  help: "If set to true, it switches on EDMFX SGS mass flux.  [`true`, `false` (default)]"
+  help: "If set to true, it switches on the eddy-diffusivity mass-flux subgrid-scale mass flux.  [`true`, `false` (default)]"
   value: false
 edmfx_sgs_diffusive_flux:
-  help: "If set to true, it switches on EDMFX SGS diffusive flux.  [`true`, `false` (default)]"
+  help: "If set to true, it switches on the eddy-diffusivity mass-flux subgrid-scale diffusive flux.  [`true`, `false` (default)]"
   value: false
 updraft_number:
-  help: "Sets the number of updrafts for the EDMF scheme"
+  help: "Sets the number of updrafts for the eddy-diffusivity mass-flux scheme"
   value: 1
 radiation_reset_rng_seed:
-  help: "Reset the RNG seed before calling RRTGMP to a known value (the timestep number). When modeling cloud optics, RRTGMP uses a random number generator. Resetting the seed every time RRTGMP is called to a deterministic value ensures that the simulation is fully reproducible and can be restarted in a reproducible way. Disable this option when running production runs. Please note that this flag is only used for `AllSkyRadiation` and `AllSkyRadiationWithClearSkyDiagnostics` radiation modes."
+  help: "Reset the RNG seed before calling RRTGMP to a known value (the timestep number). When modeling cloud optics, RRTGMP uses a random number generator. Resetting the seed every time RRTGMP is called to a deterministic value ensures that the simulation is fully reproducible and can be restarted in a reproducible way. Disable this option when running production runs. This flag is only used for `AllSkyRadiation` and `AllSkyRadiationWithClearSkyDiagnostics` radiation modes."
   value: false
 log_to_file:
   help: "Log to stdout and file simultaneously. The log file is saved within the output directory"

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -55,18 +55,6 @@
   publisher={American Meteorological Society}
 }
 
-
-@article{Shen2022,
-  title={A Library of Large-Eddy Simulations Forced by Global Climate Models},
-  author={Shen, Zhaoyi and Sridhar, Akshay and Tan, Zhihong and Jaruga, Anna and Schneider, Tapio},
-  journal={Journal of Advances in Modeling Earth Systems},
-  volume={14},
-  number={3},
-  pages={e2021MS002631},
-  year={2022},
-  publisher={Wiley Online Library}
-}
-
 @article{Sridhar2022,
   title = {Large-eddy simulations with ClimateMachine v0.2.0: a new open-source code for atmospheric simulations on GPUs and CPUs},
   author = {Sridhar, A. and Tissaoui, Y. and Marras, S. and Shen, Z. and Kawczynski, C. and Byrne, S.
@@ -101,38 +89,6 @@ and Pamnany, K. and Waruszewski, M. and Gibson, T. H. and Kozdon, J. E. and Chur
   publisher={Wiley Online Library}
 }
 
-@article{He2020,
-  title = {An Improved Perturbation Pressure Closure for Eddy-Diffusivity Mass-Flux Schemes},
-  author = {He, Jia and Cohen, Yair and Lopez-Gomez, Ignacio and Jaruga, Anna and Schneider, Tapio},
-  journal = {Journal of Advances in Modeling Earth Systems},
-  year = {2020},
-  doi = {10.1002/essoar.10505084.2},
-}
-
-@article{Nishizawa2018,
-  title = {A Surface Flux Scheme Based on the Monin-Obukhov Similarity for Finite Volume Models},
-  author = {Nishizawa, S and Kitamura, Y},
-  journal = {Journal of Advances in Modeling Earth Systems},
-  volume = {10},
-  number = {12},
-  doi = {10.1029/2018MS001534},
-  pages = {3159--3175},
-  year = {2018},
-  publisher = {Wiley Online Library}
-}
-
-@article{Tan2018,
-  title = {An extended eddy-diffusivity mass-flux scheme for unified representation of subgrid-scale turbulence and convection},
-  author = {Tan, Zhihong and Kaul, Colleen M and Pressel, Kyle G and Cohen, Yair and Schneider, Tapio and Teixeira, Jo{\~a}o},
-  journal = {Journal of Advances in Modeling Earth Systems},
-  volume = {10},
-  number = {3},
-  pages = {770--800},
-  year = {2018},
-  publisher = {Wiley Online Library},
-  doi = {10.1002/2017MS001162}
-}
-
 @article{Soares2004,
   title = {An eddy-diffusivity/mass-flux parametrization for dry and shallow cumulus convection},
   author = {Soares, PMM and Miranda, PMA and Siebesma, AP and Teixeira, J},
@@ -165,27 +121,6 @@ and Pamnany, K. and Waruszewski, M. and Gibson, T. H. and Kozdon, J. E. and Chur
   pages = {1443--1462},
   year = {2005},
   doi = {10.1175/MWR2930.1}
-}
-
-@article{Byun1990,
-  title = {On the analytical solutions of flux-profile relationships for the atmospheric surface layer},
-  author = {Byun, Daewon W},
-  journal = {Journal of Applied Meteorology (1988-2005)},
-  pages = {652--657},
-  year = {1990},
-  publisher = {JSTOR},
-  doi = {10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2}
-}
-
-@article{Brown2002,
-  title = {Large-eddy simulation of the diurnal cycle of shallow cumulus convection over land},
-  author = {Brown, AR and Cederwall, RT and Chlond, A and Duynkerke, PG and Golaz, J-C and Khairoutdinov, M and Lewellen, DC and Lock, AP and MacVean, MK and Moeng, C-H and others},
-  journal = {Quarterly Journal of the Royal Meteorological Society: A journal of the atmospheric sciences, applied meteorology and physical oceanography},
-  volume = {128},
-  number = {582},
-  pages = {1075--1093},
-  year = {2002},
-  publisher = {Wiley Online Library}
 }
 
 @article{Khairoutdinov2009,
@@ -308,4 +243,393 @@ doi = {10.5194/gmd-11-793-2018}
   pages = {247--272},
   year = {2006},
   doi = {10.1007/s10546-004-2820-6}
+}
+
+@article{Lauritzen2018,
+	title = {NCAR release of CAM-SE in CESM2.0: A reformulation of the spectral element dynamical core in dry-mass vertical coordinates with comprehensive treatment of condensates and energy},
+	volume = {10},
+	number = {7},
+	doi = {10.1029/2017MS001257},
+	journal = {Journal of Advances in Modeling Earth Systems},
+	author = {Lauritzen, P. H. and Nair, R. D. and Herrington, A. R. and Callaghan, P. and Goldhaber, S. and Dennis, J. M. and Bacmeister, J. T. and Eaton, B. E. and Zarzycki, C. M. and Taylor, M. A. and Ullrich, P. A. and Dubos, T. and Gettelman, A. and Neale, R. B. and Dobbins, B. and Reed, K. A. and Hannay, C. and Medeiros, B. and Benedict, J. J. and Tribbia, J. J.},
+	year = {2018},
+	pages = {1537--1570},
+}
+
+@article{KlempLilly1978,
+	title = {Numerical simulation of hydrostatic mountain waves},
+	volume = {35},
+	number = {1},
+	doi = {10.1175/1520-0469(1978)035<0078:NSOHMW>2.0.CO;2},
+	journal = {Journal of the Atmospheric Sciences},
+	author = {Klemp, J. B. and Lilly, D. K.},
+	year = {1978},
+	pages = {78--107},
+}
+
+@article{Romps2008,
+	title = {The dry-entropy budget of a moist atmosphere},
+	volume = {65},
+	number = {12},
+	doi = {10.1175/2008JAS2679.1},
+	journal = {Journal of the Atmospheric Sciences},
+	author = {Romps, D. M.},
+	year = {2008},
+	pages = {3779--3799},
+}
+
+@article{White2005,
+	author = {A. A. White and B. J. Hoskins and I. Roulstone and A. Staniforth},
+	doi = {10.1256/qj.04.49},
+	journal = {Quart. J. Roy. Meteor. Soc.},
+	pages = {2081--2107},
+	title = {Consistent approximate models of the global atmosphere: shallow, deep, hydrostatic, quasi-hydrostatic and non-hydrostatic},
+	volume = {131},
+	year = {2005},
+}
+
+@article{Bott2008,
+	author = {A. Bott},
+	doi = {10.1016/j.atmosres.2008.02.010},
+	journal = {Atmos. Res.},
+	pages = {252--269},
+	title = {Theoretical considerations on the mass and energy consistent treatment of precipitation in cloudy atmospheres},
+	volume = {89},
+	year = {2008},
+}
+
+@article{Lauritzen2022,
+	author = {Lauritzen, Peter Hjort and Kevlahan, NK-R and Toniazzo, Thomas and Eldred, Christopher and Dubos, Thomas and Gassmann, Almunt and Larson, Vincent E and Jablonowski, Christiane and Guba, Oksana and Shipway, Ben and others},
+	doi = {10.1029/2022MS003117},
+	journal = {J. Adv. Model. Earth Sys.},
+	pages = {e2022MS003117},
+	title = {Reconciling and improving formulations for thermodynamics and conservation principles in {E}arth {S}ystem {M}odels {(ESMs)}},
+	volume = {14},
+	year = {2022},
+}
+
+@article{Ringler2010,
+	author = {T. D. Ringler and J. Thuburn and J. B.Klemp and W. C.Skamarock},
+	doi = {10.1016/j.jcp.2009.12.007},
+	journal = {J. Comp. Phys.},
+	pages = {3065--3090},
+	title = {A unified approach to energy conservation and potential vorticity dynamics for arbitrarily-structured {C}-grids},
+	volume = {229},
+	year = {2010},
+}
+
+@article{TaylorFournier2010,
+	author = {M. A. Taylor and A. Fournier},
+	journal = {J. Comp. Phys.},
+	pages = {5879--5895},
+	title = {A compatible and conservative spectral element method on unstructured grids},
+	volume = {229},
+	year = {2010},
+}
+
+@article{Taylor2020,
+	author = {Mark A. Taylor and Oksana Guba and Andrew Steyer and Paul A. Ullrich and David M. Hall and Christopher Eldred},
+	doi = {10.1029/2019MS001783},
+	journal = {J. Adv. Model. Earth Sys.},
+	pages = {e2019MS001783},
+	title = {An Energy Consistent Discretization of the Nonhydrostatic Equations in Primitive Variables},
+	volume = {12},
+	year = {2020},
+}
+
+@article{Thuburn2008,
+	author = {J. Thuburn},
+	journal = {J. Comp. Phys.},
+	pages = {3715--3730},
+	title = {Some conservation issues for the dynamical cores of {NWP} and climate models},
+	volume = {227},
+	year = {2008},
+}
+
+@article{Peixoto1991,
+	author = {J. P. Peixoto and A. H. Oort and M. de~Almeida and A. Tom{\'e}},
+	journal = {J. Geophys. Res.},
+	pages = {10981--10988},
+	title = {Entropy budget of the atmosphere},
+	volume = {96},
+	year = {1991},
+}
+
+@article{Golaz2022,
+	author = {Golaz, Jean-Christophe and Van Roekel, Luke P and Zheng, Xue and Roberts, Andrew F and Wolfe, Jonathan D and Lin, Wuyin and Bradley, Andrew M and Tang, Qi and Maltrud, Mathew E and Forsyth, Ryan M and Zhang, Chengzhu and Zhou, Tian and Zhang, Kai and Zender, Charles S. and Wu, Mingxuan and Wang, Hailong},
+	doi = {10.1029/2022MS003156},
+	journal = {J. Adv. Model. Earth Sys.},
+	pages = {e2022MS003156},
+	title = {The {DOE} {E3SM} Model Version 2: {O}verview of the Physical Model and Initial Model Evaluation},
+	volume = {14},
+	year = {2022},
+}
+
+@article{Herrington2022,
+	author = {Adam R. Herrington and Andrew Gettelman and Peter H. Lauritzen and Mark A. Taylor},
+	doi = {10.1029/2022MS003192},
+	journal = {J. Adv. Model. Earth Sys.},
+	pages = {e2022MS003192},
+	title = {Impact of Grids and Dynamical Cores in {CESM2.2} on the Surface Mass Balance of the Greenland Ice Sheet},
+	volume = {14},
+	year = {2022},
+}
+
+@article{Ambaum2020,
+	author = {Maarten H. P. Ambaum},
+	doi = {10.1002/qj.3899},
+	journal = {Quart. J. Roy. Meteor. Soc.},
+	pages = {4252--5258},
+	title = {Accurate, simple equation for saturated vapour pressure over water and ice},
+	volume = {146},
+	year = {2020},
+}
+
+@incollection{Jablonowski2011,
+	author = {C. Jablonowski and D. L. Williamson},
+	booktitle = {Numerical Techniques for Global Atmospheric Models},
+	chapter = {13},
+	doi = {10.1007/978-3-642-11640-7_13},
+	editor = {P. H. Lauritzen and C. Jablonowski and M. A. Taylor and R. D. Nair},
+	publisher = {Springer-Verlag},
+	series = {Lecture Notes in Computational Science and Engineering},
+	title = {The Pros and Cons of Diffusion, Filters and Fixers in Atmospheric General Circulation Models},
+	volume = {80},
+	year = {2011},
+}
+
+@article{Skamarock2014,
+	author = {William C. Skamarock and Sang-Hun Park and Joseph B. Klemp and Chris Snyder},
+	doi = {10.1175/JAS-D-14-0114.1},
+	journal = {J. Atmos. Sci.},
+	pages = {4369--4381},
+	title = {Atmospheric kinetic energy spectra from global high-resolution nonhydrostatic simulations},
+	volume = {71},
+	year = {2014},
+}
+
+@article{Abbott2024,
+	author = {Abbott, Tristan H and O'Gorman, Paul A},
+	doi = {10.5194/wcd-5-17-2024},
+	journal = {Weather and Climate Dynamics},
+	pages = {17--41},
+	title = {Impact of Precipitation Mass Sinks on Midlatitude Storms over a Wide Range of Climates},
+	volume = {5},
+	year = {2024},
+}
+
+@article{Soto2015,
+	author = {A. Soto and M. Mischna and T. Schneider and C. Lee and M. Richardson},
+	journal = {Icarus},
+	pages = {553--569},
+	title = {Martian atmospheric collapse: Idealized {GCM} studies},
+	volume = {250},
+	year = {2015},
+}
+
+@article{Shepherd1996,
+	author = {T. G. Shepherd and K. Semeniuk and J. N. Koshyk},
+	doi = {10.1029/96JD01994},
+	journal = {J. Geophys. Res. Atmos.},
+	pages = {23447--23464},
+	title = {Sponge layer feedbacks in middle‐atmosphere models},
+	volume = {101},
+	year = {1996},
+}
+
+@article{Durran1983,
+	author = {D. R. Durran and J. B. Klemp},
+	journal = {Mon. Wea. Rev.},
+	pages = {2341--2361},
+	title = {A Compressible Model for the Simulation of Moist Mountain Waves},
+	volume = {111},
+	year = {1983},
+}
+
+@article{Sadourny1972,
+	author = {Sadourny, Robert},
+	journal = {Mon. Wea. Rev.},
+	pages = {136--144},
+	title = {Conservative finite-difference approximations of the primitive equations on quasi-uniform spherical grids},
+	volume = {100},
+	year = {1972},
+}
+
+@article{Ronchi1996,
+	author = {C. Ronchi and R. Iacono and P.S. Paolucci},
+	doi = {10.1006/jcph.1996.0047},
+	journal = {J. Comp. Phys.},
+	pages = {93--114},
+	title = {The ``Cubed Sphere'': A New Method for the Solution of Partial Differential Equations in Spherical Geometry},
+	volume = {124},
+	year = {1996},
+}
+
+@article{Gardner2018,
+	author = {Gardner, David J and Guerra, Jorge E and Hamon, Fran{\c{c}}ois P and Reynolds, Daniel R and Ullrich, Paul A and Woodward, Carol S},
+	doi = {10.5194/gmd-11-1497-2018},
+	journal = {Geosci. Model Dev.},
+	pages = {1497--1515},
+	title = {Implicit-explicit ({IMEX}) {R}unge-{K}utta methods for non-hydrostatic atmospheric models},
+	volume = {11},
+	year = {2018},
+}
+
+@article{Vinokur1974,
+	author = {M. Vinokur},
+	journal = {J. Comp. Phys.},
+	pages = {105--125},
+	title = {Conservation Equations of Gasdynamics in Curvilinear Coordinate Systems},
+	volume = {14},
+	year = {1974},
+}
+
+@article{Guba2014,
+	author = {O. Guba and M. A. Taylor and P. A. Ullrich and J. R. Overfelt and M. N. Levy},
+	doi = {10.5194/gmd-7-2803-2014},
+	journal = {Geosci. Model Dev.},
+	pages = {2803--2816},
+	title = {The spectral element method ({SEM}) on variable-resolution grids: evaluating grid sensitivity and resolution-aware numerical viscosity},
+	volume = {7},
+	year = {2014},
+}
+
+@book{Karniadakis2005,
+	author = {G. E. Karniadakis and S. J. Sherwin},
+	edition = {2nd},
+	pages = {676},
+	publisher = {Oxford University Press},
+	title = {Spectral/hp Element Methods for Computational Fluid Dynamics},
+	year = {2005},
+}
+
+@book{Deville2002,
+	author = {Deville, Michel O and Fischer, Paul F and Mund, Ernest H},
+	publisher = {Cambridge University Press},
+	title = {High-Order Methods for Incompressible Fluid Flow},
+	year = {2002},
+}
+
+@article{ThuburnWoollings2005,
+	author = {J. Thuburn and T. J. Woollings},
+	doi = {10.1016/j.jcp.2004.08.018},
+	journal = {J. Comp. Phys.},
+	pages = {386--404},
+	title = {Vertical discretizations for compressible Euler equation atmospheric models giving optimal representation of normal modes},
+	volume = {203},
+	year = {2005},
+}
+
+@article{SimmonsBurridge1981,
+	author = {A. J. Simmons and D. M. Burridge},
+	journal = {Mon. Wea. Rev.},
+	pages = {758--766},
+	title = {An Energy and Angular-Momentum Conserving Vertical Finite-Difference Scheme and Hybrid Vertical Coordinates},
+	volume = 109,
+	year = 1981,
+}
+
+@article{Lin1994,
+	author = {Shian-Jiann Lin and Winston C. Chao and Y. C. Sud and G. K. Walker},
+	doi = {10.1175/1520-0493(1994)122<1575:ACOTVL>2.0.CO;2},
+	journal = {Mon. Wea. Rev.},
+	pages = {1575--1593},
+	title = {A Class of the van Leer-type Transport Schemes and Its Application to the Moisture Transport in a General Circulation Model},
+	volume = {122},
+	year = {1994},
+}
+
+@article{Zalesak1979,
+	author = {Zalesak, Steven T},
+	journal = {J. Comp. Phys.},
+	pages = {335--362},
+	title = {Fully multidimensional flux-corrected transport algorithms for fluids},
+	volume = {31},
+	year = {1979},
+}
+
+@article{Ascher1997,
+	author = {U. M. Ascher and S. J. Ruuth and R. J. Spiteri},
+	journal = {Appl. Num. Math.},
+	pages = {151--167},
+	title = {Implicit-explicit {R}unge-{K}utta methods for time-dependent partial differential equations},
+	volume = {25},
+	year = {1997},
+}
+
+@article{Duarte2014,
+	author = {Max Duarte and Ann S. Almgren and Kaushik Balakrishnan and John B. Bell and David M. Romps},
+	journal = {Mon. Wea. Rev.},
+	pages = {4269--4283},
+	title = {A Numerical Study of Methods for Moist Atmospheric Flows: Compressible Equations},
+	volume = {142},
+	year = {2014},
+}
+
+@article{Romps2021,
+	author = {D. M. Romps},
+	doi = {10.1002/qj.4154},
+	journal = {Quart. J. Roy. Meteor. Soc.},
+	pages = {3493--3497},
+	title = {The {R}ankine--{K}irchhoff approximations for moist thermodynamics},
+	volume = {147},
+	year = {2021},
+}
+
+@article{Pressel2015,
+	author = {K. G. Pressel and C. M. Kaul and T. Schneider and Z. Tan and S. Mishra},
+	doi = {10.1002/2015MS000496},
+	journal = {J. Adv. Model. Earth Sys.},
+	pages = {1425--1456},
+	title = {Large-eddy simulation in an anelastic framework with closed water and entropy balances},
+	volume = {7},
+	year = {2015},
+}
+
+@article{Kaul2015,
+	author = {C. M. Kaul and J. Teixeira and K. Suzuki},
+	doi = {10.1175/MWR-D-14-00319.1},
+	journal = {Mon. Wea. Rev.},
+	pages = {4393--4421},
+	title = {Sensitivities in large-eddy simulations of mixed-phase {A}rctic stratocumulus clouds using a simple microphysics approach},
+	volume = {143},
+	year = {2015},
+}
+
+@article{vanLeer1977,
+	author = {Bram Van Leer},
+	journal = {J. Comp. Phys.},
+	pages = {263--275},
+	title = {Towards the ultimate conservative difference scheme {III.} {U}pstream-centered finite-difference schemes for ideal compressible flow},
+	year = {1977},
+}
+
+@article{Klemp2008,
+	author = {Klemp, JB and Dudhia, Jimy and Hassiotis, AD},
+	doi = {10.1175/2008MWR2596.1},
+	journal = {Mon. Wea. Rev.},
+	pages = {3987--4004},
+	title = {An upper gravity-wave absorbing layer for {NWP} applications},
+	volume = {136},
+	year = {2008},
+}
+
+@article{AbdulRazzakGhan2000,
+	author = {Abdul-Razzak, Hayder and Ghan, Steven J.},
+	doi = {10.1029/1999JD901161},
+	journal = {J. Geophys. Res.},
+	pages = {6837--6844},
+	title = {A parameterization of aerosol activation: 2. {M}ultiple aerosol types},
+	volume = {105},
+	year = {2000},
+}
+
+@article{CoxMunk1954,
+	author = {Cox, Charles and Munk, Walter},
+	doi = {10.1364/JOSA.44.000838},
+	journal = {J. Opt. Soc. Am.},
+	pages = {838--850},
+	title = {Measurement of the roughness of the sea surface from photographs of the sun's glitter},
+	volume = {44},
+	year = {1954},
 }

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -82,7 +82,12 @@ makedocs(;
         "Explanation" => [
             "The CliMA Ecosystem" => "ecosystem.md",
             "Dynamics & Numerics" => [
+                "Thermodynamics and the Working Fluid" => "thermodynamics.md",
                 "Governing Equations" => "equations.md",
+                "Discretization and Operators" => "discretization.md",
+                "Conservation Properties" => "conservation.md",
+                "Hyperdiffusion" => "hyperdiffusion.md",
+                "Model Top and Sponge Layer" => "sponge.md",
                 "Implicit Solver" => "implicit_solver.md",
                 "Integer Time (ITime)" => "itime.md",
             ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -135,7 +135,8 @@ ClimaAtmos.integrate_over_sgs
 
 ### Turbulence and convection (PROPHET)
 
-The turbulence and convection scheme, called EDMFX in the code; see the
+The turbulence and convection scheme: an eddy-diffusivity mass-flux scheme,
+named `EDMFX` in the code. See the
 [PROPHET equations](edmf_equations.md).
 
 ```@docs
@@ -284,6 +285,55 @@ ClimaAtmos.Explicit
 ClimaAtmos.Implicit
 ClimaAtmos.Hyperdiffusion
 ClimaAtmos.QuasiMonotoneLimiter
+```
+
+### Discrete operators
+
+Short names for the ClimaCore operators used throughout the tendencies. Several
+docstrings cover a group of related operators. See
+[Discretization and Operators](discretization.md) for the symbols these
+correspond to in the equations, and for the reasoning behind the strong-, weak-,
+and split-form choices.
+
+Horizontal spectral-element operators:
+
+```@docs
+ClimaAtmos.divₕ
+```
+
+Vertical operators from faces to centers:
+
+```@docs
+ClimaAtmos.ᶜinterp
+ClimaAtmos.ᶜadvdivᵥ
+ClimaAtmos.ᶜprecipdivᵥ
+ClimaAtmos.ᶜdiffdivᵥ
+```
+
+Vertical operators from centers to faces:
+
+```@docs
+ClimaAtmos.ᶠinterp
+ClimaAtmos.ᶠwinterp
+ClimaAtmos.ᶠgradᵥ
+ClimaAtmos.ᶠcurlᵥ
+ClimaAtmos.ᶠdiffdivᵥ_u₃
+```
+
+Biased and upwinded reconstructions:
+
+```@docs
+ClimaAtmos.ᶠleft_bias
+ClimaAtmos.upwind_biased_grad
+ClimaAtmos.ᶠupwind1
+ClimaAtmos.ᶠupwind3
+ClimaAtmos.ᶠlin_vanleer
+```
+
+Matrix forms, used to assemble the Jacobian:
+
+```@docs
+ClimaAtmos.ᶜinterp_matrix
 ```
 
 ### Jacobian and the implicit solver

--- a/docs/src/column_datasets_reference.md
+++ b/docs/src/column_datasets_reference.md
@@ -6,7 +6,7 @@ source code: point the config at the file and the
 case (initial condition, external forcing, surface temperature, and insolation)
 from it.
 
-```YAML
+```yaml
 initial_condition: "ForcingFromFile"
 external_forcing_file: /path/to/my_case_forcing.nc
 start_date: "20200101"

--- a/docs/src/config_table.jl
+++ b/docs/src/config_table.jl
@@ -35,7 +35,7 @@ open(output_file, "w") do config_md
 
         Every configuration argument accepted in YAML configuration files, with
         its type and default behavior, generated from
-        `config/default_configs/default_config.yml`. See
+        [`config/default_configs/default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml). See
         [Creating custom configurations](configuration.md) for how to use them.
 
         """,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,9 +2,12 @@
 
 To create a custom configuration, first make a .yml file.
 In the file, you can set configuration arguments as `key: value` pairs to override the default config.
-YAML parsing is forgiving -- values generally parse to the correct type.
-One caveat: unquoted `true`/`false` are parsed to `Bool`s; if a configuration argument
-expects the literal string `"true"` or `"false"`, put quotes around it.
+Each value is coerced to the type of the corresponding default in
+[`config/default_configs/default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml), so quoting does not
+matter (a quoted `"true"` still becomes a `Bool`); a value that cannot be coerced
+raises an error naming the key and the expected type. Keys that are not in the
+default configuration produce a warning, or an error when `strict_config: true`
+is set.
 
 To start the model with a custom configuration, run:
 
@@ -19,9 +22,9 @@ CA.solve_atmos!(simulation)
 ## Example
 
 Below is the default BOMEX configuration
-(`config/model_configs/prognostic_edmfx_bomex_column.yml`):
+([`config/model_configs/prognostic_edmfx_bomex_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_bomex_column.yml)):
 
-```
+```yaml
 initial_condition: "Bomex"
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
@@ -52,20 +55,20 @@ Keys can also point to artifacts. As artifacts are folders, we specify both the 
 column model with an external forcing file from GCM output, we include the following lines in the
 configuration:
 
-```
+```yaml
 initial_condition: "GCM"
 external_forcing_file: artifact"cfsite_gcm_forcing"/HadGEM2-A_amip.2004-2008.07.nc
 ```
 
 To learn more about artifacts and how they're used in CliMA, visit [ClimaArtifacts.jl](https://github.com/CliMA/ClimaArtifacts).
 
-To add a new configuration argument/key, open `config/default_configs/default_config.yml`.
+To add a new configuration argument/key, open [`config/default_configs/default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml).
 Add an entry with the following format:
 
-```
+```yaml
 <argument_name>:
-    value: <argument_value>
-    help: <help string>
+  help: <help string>
+  value: <argument_value>
 ```
 
 The `help` field is optional if you don't plan on making a permanent change to the configuration argument.
@@ -96,9 +99,19 @@ configuration:
 toml: [parameters.toml]
 ```
 
-and run as usual. The `toml` key accepts several files; later files override
-earlier ones, and many shipped model configurations already carry one (e.g.
-`toml/prognostic_edmfx_1M.toml` in the BOMEX example above).
+and run as usual. Three behaviors to know about:
+
+  - The `toml` key accepts several files, but a given parameter may appear in
+    only one of them; a duplicate entry across files raises a
+    `Duplicate TOML entry` error.
+  - A `toml:` key in a later configuration file *replaces* the earlier list
+    rather than appending to it. Many shipped model configurations already
+    carry one (e.g.
+    [`toml/prognostic_edmfx_1M.toml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/toml/prognostic_edmfx_1M.toml)
+    in the BOMEX example above), so to combine your overrides with such a
+    configuration, list both files.
+  - Overriding a parameter that no component of the current model uses raises
+    an error; set `strict_params: false` to allow unused overrides.
 
 ## Environment variables
 
@@ -122,27 +135,27 @@ ClimaAtmos provides a set of common numerical configurations that can be used as
 
 #### Column Configurations
 
-  - **`numerics_column_ze63.yml`**: Single column configuration with 63 vertical levels
+  - **[`numerics_column_ze63.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_column_ze63.yml)**: Single column configuration with 63 vertical levels
 
 #### Sphere Configurations
 
-  - **`numerics_sphere_he6ze10.yml`**: Spherical configuration with 6 horizontal elements (550km), 10 vertical levels, 30km domain top, no sponge, explicit vertical diffusion
+  - **[`numerics_sphere_he6ze10.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_sphere_he6ze10.yml)**: Spherical configuration with 6 horizontal elements (550km), 10 vertical levels, 30km domain top, no sponge, explicit vertical diffusion
 
-  - **`numerics_sphere_he6ze31.yml`**: Spherical configuration with 6 horizontal elements (550km), 31 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
+  - **[`numerics_sphere_he6ze31.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_sphere_he6ze31.yml)**: Spherical configuration with 6 horizontal elements (550km), 31 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 
-  - **`numerics_sphere_he16ze63.yml`**: Spherical configuration with 16 horizontal elements (206km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
+  - **[`numerics_sphere_he16ze63.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_sphere_he16ze63.yml)**: Spherical configuration with 16 horizontal elements (206km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 
-  - **`numerics_sphere_he30ze43.yml`**: Spherical configuration with 30 horizontal elements (110km), 43 vertical levels, 30km domain top, no sponge, explicit vertical diffusion
+  - **[`numerics_sphere_he30ze43.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_sphere_he30ze43.yml)**: Spherical configuration with 30 horizontal elements (110km), 43 vertical levels, 30km domain top, no sponge, explicit vertical diffusion
 
-  - **`numerics_sphere_he30ze63.yml`**: Spherical configuration with 30 horizontal elements (110km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
+  - **[`numerics_sphere_he30ze63.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/numerics_sphere_he30ze63.yml)**: Spherical configuration with 30 horizontal elements (110km), 63 vertical levels, 60km domain top, rayleigh and viscous sponges, implicit vertical diffusion
 
 #### Diagnostics Configurations for PROPHET Columns
 
-Common diagnostics sets for PROPHET (prognostic EDMF) single-column runs. Each file defines a `diagnostics:` block mostly at 10-minute output frequency; individual model configs can add case-specific diagnostics on top.
+Common diagnostics sets for PROPHET single-column runs. Each file defines a `diagnostics:` block mostly at 10-minute output frequency; individual model configs can add case-specific diagnostics on top.
 
-  - **`diagnostics_column_progedmf_0M.yml`**: Standard diagnostics for PROPHET columns with 0-moment microphysics (`microphysics_model: "0M"`). Includes atmospheric state, surface fluxes and precipitation, updraft/environment profiles, and entrainment/detrainment variables.
+  - **[`diagnostics_column_progedmf_0M.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/diagnostics_column_progedmf_0M.yml)**: Standard diagnostics for PROPHET columns with 0-moment microphysics (`microphysics_model: "0M"`). Includes atmospheric state, surface fluxes and precipitation, updraft/environment profiles, and entrainment/detrainment variables.
 
-  - **`diagnostics_column_progedmf_1M.yml`**: Standard diagnostics for PROPHET columns with 1-moment microphysics (`microphysics_model: "1M"`). Extends the 0M set with rain/snow specific humidities, updraft/environment precipitation variables, and the full suite of 1M bulk microphysics process rates for the grid mean, updraft, and environment (`mp1m_*`, `mp1mup_*`, `mp1men_*`).
+  - **[`diagnostics_column_progedmf_1M.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/common_configs/diagnostics_column_progedmf_1M.yml)**: Standard diagnostics for PROPHET columns with 1-moment microphysics (`microphysics_model: "1M"`). Mirrors the 0M set (without the static-energy variables `ha`/`haup`/`haen`) and adds rain/snow specific humidities, supersaturations, updraft/environment precipitation variables, and the full suite of 1M bulk microphysics process rates for the grid mean, updraft, and environment (`mp1m_*`, `mp1mup_*`, `mp1men_*`).
 
 ### Using Common Configurations
 

--- a/docs/src/conservation.md
+++ b/docs/src/conservation.md
@@ -1,0 +1,134 @@
+# Conservation Properties
+
+ClimaAtmos conserves total energy, air mass, and water to floating-point
+precision, without ad hoc fixers. It does so in moist atmospheres, in the
+presence of subgrid-scale parameterizations, over complex topography, and in a
+deep atmosphere [Yatunin2026](@cite).
+
+Conservation is a design goal, and it constrains choices throughout the model.
+This page collects those choices in one place and describes what is conserved,
+what is not, and how to check.
+
+## Why it matters
+
+An energy leak of a fraction of a watt per square meter is small against the
+roughly 240 W m⁻² of top-of-atmosphere radiation. Integrated over a century-long
+simulation, it produces a temperature drift that cannot be distinguished from a
+real climate signal [Thuburn2008](@cite).
+
+Models that do not conserve by construction often add *energy fixers*
+[Lauritzen2022, Jablonowski2011](@cite):
+corrections that redistribute the imbalance to close the budget. A fixer hides
+the error instead of removing it, and it obscures how energy moves through the
+model. Here the discrete equations conserve to floating-point precision, so no
+fixer is needed.
+
+## Where conservation comes from
+
+Conservation rests on four ingredients, and it fails if any one of them is
+missing.
+
+**Flux-conservative equations.** The governing equations for mass, energy, and
+total water are written in flux form: their right-hand sides contain only
+flux-divergence terms, with no non-conservative sources or sinks. The
+domain-integrated quantities can then change only through fluxes across the
+boundaries. This structure holds even for the subgrid-scale fluxes that
+parameterizations contribute. See [Governing Equations](equations.md).
+
+**Specific total energy as a prognostic variable.** The model prognoses
+``e_{tot} = I + \Phi + \kappa + \kappa_{SGS}``, the specific total energy of
+moist air, instead of a temperature-like variable. Total energy is an extensive
+quantity satisfying a volume-integrated conservation law, so a flux-form
+equation for it conserves it.
+
+**A consistent thermodynamic formulation.** The internal energies, enthalpies,
+and latent heats must be mutually consistent for the energy budget to close in
+the presence of phase changes.
+[Thermodynamics and the Working Fluid](thermodynamics.md) develops this,
+including the reference-temperature invariance that any new energy flux must
+respect.
+
+**A mimetic discretization.** A discretization can break conservation that the
+continuous equations have. The spectral element method's weak-form flux
+divergences satisfy discrete analogues of the divergence and Stokes theorems;
+direct stiffness summation preserves the discrete inner product; the vertical
+averaging and difference operators satisfy discrete integration-by-parts and
+averaging-by-parts identities; and the reconstructions between cell centers and
+faces are chosen so that combinations of these operators satisfy discrete
+conservation laws. See [Discretization and Operators](discretization.md).
+
+## Consequences
+
+Because momentum advection in vector-invariant form conserves kinetic energy and
+vorticity globally, and because total energy is separately conserved, any
+numerical conversion between kinetic and non-kinetic energy is performed
+**solely** by the discretized pressure-gradient term and by the physical sources
+and sinks. The advection scheme contributes none. Energy therefore moves between
+the resolved scales and the thermodynamic reservoirs along one path, in moist
+conditions as well as dry.
+
+The subgrid-scale and numerical terms follow the same rule.
+[Hyperdiffusion](hyperdiffusion.md) is written as flux divergences along
+coordinate surfaces, so it redistributes without creating or destroying
+anything; its enthalpy flux is decomposed to account for the energy carried by
+the hyperdiffusive water flux, so total energy and water are conserved together.
+The same decomposition governs the turbulent enthalpy flux and the
+[sponge layer](sponge.md).
+
+## What is not conserved
+
+There is a trade-off. Potential temperature, which some models conserve
+discretely along material trajectories, has no such guarantee here.
+
+Potential temperature is conserved only for dry, adiabatic dynamics, and it is
+not an extensive quantity satisfying a volume-integrated conservation law. Under
+the moist, diabatic conditions of the real atmosphere, it is not conserved
+physically either. Total energy is, so that is what the model conserves.
+
+The effective moisture source in the mass continuity equation, which comes from
+subgrid-scale water fluxes, is retained for generality. In Earth's atmosphere, it
+is two or more orders of magnitude smaller than the other terms. It matters
+where the condensable species is a major atmospheric constituent, such as carbon
+dioxide on Mars.
+
+## Checking conservation in a run
+
+The model's test suite checks conservation, and you can measure it in any
+simulation. Enable the conservation callback with the `check_conservation`
+configuration key, then compare the first and last saved states:
+
+```julia
+import ClimaAtmos as CA
+
+errors = CA.check_conservation(simulation)
+```
+
+This returns dimensionless relative errors:
+
+  - `energy_conservation`: the change in atmospheric plus surface energy, less
+    the net radiative input at the top, divided by the initial total energy.
+  - `mass_conservation`: the change in total dry-plus-moist mass, divided by the
+    initial mass.
+  - `water_conservation`: the change in atmospheric plus surface water, divided
+    by the final total atmospheric water. Zero for dry runs.
+
+The surface terms matter: energy and water leave the atmosphere through surface
+fluxes and precipitation, so a closed budget has to account for what the surface
+receives. With a slab ocean the surface reservoir is explicit; otherwise the
+accumulated surface fluxes stand in for it.
+
+!!! note "Interpreting the numbers"
+
+    These errors mean something only for setups whose boundary fluxes are all
+    accounted for, and only when the run saved both endpoints. For the
+    quantities the model conserves by construction, expect values near
+    floating-point precision. A 32-bit run carries about seven significant
+    decimal digits, so its floor is well above a 64-bit run's.
+
+## Where this is implemented
+
+| Concept              | Source                                                                                                 |
+|:-------------------- |:------------------------------------------------------------------------------------------------------ |
+| Conservation check   | [src/simulation/solve.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/simulation/solve.jl)    |
+| Flux-form tendencies | [src/prognostic_equations/](https://github.com/CliMA/ClimaAtmos.jl/tree/main/src/prognostic_equations) |
+| Conservation tests   | [test/](https://github.com/CliMA/ClimaAtmos.jl/tree/main/test)                                         |

--- a/docs/src/contributor_guide.md
+++ b/docs/src/contributor_guide.md
@@ -34,7 +34,7 @@ The most useful bug reports:
 
 Discussions are recommended for asking questions about (for example) the user interface, implementation details, science, and life in general.
 
-## But I want to _code_!
+## But I want to _code_
 
   - New users help write ClimaAtmos code and documentation by [forking the ClimaAtmos repository](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks), [using git](https://guides.github.com/introduction/git-handbook/) to edit code and docs, and then creating a [pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork). Pull requests are reviewed by ClimaAtmos collaborators.
 
@@ -161,8 +161,8 @@ and [submit a pull request](https://github.com/CLiMA/ClimaAtmos.jl/compare/).
 ## Documentation
 
 Now that you've made your awesome contribution, it's time to tell the world how to use it.
-Writing documentation strings is important to make sure others use your functionality
-properly. Didn't write new functions? That's fine, but be sure that the documentation for
+Writing documentation strings is important to make sure others can use your
+functionality. Didn't write new functions? That's fine, but be sure that the documentation for
 the code you touched is still in great shape. It is not uncommon to find some strange wording
 or clarification that you can take care of while you are here.
 
@@ -174,7 +174,7 @@ follow it for every docstring and documentation page you touch.
 You can preview how the documentation will look after merging by building the documentation
 locally. From the main directory of your local repository call
 
-```
+```bash
 julia --project=docs -e 'using Pkg; Pkg.develop(Pkg.PackageSpec(path = ".")); Pkg.instantiate()'
 JULIA_DEBUG=Documenter julia --project=docs docs/make.jl
 ```
@@ -198,21 +198,13 @@ punctuation, or wrap the units in backticks; both are spelled out in the shared
 
 One of the CI checks verifies that the code is uniformly formatted with
 [JuliaFormatter.jl](https://github.com/JuliaEditorSupport/JuliaFormatter.jl);
-the rules are defined in the root `.JuliaFormatter.toml`. Usage, the
+the rules are defined in the root [`.JuliaFormatter.toml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/.JuliaFormatter.toml). Usage, the
 version-consistency requirement, and the recommended `prek` pre-commit hooks
-(defined in `.pre-commit-config.yaml`, running the formatter from the
+(defined in [`.pre-commit-config.yaml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/.pre-commit-config.yaml), running the formatter from the
 version-pinned `.dev/format/` environment so results match the
 [Prek CI check](https://github.com/CliMA/ClimaAtmos.jl/blob/main/.github/workflows/run-prek.yml))
 are all documented in the shared
 [code style guide, §1](https://github.com/CliMA/ClimaAtmos.jl/blob/main/docs/dev-guides/code-quality/code_style.md).
-
-!!! note
-
-    In the past, `ClimaAtmos` used to have a `.dev/climaformat.jl` script. We moved
-    away from it to reduce complexity in our repository and to align with the
-    general tools used by the Julia community. If you are still using
-    `climaformat.jl`, migrate to `JuliaFormatter` (`climaformat.jl` was just a
-    wrapper around `JuliaFormatter`).
 
 ## Updating environments
 
@@ -222,12 +214,6 @@ is to help with reproducing results.
 convenient system to quickly update all the `Manifests.toml`: add it to your
 base environment with `Pkg.add("PkgDevTools")`, then run
 `using PkgDevTools; PkgDevTools.update_deps(".")` from the repository root.
-
-!!! note
-
-    In the past, `ClimaAtmos` used to have a `.dev/up_deps.jl` script. We moved away
-    from it because `PkgDevTools` provides a simpler and more efficient way to
-    accomplish the same result.
 
 ## Credits
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -6,14 +6,14 @@
 
 If you configure your simulation with YAML files, there are two important
 options. When `output_default_diagnostics` is set to `true`, the
-default diagnostics for the given atmospheric model will be output. Note that
-they might be incompatible with your simulation (e.g., you want to output
-hourly maxima when the timestep is 4 hours).
+default diagnostics for the given atmospheric model will be output. These may
+be incompatible with your simulation, if for instance you ask for hourly maxima
+when the timestep is 4 hours.
 
 Second, you can specify the diagnostics you want to output directly in the
 `diagnostics` section of your YAML file. For instance:
 
-```
+```yaml
 diagnostics:
   - short_name: rhoa
     output_name: a_name
@@ -28,25 +28,31 @@ diagnostics:
 
 This adds two diagnostics (both for `rhoa`). The `period` keyword
 identifies the period over which to compute the reduction and how often to save
-to disk. `output_name` is optional, and if provided, it identifies the name of the
-output file. The `compute_every` keyword identifies how often the field should
-be computed; it applies only when a `reduction_time` is specified. Without a
+to disk. `reduction_time` is one of `inst` (instantaneous, the default),
+`average`, `max`, or `min`. `output_name` is optional, and if provided, it
+identifies the name of the output file. The `compute_every` keyword identifies
+how often the field should be computed; it applies only when a
+`reduction_time` is specified, and **defaults to every timestep**, so it is
+what to change when a reduced diagnostic is expensive to compute. Without a
 reduction, the field is computed on the output schedule.
 
 For multiple diagnostics with the same specs, you can also pass a vector of
 `short_names` directly, as in
 
-```
+```yaml
 diagnostics:
   - short_name: [rhoa, ua, ta]
     reduction_time: average
     period: 12hours
 ```
 
-The default `writer` is NetCDF. If `writer` is `nc` or `netcdf`, the output is
+The accepted `writer` values are `nc`/`netcdf` (the default), `h5`/`hdf5`, and
+`dict` (in-memory, for testing). If `writer` is `nc` or `netcdf`, the output is
 remapped non-conservatively on a Cartesian grid and saved to a NetCDF file.
 Remapping is most commonly used for cubed-sphere runs; column and box
-configurations are also supported.
+configurations are also supported. By default
+(`netcdf_output_at_levels: true`), fields are written at the model levels, with
+no vertical interpolation.
 
 !!! note "Did you know?"
 
@@ -66,10 +72,6 @@ configurations are also supported.
 
 #### Writing in pressure coordinates
 
-!!! compat "Compatibility"
-
-    This is only available in versions after ClimaAtmos v0.35.4.
-
 You can write diagnostics to NetCDF files in pressure coordinates by setting
 `pressure_coordinates` to true. This replaces the vertical dimension `z` in
 the NetCDF files with the dimension `pressure_level`. For more information about
@@ -77,7 +79,7 @@ writing diagnostics in pressure coordinates, see the
 [documentation](https://clima.github.io/ClimaDiagnostics.jl/dev/writers/#Output-diagnostics-in-pressure-coordinates)
 in ClimaDiagnostics.
 
-```
+```yaml
 diagnostics:
   - short_name: [pfull, wa, va, rv, hus, ke]
     period: 1days
@@ -87,22 +89,28 @@ diagnostics:
 ### From a script
 
 The simplest way to get started with diagnostics is to use the defaults for your
-atmospheric model. `ClimaAtmos` defines a function `default_diagnostics`. You
-can execute this function on an `AtmosModel` or on any of its fields to obtain a
-list of diagnostics ready to be passed to the simulation. So, for example
+atmospheric model. The `ClimaAtmos.Diagnostics` submodule defines a function
+`default_diagnostics`. You can execute this function on an `AtmosModel` or on any
+of its fields to obtain a list of diagnostics ready to be passed to the
+simulation. So, for example
 
 ```julia
-model = ClimaAtmos.AtmosModel(; microphysics_model = ClimaAtmos.DryModel())
+import ClimaAtmos as CA
+import ClimaAtmos.Diagnostics as CAD
 
-diagnostics = ClimaAtmos.default_diagnostics(
+model = CA.AtmosModel(; microphysics_model = CA.DryModel())
+
+diagnostics = CAD.default_diagnostics(
     model, duration, start_date, t_start;
     output_writer, topography,
 )
 # => List of diagnostics that include the ones specified for the DryModel
 ```
 
-(`DiagnosticsConfig(; default = true)` is the higher-level entry point that
-supplies these arguments for you.)
+(The block is schematic: `duration`, `start_date`, `t_start`, `output_writer`,
+and `topography` stand for values you supply, and the last two are required
+keyword arguments. `DiagnosticsConfig(; default = true)` is the higher-level
+entry point that supplies all of them for you.)
 
 Technically, the diagnostics are represented as `ScheduledDiagnostic` objects,
 which contain information about what variable has to be computed, how often,
@@ -110,19 +118,20 @@ where to save it, and so on (read below for more information on this). You can
 construct your own lists of `ScheduledDiagnostic`s starting from the variables
 defined by `ClimaAtmos`. The `DiagnosticVariable`s in `ClimaAtmos` are
 identified by their short, unique names, so that you can access them
-directly with the function `get_diagnostic_variable`. One way to do so is by
+directly with the function `CAD.get_diagnostic_variable`. One way to do so is by
 using the provided convenience functions for common operations, e.g., continuing
 the previous example
 
 ```julia
 append!(
     diagnostics,
-    daily_maxs(FT, "rhoa", "ta"; output_writer, start_date, t_start),
+    CAD.daily_maxs(FT, "rhoa", "ta"; output_writer, start_date, t_start),
 )
 ```
 
 Now `diagnostics` will also contain the instructions to compute the daily
-maxima of the air density (`rhoa`) and air temperature (`ta`).
+maxima of the air density (`rhoa`) and air temperature (`ta`); `FT` is the
+simulation's float type (e.g. `Float32`).
 
 The diagnostics built into `ClimaAtmos` are collected in [Available
 diagnostic variables](@ref).

--- a/docs/src/discretization.md
+++ b/docs/src/discretization.md
@@ -1,0 +1,652 @@
+# Discretization and Operators
+
+ClimaAtmos discretizes the [governing equations](equations.md) with a hybrid
+scheme: a spectral element method in the horizontal and finite differences on a
+staggered grid in the vertical [Yatunin2026](@cite). This page explains that
+choice and defines the discrete operators once, for use by every other page in
+these docs.
+
+The operators themselves come from
+[ClimaCore.jl](https://clima.github.io/ClimaCore.jl/stable/). This page gives the
+symbol used for each one in the equations and the discrete identities each
+satisfies. For the short names the tendencies are written in, and what each
+accepts, see [Discrete operators](@ref) in the API.
+
+## Why a hybrid scheme
+
+The horizontal and vertical directions of an atmospheric grid have different
+requirements, and the scheme treats them differently.
+
+Horizontally, the spectral element method [Karniadakis2005, Deville2002](@cite)
+gives high-order accuracy and scales to many nodes. Only one operation communicates between elements, a single
+neighbor exchange, which is why the method parallelizes well.
+
+Vertical resolution is much finer than horizontal resolution: tens of meters
+near the surface against tens of kilometers horizontally. The fast vertical
+waves this allows would otherwise set the timestep. Finite differences on a
+staggered grid suppress the computational modes that an unstaggered high-order
+vertical discretization admits, and they couple only neighboring levels, so the
+vertical terms can be solved implicitly. See
+[Implicit Solver](implicit_solver.md) for that solve.
+
+The two parts are independent. The vertical staggering, the reconstruction
+rules, and the implicit solve make no reference to how horizontal derivatives
+are computed, and the [semi-discrete equations](@ref "Semi-discrete equations")
+at the end of this page are written in operator symbols rather than in any one
+method's terms. An alternative horizontal discretization — a discontinuous
+Galerkin method, for example — would supply its own realization of the
+horizontal operators and of the projection ``\mathcal{P}``, and leave the rest
+of this page, and of the model, unchanged.
+
+## Grid layout and staggering
+
+The domain is divided into ``N_h`` horizontal elements, each extruded into
+``N_v`` vertical layers. Horizontal elements carry ``(N_p + 1)^2``
+Gauss–Lobatto–Legendre nodal points, so fields are polynomials of order ``N_p``
+within an element. On the sphere the horizontal mesh is an equiangular cubed
+sphere [Sadourny1972, Ronchi1996](@cite); in Cartesian geometry the same
+machinery discretizes a box. See
+[Grids](grids.md) for the constructors and
+[Topography Representation](topography.md) for the terrain-following vertical
+coordinate.
+
+The vertical arrangement is a **Lorenz staggering**: the covariant
+vertical velocity component ``u_3`` is defined on element faces, and every other
+variable — including the horizontal velocity components ``u_1`` and ``u_2`` —
+is defined on element centers. Lorenz staggering is used in preference to
+Charney–Phillips because it is less involved and still has similar wave propagation
+properties [ThuburnWoollings2005, Yatunin2026](@cite).
+
+Throughout the docs and the code, a ``ᶜ`` prefix marks a center field and a
+``ᶠ`` prefix marks a face field; see [Notation and Symbols](notation.md) for the
+full convention.
+
+## The horizontal discretization: spectral elements
+
+Within each element, fields are expanded in a nodal polynomial basis on the
+Gauss–Lobatto–Legendre points, and horizontal derivatives are computed by
+differentiating that expansion. Everything in this section is specific to the
+continuous spectral element method; the vertical discretization and the
+semi-discrete equations do not depend on it.
+
+### Strong and weak forms: which to use
+
+The spectral element method offers two formulations of every horizontal
+derivative. They have the same order of accuracy and the same cost, and both
+satisfy the vector identities ``\nabla_h \times \nabla_h = 0`` and
+``\nabla_h \cdot (\nabla_h \times) = 0`` [TaylorFournier2010](@cite). They
+differ in one property, and that property decides which to use.
+
+The **strong** form differentiates the basis functions directly, which is the
+obvious discrete derivative.
+
+The **weak** form is constructed so that it is the *negative adjoint* of the
+strong form under the discrete inner product: for any two fields ``\phi`` and
+``\psi``,
+
+```math
+\mathscr{I}\!\left( \phi, \tilde{\partial}_i \psi \right)
+  + \mathscr{I}\!\left( \psi, \partial_i \phi \right) = 0 ,
+```
+
+a discrete integration by parts. From that identity follow discrete analogues of
+the divergence and Stokes theorems, and those are what turn a local operator into
+a global conservation statement.
+
+#### The rule
+
+Adjointness is a property of a *pair*. A term conserves what it should when the
+two operators acting in it are adjoint to one another, so that summing over the
+domain telescopes into boundary terms alone. That gives a short rule:
+
+| Term                                  | Form                                                                              | Why                                                                                                                               |
+|:------------------------------------- |:--------------------------------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------- |
+| Flux divergence of a conserved scalar | **weak**                                                                          | Discrete divergence theorem: the domain integral changes only through boundary fluxes                                             |
+| Curl in the momentum equation         | **weak**                                                                          | Discrete Stokes theorem: vorticity is conserved globally                                                                          |
+| Gradient in the momentum equation     | **strong**                                                                        | Pairs with the weak divergence, so kinetic energy is conserved when pressure gradients and sources are absent [Taylor2020](@cite) |
+| Scalar Laplacian                      | ``\tilde{\nabla}_h \cdot \nabla_h``                                               | Weak divergence of a strong gradient satisfies a second-order integration by parts                                                |
+| Vector Laplacian                      | ``\tilde{\nabla}_h (\nabla_h \cdot) - \tilde{\nabla}_h \times (\nabla_h \times)`` | Same identity, with the weak operator on the outside                                                                              |
+
+Mixing the two forms is therefore deliberate rather than incidental: using the
+weak divergence for the mass flux and the strong gradient for kinetic energy is
+what makes the two terms cancel exactly in the energy budget. Using the same form
+for both would break that cancellation and leave a spurious energy source. See
+[Conservation Properties](conservation.md).
+
+Note the asymmetry between the two Laplacians. Both put one strong and one weak
+operator in the pair, but the scalar Laplacian takes the divergence weakly, while
+the vector Laplacian takes the outer operator weakly. Either arrangement
+satisfies the identity, because each is the adjoint of the other; what matters is
+that the pair contains one of each. Fourth-order hyperdiffusion applies the
+Laplacian twice with direct stiffness summation in between, which removes
+inter-element discontinuities without disturbing the inner product; see
+[Hyperdiffusion](hyperdiffusion.md).
+
+#### In the code
+
+The strong operators are `divₕ`, `gradₕ`, and `curlₕ`; the weak ones carry a `w`
+prefix: `wdivₕ`, `wgradₕ`, `wcurlₕ`; the split divergence is `split_divₕ`. So
+the scalar and vector Laplacians read
+
+```julia
+ᶜ∇²s_d = @. wdivₕ(gradₕ(s_d))                                  # weak div ∘ strong grad
+ᶜ∇²u = @. C123(wgradₕ(divₕ(ᶜu))) - C123(wcurlₕ(C123(curlₕ(ᶜu))))
+```
+
+The variable-resolution behavior of these operators is examined by
+[Guba2014](@cite).
+
+### Projection: direct stiffness summation
+
+The nodal expansions of neighboring elements meet at shared boundary points,
+where their values can disagree. The projection ``\mathcal{P}`` onto the
+continuous spectral element basis is the
+[direct stiffness summation](@extref ClimaCore DSS) (DSS): it replaces the
+value at each element boundary point with a volume-weighted average over the
+points collocated with it in neighboring elements.
+
+DSS is the only operation that communicates horizontally between elements,
+which is why the horizontal discretization parallelizes well. It preserves the
+discrete inner product, so it leaves the conservation properties of the weak
+operators intact. The timestepper applies it several times per step — at stage
+boundaries, around the implicit solve, and at the end of the step — which keeps
+round-off errors from accumulating as discontinuities across element
+boundaries.
+
+## The vertical discretization: interpolating between centers and faces
+
+Staggering forces interpolation. The covariant vertical velocity ``u_3`` is
+defined on faces and everything else on centers, so any flux term needs one or
+the other moved. Which average is used is not a matter of taste: as with the
+strong and weak forms, the choice determines whether a discrete conservation law
+holds.
+
+Three kinds appear, and they answer three different questions.
+
+**Arithmetic mean** (``I^c``, ``I^f``; `ᶜinterp`, `ᶠinterp`). The plain average of
+the two neighbors. Use it for quantities that are not weighted by mass, such as
+the covariant velocity components, and wherever no conservation statement rides
+on the result.
+
+**Mass-weighted average** (``WI^f``; `ᶠwinterp`). The average weighted by ``\rho J``, that is, ``WI^f(J, x) = I^f(J x) / I^f(J)``. Use it for a quantity that will
+be multiplied by a mass flux. The arithmetic and mass-weighted averages form an
+adjoint pair satisfying a density-weighted averaging-by-parts identity, which is
+what lets the vertical flux divergence telescope; using two arithmetic means
+instead would leave a residual. In the code it appears where the horizontal
+velocity is reconstructed onto faces to build the face mass flux, and in the
+hyperdiffusive momentum tendency.
+
+**Upwind or limited reconstruction** (``U^f``; `ᶠupwind1`, `ᶠupwind3`,
+`ᶠlin_vanleer`). A biased or flux-corrected reconstruction
+[vanLeer1977, Lin1994, Zalesak1979](@cite). Use it for advected scalars, where
+a centered average would produce dispersive oscillations and negative
+concentrations. The default for grid-mean energy and tracer transport is the van
+Leer limiter of [Lin1994](@cite), constrained by the local extrema of the
+neighboring center values.
+
+| You need                                       | Use                   | Because                                                         |
+|:---------------------------------------------- |:--------------------- |:--------------------------------------------------------------- |
+| A face value of a covariant velocity component | Arithmetic mean       | No mass weighting is involved                                   |
+| A face value that multiplies a mass flux       | Mass-weighted average | Forms the adjoint pair that makes the flux divergence telescope |
+| A face value of an advected scalar             | Upwind or limited     | Preserves monotonicity and positivity                           |
+| A center value of the vertical velocity        | Arithmetic mean       | There is no unique mass-weighted inverse                        |
+
+Two consequences are worth keeping in mind. Setting ``\psi = 1`` in the scalar
+flux reconstruction recovers the mass flux divergence, so tracer transport stays
+consistent with mass transport, and a uniform tracer field stays uniform. And at
+the domain boundaries ``I^f`` extrapolates by reusing the nearest interior value,
+while the vertical gradient and curl operators are set to zero there.
+
+## Operator reference
+
+!!! note
+
+    Since ClimaCore 0.15, the strong- and weak-form horizontal spectral
+    operators are unified: `Divergence`, `Gradient`, and `Curl` take a
+    form-type parameter (`StrongForm`, the default, or `WeakForm`), so the weak
+    divergence, for example, is `Divergence{I, WeakForm}`. The ClimaAtmos code
+    still uses the legacy names (`WeakDivergence`, `WeakGradient`, `WeakCurl`),
+    which remain as aliases.
+
+Each operator below has a short name in the ClimaAtmos source, documented under
+[Discrete operators](@ref) in the API.
+
+### Reconstruction between centers and faces
+
+  - ``I^c`` is the face-to-center interpolation
+    [`ClimaCore.Operators.InterpolateF2C`](@extref), an arithmetic mean.
+  - ``I^f`` is the center-to-face interpolation
+    [`ClimaCore.Operators.InterpolateC2F`](@extref), an arithmetic mean with
+    constant extrapolation to the domain boundaries.
+  - ``WI^f`` is the center-to-face weighted interpolation
+    [`ClimaCore.Operators.WeightedInterpolateC2F`](@extref), with
+    ``WI^f(J, x) = I^f(J x) / I^f(J)`` for a weight ``J``. With the metric
+    Jacobian as the weight, this is the mass-weighted average the conservation
+    proofs use.
+  - ``U^f`` is the center-to-face upwind product: first order
+    [`ClimaCore.Operators.UpwindBiasedProductC2F`](@extref), third order
+    [`ClimaCore.Operators.Upwind3rdOrderBiasedProductC2F`](@extref), or the van
+    Leer limiter [`ClimaCore.Operators.LinVanLeerC2F`](@extref). The van Leer
+    limiter is the default for grid-mean energy and tracer vertical transport,
+    set by the `energy_q_tot_upwinding` and `tracer_upwinding` configuration
+    keys.
+
+### Horizontal differential operators
+
+These realize the spectral element forms of the previous section; a different
+horizontal discretization would replace this list.
+
+  - ``\mathcal{D}_h`` is the strong horizontal spectral divergence
+    [`ClimaCore.Operators.Divergence`](@extref).
+
+  - ``\hat{\mathcal{D}}_h`` is the weak horizontal spectral divergence
+    [`ClimaCore.Operators.WeakDivergence`](@extref).
+
+  - ``\mathcal{D}^{split}_h`` is the split, skew-symmetric horizontal divergence
+    [`ClimaCore.Operators.SplitDivergence`](@extref),
+
+    ```math
+    \mathcal{D}^{split}_h(\rho \boldsymbol{u}, \psi) =
+      \tfrac{1}{2} \hat{\mathcal{D}}_h(\rho \boldsymbol{u} \psi)
+      + \tfrac{1}{2} \left[ \psi \, \hat{\mathcal{D}}_h(\rho \boldsymbol{u})
+        + \rho \boldsymbol{u} \cdot \mathcal{G}_h \psi \right].
+    ```
+
+    The horizontal advective fluxes of energy, moisture, and tracers use this
+    entropy-stable split form; for ``\psi = 1`` it reduces to the weak
+    divergence, which is why the semi-discrete mass equation below is written
+    with ``\hat{\mathcal{D}}_h`` (in the code, the mass flux is
+    `split_divₕ(ρu, 1)`). The horizontal pressure-gradient term uses an
+    analogous split form.
+
+  - ``\mathcal{G}_h`` is the strong horizontal spectral gradient
+    [`ClimaCore.Operators.Gradient`](@extref).
+
+  - ``\hat{\mathcal{G}}_h`` is the weak horizontal spectral gradient
+    [`ClimaCore.Operators.WeakGradient`](@extref), the outer gradient of the
+    vector Laplacian.
+
+  - ``\mathcal{C}_h`` is the curl of the components involving horizontal
+    derivatives [`ClimaCore.Operators.Curl`](@extref). Applied to
+    ``\boldsymbol{u}_h`` it returns a vector with only vertical contravariant
+    components; applied to ``\boldsymbol{u}_v`` it returns a vector with only
+    horizontal contravariant components.
+
+  - ``\hat{\mathcal{C}}_h`` is the corresponding weak curl
+    [`ClimaCore.Operators.WeakCurl`](@extref).
+
+  - ``\mathcal{P}`` is the projection onto the continuous spectral element
+    basis; see [Projection: direct stiffness summation](@ref).
+
+### Vertical differential operators
+
+  - ``\mathcal{D}^c_v`` is the face-to-center vertical divergence
+    [`ClimaCore.Operators.DivergenceF2C`](@extref). Separate variants carry the
+    boundary conditions for advective, precipitation, and diffusive fluxes.
+
+  - ``\mathcal{G}^f_v`` is the center-to-face vertical gradient
+    [`ClimaCore.Operators.GradientC2F`](@extref), set to zero at the top and
+    bottom boundaries.
+
+  - ``\mathcal{C}^f_v`` is the center-to-face curl of the components involving
+    vertical derivatives [`ClimaCore.Operators.CurlC2F`](@extref), set to zero
+    at the top and bottom boundaries. Applied to ``\boldsymbol{u}_h`` it returns
+    a vector with only a horizontal contravariant component.
+
+## Reconstructions and conservation
+
+The reconstructions above are the ones that make the global conservation laws
+hold [Yatunin2026](@cite); they resemble those of
+[SimmonsBurridge1981](@cite) in some respects.
+
+  - **Density** is reconstructed onto faces with a Jacobian-weighted average,
+    which is the weight the mass-weighted average ``WI^f`` needs.
+  - **Velocity** covariant components use unweighted averages; the contravariant
+    vertical component on faces uses a mass-weighted average. There is no unique
+    reconstruction of the contravariant vertical velocity onto centers.
+  - **Vorticity** contravariant components are computed with a weak horizontal
+    curl.
+  - **Momentum advection** uses the vector-invariant form, with a strong
+    horizontal gradient of kinetic energy and a weighted average of the vorticity
+    term. In this form momentum advection conserves kinetic energy and vorticity
+    globally, and avoids the curvature terms that appear in advection terms in
+    non-orthogonal coordinates.
+
+Because total energy is separately conserved, any numerical conversion between
+kinetic and non-kinetic energy comes from the discretized pressure-gradient term
+and the physical sources, and not from the advection scheme.
+
+## Writing a new tendency
+
+Putting the two rules together, a new term added to `src/prognostic_equations/`
+generally follows this pattern.
+
+ 1. Decide where the result lives. A tendency for a center variable must end on
+    centers, one for `u₃` on faces.
+ 2. For a horizontal advective flux of a conserved scalar, use the split form
+    `split_divₕ`; for other horizontal flux divergences, such as diffusive
+    ones, use `wdivₕ`. For a gradient in the momentum equation, use `gradₕ`.
+ 3. For the vertical part, use `ᶜdivᵥ` on a face flux, and build that face flux
+    with `ᶠwinterp` if it multiplies a mass flux, or with an upwind operator if it
+    transports a scalar.
+ 4. If the term diffuses energy, diffuse the dry static energy and the effective
+    total water separately rather than a lumped total enthalpy, so the
+    decomposition stays energetically consistent. See
+    [Thermodynamics and the Working Fluid](thermodynamics.md).
+ 5. If the term is vertical and fast, add it to the implicit tendency and to the
+    Jacobian; see [Implicit Solver](implicit_solver.md).
+
+The semi-discrete equations at the end of this page show these patterns applied
+to each governing equation.
+
+## Timestepping
+
+Tendencies are split into an explicit part and an implicit part and advanced
+with a horizontally explicit, vertically implicit (HEVI) additive Runge–Kutta
+method [Ascher1997, Gardner2018](@cite). The implicit part carries the vertical terms responsible for sound and
+gravity waves, falling and sedimenting condensate, vertical diffusion, and
+sponge damping; because it involves no horizontal derivatives, it can be solved
+independently in each column, with no horizontal communication.
+
+This lifts the timestep restriction from fast vertical dynamics and leaves the
+horizontal propagation of sound waves as the limit, so the maximum timestep
+scales as ``\delta t \sim (\delta x)_{\min} / c_s`` with the minimum horizontal
+distance between nodal points and the speed of sound.
+
+[Implicit Solver](implicit_solver.md) documents the Newton solve, the Jacobian
+approximation, and the available Jacobian algorithms.
+[Integer Time (ITime)](itime.md) explains how time itself is represented.
+
+## Semi-discrete equations
+
+The sections above define the operators. What follows applies them: the
+semi-discrete form of each governing equation, that is, the equations discretized
+in space but still continuous in time. The continuous equations these come from
+are on the [Governing Equations](equations.md) page.
+
+### Reconstructed velocities and kinetic energy
+
+Two reconstructed velocities appear throughout, along with the kinetic energy
+built from them. All follow from the staggering: the covariant vertical
+component lives on faces and everything else on centers, so each flux term
+needs one or the other interpolated.
+
+  - ``\tilde{\boldsymbol{u}}`` is the mass-weighted reconstruction of velocity at the interfaces,
+    carried out by weighted interpolation of the horizontal components (see `compute_ᶠuₕ³` in
+    `src/cache/precomputed_quantities.jl`):
+
+    ```math
+    \tilde{\boldsymbol{u}} = WI^f(\rho J, \boldsymbol{u}_h) + \boldsymbol{u}_v
+    ```
+
+  - ``\bar{\boldsymbol{u}}`` is the reconstruction of velocity at cell-centers, carried out by linear interpolation of the covariant vertical component:
+
+    ```math
+    \bar{\boldsymbol{u}} = \boldsymbol{u}_h + I^c(\boldsymbol{u}_v)
+    ```
+
+  - ``K = \tfrac{1}{2} \|\boldsymbol{u}\|^2`` is the specific kinetic energy (J/kg), reconstructed at cell centers by
+
+    ```math
+    K = \tfrac{1}{2} (\boldsymbol{u}_{h} \cdot \boldsymbol{u}_{h} + 2 \boldsymbol{u}_{h} \cdot I^c (\boldsymbol{u}_{v}) + I^c(\boldsymbol{u}_{v} \cdot \boldsymbol{u}_{v})),
+    ```
+
+    where ``\boldsymbol{u}_{h}`` is defined on cell-centers, ``\boldsymbol{u}_{v}`` is defined on cell-faces, and ``I^c (\boldsymbol{u}_{v})`` is interpolated using covariant components.
+
+  - No-flux boundary conditions are enforced by requiring the vertical contravariant component ``\tilde{u}^3`` of the face-valued velocity at the boundary to be zero, which fixes the boundary value of the covariant component:
+
+    ```math
+    u_3 = -\frac{g^{31} u_1 + g^{32} u_2}{g^{33}}.
+    ```
+
+### Mass
+
+Follows the continuity equation
+
+```math
+\frac{\partial}{\partial t} \rho = - \nabla \cdot(\rho \boldsymbol{u}) + \rho \hat{S}_{q_t}.
+```
+
+This is discretized using the following
+
+```math
+\frac{\partial}{\partial t} \rho
+= - \hat{\mathcal{D}}_h[ \rho \bar{\boldsymbol{u}}] - \mathcal{D}^c_v \left[WI^f( J, \rho) \tilde{\boldsymbol{u}} \right] + \rho \hat{S}_{q_t}
+```
+
+with the
+
+```math
+-\mathcal{D}^c_v[WI^f(J, \rho) \tilde{\boldsymbol{u}}]
+```
+
+term treated implicitly (the full face velocity ``\tilde{\boldsymbol{u}}``, including
+the topographic contribution of ``\boldsymbol{u}_h``, enters the implicit term).
+
+### Momentum
+
+Uses the vector-invariant form
+
+```math
+\frac{\partial}{\partial t} \boldsymbol{u}  = - (2 \boldsymbol{\Omega} + \nabla \times \boldsymbol{u}) \times \boldsymbol{u} - c_{pd} (\theta_v - \theta_{v, r}) \nabla \Pi  - \nabla [(\Phi - \Phi_r) + K].
+```
+
+The pressure-gradient force is expressed through the Exner function,
+``-\nabla p / \rho = -c_{pd} \theta_v \nabla \Pi``, with a hydrostatically
+balanced reference state ``(\theta_{v,r}, \Phi_r)`` subtracted; the reference
+profile, its defining formulas, and its parameters are given on the
+[Governing Equations](equations.md) page.
+
+#### Horizontal momentum
+
+By breaking the curl and cross product terms into horizontal and vertical contributions, and removing zero terms (e.g. ``\nabla_v \times \boldsymbol{u}_v = 0``), we obtain
+
+```math
+\frac{\partial}{\partial t} \boldsymbol{u}_h  =
+  - (2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h +  \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^v
+  - (2 \boldsymbol{\Omega}^v + \nabla_h \times \boldsymbol{u}_h) \times \boldsymbol{u}^h
+  - c_{pd} (\theta_v - \theta_{v, r}) \nabla_h \Pi  - \nabla_h [(\Phi - \Phi_r) + K],
+```
+
+where ``\boldsymbol{u}^h`` and ``\boldsymbol{u}^v`` are the horizontal and vertical *contravariant* vectors.
+
+Topography enters through the computation of the contravariant velocity components (projections from the covariant velocity representation) before the cross-product contributions.
+
+This is stabilized by adding 4th-order vector hyperviscosity
+
+```math
+-\nu_u \, \nabla_h^2 (\nabla_h^2(\boldsymbol{\overline{u}})),
+```
+
+projected onto the first two covariant directions, where
+``\boldsymbol{\overline{u}}`` is the center-valued velocity defined above and
+
+```math
+\nabla_h^2(\boldsymbol{v}) = \nabla_h(\nabla_{h} \cdot \boldsymbol{v}) - \nabla_{h} \times (\nabla_{h} \times \boldsymbol{v})
+```
+
+is the horizontal vector Laplacian.
+
+The ``(2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^v`` term is discretized as:
+
+```math
+\frac{I^c\{(2 \boldsymbol{\Omega}^h + \mathcal{C}^f_v[\boldsymbol{u}_h] + \hat{\mathcal{C}}_h[\boldsymbol{u}_v]) \times (I^f(\rho J)\tilde{\boldsymbol{u}}^v)\}}{\rho J} ,
+```
+
+in which ``\mathcal{C}^f_v[\boldsymbol{u}_h] + \hat{\mathcal{C}}_h[\boldsymbol{u}_v]`` is the discrete horizontal relative vorticity ``\boldsymbol{\omega}^h``.
+
+The ``(2 \boldsymbol{\Omega}^v + \nabla_h \times \boldsymbol{u}_h) \times \boldsymbol{u}^h`` term is discretized as
+
+```math
+(2 \boldsymbol{\Omega}^v + \hat{\mathcal{C}}_h[\boldsymbol{u}_h]) \times \boldsymbol{u}^h
+```
+
+and the ``c_{pd} (\theta_v - \theta_{v,r}) \nabla_h \Pi + \nabla_h (\Phi - \Phi_r + K)`` term is discretized as
+
+```math
+c_{pd} (\theta_v - \theta_{v,r}) \mathcal{G}_h[\Pi] + \mathcal{G}_h[\Phi - \Phi_r + K] ,
+```
+
+where all these terms are treated explicitly.
+
+The hyperviscosity term is
+
+```math
+- \nu_u \left\{ \delta_{div} \, \hat{\mathcal{G}}_h ( \mathcal{D}_h(\boldsymbol{\psi}_h) ) - \hat{\mathcal{C}}_h( \mathcal{C}_h( \boldsymbol{\psi}_h )) \right\}
+```
+
+where
+
+```math
+\boldsymbol{\psi}_h = \mathcal{P} \left[ \hat{\mathcal{G}}_h ( \mathcal{D}_h(\boldsymbol{u}_h) ) - \hat{\mathcal{C}}_h( \mathcal{C}_h( \boldsymbol{u}_h )) \right]
+```
+
+and ``\delta_{div}`` is the divergence damping factor, which strengthens the
+damping of divergent modes; see [Hyperdiffusion](hyperdiffusion.md).
+
+#### Vertical momentum
+
+Similarly for vertical velocity
+
+```math
+\frac{\partial}{\partial t} \boldsymbol{u}_v  =
+  - (2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^h
+  -c_{pd} (\theta_v - \theta_{v, r}) \nabla_v \Pi  - \nabla_v [(\Phi - \Phi_r)].
+```
+
+The ``(2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^h`` term is discretized as
+
+```math
+(2 \boldsymbol{\Omega}^h + \mathcal{C}^f_v[\boldsymbol{u}_h] + \hat{\mathcal{C}}_h[\boldsymbol{u}_v]) \times I^f(\boldsymbol{u}^h) ,
+```
+
+The ``\nabla_v K`` term is discretized as
+
+```math
+\mathcal{G}^f_v[K],
+```
+
+The ``c_{pd} (\theta_v - \theta_{v,r}) \nabla_v \Pi + \nabla_v (\Phi - \Phi_r)`` term is discretized as
+
+```math
+I^f[c_{pd} (\theta_v - \theta_{v, r} ) ] \mathcal{G}^f_v[\Pi] + \mathcal{G}^f_v[\Phi - \Phi_r],
+```
+
+and is treated implicitly.
+
+This is stabilized by adding 4th-order vector hyperviscosity
+
+```math
+-\nu_u \, \nabla_h^2 (\nabla_h^2(\boldsymbol{\overline{u}})),
+```
+
+projected onto the third covariant direction after a ``\rho J``-weighted
+interpolation to faces.
+
+### Total energy
+
+```math
+\frac{\partial}{\partial t} \rho e_{tot} = - \nabla \cdot((\rho e_{tot} + p) \boldsymbol{u} + \boldsymbol{F}_R) + \rho S_{e},
+```
+
+which is stabilized by adding a 4th-order hyperdiffusion term on total enthalpy:
+
+```math
+- \nu_h \left[ \nabla \cdot \left( \rho \nabla^3 s_d \right)
+  + \sum_\mu \nabla \cdot \left( \rho \, (h_\mu + \Phi) \, \nabla^3 q_\mu \right) \right],
+```
+
+where the total enthalpy is decomposed into dry static energy ``s_d`` and the
+water-species enthalpies ``h_\mu`` (for ``\mu \in \{v, l, i\}``), so that the
+``\nabla^4`` operator never acts on a lumped total enthalpy.
+
+This is discretized using
+
+```math
+\frac{\partial}{\partial t} \rho e_{tot} \approx
+- \mathcal{D}^{split}_h[ \rho \bar{\boldsymbol{u}}, \tfrac{\rho e_{tot} + p}{\rho} ]
+- \mathcal{D}^c_v \left[ WI^f(J,\rho) \,  \tilde{\boldsymbol{u}} \, I^f \left(\frac{\rho e_{tot} + p}{\rho} \right) \right]
+- \mathcal{D}^c_v \left[ \boldsymbol{F}_R \right]
+- \nu_h \left[ \hat{\mathcal{D}}_h( \rho \mathcal{G}_h(\psi_{s_d}) )
+  + \sum_\mu \hat{\mathcal{D}}_h( \rho (h_\mu + \Phi) \mathcal{G}_h(\psi_{q_\mu}) ) \right],
+```
+
+where
+
+```math
+\psi_x = \mathcal{P} \left[ \hat{\mathcal{D}}_h \left( \mathcal{G}_h (x) \right) \right],
+```
+
+and the radiative flux divergence ``-\mathcal{D}^c_v[\boldsymbol{F}_R]`` is
+applied separately as an explicit tendency.
+
+The central reconstruction
+
+```math
+- \mathcal{D}^c_v \left[ WI^f(J,\rho) \,  \tilde{\boldsymbol{u}} \, I^f \left(\frac{\rho e_{tot} + p}{\rho} \right) \right]
+```
+
+is treated implicitly.
+
+!!! note
+
+    When upwinding is enabled for energy advection (the van Leer limiter by
+    default), the implicit solve still uses the central reconstruction; the
+    difference between the upwinded and central fluxes is applied after the
+    Newton solve as a `T_post_imp!` correction
+    (`correct_implicit_advection_tendency!`), so the upwind flux is evaluated
+    with the Newton-solved velocity.
+
+### Scalars
+
+For an arbitrary scalar ``\chi``, the density-weighted scalar ``\rho\chi`` follows the continuity equation
+
+```math
+\frac{\partial}{\partial t} \rho \chi = - \nabla \cdot(\rho \chi \boldsymbol{u}) + \rho S_{\chi}.
+```
+
+This is stabilized by adding a 4th-order hyperdiffusion term
+
+```math
+- \nu_\chi \nabla \cdot(\rho \nabla^3(\chi))
+```
+
+This is discretized using
+
+```math
+\frac{\partial}{\partial t} \rho \chi \approx
+- \mathcal{D}^{split}_h[ \rho \bar{\boldsymbol{u}}, \chi ]
+- \mathcal{D}^c_v \left[ WI^f(J,\rho) \, U^f\left( \tilde{\boldsymbol{u}},  \frac{\rho \chi}{\rho} \right) \right]
+- \nu_\chi \hat{\mathcal{D}}_h ( \rho \, \mathcal{G}_h (\psi) )
+```
+
+where
+
+```math
+\psi = \mathcal{P} \left[ \hat{\mathcal{D}}_h \left( \mathcal{G}_h \left( \frac{\rho \chi}{\rho} \right)\right) \right]
+```
+
+For total water ``\rho q_\mathrm{tot}``, the central reconstruction
+
+```math
+- \mathcal{D}^c_v \left[ WI^f(J,\rho) \, \tilde{\boldsymbol{u}} \, I^f\left( \frac{\rho \chi}{\rho} \right) \right]
+```
+
+is treated implicitly (as for total energy), with the upwind-central difference
+applied after the Newton solve as a `T_post_imp!` correction. All other
+grid-mean tracers are advected fully explicitly with the reconstruction
+selected by `tracer_upwinding` (the van Leer limiter by default).
+
+## Where this is implemented
+
+| Concept                           | Source                                                                                                                                           |
+|:--------------------------------- |:------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Operator short names              | [Discrete operators](@ref), defined in [src/utils/abbreviations.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/utils/abbreviations.jl) |
+| Horizontal and vertical advection | [src/prognostic_equations/advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl)                  |
+| Sedimentation and water transport | [src/prognostic_equations/water_advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/water_advection.jl)      |
+| Implicit/explicit tendency split  | [src/prognostic_equations/implicit/](https://github.com/CliMA/ClimaAtmos.jl/tree/main/src/prognostic_equations/implicit)                         |
+| Grid construction                 | [src/simulation/grids.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/simulation/grids.jl)                                              |
+
+The upwinding and limiter choices are exposed as configuration keys; see
+[Configuration Options](configuration_options.md) for `energy_q_tot_upwinding`,
+`tracer_upwinding`, and the corresponding PROPHET keys.

--- a/docs/src/ecosystem.md
+++ b/docs/src/ecosystem.md
@@ -1,9 +1,9 @@
 # The CliMA Ecosystem
 
 ClimaAtmos composes focused, independently developed and tested packages
-from the [CliMA](https://github.com/CliMA) ecosystem. Each package owns one
+from the [CliMA](https://github.com/CliMA) ecosystem. Each package covers one
 aspect of the model (thermodynamics, radiative transfer, surface fluxes,
-microphysics, parameters), and ClimaAtmos wires them together into an atmosphere model. This page explains what each
+microphysics, parameters), and ClimaAtmos links them together into an atmosphere model. This page explains what each
 package contributes, why the decomposition matters physically, and where each
 package enters the ClimaAtmos source code.
 
@@ -15,10 +15,9 @@ Two consistency principles motivate the decomposition:
     do not close. A single shared thermodynamics package guarantees this by
     construction.
   - **A single source of truth for parameters.** All physical constants and
-    calibratable parameters live in one place. The model can be adapted to
-    past climates or other planetary configurations just by changing
-    parameters there, without touching model code; calibration tools can
-    target any parameter uniformly.
+    calibratable parameters are defined in one place. The model can be adapted to
+    past climates or other planetary configurations by changing
+    parameters there; calibration tools can target any parameter.
 
 ## How the packages fit together
 
@@ -33,14 +32,17 @@ Two consistency principles motivate the decomposition:
 │   CloudMicrophysics.jl       │   ClimaDiagnostics.jl         │
 │                              │   ClimaUtilities.jl           │
 ├──────────────────────────────┴───────────────────────────────┤
-│ Shared foundation, used by every package above:              │
+│ Shared foundation for ClimaAtmos and the physics libraries:  │
 │   Thermodynamics.jl  ·  ClimaParams.jl                       │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-The physics libraries are themselves clients of Thermodynamics.jl and
-ClimaParams.jl; this shared foundation, not ClimaAtmos, keeps the
-formulations consistent across packages.
+CloudMicrophysics.jl and SurfaceFluxes.jl themselves use
+Thermodynamics.jl, so this shared foundation, not ClimaAtmos, keeps the
+thermodynamic formulations consistent across packages. RRTMGP.jl and
+Insolation.jl do not depend on ClimaParams.jl, but their parameter structs are
+built by ClimaAtmos from the same ClimaParams TOML database, so their
+parameters are calibratable in the same way.
 
 ## Shared foundation
 
@@ -69,7 +71,7 @@ packages: fixed physical constants such as gas constants and latent heats, as
 well as calibratable closure parameters such as entrainment coefficients and
 mixing-length parameters.
 Because packages never hard-code parameter values, the model can be adapted to
-past climates or other planetary configurations just by changing parameters
+past climates or other planetary configurations by changing parameters
 (e.g., a different solar constant, rotation rate, gravity, or CO2
 concentration), and calibration frameworks can override any parameter through
 the same [TOML interface](@ref "Overriding parameters") used for manual
@@ -88,7 +90,7 @@ parameters via `toml: [...]`.
 [Insolation.jl](https://clima.github.io/Insolation.jl/stable/) sets the
 insolation at the top of the atmosphere: it computes the incoming solar flux
 and solar zenith angle from time, location, and the planet's orbital parameters
-(eccentricity, obliquity, precession). Because the orbital parameters are just
+(eccentricity, obliquity, precession). Because the orbital elements are ordinary
 parameters, paleoclimate (Milankovitch) configurations and idealized insolation
 experiments require no code changes.
 
@@ -132,7 +134,7 @@ instead.
 provides the microphysical process rates (condensation/evaporation,
 autoconversion, accretion, sedimentation velocities, ice nucleation, aerosol
 activation) for the 0-moment to 2-moment bulk schemes. ClimaAtmos calls these
-rates pointwise and handles their coupling to the dynamics (advection,
+rates pointwise and couples them to the dynamics (advection,
 sedimentation fluxes, energy sinks); see [Microphysics](microphysics.md).
 
 *Where it enters ClimaAtmos:* `src/parameterized_tendencies/microphysics/`,
@@ -142,7 +144,7 @@ selected by the `microphysics_model` configuration argument.
 
   - [ClimaCore.jl](https://clima.github.io/ClimaCore.jl/stable/) provides the
     spatial discretization: spectral-element/finite-difference grids, fields,
-    and the [discrete operators](equations.md) used to express the equations.
+    and the [discrete operators](discretization.md) used to express the equations.
   - [ClimaTimeSteppers.jl](https://clima.github.io/ClimaTimeSteppers.jl/stable/)
     provides the IMEX time integrators used together with the
     [implicit solver](implicit_solver.md).
@@ -169,11 +171,11 @@ selected by the `microphysics_model` configuration argument.
 ## Calibration
 
 ClimaAtmos is designed to be calibrated against data, and the parameter
-architecture above makes this work: because every closure parameter
-lives in ClimaParams.jl, a calibration only has to write TOML overrides.
+architecture above makes this work: because every closure parameter is defined
+in ClimaParams.jl, a calibration only has to write TOML overrides.
 
   - [ClimaCalibrate.jl](https://clima.github.io/ClimaCalibrate.jl/stable/)
-    orchestrates calibration-with-data workflows: it runs ensembles of
+    drives calibration-with-data workflows: it runs ensembles of
     ClimaAtmos simulations (locally or on HPC clusters), maps observations to
     model diagnostics, and iterates the parameter ensemble.
   - [EnsembleKalmanProcesses.jl](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/)

--- a/docs/src/edmf_equations.md
+++ b/docs/src/edmf_equations.md
@@ -27,7 +27,7 @@ handle the conversions between bases internally.
     where ``\phi`` is latitude, and ``\Omega`` is the planetary rotation rate in rads/sec (for Earth, ``7.29212 \times 10^{-5} s^{-1}``) and ``\boldsymbol{e}^v`` is the unit radial basis vector. This implies that the horizontal contravariant component ``\boldsymbol{\Omega}^h`` is zero.
   - ``\boldsymbol{u}_h = u_1 \boldsymbol{e}^1 + u_2 \boldsymbol{e}^2`` is the projection onto horizontal covariant components (covariance here means with respect to the reference element), stored at cell centers.
   - ``\Phi = g z`` is the geopotential, where ``g`` is the gravitational acceleration rate and ``z`` is altitude above the mean sea level.
-  - ``\rho`` is the grid-mean density; draft buoyancy is computed relative to it (the code no longer carries a separate reference-state density or pressure for the drafts).
+  - ``\rho`` is the grid-mean density; draft buoyancy is computed relative to it. The drafts carry no separate reference-state density or pressure.
   - ``p`` is air pressure, derived from the thermodynamic state, reconstructed at cell centers.
 
 ## Prognostic variables
@@ -41,44 +41,10 @@ handle the conversions between bases internally.
 
 ## Operators
 
-We make use of the following operators.
-
-!!! note
-
-    On ClimaCore `main`, the strong- and weak-form horizontal spectral operators
-    have been unified: `Divergence`, `Gradient`, and `Curl` take a form-type
-    parameter (`StrongForm`, the default, or `WeakForm`), so the weak divergence,
-    for example, is `Divergence{I, WeakForm}`. The ClimaAtmos code does not use
-    the unified names yet; the links below point to the operator documentation
-    in the latest ClimaCore release.
-
-### Reconstruction
-
-  - ``I^c`` is the face-to-center reconstruction operator [`ClimaCore.Operators.InterpolateF2C`](@extref) (arithmetic mean).
-  - ``I^f`` is the center-to-face reconstruction operator [`ClimaCore.Operators.InterpolateC2F`](@extref) (arithmetic mean).
-  - ``WI^f`` is the center-to-face weighted reconstruction operator [`ClimaCore.Operators.WeightedInterpolateC2F`](@extref).
-      + ``WI^f(J, x) = I^f(J*x) / I^f(J)``, where ``J`` is the value of the Jacobian for use in the weighted interpolation operator.
-  - ``U^f`` is the 1st-order ([`ClimaCore.Operators.UpwindBiasedProductC2F`](@extref)) or 3rd-order ([`ClimaCore.Operators.Upwind3rdOrderBiasedProductC2F`](@extref)) center-to-face upwind product operator.
-
-### Differential operators
-
-  - ``D_h`` is the discrete horizontal spectral divergence [`ClimaCore.Operators.Divergence`](@extref).
-  - ``\hat{\mathcal{D}}_h`` is the discrete horizontal spectral weak divergence [`ClimaCore.Operators.WeakDivergence`](@extref).
-  - ``D^c_v`` is the face-to-center vertical divergence [`ClimaCore.Operators.DivergenceF2C`](@extref).
-  - ``G_h`` is the discrete horizontal spectral gradient [`ClimaCore.Operators.Gradient`](@extref).
-  - ``G^f_v`` is the center-to-face vertical gradient [`ClimaCore.Operators.GradientC2F`](@extref).
-      + the gradient is set to 0 at the top and bottom boundaries.
-  - ``C_h`` is the curl components involving horizontal derivatives [`ClimaCore.Operators.Curl`](@extref).
-      + ``C_h[\boldsymbol{u}_h]`` returns a vector with only vertical _contravariant_ components.
-      + ``C_h[\boldsymbol{u}_v]`` returns a vector with only horizontal _contravariant_ components.
-  - ``\hat{\mathcal{C}}_h`` is the weak curl components involving horizontal derivatives [`ClimaCore.Operators.WeakCurl`](@extref).
-  - ``C^f_v`` is the center-to-face curl involving vertical derivatives [`ClimaCore.Operators.CurlC2F`](@extref).
-      + ``C^f_v[\boldsymbol{u}_h]`` returns a vector with only a horizontal _contravariant_ component.
-      + the curl is set to 0 at the top and bottom boundaries.
-
-### Projection
-
-  - ``\mathcal{P}`` is the [direct stiffness summation (DSS) operation](@extref ClimaCore DSS), which computes the projection onto the continuous spectral element basis.
+This page uses the same discrete operators as the rest of the model. They are
+defined once in [Discretization and Operators](discretization.md), which also
+gives the code alias for each one and the reason behind each strong-, weak-, and
+split-form choice.
 
 ## Auxiliary and derived quantities
 
@@ -136,7 +102,7 @@ This is discretized using the following
 
 ```math
 \frac{\partial}{\partial t} \hat{\rho}^j
-= - D_h \left[ \hat{\rho}^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j)) \right] - D^c_v \left[WI^f( J, \hat{\rho}^j) \tilde{\boldsymbol{u}^j} \right] + RHS.
+= - \mathcal{D}_h \left[ \hat{\rho}^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j)) \right] - \mathcal{D}^c_v \left[WI^f( J, \hat{\rho}^j) \tilde{\boldsymbol{u}^j} \right] + RHS.
 ```
 
 ### Momentum
@@ -169,13 +135,13 @@ projected onto the third contravariant direction.
 The ``(\nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v^j) \times \boldsymbol{u}^h`` term is discretized as
 
 ```math
-(C^f_v[\boldsymbol{u}_h] + C_h[\boldsymbol{u}_v^j]) \times I^f(\boldsymbol{u}^h) ,
+(\mathcal{C}^f_v[\boldsymbol{u}_h] + \mathcal{C}_h[\boldsymbol{u}_v^j]) \times I^f(\boldsymbol{u}^h) ,
 ```
 
 and the ``-\frac{\rho^j - \rho}{\rho^j} \nabla_v \Phi - \nabla_v K^j`` terms as
 
 ```math
-- \frac{I^f(\rho^j - \rho)}{I^f(\rho^j)} G^f_v[\Phi] - G^f_v[K^j] ,
+- \frac{I^f(\rho^j - \rho)}{I^f(\rho^j)} \mathcal{G}^f_v[\Phi] - \mathcal{G}^f_v[K^j] ,
 ```
 
 The hyperviscosity term is
@@ -206,11 +172,11 @@ The equation is discretized as
 
 ```math
 \frac{\partial}{\partial t} \hat{\rho}^j e^j \approx
-- D_h \left[
+- \mathcal{D}_h \left[
     \left( \hat{\rho}^j e^j + \frac{\hat{\rho}^j}{\rho^j}p \right)
     \left( \boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j) \right)
   \right]
-- D^c_v \left[
+- \mathcal{D}^c_v \left[
     WI^f(J,\hat{\rho}^j) \,  \tilde{\boldsymbol{u}}^j \, I^f \left(\frac{\hat{\rho}^j e^j + \frac{\hat{\rho}^j}{\rho^j}p}{\hat{\rho}^j} \right)
   \right]
   - \frac{p}{\rho} \frac{\partial}{\partial t} \hat{\rho}^j - \nu_h \hat{\mathcal{D}}_h( \rho \mathcal{G}_h(\psi^j) ) + RHS .
@@ -249,8 +215,8 @@ This is discretized using the following
 
 ```math
 \frac{\partial}{\partial t} \hat{\rho}^j q^j \approx
-- D_h[ \hat{\rho}^j q^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j))]
-- D^c_v \left[ WI^f(J,\hat{\rho}^j) \, U^f\left( \tilde{\boldsymbol{u}}^j,  \frac{\hat{\rho}^j q^j}{\hat{\rho}^j} \right) \right]
+- \mathcal{D}_h[ \hat{\rho}^j q^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j))]
+- \mathcal{D}^c_v \left[ WI^f(J,\hat{\rho}^j) \, U^f\left( \tilde{\boldsymbol{u}}^j,  \frac{\hat{\rho}^j q^j}{\hat{\rho}^j} \right) \right]
 - \nu_\chi \hat{\mathcal{D}}_h ( \hat{\rho^j} \, \mathcal{G}_h (\psi^j) ) + sedimentation + RHS.
 ```
 
@@ -263,7 +229,7 @@ where
 The `none` option corresponds to the central reconstruction
 
 ```math
-- D^c_v \left[ WI^f(J,\hat{\rho}^j) \, \tilde{\boldsymbol{u}}^j \, I^f\left( \frac{\hat{\rho}^j q^j}{\hat{\rho}^j} \right) \right]
+- \mathcal{D}^c_v \left[ WI^f(J,\hat{\rho}^j) \, \tilde{\boldsymbol{u}}^j \, I^f\left( \frac{\hat{\rho}^j q^j}{\hat{\rho}^j} \right) \right]
 ```
 
 !!! note
@@ -292,8 +258,8 @@ This is discretized using the following
 
 ```math
 \frac{\partial}{\partial t} \hat{\rho}^j \chi^j \approx
-- D_h[ \hat{\rho^j} \chi^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j))]
-- D^c_v \left[ WI^f(J,\hat{\rho^j}) \, U^f\left( \tilde{\boldsymbol{u}}^j,  \frac{\hat{\rho}^j \chi^j}{\hat{\rho^j}} \right) \right]
+- \mathcal{D}_h[ \hat{\rho^j} \chi^j (\boldsymbol{u}_h + I^c(\boldsymbol{u}_v^j))]
+- \mathcal{D}^c_v \left[ WI^f(J,\hat{\rho^j}) \, U^f\left( \tilde{\boldsymbol{u}}^j,  \frac{\hat{\rho}^j \chi^j}{\hat{\rho^j}} \right) \right]
 - \nu_\chi \hat{\mathcal{D}}_h ( \hat{\rho^j} \, \mathcal{G}_h (\psi^j) ) + RHS.
 ```
 
@@ -306,7 +272,7 @@ where
 The `none` option corresponds to the central reconstruction
 
 ```math
-- D^c_v \left[ WI^f(J,\hat{\rho}^j) \, \tilde{\boldsymbol{u}}^j \, I^f\left( \frac{\hat{\rho}^j \chi^j}{\hat{\rho}^j} \right) \right]
+- \mathcal{D}^c_v \left[ WI^f(J,\hat{\rho}^j) \, \tilde{\boldsymbol{u}}^j \, I^f\left( \frac{\hat{\rho}^j \chi^j}{\hat{\rho}^j} \right) \right]
 ```
 
 !!! note

--- a/docs/src/equations.md
+++ b/docs/src/equations.md
@@ -1,364 +1,380 @@
-# Equations
+# Governing Equations
 
-!!! note
+ClimaAtmos solves the fully compressible, nonhydrostatic equations of motion for
+a deep atmosphere [Yatunin2026](@cite). This page states those equations in
+continuous form. Their discretization is treated separately, in
+[Discretization and Operators](discretization.md), and the thermodynamic
+quantities they contain are defined in
+[Thermodynamics and the Working Fluid](thermodynamics.md).
 
-    This follows what is currently implemented in `src/prognostic_equations/`: it should be kept up-to-date as code is modified. If you think something _should_ be changed (but hasn't been), please open an issue.
+The equations appear first in a form independent of any coordinate system, which
+is what lets the same equation set serve Cartesian geometries for large-eddy and
+cloud-resolving simulation and the sphere for global weather and climate
+simulation.
 
-This describes the ClimaAtmos model equations and its discretizations. Where possible, we use a coordinate invariant form: the ClimaCore operators generally handle the conversions between bases internally.
+That coordinate-independent form is also the one ClimaAtmos implements. The
+tendencies in `src/prognostic_equations/` are written as the equations are
+written here — divergences, gradients, and curls of vectors — with no metric
+terms spelled out. Vectors carry their basis in their type, so ClimaCore
+converts to the generalized-coordinate components and applies the metric terms
+when it evaluates an operator. A later section gives that generalized-coordinate
+form, which is what ClimaCore works in, and which a reader comparing the code
+against the metric expressions will need.
 
 ## Prognostic variables
 
-  - ``\rho``: _density_ in kg/m³. This is discretized at cell centers.
-  - ``\boldsymbol{u}`` _velocity_, a vector in m/s. This is discretized via ``\boldsymbol{u} = \boldsymbol{u}_h + \boldsymbol{u}_v`` where
-      + ``\boldsymbol{u}_h = u_1 \boldsymbol{e}^1 + u_2 \boldsymbol{e}^2`` is the projection onto horizontal covariant components (covariance here means with respect to the reference element), stored at cell centers.
-      + ``\boldsymbol{u}_v = u_3 \boldsymbol{e}^3`` is the projection onto the vertical covariant components, stored at cell faces.
-  - ``\rho e``: _total energy_ in J/m³, stored at cell centers (the prognostic field is named `ρe_tot` in the code).
-  - ``\rho \chi``: _other conserved scalars_ (moisture, tracers, etc), again stored at cell centers.
+The prognostic variables for water are the total water specific humidity
+``q_t``, the liquid specific humidities ``q_l^\sigma``, and the ice specific
+humidities ``q_i^\sigma``. The superscript ``\sigma`` denotes cloud condensate
+(`cl`) or precipitation (`pr`) where these are separate water mass categories,
+and is omitted where they are not. Under the assumption of local thermodynamic
+equilibrium, ``q_l^{cl}`` and ``q_i^{cl}`` follow from the other thermodynamic
+variables by saturation adjustment.
 
-When prognostic turbulence kinetic energy or PROPHET is enabled, the state additionally carries ``\rho \, \mathrm{tke}`` (and the PROPHET subdomain variables described in the [PROPHET equations](@ref "PROPHET Sub-Grid Scale Equations")); with a slab-ocean surface, a prognostic surface state `Y.sfc` is added.
-
-## Operators
-
-We make use of the following operators.
-
-!!! note
-
-    On ClimaCore `main`, the strong- and weak-form horizontal spectral operators
-    have been unified: `Divergence`, `Gradient`, and `Curl` take a form-type
-    parameter (`StrongForm`, the default, or `WeakForm`), so the weak divergence,
-    for example, is `Divergence{I, WeakForm}`. The ClimaAtmos code does not use
-    the unified names yet; the links below point to the operator documentation
-    in the latest ClimaCore release.
-
-### Reconstruction
-
-  - ``I^c`` is the face-to-center reconstruction operator [`ClimaCore.Operators.InterpolateF2C`](@extref) (arithmetic mean).
-  - ``I^f`` is the center-to-face reconstruction operator [`ClimaCore.Operators.InterpolateC2F`](@extref) (arithmetic mean).
-  - ``WI^f`` is the center-to-face weighted reconstruction operator [`ClimaCore.Operators.WeightedInterpolateC2F`](@extref).
-      + ``WI^f(J, x) = I^f(J*x) / I^f(J)``, where ``J`` is the value of the Jacobian for use in the weighted interpolation operator.
-  - ``U^f`` is the 1st-order ([`ClimaCore.Operators.UpwindBiasedProductC2F`](@extref)) or 3rd-order ([`ClimaCore.Operators.Upwind3rdOrderBiasedProductC2F`](@extref)) center-to-face upwind product operator, or the van Leer flux limiter ([`ClimaCore.Operators.LinVanLeerC2F`](@extref)); the van Leer limiter is the default for grid-mean energy and tracer vertical transport (`energy_q_tot_upwinding`, `tracer_upwinding`).
-
-### Differential operators
-
-  - ``\hat{\mathcal{D}}_h`` is the discrete horizontal spectral weak divergence [`ClimaCore.Operators.WeakDivergence`](@extref).
-  - ``\mathcal{D}^{split}_h`` is the split (skew-symmetric) horizontal divergence [`ClimaCore.Operators.SplitDivergence`](@extref), ``\mathcal{D}^{split}_h(\rho\boldsymbol{u}, \psi) = \tfrac12 \hat{\mathcal{D}}_h(\rho\boldsymbol{u}\psi) + \tfrac12(\psi\,\hat{\mathcal{D}}_h(\rho\boldsymbol{u}) + \rho\boldsymbol{u}\cdot\mathcal{G}_h\psi)``. The horizontal advective fluxes of energy, moisture, and tracers use this split form (for ``\psi = 1`` it reduces to the weak divergence, so the mass flux below is written with ``\hat{\mathcal{D}}_h``); the horizontal pressure-gradient term is likewise applied in an analogous split form.
-  - ``\mathcal{D}^c_v`` is the face-to-center vertical divergence [`ClimaCore.Operators.DivergenceF2C`](@extref).
-  - ``\mathcal{G}_h`` is the discrete horizontal spectral gradient [`ClimaCore.Operators.Gradient`](@extref).
-  - ``\mathcal{G}^f_v`` is the center-to-face vertical gradient [`ClimaCore.Operators.GradientC2F`](@extref).
-      + the gradient is set to 0 at the top and bottom boundaries.
-  - ``\mathcal{C}_h`` is the curl components involving horizontal derivatives [`ClimaCore.Operators.Curl`](@extref).
-      + ``\mathcal{C}_h[\boldsymbol{u}_h]`` returns a vector with only vertical _contravariant_ components.
-      + ``\mathcal{C}_h[\boldsymbol{u}_v]`` returns a vector with only horizontal _contravariant_ components.
-  - ``\hat{\mathcal{C}}_h`` is the weak curl components involving horizontal derivatives [`ClimaCore.Operators.WeakCurl`](@extref).
-  - ``\mathcal{C}^f_v`` is the center-to-face curl involving vertical derivatives [`ClimaCore.Operators.CurlC2F`](@extref).
-      + ``\mathcal{C}^f_v[\boldsymbol{u}_h]`` returns a vector with only a horizontal _contravariant_ component.
-      + the curl is set to 0 at the top and bottom boundaries.
-
-### Projection
-
-  - ``\mathcal{P}`` is the [direct stiffness summation (DSS) operation](@extref ClimaCore DSS), which computes the projection onto the continuous spectral element basis.
-
-## Auxiliary and derived quantities
-
-  - ``\boldsymbol{\Omega}`` is the planetary angular velocity. We use either:
-
-      + a _shallow atmosphere_ approximation, with
-
-        ```math
-        \boldsymbol{\Omega} = \Omega \sin(\phi) \boldsymbol{e}^v
-        ```
-
-        where ``\phi`` is latitude, and ``\Omega`` is the planetary rotation rate in rads/sec (for Earth, ``7.29212 \times 10^{-5} s^{-1}``) and ``\boldsymbol{e}^v`` is the unit radial basis vector. This implies that the horizontal contravariant component ``\boldsymbol{\Omega}^h`` is zero.
-
-      + a _deep atmosphere_, with
-
-        ```math
-        \boldsymbol{\Omega} = (0, 0, \Omega)
-        ```
-
-        i.e. aligned with Earth's rotational axis.
-
-  - ``\tilde{\boldsymbol{u}}`` is the mass-weighted reconstruction of velocity at the interfaces,
-    carried out by weighted interpolation of the horizontal components (see `compute_ᶠuₕ³` in
-    `src/cache/precomputed_quantities.jl`):
-
-    ```math
-    \tilde{\boldsymbol{u}} = WI^f(\rho J, \boldsymbol{u}_h) + \boldsymbol{u}_v
-    ```
-
-  - ``\bar{\boldsymbol{u}}`` is the reconstruction of velocity at cell-centers, carried out by linear interpolation of the covariant vertical component:
-
-    ```math
-    \bar{\boldsymbol{u}} = \boldsymbol{u}_h + I_{c}(\boldsymbol{u}_v)
-    ```
-
-  - ``\Phi = g z`` is the geopotential, where ``g`` is the gravitational acceleration rate and ``z`` is altitude above the mean sea level.
-
-  - ``K = \tfrac{1}{2} \|\boldsymbol{u}\|^2`` is the specific kinetic energy (J/kg), reconstructed at cell centers by
-
-    ```math
-    K = \tfrac{1}{2} (\boldsymbol{u}_{h} \cdot \boldsymbol{u}_{h} + 2 \boldsymbol{u}_{h} \cdot I_{c} (\boldsymbol{u}_{v}) + I_{c}(\boldsymbol{u}_{v} \cdot \boldsymbol{u}_{v})),
-    ```
-
-    where ``\boldsymbol{u}_{h}`` is defined on cell-centers, ``\boldsymbol{u}_{v}`` is defined on cell-faces, and ``I_{c} (\boldsymbol{u}_{v})`` is interpolated using covariant components.
-
-  - ``p`` is air pressure, derived from the thermodynamic state, reconstructed at cell centers.
-
-  - ``\Pi = (\frac{p}{p_0})^{\frac{R_d}{c_{pd}}}`` is the Exner function evaluated with dry-air constants.
-
-  - ``\boldsymbol{F}_R`` are the radiative fluxes: these are assumed to align vertically (i.e. the horizontal contravariant components are zero), and are constructed at cell faces from [RRTMGP.jl](https://github.com/CliMA/RRTMGP.jl).
-
-  - ``\nu_u``, ``\nu_h``, and ``\nu_\chi`` are hyperdiffusion coefficients, and ``c`` is the divergence damping factor. In the code there are two coefficients: ``\nu_u`` (scaled with the cube of the element width) and ``\nu_h = \nu_\chi = \nu_u/\mathrm{Pr}``. Rain, snow, and rain number density receive no hyperdiffusion; the remaining sedimenting cloud species inherit their share of the ``\rho q_{\text{tot}}`` tendency by proportional distribution.
-
-  - No-flux boundary conditions are enforced by requiring the third contravariant component ``\boldsymbol{\tilde{u}}^{v}`` of the face-valued velocity at the boundary to be zero. The vertical covariant velocity component is computed as
-
-    ```math
-    \tilde{u}_{v} = \tfrac{-(u_{1}g^{31} + u_{2}g^{32})}{g^{33}}.
-    ```
-
-## Equations and discretizations
-
-### Mass
-
-Follows the continuity equation
+The prognostic variable for energy is the specific total energy of moist air
+[Romps2008, Bott2008, Sridhar2022](@cite),
 
 ```math
-\frac{\partial}{\partial t} \rho = - \nabla \cdot(\rho \boldsymbol{u}) + \rho \mathcal{S}_{qt}.
+e_{tot} = I + \Phi + \kappa + \kappa_{SGS} .
 ```
 
-This is discretized using the following
+Here ``\Phi = g z`` is the geopotential in the approximation of Earth as a
+sphere [White2005](@cite), with ``z`` the altitude above a reference level and
+``g`` taken constant; ``\kappa = \tfrac{1}{2} \|\boldsymbol{u}\|^2`` is the
+specific kinetic energy of the resolved three-dimensional velocity
+``\boldsymbol{u}``, which following [Romps2008](@cite) is the velocity of dry
+air; and ``\kappa_{SGS}`` is the parameterized subgrid-scale kinetic energy
+where a scheme provides one.
+
+This choice of energy variable, together with a conservative discretization and
+the consistent thermodynamics, conserves total energy, air mass, and water mass
+to floating-point precision. Conservation then holds over complex topography and
+in the presence of parameterizations, without the ad hoc fixers common in
+atmosphere models [Lauritzen2022](@cite). See
+[Conservation Properties](conservation.md).
+
+When prognostic turbulence kinetic energy or PROPHET is enabled, the state also
+carries ``\rho \, \mathrm{tke}`` and the PROPHET subdomain variables described in
+the [PROPHET equations](@ref "PROPHET Sub-Grid Scale Equations"); a slab-ocean
+surface adds a prognostic surface state. [Notation and
+Symbols](notation.md) maps the symbols used here onto the names in the code.
+
+## Coordinate-independent equations of motion
+
+Scalar quantities use flux form, which is what makes discrete conservation
+attainable. Momentum uses the vector-invariant form, in which advection is
+expressed through vorticity and a kinetic-energy gradient by the identity
+``\boldsymbol{u} \cdot \nabla \boldsymbol{u} = \nabla \|\boldsymbol{u}\|^2 / 2 + (\nabla \times \boldsymbol{u}) \times \boldsymbol{u}``. This form represents
+rotational wave modes accurately in the discrete model
+[Ringler2010, TaylorFournier2010](@cite) and avoids the curvature terms
+(Christoffel symbols) that arise in advection terms from coordinate derivatives
+in non-orthogonal coordinates.
+
+The governing equations for a general deep atmosphere are as follows
+[White2005, Romps2008](@cite).
+
+**Mass continuity:**
 
 ```math
-\frac{\partial}{\partial t} \rho
-= - \hat{\mathcal{D}}_h[ \rho \bar{\boldsymbol{u}}] - \mathcal{D}^c_v \left[WI^f( J, \rho) \tilde{\boldsymbol{u}} \right] + \rho \mathcal{S}_{qt}
+\frac{\partial \rho}{\partial t}
+  + \nabla \cdot \left[ \rho (\boldsymbol{u} - W_{q_t} \hat{\boldsymbol{k}}) \right]
+  = \rho \hat{S}_{q_t}
 ```
 
-with the
+**Momentum:**
 
 ```math
--\mathcal{D}^c_v[WI^f(J, \rho) \tilde{\boldsymbol{u}}]
+\frac{\partial \boldsymbol{u}}{\partial t}
+  + (2 \boldsymbol{\Omega} + \boldsymbol{\omega}) \times \boldsymbol{u}
+  = -c_{pd} (\theta_v - \theta_{v,r}) \nabla \Pi
+    - \nabla (\Phi - \Phi_r) - \nabla \kappa + \boldsymbol{S}_u
+    - \frac{1}{\rho} \nabla \cdot
+      \left[ \rho (\boldsymbol{\mathcal{T}} + \boldsymbol{\mathcal{H}}_u) \right]
 ```
 
-term treated implicitly (the full face velocity ``\tilde{\boldsymbol{u}}``, including
-the topographic contribution of ``\boldsymbol{u}_h``, enters the implicit term).
-
-### Momentum
-
-Uses the advective form equation
+**Total energy:**
 
 ```math
-\frac{\partial}{\partial t} \boldsymbol{u}  = - (2 \boldsymbol{\Omega} + \nabla \times \boldsymbol{u}) \times \boldsymbol{u} - c_{pd} (\theta_v - \theta_{v, r}) \nabla_h \Pi  - \nabla_h [(\Phi - \Phi_r) + K].
+\frac{\partial}{\partial t} (\rho e_{tot})
+  + \nabla \cdot \left[ \rho (h_{tot} \boldsymbol{u} - W_h \hat{\boldsymbol{k}}) \right]
+  = -\nabla \cdot \left[ \rho \left( \boldsymbol{\mathcal{F}}_R
+    + \boldsymbol{\mathcal{F}}_h + \boldsymbol{\mathcal{H}}_h
+    + \boldsymbol{u} \cdot (\boldsymbol{\mathcal{T}}
+      + \boldsymbol{\mathcal{H}}_u) \right) \right]
 ```
 
-Here, we use the Exner function to compute pressure gradients and subtract a hydrostatic reference state
+!!! note "TODO: not yet implemented"
+
+    The work done by the subgrid-scale and hyperdiffusive momentum fluxes, the
+    term ``\boldsymbol{u} \cdot (\boldsymbol{\mathcal{T}} + \boldsymbol{\mathcal{H}}_u)`` in the energy equation above, is part of the
+    formulation in [Yatunin2026](@cite) but is not yet in the code. The energy
+    tendency currently carries advection, vertical diffusion, subgrid-scale and
+    surface fluxes, sedimentation, and hyperdiffusion.
+
+**Total water:**
 
 ```math
-- \frac{1}{\rho} \nabla p = - c_{pd} \theta_v \nabla \Pi
+\frac{\partial}{\partial t} (\rho q_t)
+  + \nabla \cdot \left[ \rho (q_t \boldsymbol{u} - W_{q_t} \hat{\boldsymbol{k}}) \right]
+  = -\nabla \cdot \left[ \rho (\boldsymbol{\mathcal{F}}_{q_t}
+    + \boldsymbol{\mathcal{H}}_{q_t}) \right]
+  \equiv \rho \hat{S}_{q_t}
 ```
 
-where ``\theta_v`` is the virtual potential temperature. ``\theta_{v,r} = T_r / \Pi`` is a reference virtual potential temperature (with reference temperature ``T_r``), and
+**Condensate and precipitation**, for ``\mu \in \{l, i\}`` and
+``\sigma \in \{\cdot, \mathrm{cl}, \mathrm{pr}\}`` as needed:
 
 ```math
-\Phi_r = -c_{pd} \left[ T_\text{min} \log(\Pi) + \frac{(T_\text{sfc} - T_\text{min})}{n_s} (\Pi^{n_s} - 1) \right],
+\frac{\partial}{\partial t} (\rho q_\mu^\sigma)
+  + \nabla \cdot \left[ \rho q_\mu^\sigma
+    (\boldsymbol{u} - w_\mu^\sigma \hat{\boldsymbol{k}}) \right]
+  = \rho S_{q_\mu^\sigma}
+    - \nabla \cdot \left[ \rho (\boldsymbol{\mathcal{F}}_{q_\mu^\sigma}
+      + \boldsymbol{\mathcal{H}}_{q_\mu^\sigma}) \right]
 ```
 
-is a reference geopotential, which satisfies the hydrostatic balance equation $c_{pd} \theta_{v,r} \nabla \Pi + \nabla \Phi_r = 0$ for any $\Pi$.
-We use the reference temperature profile ``T_r = T_\text{min} + (T_\text{sfc} - T_\text{min}) \Pi^{n_s}``, with ``n_s = 7`` and the ClimaParams defaults ``T_\text{min} = 220\,K`` (`temperature_min_reference`) and ``T_\text{sfc} = 290\,K`` (`temperature_surface_reference`).
-
-#### Horizontal momentum
-
-By breaking the curl and cross product terms into horizontal and vertical contributions, and removing zero terms (e.g. ``\nabla_v \times \boldsymbol{u}_v = 0``), we obtain
+**Tracers:**
 
 ```math
-\frac{\partial}{\partial t} \boldsymbol{u}_h  =
-  - (2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h +  \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^v
-  - (2 \boldsymbol{\Omega}^v + \nabla_h \times \boldsymbol{u}_h) \times \boldsymbol{u}^h
-  - c_{pd} (\theta_v - \theta_{v, r}) \nabla_h \Pi  - \nabla_h [(\Phi - \Phi_r) + K],
+\frac{\partial}{\partial t} (\rho \chi)
+  + \nabla \cdot \left[ \rho \chi
+    (\boldsymbol{u} - w_\chi \hat{\boldsymbol{k}}) \right]
+  = \rho S_\chi
+    - \nabla \cdot \left[ \rho (\boldsymbol{\mathcal{F}}_\chi
+      + \boldsymbol{\mathcal{H}}_\chi) \right]
 ```
 
-where ``\boldsymbol{u}^h`` and ``\boldsymbol{u}^v`` are the horizontal and vertical _contravariant_ vectors.
-
-Topography enters through the computation of the contravariant velocity components (projections from the covariant velocity representation) before the cross-product contributions.
-
-This is stabilized by adding 4th-order vector hyperviscosity
+**Equation of state:**
 
 ```math
--\nu_u \, \nabla_h^2 (\nabla_h^2(\boldsymbol{\overline{u}})),
+p = \rho R_m T
 ```
 
-projected onto the first two covariant directions, where ``\nabla_{h}^2(\boldsymbol{v})`` is the horizontal vector Laplacian. For grid scale hyperdiffusion, ``\boldsymbol{v}`` is identical to ``\boldsymbol{\overline{u}}``, the cell-center valued velocity vector.
+### Symbols
+
+| Symbol                                                                                            | Meaning                                                                    | Units           |
+|:------------------------------------------------------------------------------------------------- |:-------------------------------------------------------------------------- |:--------------- |
+| ``e_{tot}``                                                                                       | Specific total energy of moist air                                         | J kg⁻¹          |
+| ``h_{tot}``                                                                                       | Specific total enthalpy, ``h_{tot} = e_{tot} + p/\rho``                    | J kg⁻¹          |
+| ``I``                                                                                             | Specific internal energy of moist air                                      | J kg⁻¹          |
+| ``\hat{\boldsymbol{k}}``                                                                          | Vertical unit vector                                                       |                 |
+| ``p``                                                                                             | Pressure                                                                   | Pa              |
+| ``q_t``, ``q_l``, ``q_i``                                                                         | Total water, liquid, and ice specific humidity                             | kg kg⁻¹         |
+| ``R_m``                                                                                           | Gas constant of moist air, dependent on the specific humidities            | J kg⁻¹ K⁻¹      |
+| ``s_d``                                                                                           | Dry static energy, ``s_d = c_{pd}(T - T_0) + \Phi``                        | J kg⁻¹          |
+| ``T``                                                                                             | Temperature                                                                | K               |
+| ``\boldsymbol{u}``                                                                                | Three-dimensional velocity of dry air                                      | m s⁻¹           |
+| ``w_\mu^\sigma``                                                                                  | Sedimentation or fall velocity, positive downward                          | m s⁻¹           |
+| ``W_h``, ``W_{q_t}``                                                                              | Sedimentation flux of enthalpy, of total water                             | W m kg⁻¹, m s⁻¹ |
+| ``\theta_v``, ``\theta_{v,r}``                                                                    | Virtual potential temperature and its reference                            | K               |
+| ``\kappa``, ``\kappa_{SGS}``                                                                      | Resolved and subgrid-scale specific kinetic energy                         | J kg⁻¹          |
+| ``\Pi``                                                                                           | Exner function, ``\Pi = (p/p_0)^{R_d/c_{pd}}``                             |                 |
+| ``\rho``                                                                                          | Density of moist air                                                       | kg m⁻³          |
+| ``\Phi``, ``\Phi_r``                                                                              | Geopotential and its reference                                             | m² s⁻²          |
+| ``\chi``                                                                                          | Generic tracer                                                             | kg kg⁻¹         |
+| ``\boldsymbol{\omega}``                                                                           | Relative vorticity, ``\boldsymbol{\omega} = \nabla \times \boldsymbol{u}`` | s⁻¹             |
+| ``\boldsymbol{\Omega}``                                                                           | Angular velocity of planetary rotation                                     | s⁻¹             |
+| ``\boldsymbol{S}_u``                                                                              | Specific momentum source                                                   | m s⁻²           |
+| ``S_\psi``, ``\hat{S}_{q_t}``                                                                     | Source of scalar ``\psi``; effective source of total water                 | s⁻¹             |
+| ``\boldsymbol{\mathcal{F}}_R``                                                                    | Radiative energy flux                                                      | W m kg⁻¹        |
+| ``\boldsymbol{\mathcal{F}}_h``, ``\boldsymbol{\mathcal{F}}_\psi``                                 | Subgrid-scale flux of enthalpy, of scalar ``\psi``                         | W m kg⁻¹, m s⁻¹ |
+| ``\boldsymbol{\mathcal{H}}_h``, ``\boldsymbol{\mathcal{H}}_\psi``, ``\boldsymbol{\mathcal{H}}_u`` | Hyperdiffusive fluxes                                                      |                 |
+| ``\boldsymbol{\mathcal{T}}``                                                                      | Subgrid-scale momentum flux tensor                                         | m² s⁻²          |
+
+Under the shallow-atmosphere approximation, the planetary rotation vector is
+``\boldsymbol{\Omega} = \Omega \sin(\phi) \boldsymbol{e}^v``, with ``\phi``
+latitude and ``\boldsymbol{e}^v`` the unit radial vector, so that its horizontal
+contravariant component vanishes. For a deep atmosphere it is
+``\boldsymbol{\Omega} = (0, 0, \Omega)``, aligned with the rotation axis. For
+Earth, ``\Omega = 7.2921159 \times 10^{-5}`` s⁻¹ (the
+`angular_velocity_planet_rotation` parameter).
+
+## Properties of the equation set
+
+**Conservation.** The equations for mass, energy, and total water are written in
+flux-conservative form: their right-hand sides contain only flux-divergence
+terms, with no non-conservative sources or sinks. With a flux-conservative
+discretization, the volume-integrated air mass, total water, and total energy
+change only through fluxes across the boundaries. This holds in the presence of
+the parameterizations contained in the subgrid-scale fluxes.
+
+**Closures and the equation of state.** The advective flux in the total energy
+equation carries the specific total enthalpy ``h_{tot} = e_{tot} + p/\rho``,
+which includes kinetic and potential contributions. Pressure follows from the
+ideal-gas equation of state, which neglects pressure contributions from averaging
+over correlated subgrid-scale fluctuations.
+
+**Dry-air reference frame.** Following [Romps2008](@cite), ``\boldsymbol{u}`` is
+the velocity of dry air. The differential motion of water relative to dry air,
+such as hydrometeor fall, appears explicitly as mass and energy flux terms. The
+wall-normal velocity of dry air can then be set to zero at a rigid boundary even
+where surface moisture fluxes are present.
+
+**Simplifications.** The model disregards the transport of momentum and the
+kinetic energy associated with the differential motion of water relative to dry
+air [Romps2008](@cite). The omitted momentum terms describe an internal
+redistribution whose global integral is zero, and a precise local momentum
+balance matters less for long-term stability than an exact balance for mass and
+energy, where small spurious sources cause climate drift [Thuburn2008](@cite).
+
+**Temperature.** Temperature is computed from ``e_{tot}``. Subtracting kinetic
+energy from total energy does not cause catastrophic cancellation of round-off
+errors, because kinetic energy is a small fraction of the total, in the ratio of
+the squared Mach number ``(U/c_s)^2 \lesssim 10^{-2}`` for the atmosphere
+[Peixoto1991](@cite). For perturbations alone, the ratio of kinetic to thermal
+perturbations scales as ``0.5 (\delta U)^2 / (c_{vd} \delta T)``, still of order
+``10^{-2}`` for ``\delta U \sim 10`` m s⁻¹ and ``\delta T \sim 5`` K.
+
+**Pressure-gradient force.** Following [Taylor2020](@cite), the pressure-gradient
+acceleration uses the Exner function and the virtual potential temperature,
 
 ```math
-\nabla_h^2(\boldsymbol{v}) = \nabla_h(\nabla_{h} \cdot \boldsymbol{v}) - \nabla_{h} \times (\nabla_{h} \times \boldsymbol{v}).
+-\frac{1}{\rho} \nabla p = -c_{pd} \theta_v \nabla \Pi,
+\qquad \theta_v = \frac{R_m}{R_d} \frac{T}{\Pi} .
 ```
 
-The ``(2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^v`` term is discretized as:
+Paired with a mimetic discretization, this avoids spurious conversions between
+potential and kinetic energy in the pressure work terms [Taylor2020](@cite). To
+improve accuracy and reduce discretization noise near topography, the force is
+expressed as a deviation from a hydrostatically balanced reference state
+[Golaz2022, Herrington2022](@cite). The reference temperature profile is
 
 ```math
-\frac{I^c\{(2 \boldsymbol{\Omega}^h + \mathcal{C}^f_v[\boldsymbol{u}_h] + \hat{\mathcal{C}}_h[\boldsymbol{u}_v]) \times (I^f(\rho J)\tilde{\boldsymbol{u}}^v)\}}{\rho J}
+T_r(\Pi) = T_{\min} + (T_{sfc} - T_{\min}) \Pi^{n_s} ,
 ```
 
-where
+which passes smoothly from ``T_{sfc}`` at the surface to ``T_{\min}`` in the
+stratosphere. Two of the three numbers in it are configurable:
+
+  - ``T_{sfc}`` and ``T_{\min}`` are Thermodynamics parameters, defaulting to
+    290 K and 220 K. Override them like any other parameter, through the
+    `temperature_surface_reference` and `temperature_min_reference` entries of a
+    TOML file; see [Creating custom configurations](configuration.md).
+  - ``n_s`` is the exponent `s_ref`, fixed at 7 by a constant in
+    `src/utils/refstate_thermodynamics.jl`. Changing it requires editing the
+    source.
+
+With ``\theta_{v,r} = T_r / \Pi`` and
 
 ```math
-\omega^{h} = (\nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v)
+\Phi_r = -c_{pd} \left[ T_{\min} \log \Pi
+  + \frac{T_{sfc} - T_{\min}}{n_s} \left( \Pi^{n_s} - 1 \right) \right],
 ```
 
-The ``(2 \boldsymbol{\Omega}^v + \nabla_h \times \boldsymbol{u}_h) \times \boldsymbol{u}^h`` term is discretized as
+the reference state satisfies ``c_{pd} \theta_{v,r} \nabla \Pi + \nabla \Phi_r = 0`` for any ``\Pi``, which gives the combined pressure-gradient and geopotential
+terms in the momentum equation.
+
+**Reference temperature invariance.** The energetics are invariant under shifts
+of the reference temperature ``T_0``, so the choice of ``T_0`` affects physical
+results only through the quality of the linearization of the latent heats
+[Ambaum2020](@cite). See
+[Thermodynamics and the Working Fluid](thermodynamics.md).
+
+## Parameterized terms
+
+Several terms above come from parameterizations, each documented on its own page.
+
+**Subgrid-scale fluxes.** The momentum flux tensor ``\boldsymbol{\mathcal{T}}``
+and the scalar fluxes ``\boldsymbol{\mathcal{F}}_h``,
+``\boldsymbol{\mathcal{F}}_{q_t}``, ``\boldsymbol{\mathcal{F}}_{q_\mu^\sigma}``,
+and ``\boldsymbol{\mathcal{F}}_\chi`` represent the effect of unresolved
+processes on the resolved flow. They may have diffusive and advective components,
+the latter associated with convection closures; see
+[PROPHET](edmf_equations.md). Energetic consistency and invariance to the
+reference temperature constrain the diffusive part: the total enthalpy flux is
+decomposed into the enthalpy carried by the diffusive water flux and a thermal
+diffusion of dry static energy, rather than modeled as the gradient of a single
+lumped enthalpy.
+
+**Hyperdiffusion.** The fluxes ``\boldsymbol{\mathcal{H}}`` serve numerical
+stability rather than physics, and act along terrain-following coordinate
+surfaces. See [Hyperdiffusion](hyperdiffusion.md).
+
+**Sedimentation and fall velocities.** Condensate sediments and precipitation
+falls with velocities ``w_\mu^\sigma``, defined positive downward. A microphysics
+scheme relates them to hydrometeor size distributions; see
+[Microphysics](microphysics.md). The total water sedimentation flux is the
+weighted sum ``W_{q_t} = q_l w_l + q_i w_i``, and the sedimentation flux of
+enthalpy is ``W_h = q_l h_{tot,l} w_l + q_i h_{tot,i} w_i``.
+
+**Mass sources and sinks.** The effective moisture source ``\hat{S}_{q_t}`` in
+the continuity equation arises from the subgrid-scale water fluxes. Taking the
+difference between the continuity and total water equations yields an exact
+conservation law for the dry air mass density ``\rho (1 - q_t)``, with no source
+term. In Earth's atmosphere ``\hat{S}_{q_t}`` is usually at least two orders of
+magnitude smaller than the other terms, and most models neglect it
+[Abbott2024](@cite). It is retained here for generality, and matters where the
+condensable species is a major atmospheric constituent, as carbon dioxide is on
+Mars [Soto2015](@cite).
+
+**Boundaries.** The wall-normal dry-air velocity vanishes at the surface, and the
+subgrid-scale fluxes there follow bulk exchange laws with coefficients from
+Monin–Obukhov similarity theory; see
+[Surface Conditions](surface_conditions.md). The model top is a rigid lid with a
+sponge layer beneath it; see [Model Top and Sponge Layer](sponge.md).
+
+## Generalized coordinates
+
+This section gives the form ClimaCore evaluates. Nothing here appears in the
+ClimaAtmos tendencies, which stay in the coordinate-independent form above; it is
+included because the metric terms determine what the operators do, and a reader
+tracing an operator or a boundary condition will meet them.
+
+The grid uses a height-based, terrain-following, stretched vertical coordinate
+``\xi^3`` together with horizontal coordinates ``(\xi^1, \xi^2)`` that
+parameterize a cubed sphere [Sadourny1972, Ronchi1996](@cite). In the presence of
+topography these coordinates are curvilinear and non-orthogonal. See
+[Topography Representation](topography.md) for the vertical coordinate and
+[Grids](grids.md) for the meshes.
+
+Write ``\boldsymbol{e}_i = \partial \boldsymbol{r} / \partial \xi^i`` for the
+covariant basis vectors, tangent to the coordinate surfaces, and
+``\boldsymbol{e}^i = \nabla \xi^i`` for the contravariant basis vectors,
+orthogonal to them. The metric tensor components are ``g_{ij} = \boldsymbol{e}_i \cdot \boldsymbol{e}_j`` and ``g^{ij} = \boldsymbol{e}^i \cdot \boldsymbol{e}^j``, and ``J = (\det(\boldsymbol{g}))^{1/2}`` is the Jacobian
+determinant, the volume element in generalized coordinates. Any vector has
+covariant and contravariant components, ``\boldsymbol{u} = u_i \boldsymbol{e}^i = u^i \boldsymbol{e}_i``, related by ``u_i = g_{ij} u^j``. The differential
+operators become
 
 ```math
-(2 \boldsymbol{\Omega}^v + \hat{\mathcal{C}}_h[\boldsymbol{u}_h]) \times \boldsymbol{u}^h
+\nabla = \boldsymbol{e}^i \frac{\partial}{\partial \xi^i}, \qquad
+\nabla \cdot {} = \frac{1}{J} \frac{\partial}{\partial \xi^i} J (\boldsymbol{e}^i)^\top, \qquad
+\nabla \times {} = \mathcal{E}^{ijk} \boldsymbol{e}_i
+  \frac{\partial}{\partial \xi^j} (\boldsymbol{e}_k)^\top ,
 ```
 
-and the ``c_{pd} (\theta_v - \theta_{v,r}) \nabla_h \Pi + \nabla_h (\Phi - \Phi_r + K)`` term is discretized as
+with ``\mathcal{E}^{ijk} = \varepsilon^{ijk} / J`` the contravariant alternating
+tensor. Applying these to the equations above gives the same system in
+generalized coordinates.
 
-```math
-c_{pd} (\theta_v - \theta_{v,r}) \mathcal{G}_h[\Pi] + \mathcal{G}_h[\Phi - \Phi_r + K] ,
-```
+The covariant velocity components ``u_i`` are the prognostic variables, following
+[Gardner2018](@cite). That choice isolates the vertical pressure and geopotential
+gradients in the ``i = 3`` component of the momentum equation, which keeps
+hydrostatic balance straightforward to maintain and confines the implicit
+vertical solve to one momentum component.
 
-where all these terms are treated explicitly.
+Evaluating a tensor divergence in these coordinates brings in curvature terms.
+The model avoids computing them by transforming to Cartesian coordinates, taking
+the divergence there, and transforming back [Vinokur1974](@cite).
 
-The hyperviscosity term is
+## Where this is implemented
 
-```math
-- \nu_u \left\{ c \, \hat{\mathcal{G}}_h ( \mathcal{D}(\boldsymbol{\psi}_h) ) - \hat{\mathcal{C}}_h( \mathcal{C}_h( \boldsymbol{\psi}_h )) \right\}
-```
+Each equation is assembled from tendency functions across
+`src/prognostic_equations/`. Use this table to trace a term from the mathematics
+to the code.
 
-where
+| Equation                                 | Primary source                                                                                                                                                                                                                                                           |
+|:---------------------------------------- |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Mass continuity                          | [advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl) (horizontal), [implicit/implicit_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/implicit_tendency.jl) (vertical) |
+| Momentum, horizontal                     | [advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl)                                                                                                                                                                   |
+| Momentum, vertical and pressure gradient | [advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl), [implicit/implicit_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/implicit_tendency.jl)                         |
+| Total energy                             | [advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl) (horizontal), [implicit/implicit_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/implicit_tendency.jl) (vertical) |
+| Total water and condensate advection     | [advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/advection.jl) (horizontal), [implicit/implicit_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/implicit_tendency.jl) (vertical) |
+| Sedimentation and fall velocities        | [water_advection.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/water_advection.jl)                                                                                                                                                       |
+| Hyperdiffusive fluxes                    | [hyperdiffusion.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/hyperdiffusion.jl)                                                                                                                                                         |
+| Vertical diffusion                       | [vertical_diffusion_boundary_layer.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/vertical_diffusion_boundary_layer.jl)                                                                                                                   |
+| Sponge terms                             | [sponge/](https://github.com/CliMA/ClimaAtmos.jl/tree/main/src/parameterized_tendencies/sponge)                                                                                                                                                                          |
+| Subgrid-scale fluxes (PROPHET)           | [edmfx_sgs_flux.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/edmfx_sgs_flux.jl)                                                                                                                                                         |
+| Assembly of all tendencies               | [remaining_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/remaining_tendency.jl)                                                                                                                                                 |
 
-```math
-\boldsymbol{\psi}_h = \mathcal{P} \left[ \hat{\mathcal{G}}_h ( \mathcal{D}(\boldsymbol{u}_h) ) - \hat{\mathcal{C}}_h( \mathcal{C}_h( \boldsymbol{u}_h )) \right]
-```
-
-#### Vertical momentum
-
-Similarly for vertical velocity
-
-```math
-\frac{\partial}{\partial t} \boldsymbol{u}_v  =
-  - (2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^h
-  -c_{pd} (\theta_v - \theta_{v, r}) \nabla_v \Pi  - \nabla_v [(\Phi - \Phi_r)].
-```
-
-The ``(2 \boldsymbol{\Omega}^h + \nabla_v \times \boldsymbol{u}_h + \nabla_h \times \boldsymbol{u}_v) \times \boldsymbol{u}^h`` term is discretized as
-
-```math
-(2 \boldsymbol{\Omega}^h + \mathcal{C}^f_v[\boldsymbol{u}_h] + \hat{\mathcal{C}}_h[\boldsymbol{u}_v]) \times I^f(\boldsymbol{u}^h) ,
-```
-
-The ``\nabla_v K`` term is discretized as
-
-```math
-\mathcal{G}^f_v[K],
-```
-
-The ``c_{pd} (\theta_v - \theta_{v,r}) \nabla_v \Pi + \nabla_v (\Phi - \Phi_r)`` term is discretized as
-
-```math
-I^f[c_{pd} (\theta_v - \theta_{v, r} ) ] \mathcal{G}^f_v[\Pi] + \mathcal{G}^f_v[\Phi - \Phi_r],
-```
-
-and is treated implicitly.
-
-This is stabilized by adding 4th-order vector hyperviscosity
-
-```math
--\nu_u \, \nabla_h^2 (\nabla_h^2(\boldsymbol{\overline{u}})),
-```
-
-projected onto the third covariant direction after a ``\rho J``-weighted
-interpolation to faces.
-
-### Total energy
-
-```math
-\frac{\partial}{\partial t} \rho e = - \nabla \cdot((\rho e + p) \boldsymbol{u} + \boldsymbol{F}_R) + \rho \mathcal{S}_{e},
-```
-
-which is stabilized by adding a 4th-order hyperdiffusion term on total enthalpy:
-
-```math
-- \nu_h \left[ \nabla \cdot \left( \rho \nabla^3 s_d \right)
-  + \sum_\mu \nabla \cdot \left( \rho \, (h_\mu + \Phi) \, \nabla^3 q_\mu \right) \right],
-```
-
-where the total enthalpy is decomposed into dry static energy ``s_d`` and the
-water-species enthalpies ``h_\mu`` (for ``\mu \in \{v, l, i\}``), so that the
-``\nabla^4`` operator never acts on a lumped total enthalpy.
-
-This is discretized using
-
-```math
-\frac{\partial}{\partial t} \rho e \approx
-- \mathcal{D}^{split}_h[ \rho \bar{\boldsymbol{u}}, \tfrac{\rho e + p}{\rho} ]
-- \mathcal{D}^c_v \left[ WI^f(J,\rho) \,  \tilde{\boldsymbol{u}} \, I^f \left(\frac{\rho e + p}{\rho} \right) \right]
-- \mathcal{D}^c_v \left[ \boldsymbol{F}_R \right]
-- \nu_h \left[ \hat{\mathcal{D}}_h( \rho \mathcal{G}_h(\psi_{s_d}) )
-  + \sum_\mu \hat{\mathcal{D}}_h( \rho (h_\mu + \Phi) \mathcal{G}_h(\psi_{q_\mu}) ) \right],
-```
-
-where
-
-```math
-\psi_x = \mathcal{P} \left[ \hat{\mathcal{D}}_h \left( \mathcal{G}_h (x) \right) \right],
-```
-
-and the radiative flux divergence ``-\mathcal{D}^c_v[\boldsymbol{F}_R]`` is
-applied separately as an explicit tendency.
-
-The central reconstruction
-
-```math
-- \mathcal{D}^c_v \left[ WI^f(J,\rho) \,  \tilde{\boldsymbol{u}} \, I^f \left(\frac{\rho e + p}{\rho} \right) \right]
-```
-
-is treated implicitly.
-
-!!! note
-
-    When upwinding is enabled for energy advection (the van Leer limiter by
-    default), the implicit solve still uses the central reconstruction; the
-    difference between the upwinded and central fluxes is applied after the
-    Newton solve as a `T_post_imp!` correction
-    (`correct_implicit_advection_tendency!`), so the upwind flux is evaluated
-    with the Newton-solved velocity.
-
-### Scalars
-
-For an arbitrary scalar ``\chi``, the density-weighted scalar ``\rho\chi`` follows the continuity equation
-
-```math
-\frac{\partial}{\partial t} \rho \chi = - \nabla \cdot(\rho \chi \boldsymbol{u}) + \rho \mathcal{S}_{\chi}.
-```
-
-This is stabilized by adding a 4th-order hyperdiffusion term
-
-```math
-- \nu_\chi \nabla \cdot(\rho \nabla^3(\chi))
-```
-
-This is discretized using
-
-```math
-\frac{\partial}{\partial t} \rho \chi \approx
-- \mathcal{D}^{split}_h[ \rho \bar{\boldsymbol{u}}, \chi ]
-- \mathcal{D}^c_v \left[ WI^f(J,\rho) \, U^f\left( \tilde{\boldsymbol{u}},  \frac{\rho \chi}{\rho} \right) \right]
-- \nu_\chi \hat{\mathcal{D}}_h ( \rho \, \mathcal{G}_h (\psi) )
-```
-
-where
-
-```math
-\psi = \mathcal{P} \left[ \hat{\mathcal{D}}_h \left( \mathcal{G}_h \left( \frac{\rho \chi}{\rho} \right)\right) \right]
-```
-
-For total water ``\rho q_\mathrm{tot}``, the central reconstruction
-
-```math
-- \mathcal{D}^c_v \left[ WI^f(J,\rho) \, \tilde{\boldsymbol{u}} \, I^f\left( \frac{\rho \chi}{\rho} \right) \right]
-```
-
-is treated implicitly (as for total energy), with the upwind-central difference
-applied after the Newton solve as a `T_post_imp!` correction. All other
-grid-mean tracers are advected fully explicitly with the reconstruction
-selected by `tracer_upwinding` (the van Leer limiter by default).
+The discretized form of each equation, and the operators it is written in, are
+given in [Discretization and Operators](discretization.md).

--- a/docs/src/extending_column_datasets.md
+++ b/docs/src/extending_column_datasets.md
@@ -84,7 +84,7 @@ expects three files in one directory, following the ERA5 variable naming:
 
 On the `clima` and Caltech HPC servers, sites already covered by the
 `era5_hourly_atmos_raw` artifact (the tropical Pacific, first 5 days of July
-2007) work out of the box. To run elsewhere, download the raw data from
+2007) need no further setup. To run elsewhere, download the raw data from
 ECMWF, place the three files in one directory, and point the artifact at it
 in `~/.julia/artifacts/Overrides.toml`:
 

--- a/docs/src/extending_diagnostics.md
+++ b/docs/src/extending_diagnostics.md
@@ -8,12 +8,16 @@ Diagnostic variables are represented in `ClimaAtmos` with a `DiagnosticVariable`
 `struct`. A `DiagnosticVariable` contains metadata about the variable and a
 function that computes it from the state.
 
+New variables are defined in files under `src/diagnostics/`, so the code on this
+page is written as it appears there: unqualified, with `CAP`
+(`ClimaAtmos.Parameters`), `TD` (`Thermodynamics`), and `lazy` already in scope.
+
 ## Metadata
 
 The metadata we currently support is `short_name`, `long_name`,
 `standard_name`, `units`, and `comments`. This metadata is relevant mainly to how the variable is output.
 Therefore, it is the responsibility of the `output_writer` (see
-`ScheduledDiagnostic`) to handle the metadata properly. The `output_writer`s
+`ScheduledDiagnostic`) to handle the metadata. The `output_writer`s
 provided by `ClimaAtmos` use this metadata.
 
 In `ClimaAtmos`, we follow the convention that:

--- a/docs/src/extending_setups.md
+++ b/docs/src/extending_setups.md
@@ -38,9 +38,9 @@ CA.solve_atmos!(simulation)
 The forcing is a tuple of
 [`AbstractForcingTerm`](@ref ClimaAtmos.AbstractForcingTerm)s (`HorizontalAdvection()`, `VerticalFluctuation()`,
 `Nudging(variables...; timescale, mask)`, `Subsidence()`) passed to the setup's
-`forcing` slot. Note that the `AtmosSimulation(; model, setup)` constructor uses
+`forcing` slot. The `AtmosSimulation(; model, setup)` constructor uses
 `setup` only for the initial state, so the setup's forcing / insolation / surface
-models must be threaded into the `AtmosModel` explicitly (tracked by [#4696](https://github.com/CliMA/ClimaAtmos.jl/issues/4696)).
+models must be passed to the `AtmosModel` explicitly (tracked by [#4696](https://github.com/CliMA/ClimaAtmos.jl/issues/4696)).
 
 ```julia
 import ClimaAtmos as CA

--- a/docs/src/extending_tracers.md
+++ b/docs/src/extending_tracers.md
@@ -4,11 +4,11 @@ How to add a new passive tracer that is transported through the full
 grid-scale + SGS system. For the tracer naming conventions and the operations
 that are handled automatically, see [Passive Tracers](passive_tracers.md).
 
-A working, config-selectable passive tracer already ships with the model:
+The model includes a working, config-selectable passive tracer:
 setting `chemistry_model: "passive"` enables the tracer `q_gas_A`, threaded
 through [`physical_state`](@ref ClimaAtmos.Setups.physical_state) and the
 prognostic-variable construction, with `q_gas_A`/`q_gas_Aup` diagnostics. It is
-exercised by `config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml`
+exercised by [`config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_bomex_tracerA_column.yml)
 and is the best reference implementation for the steps below.
 
 To add a new passive tracer `A` that is transported through the full

--- a/docs/src/first_simulation.md
+++ b/docs/src/first_simulation.md
@@ -2,8 +2,9 @@
 
 This page walks through building, running, and inspecting one simulation. To
 configure each component in turn, see
-[Scripting Simulations](scripting_simulations.md); to do the same from a YAML
-file, see [Script vs Config Interface](interfaces.md).
+[Scripting Simulations](scripting_simulations.md); to run from a YAML file
+instead, see [Creating Custom Configurations](configuration.md), and for how
+the two interfaces relate, [Script vs Config Interface](interfaces.md).
 
 ## Minimal example
 
@@ -54,32 +55,40 @@ propertynames(Y.f)  # e.g., (:u₃,)
 
 ## Running a case end to end
 
-The default simulation is deliberately plain, and a global run is slow to
+The default simulation is plain, and a global run is slow to
 integrate. Presets bundle a grid, a setup, and matching physics into one call,
-which is the quickest way to a real case, here the BOMEX shallow-cumulus
-column. `solve_atmos!` integrates it forward to `t_end`:
+which is the quickest way to a running case, here a column with the BOMEX
+shallow-cumulus initial state and moist physics. `solve_atmos!` integrates it
+forward to `t_end`, and the integrator time confirms where the run stopped:
 
 ```@example first_sim
 simulation = CA.Presets.bomex(Float32; t_end = "10mins", output_dir = mktempdir())
 CA.solve_atmos!(simulation)
-nothing # hide
+simulation.integrator.t
 ```
 
 (This page runs during the documentation build, so it writes to a temporary
 directory; drop `output_dir` to get the default location described below.)
 
-Presets matter beyond brevity: a setup supplies the initial state only, and the
-physics comes from the model, so the two have to be chosen together. BOMEX with
-the default dry model would have no moisture to convect. Each preset pairs them
-correctly. See the [Presets](api.md#Presets) section of the API for the full
-list.
+Presets matter beyond brevity: the `setup` argument sets the initial state,
+while the physics comes from the model, so the two have to be chosen together.
+BOMEX with the default dry model would have no moisture to convect. Each preset
+pairs a setup with a matching grid and model. The pairing is minimal rather
+than complete: `Presets.bomex` enables moist physics but no
+turbulence-convection scheme or case forcings; pass
+`model = CA.Presets.prognostic_edmf(Float32)` to add convective transport, or
+run the corresponding YAML case config for the full published setup. See the
+[Presets](api.md#Presets) section of the API for the full list.
 
 ## Where output goes
 
-Output is written to `simulation.output_dir`, which defaults to
-`output/<job_id>` under the directory Julia was started in; with the default
-`job_id` of `atmos_sim`, that is `output/atmos_sim`. Each run writes to a
-numbered subdirectory, and `output_active` links to the most recent one. Two
+Output is written to `simulation.output_dir`. The base directory defaults to
+`output/<job_id>` under the directory Julia was started in (just `<job_id>`
+when the `CI` environment variable is set); with the default `job_id` of
+`atmos_sim`, that is `output/atmos_sim`. Each run writes to a numbered
+subdirectory of the base directory — `simulation.output_dir` is that
+subdirectory, such as `output/atmos_sim/output_0000` — and
+`output/atmos_sim/output_active` links to the most recent one. Two
 formats appear there, each with a distinct role:
 
   - **NetCDF** (`.nc`) files hold the **diagnostics** -- derived (and often interpolated)

--- a/docs/src/global_simulations.md
+++ b/docs/src/global_simulations.md
@@ -31,9 +31,9 @@ corresponds to about 550 km, 16 to about 206 km, and 30 to about 110 km.
 ## From a configuration file
 
 The aquaplanet configurations in `config/model_configs/` (e.g.,
-`prognostic_edmfx_aquaplanet.yml`, `aquaplanet_equil_allsky_gw_raw.yml`) and
+[`prognostic_edmfx_aquaplanet.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_aquaplanet.yml), [`aquaplanet_equil_allsky_gw_raw.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/aquaplanet_equil_allsky_gw_raw.yml)) and
 the production-oriented configurations in `config/longrun_configs/` (e.g.,
-`longrun_aquaplanet_allsky_progedmf_1M.yml`, `amip_target.yml`) are the best
+[`longrun_aquaplanet_allsky_progedmf_1M.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/longrun_configs/longrun_aquaplanet_allsky_progedmf_1M.yml), [`amip_target.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/longrun_configs/amip_target.yml)) are the best
 starting points:
 
 ```julia
@@ -54,7 +54,8 @@ in [Creating custom configurations](configuration.md), applies only to model
 configurations that do not fix those keys themselves; later files override
 earlier ones key by key.
 
-Output lands in `output/<job_id>` (see
+Output lands in a numbered subdirectory of `output/<job_id>`, with
+`output/<job_id>/output_active` linking to the latest run (see
 [Loading and Visualizing Output](visualizing_output.md)). The tested global
 production configurations can be found in `config/longrun_configs/`. For GPU runs, see
 [Running on GPUs and MPI](gpu_and_mpi.md).

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -6,7 +6,7 @@ depth.
 
 ## State and cache
 
-ClimaAtmos integrates a prognostic state vector forward in time. A handful of
+ClimaAtmos integrates a prognostic state vector forward in time. A few
 single-letter names appear throughout the code:
 
 | Symbol | Meaning                                                                                                                                                                                                                              |
@@ -32,7 +32,7 @@ These are accessed through the integrator after a run, e.g.
   - **IMEX time stepping**: the implicit–explicit scheme used by default; the
     implicit part is handled by the [Implicit Solver](@ref).
   - **ITime**: the integer time type used for reproducible, exactly representable
-    simulation times. See [ITime](@ref).
+    simulation times. See [Integer Time (ITime)](@ref).
   - **PROPHET**: the Prognostic Representation Of Physics for Eddy Transport,
     the turbulence/convection scheme of ClimaAtmos: an extended, prognostic
     eddy-diffusivity mass-flux (EDMF) scheme, still called EDMFX in the code.

--- a/docs/src/gpu_and_mpi.md
+++ b/docs/src/gpu_and_mpi.md
@@ -5,14 +5,19 @@ MPI, and on GPUs. [ClimaComms.jl](https://clima.github.io/ClimaComms.jl/stable/)
 selects the compute device and the communication context from environment
 variables, so switching hardware requires no change to Julia scripts or YAML
 configuration files: set the environment variables and launch the process
-accordingly.
+accordingly. (In a YAML configuration, the device can also be set with the
+`device` key, e.g. `device: CUDADevice`.)
 
 The examples below launch a run script from the repository root. Any script
-that builds and solves a simulation works; this one runs the aquaplanet
+that builds and solves a simulation works, provided it loads the backend that
+the environment variables request, through
+[`ClimaComms.@import_required_backends`](@extref). This one runs the aquaplanet
 configuration from [Global Simulations](global_simulations.md):
 
 ```julia
 # run_aquaplanet.jl
+import ClimaComms
+ClimaComms.@import_required_backends   # loads CUDA.jl and/or MPI.jl on demand
 import ClimaAtmos as CA
 
 config = CA.AtmosConfig(
@@ -32,8 +37,11 @@ CLIMACOMMS_DEVICE="CUDA" julia --project run_aquaplanet.jl
 ```
 
 GPU support is loaded through
-[CUDA.jl](https://cuda.julialang.org/stable/), which must be installed in the
-active project. For first-time
+[CUDA.jl](https://cuda.julialang.org/stable/), which must be available in the
+load path. The package's own `Project.toml` does not include it; install it
+once into your default environment from a plain `julia` session
+(`import Pkg; Pkg.add("CUDA")`), where the load path picks it up, as described
+in [Installation](installation.md). For first-time
 machine setup, from a fresh node to a working GPU run, including CUDA runtime
 and driver compatibility, see the shared guide
 [running\_on\_gpu.md](https://github.com/CliMA/ClimaAtmos.jl/blob/main/docs/dev-guides/workflow/running_on_gpu.md).
@@ -48,12 +56,14 @@ and driver compatibility, see the shared guide
 
 To distribute a simulation across CPU cores or compute nodes:
 
- 1. Make an MPI implementation available. On clusters, this is usually a
+ 1. Add [MPI.jl](https://juliaparallel.org/MPI.jl/stable/) to your default
+    environment (`import Pkg; Pkg.add("MPI")`), as with CUDA.jl above.
+ 2. Make an MPI implementation available. On clusters, this is usually a
     system module; see the
     [MPI.jl configuration documentation](https://juliaparallel.org/MPI.jl/stable/configuration/)
     for pointing Julia at a system MPI.
- 2. Set `CLIMACOMMS_CONTEXT` to `"MPI"`.
- 3. Launch through the MPI launcher (`mpiexec`, `mpirun`, or `srun` under
+ 3. Set `CLIMACOMMS_CONTEXT` to `"MPI"`.
+ 4. Launch through the MPI launcher (`mpiexec`, `mpirun`, or `srun` under
     Slurm).
 
 ```bash
@@ -62,8 +72,8 @@ CLIMACOMMS_CONTEXT="MPI" srun --ntasks=4 julia --project run_aquaplanet.jl
 
 Two behaviors specific to distributed runs:
 
-  - The root process (rank 0) writes the diagnostic NetCDF files and the HDF5
-    restart files.
+  - The root process (rank 0) writes the diagnostic NetCDF files; the HDF5
+    checkpoints are written collectively by all ranks through parallel HDF5.
   - ClimaAtmos triggers garbage collection on all processes together, every
     1000 steps by default, to keep collections from running at different
     times on different ranks. The `CLIMAATMOS_GC_NSTEPS` environment variable

--- a/docs/src/hyperdiffusion.md
+++ b/docs/src/hyperdiffusion.md
@@ -1,0 +1,197 @@
+# Hyperdiffusion
+
+Hyperdiffusion serves numerical rather than physical ends: it stabilizes the
+model and damps the small-scale oscillations that a high-order horizontal
+discretization admits. It acts along terrain-following coordinate surfaces, so
+it depends on the model's notion of "horizontal"
+[Jablonowski2011, Yatunin2026](@cite).
+
+Even so, hyperdiffusion is written to respect the model's conservation laws to
+floating-point precision. That requirement shapes its form, and is the main
+subject of this page.
+
+## Biharmonic form
+
+For a generic scalar ``\psi``, the hyperdiffusive flux is proportional to the
+third derivative of the field,
+
+```math
+\boldsymbol{\mathcal{H}}_\psi = \nu_\psi \nabla_h
+  \left[ \nabla_h^2 (\psi - \psi_r) \right],
+```
+
+with a hyperdiffusion coefficient ``\nu_\psi`` and the horizontal del operator
+``\nabla_h`` taken along terrain-following coordinate surfaces.
+
+A vertically varying reference state ``\psi_r`` is subtracted from dry static
+energy and total specific humidity. This reduces the spurious vertical mixing
+that arises when diffusion acts along coordinate surfaces that warp over steep
+topography [Herrington2022](@cite). The reference state is built from the
+reference temperature profile ``T_r(\Pi)`` used for the pressure-gradient
+force (see [Governing Equations](equations.md)): the reference dry static
+energy is
+
+```math
+s_{d,r} = c_{pd} (T_r - T_0) + \Phi_r ,
+```
+
+with ``\Phi_r`` the associated reference geopotential, and the reference total
+specific humidity is the specific humidity at a constant relative humidity of
+50% along that profile,
+
+```math
+q_{t,r} = 0.5 \, q_v^*(T_r, p) ,
+```
+
+where ``q_v^*`` is the saturation specific humidity.
+
+!!! note "TODO: not yet implemented"
+
+    The reference-state subtraction is part of the formulation in
+    [Yatunin2026](@cite) but is not yet in the code, which hyperdiffuses ``s_d``
+    and the effective total water directly. The reference geopotential
+    ``\Phi_r`` is used in the pressure-gradient force; see
+    [Governing Equations](equations.md).
+
+The tendency is applied as two successive Laplacians with the direct stiffness
+summation operator applied in between. This removes the discontinuities across
+element boundaries and preserves the discrete inner product, so the operation
+remains globally conservative. In the code this is the split between
+`prep_hyperdiffusion_tendency!`, which computes and DSSes the Laplacians into
+cache fields, and `apply_hyperdiffusion_tendency!`, which takes the second
+derivative.
+
+## Water: partitioning to the suspended species
+
+Hyperdiffusion is applied to the total specific humidity ``q_t``. How the
+resulting tendency is distributed among the individual water species is a
+physical question, not a numerical one.
+
+Horizontal diffusion of precipitating species would smear out features such as
+rain shafts, which evolve through vertical sedimentation and microphysics. The
+hyperdiffusive tendency for total water therefore goes **only to the suspended
+species** — water vapor, cloud liquid, and cloud ice — in proportion to their
+share of the suspended total humidity ``q_t^{cl}``, and is zero for rain and
+snow:
+
+```math
+-\frac{1}{\rho} \nabla_h \cdot (\rho \boldsymbol{\mathcal{H}}_{q_\mu^\sigma}) =
+\begin{cases}
+  \dfrac{q_\mu^\sigma}{q_t^{cl}}
+    \left( -\dfrac{1}{\rho} \nabla_h \cdot
+      (\rho \boldsymbol{\mathcal{H}}_{q_t}) \right)
+    & \text{if } \sigma = \mathrm{cl} \text{ (cloud)}, \\[2ex]
+  0 & \text{if } \sigma = \mathrm{pr} \text{ (precipitation)}.
+\end{cases}
+```
+
+The water vapor tendency follows implicitly, since its specific humidity is
+diagnosed from the total and the condensate specific humidities.
+
+The implementation adds two details to the expression above. The share each
+cloud species receives is **clipped** to the interval ``[0, 1]``, so a species'
+specific humidity exceeding the suspended total through limiter or round-off
+effects cannot produce a share above one. Where a two-moment scheme carries
+number densities, those scale with their corresponding mass species; rain number
+density, like rain and snow mass, receives no hyperdiffusion.
+
+## Energy: an enthalpy-consistent flux
+
+The total hyperdiffusive enthalpy flux is built from two components, in parallel
+with the turbulent enthalpy flux described in
+[Thermodynamics and the Working Fluid](thermodynamics.md). It is not the
+diffusion of a lumped total enthalpy:
+
+```math
+\boldsymbol{\mathcal{H}}_h = \boldsymbol{\mathcal{H}}_{s_d}
+  + h_{\mathrm{tot,cl}} \, \boldsymbol{\mathcal{H}}_{q_t}
+= \nu_h \nabla_h \left[ \nabla_h^2 (s_d - s_{d,r}) \right]
+  + h_{\mathrm{tot,cl}} \, \boldsymbol{\mathcal{H}}_{q_t} .
+```
+
+The first term hyperdiffuses the dry static energy ``s_d = h_d + \Phi``. The
+second accounts for the enthalpy transported by the hyperdiffusive flux of total
+water, weighted by the mass-weighted average specific total enthalpy of the
+suspended water species,
+
+```math
+h_{\mathrm{tot,cl}} = \frac{q_v h_{\mathrm{tot},v}
+  + q_l^{cl} h_{\mathrm{tot},l} + q_i^{cl} h_{\mathrm{tot},i}}{q_t^{cl}} .
+```
+
+Given the water partitioning above, this expression for the water-enthalpy flux
+is exact. In the code these are the cache fields `ᶜ∇²s_d` and `ᶜ∇²q_tot_eff`,
+with the weighting held in `ᶜh_eff_plus_Φ` (the average
+``h_{\mathrm{tot,cl}}`` includes the geopotential); energy hyperdiffusion does
+not act on a lumped `h_tot`.
+
+The decomposition allows total energy and water to be conserved together.
+Hyperdiffusing potential temperature or another intensive thermodynamic variable
+instead creates sources and sinks of total energy that then need an energy fixer
+to offset them. Here every hyperdiffusive term is a flux divergence along a
+coordinate surface, so the operators move quantities around without adding to or
+removing from the global total.
+
+The hyperdiffusion coefficients for dry static energy and total specific
+humidity are equal, which corresponds to a turbulent Lewis number of one.
+
+## Momentum
+
+Horizontal biharmonic hyperviscosity is applied to the three-dimensional
+velocity, ``\boldsymbol{\mathcal{H}}_u = \nu_u \nabla_h (\Delta_h \boldsymbol{u})``, with the horizontal vector Laplacian
+
+```math
+\Delta_h \boldsymbol{u} = \nabla_h (\nabla_h \cdot \boldsymbol{u})
+  - \nabla_h \times (\nabla_h \times \boldsymbol{u}).
+```
+
+A tensor divergence in non-orthogonal coordinates brings in curvature terms, so
+the model uses the cheaper form common in atmosphere models,
+
+```math
+-\frac{1}{\rho} \nabla_h \cdot (\rho \boldsymbol{\mathcal{H}}_u)
+\approx -\nu_u \left[ \delta_{div} \nabla_h (\nabla_h \cdot \Delta_h \boldsymbol{u})
+  - \nabla \times (\nabla_h \times \Delta_h \boldsymbol{u}) \right].
+```
+
+With ``\delta_{div} = 1`` and constant ``\nu_u`` this amounts to neglecting
+density variations along horizontal coordinate surfaces. Values ``\delta_{div} > 1`` increase the damping of two-dimensional divergent flow components, which
+include gravity waves; the default is ``\delta_{div} = 5``, set by the
+`divergence_damping_factor` configuration key.
+
+## Coefficients
+
+For numerical stability the hyperviscosity must grow with horizontal grid
+spacing, typically like ``(\delta x)^3``
+[Lauritzen2018, Skamarock2014](@cite). Both
+coefficients in ClimaAtmos are set that way, from the mean nodal distance ``h``
+of the horizontal grid:
+
+```math
+\nu_u = c_\nu h^3, \qquad
+\nu_\psi = \frac{\nu_u}{\mathrm{Pr}_t} ,
+```
+
+where ``c_\nu`` is the `vorticity_hyperdiffusion_coefficient`, with default
+0.1857 in units of m s⁻¹, and ``\mathrm{Pr}_t`` is the
+`hyperdiffusion_prandtl_number`, with default 0.2. A Prandtl number below one
+damps scalars more strongly than vorticity; with these defaults, five times as
+strongly.
+
+Setting `hyperdiff` to `CAM_SE` selects preset coefficients matching the
+hyperviscosity of [Lauritzen2018](@cite) instead; setting it to `~` disables
+hyperdiffusion entirely.
+
+## Where this is implemented
+
+| Concept                     | Source                                                                                                                                    |
+|:--------------------------- |:----------------------------------------------------------------------------------------------------------------------------------------- |
+| Coefficients and cache      | [src/prognostic_equations/hyperdiffusion.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/hyperdiffusion.jl) |
+| `Hyperdiffusion` model type | [`ClimaAtmos.Hyperdiffusion`](@ref)                                                                                                       |
+| Operators used              | [Discretization and Operators](discretization.md)                                                                                         |
+| Parameter values            | [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl)                                                                                 |
+
+The relevant configuration keys are `hyperdiff`,
+`vorticity_hyperdiffusion_coefficient`, `hyperdiffusion_prandtl_number`, and
+`divergence_damping_factor`; see
+[Configuration Options](configuration_options.md).

--- a/docs/src/implicit_solver.md
+++ b/docs/src/implicit_solver.md
@@ -1,406 +1,286 @@
 # Implicit Solver
 
-The state ``Y`` is evolved using a split implicit-explicit (IMEX) timestepping
-scheme, which separates the tendency ``T(Y) = \partial Y/\partial t`` into
-implicit (fast) and explicit (slow) components,
+This page documents the solve at the heart of the timestepping split introduced
+in [Discretization and Operators](discretization.md): the vertical terms of the
+[governing equations](equations.md) are treated implicitly, and this is how that
+implicit system is solved.
+
+## The implicit equation
+
+The tendency ``T(Y) = \partial Y / \partial t`` is split into an implicit
+(fast) and an explicit (slow) part,
 
 ```math
 T(Y) = T_{imp}(Y) + T_{exp}(Y).
 ```
 
-For an implicit step from time ``t`` to ``t + \Delta t``, we begin with the
-state ``Y_{prev}`` from the explicit step at time ``t`` (which also includes
-information from all previous times before ``t``), and we find a state ``Y``
-that solves the implicit equation
+An implicit step starts from a state ``Y_{prev}``, assembled by the timestepper
+from the explicit stages, and looks for a state ``Y`` that satisfies
 
 ```math
-Y = Y_{prev} + \Delta t * T_{imp}(Y),
+Y = Y_{prev} + \Delta t \, T_{imp}(Y).
 ```
 
-where ``\Delta t * T_{imp}(Y)`` is a linear approximation of the state change
-due to the implicit tendency between times ``t`` and ``t + \Delta t``. Solving
-this equation amounts to finding a root of the residual function
+Equivalently, ``Y`` is a root of the residual
 
 ```math
-R(Y) = Y_{prev} + \Delta t * T_{imp}(Y) - Y,
+R(Y) = Y_{prev} + \Delta t \, T_{imp}(Y) - Y.
 ```
 
-since any state ``Y`` that satisfies ``R(Y) = 0`` is consistent with the linear
-approximation of the implicit state change.
+A higher-order Runge–Kutta scheme takes several stages per step, and the
+coefficient multiplying the tendency in stage ``i`` is ``\Delta t \gamma_i``
+rather than ``\Delta t``, where ``\gamma_i`` is the diagonal implicit
+coefficient of the tableau. Everything below carries over with ``\Delta t``
+replaced by ``\Delta t \gamma_i``; in the code this product is the argument
+`dtγ`.
 
-*Note:* When we use a higher-order timestepping scheme, the full step
-``\Delta t`` is divided into several sub-steps or "stages", where the duration
-of stage ``i`` is ``\Delta t * γ_i`` for some constant ``γ_i`` between 0 and 1.
-
-To find the root of ``R(Y)`` using Newton's method, we must specify the
-derivative ``\partial R/\partial Y``. Since ``Y_{prev}`` does not depend on
-``Y`` (it is only a function of the state at or before time ``t``), this
-derivative is given by
+The root is found with Newton's method. Because ``Y_{prev}`` does not depend on
+``Y``, the derivative of the residual is
 
 ```math
-R'(Y) = \Delta t * \frac{\partial T_{imp}}{\partial Y} - I.
+R'(Y) = \Delta t \, \frac{\partial T_{imp}}{\partial Y} - I .
 ```
 
-For each state ``Y``, Newton's method computes an update ``\Delta Y`` that
-brings ``R(Y)`` closer to 0 by solving the linear equation
+Starting from ``Y[0] = Y_{prev}``, each Newton iteration evaluates the residual
+and its derivative, solves the linear system
 
 ```math
-R'(Y) * \Delta Y = R(Y).
+R'(Y[k]) \, \Delta Y[k] = R(Y[k]) ,
 ```
 
-*Note:* This equation comes from assuming that there is some ``\Delta Y``
-for which ``R(Y - \Delta Y) = 0`` and approximating
+and updates ``Y[k+1] = Y[k] - \Delta Y[k]``. The update follows from the
+linearization ``R(Y - \Delta Y) \approx R(Y) - R'(Y) \Delta Y``, set to zero.
+
+By default a single iteration is taken (`max_newton_iters_ode`), so ``Y[1]`` is
+the solution of the implicit step. Iterating to a tolerance instead is available
+through `use_newton_rtol` and `newton_rtol`. The linear system is solved
+directly by default; setting `use_krylov_method` solves it instead with a
+Jacobian-free Krylov method, which forms Jacobian-vector products by finite
+differences and uses the Jacobian below as a left preconditioner.
+
+## Jacobian algorithms
+
+The matrix ``\partial R / \partial Y`` is held in a
+[`ClimaAtmos.Jacobian`](@ref), and the method used to fill it and to solve its
+linear system is a [`ClimaAtmos.JacobianAlgorithm`](@ref). Three are available:
+
+| Algorithm                                 | Entries from                     | Selected by                                 |
+|:----------------------------------------- |:-------------------------------- |:------------------------------------------- |
+| [`ClimaAtmos.ManualSparseJacobian`](@ref) | Analytically derived derivatives | default                                     |
+| [`ClimaAtmos.AutoSparseJacobian`](@ref)   | Automatic differentiation        | `use_auto_jacobian: true`                   |
+| [`ClimaAtmos.AutoDenseJacobian`](@ref)    | Automatic differentiation        | `use_dense_jacobian: true` (takes priority) |
+
+`update_jacobian_every` controls how often the matrix is refreshed — once per
+linear solve (`"solve"`, the default), once per stage (`"stage"`), or once per
+timestep (`"dt"`).
+
+### Manual differentiation
+
+Assumptions about the physical significance of each block in the Jacobian (see
+[Yatunin2026](@cite), Appendix F) give a sparse matrix structure that admits an
+efficient linear solver. The time and memory needed to build the matrix, and the
+time needed to solve with it, then all scale linearly with the number ``N`` of
+values in a column's state vector.
+
+The [`ClimaAtmos.ManualSparseJacobian`](@ref) fills the nonzero entries with
+approximate derivatives, derived analytically from the expressions that compute
+the implicit tendency, and zeroes out blocks belonging to processes that are not
+treated implicitly. Which blocks are nonzero follows from the `AtmosModel` —
+the presence of topography, the diffusion mode, and the prognostic variables in
+``Y`` — and is fixed when the cache is built, not configured by the user.
+
+When grid-scale diffusion is implicit, the linear solve is itself approximate;
+`approximate_linear_solve_iters` sets how many iterations it takes.
+
+### Automatic differentiation
+
+The alternative is to differentiate the tendency automatically, by replacing
+every real number in the prognostic state with a dual number
 
 ```math
-R(Y - \Delta Y) \approx R(Y) - R'(Y) * \Delta Y.
+x^D = x + \hat{x}^1 \varepsilon_1 + \hat{x}^2 \varepsilon_2 + \ldots +
+      \hat{x}^n \varepsilon_n ,
 ```
 
-After initializing ``Y`` to ``Y[0] = Y_{prev}``, Newton's method executes the
-following steps:
-
- 1. Compute the residual ``R(Y[0])`` and its derivative ``R'(Y[0])``.
- 2. Solve ``R'(Y[0]) * \Delta Y[0] = R(Y[0])`` for ``\Delta Y[0]``.
- 3. Update ``Y`` to ``Y[1] = Y[0] - \Delta Y[0]``.
-
-If the number of Newton iterations is limited to 1, this new value of ``Y`` is
-taken to be the solution of the implicit equation. Otherwise, this sequence of
-steps is repeated, i.e., ``\Delta Y[1]`` is computed and ``Y`` is updated to
-``Y[2] = Y[1] - \Delta Y[1]``, then ``\Delta Y[2]`` is computed and ``Y`` is
-updated to ``Y[3] = Y[2] - \Delta Y[2]``, and so on until the maximum number of
-iterations is reached.
-
-## Jacobian Algorithms
-
-The derivative ``\partial R/\partial Y`` is represented as a
-[`ClimaAtmos.Jacobian`](@ref), and the method for computing it and solving its
-linear equation is given by a [`ClimaAtmos.JacobianAlgorithm`](@ref).
-
-### Manual Differentiation
-
-By making certain assumptions about the physical significance of each block in
-the Jacobian (see [Yatunin2026](@cite), Appendix F), we can obtain a sparse matrix
-structure that allows for an efficient linear solver. Specifically, the time and
-memory required to compute the sparse matrix and the time required to run the
-linear solver all scale linearly with the number of values in each column's
-state vector.
-
-To populate the nonzero entries of this sparse matrix, the
-[`ClimaAtmos.ManualSparseJacobian`](@ref) specifies approximate derivatives for
-all possible configurations of the atmosphere model, which are analytically
-derived from expressions used to compute the implicit tendency. This algorithm
-zeroes out blocks corresponding to processes that are not treated implicitly;
-which blocks are nonzero is derived automatically from the `AtmosModel`
-(topography and the diffusion mode) when the cache is built, rather than being
-configured by the user.
-
-### Automatic Differentiation
-
-Another way to compute the Jacobian is through automatic differentiation. This
-involves replacing all real numbers in the prognostic state with dual numbers of
-the form
+where ``x`` and ``\hat{x}^i`` are real and the ``\varepsilon_i`` are
+infinitesimals satisfying ``\varepsilon_i \varepsilon_j = 0``. Passing
+``x + \hat{x} \varepsilon`` to a function ``f`` yields
 
 ```math
-x^D =
-x + \hat{x}^1 * \varepsilon_1 + \hat{x}^2 * \varepsilon_2 + \ldots +
-    \hat{x}^n * \varepsilon_n,
+f(x + \hat{x} \varepsilon) =
+f(x) + \frac{\partial f(x)}{\partial x} \hat{x} \varepsilon ,
 ```
 
-where
-
-  - ``x`` and ``\hat{x}^i`` are real numbers, and
-  - ``\varepsilon_i`` is an infinitesimal number with the property that
-    ``\varepsilon_i * \varepsilon_j = 0``.
-
-Passing the dual number ``x + \hat{x} * \varepsilon`` to any function ``f(x)``
-yields
+and the same holds componentwise for a vector ``X`` of length ``N`` seeded with
+an ``N \times n`` matrix ``\hat{X}``:
 
 ```math
-f(x + \hat{x} * \varepsilon) =
-f(x) + \frac{\partial f(x)}{\partial x} * \hat{x} * \varepsilon.
+f(X + \hat{X} \mathcal{E}) =
+f(X) + \frac{\partial f(X)}{\partial X} \hat{X} \mathcal{E} ,
+\quad \mathcal{E} = (\varepsilon_1, \ldots, \varepsilon_n)^T .
 ```
 
-By extension, passing the dual vector ``X + \hat{X} * \mathcal{E}``, where
-
-```math
-X =
-\begin{pmatrix}
-    X_1 \\
-    X_2 \\
-    \vdots \\
-    X_N
-\end{pmatrix},
-\mathcal{E} =
-\begin{pmatrix}
-    \varepsilon_1 \\
-    \varepsilon_2 \\
-    \vdots \\
-    \varepsilon_n
-\end{pmatrix},
-\textrm{ and }
-\hat{X} =
-\begin{pmatrix}
-    \hat{X}^1_1 & \hat{X}^2_1 & \ldots & \hat{X}^n_1 \\
-    \hat{X}^1_2 & \hat{X}^2_2 & \ldots & \hat{X}^n_2 \\
-    \vdots & \vdots & \ddots & \vdots \\
-    \hat{X}^1_N & \hat{X}^2_N & \ldots & \hat{X}^n_N
-\end{pmatrix},
-```
-
-to any function ``f(X)`` yields
-
-```math
-f(X + \hat{X} * \mathcal{E}) =
-f(X) + \frac{\partial f(X)}{\partial X} * \hat{X} * \mathcal{E}.
-```
-
-If the dual vector is
-
-```math
-Y^D = Y + P * \mathcal{E},
-```
-
-passing it to the implicit tendency ``T_{imp}(Y)`` yields the dual tendency
+Seeding the state as ``Y^D = Y + P \mathcal{E}`` and passing it to the implicit
+tendency gives
 
 ```math
 T_{imp}^D = T_{imp}(Y^D) =
-T_{imp}(Y) + \frac{\partial T_{imp}(Y)}{\partial Y} * P * \mathcal{E},
+T_{imp}(Y) + \frac{\partial T_{imp}(Y)}{\partial Y} P \mathcal{E} .
 ```
 
-so ``P`` acts as a right preconditioner for ``\partial T_{imp}(Y)/\partial Y``.
-The tendency derivative can be extracted from the ``\varepsilon`` components of
-the dual tendency by inverting the preconditioner, after which a multiplication
-by ``\Delta t`` and subtraction of ``I`` gives the full Jacobian matrix
-``\partial R(Y)/\partial Y``.
+The ``\varepsilon`` components of ``T_{imp}^D`` therefore hold the compressed
+derivative ``(\partial T_{imp} / \partial Y) P``, not the derivative itself. The
+seed matrix ``P`` is chosen so that the individual entries can be recovered from
+that product; multiplying by ``\Delta t`` and subtracting ``I`` then gives
+``\partial R / \partial Y``. The two algorithms below differ only in the choice
+of ``P``.
 
-To be more precise, the implicit tendency is evaluated in two function calls.
-The first function ``p_{imp}(Y)`` computes cached values that are treated
-implicitly, and the second function ``T_{imp}(Y, p_{imp})`` computes the
-tendency itself. Further generalizing the property of
-``\varepsilon_i * \varepsilon_j = 0`` to functions of two vectors, passing
-``A + \hat{A} * \mathcal{E}`` and ``B + \hat{B} * \mathcal{E}`` to any function
-``f(A, B)`` yields
-
-```math
-f(A + \hat{A} * \mathcal{E}, B + \hat{B} * \mathcal{E}) =
-f(A, B) +
-\left(
-    \frac{\partial f(A, B)}{\partial A} * \hat{A} +
-    \frac{\partial f(A, B)}{\partial B} * \hat{B}
-\right) * \mathcal{E}.
-```
-
-So, the dual tendency ``T_{imp}^D`` is computed in two steps, first evaluating
-``p_{imp}(Y^D)`` to get
-
-```math
-p_{imp}^D =
-p_{imp}(Y) + \frac{\partial p_{imp}(Y)}{\partial Y} * P * \mathcal{E},
-```
-
-and then evaluating ``T_{imp}(Y^D, p_{imp}^D)`` to get
-
-```math
-T_{imp}^D =
-T_{imp}(Y, p_{imp}(Y)) +
-\left(
-    \frac{\partial T_{imp}(Y, p_{imp}(Y))}{\partial Y} +
-    \frac{\partial T_{imp}(Y, p_{imp}(Y))}{\partial p_{imp}(Y)} *
-    \frac{\partial p_{imp}(Y)}{\partial Y}
-\right) * P * \mathcal{E}.
-```
-
-In other words, the single-argument tendency derivative
-``\partial T_{imp}(Y)/\partial Y`` is shorthand for
+The tendency is evaluated in two calls rather than one: ``p_{imp}(Y)`` computes
+the cached quantities that are treated implicitly, and ``T_{imp}(Y, p_{imp})``
+computes the tendency from them. Dual numbers propagate through both, so
+evaluating ``p_{imp}(Y^D)`` and then ``T_{imp}(Y^D, p_{imp}^D)`` accumulates the
+chain rule automatically:
 
 ```math
 \frac{\partial T_{imp}(Y)}{\partial Y} =
 \frac{\partial T_{imp}(Y, p_{imp}(Y))}{\partial Y} +
-\frac{\partial T_{imp}(Y, p_{imp}(Y))}{\partial p_{imp}(Y)} *
-\frac{\partial p_{imp}(Y)}{\partial Y}.
+\frac{\partial T_{imp}(Y, p_{imp}(Y))}{\partial p_{imp}(Y)}
+\frac{\partial p_{imp}(Y)}{\partial Y} .
 ```
 
-#### Dense Automatic Differentiation
+The single-argument notation ``\partial T_{imp}(Y)/\partial Y`` used above is
+shorthand for this sum.
 
-The simplest form of automatic differentiation uses a dense representation of
-the tendency matrix. When the number of ``\varepsilon`` components ``n`` equals
-the number ``N`` of values in each column's state vector, this involves
-setting ``P`` to the ``N \times N`` identity matrix, so that the dual
-counterpart of each column's state vector is
+### Dense automatic differentiation
 
-```math
-Y^D = Y + \mathcal{E} =
-\begin{pmatrix}
-    Y_1 + \varepsilon_1 \\
-    Y_2 + \varepsilon_2 \\
-    \vdots \\
-    Y_N + \varepsilon_N
-\end{pmatrix}.
-```
+The simplest choice is ``P = I``, the ``N \times N`` identity, so that
+``Y^D_i = Y_i + \varepsilon_i``. The coefficient of ``\varepsilon_j`` in the
+``i``-th component of ``T_{imp}^D`` is then the entry in row ``i`` and column
+``j`` of ``\partial T_{imp} / \partial Y``, read off directly.
 
-Evaluating ``T_{imp}(Y)`` on this input yields the dual tendency
+Carrying ``n = N`` dual components at once is expensive to compile and often
+slow to run, so [`ClimaAtmos.AutoDenseJacobian`](@ref) splits them into
+partitions of ``n < N`` components, with ``n = 32`` by default. Each partition
+sets ``P`` to an ``N \times n`` slice of the identity and recovers the
+corresponding slice of the derivative matrix; the partitions together give the
+full matrix.
 
-```math
-T_{imp}^D = T_{imp}(Y) + \frac{\partial T_{imp}(Y)}{\partial Y} * \mathcal{E} =
-\begin{pmatrix}
-    T_{imp, 1}(Y) + \frac{\partial T_{imp, 1}(Y)}{\partial Y_1} * \varepsilon_1 +
-    \frac{\partial T_{imp, 1}(Y)}{\partial Y_2} * \varepsilon_2 + \ldots +
-    \frac{\partial T_{imp, 1}(Y)}{\partial Y_N} * \varepsilon_N \\
-    T_{imp, 2}(Y) + \frac{\partial T_{imp, 2}(Y)}{\partial Y_1} * \varepsilon_1 +
-    \frac{\partial T_{imp, 2}(Y)}{\partial Y_2} * \varepsilon_2 + \ldots +
-    \frac{\partial T_{imp, 2}(Y)}{\partial Y_N} * \varepsilon_N \\
-    \vdots \\
-    T_{imp, N}(Y) + \frac{\partial T_{imp, N}(Y)}{\partial Y_1} * \varepsilon_1 +
-    \frac{\partial T_{imp, N}(Y)}{\partial Y_2} * \varepsilon_2 + \ldots +
-    \frac{\partial T_{imp, N}(Y)}{\partial Y_N} * \varepsilon_N
-\end{pmatrix},
-```
+Storing ``\partial R / \partial Y`` densely costs time and memory proportional
+to ``N^2``. The linear system is solved by
+[LU factorization](https://en.wikipedia.org/wiki/LU_decomposition), factorized
+and back-substituted in parallel across columns; forming the factors costs
+``N^3`` and applying them ``N^2``.
 
-where the entry in the ``i``-th row and ``j``-th column of
-``\partial T_{imp}(Y)/\partial Y`` is the coefficient of ``\varepsilon_j`` in
-the ``i``-th value of ``T_{imp}^D``.
+This algorithm is a reference rather than a production choice: it makes no
+assumptions about sparsity, so it is the standard against which the two sparse
+algorithms are checked.
 
-When there are many values in each column, setting ``n = N`` can lead to
-excessive compilation latency, and often also poor performance. To compensate
-for this, the [`ClimaAtmos.AutoDenseJacobian`](@ref) splits the ``N`` values in
-each column's state vector into partitions of length ``n < N``, where the
-default value of ``n`` is 32. The partitioning is implemented by setting ``P``
-to ``N \times n`` slices of the identity matrix (with the last slice possibly
-containing fewer than ``n`` columns), so that ``T_{imp}^D`` only contains an
-``N \times n`` slice of the matrix ``\partial T_{imp}(Y)/\partial Y``. Computing
-``T_{imp}^D`` for all partitions yields the full derivative matrix.
+### Sparse automatic differentiation
 
-With ``\partial R(Y)/\partial Y`` specified as a dense matrix, the time and
-memory required to compute it scale in proportion to ``N^2``. The linear
-equation ``R'(Y) * \Delta Y = R(Y)`` is solved by
-[LU factorization](https://en.wikipedia.org/wiki/LU_decomposition), where the
-time required to compute the L and U factors scales as ``N^3``. After the
-factors are computed, the time required to invert them scales as ``N^2``.
+Introducing sparsity only to avoid the LU factorization would not help much. The
+dense matrix could be copied into the sparse structure and inverted with the
+linear solver that scales as ``N``, which is faster on CPUs, but the ``N^2``
+memory of the dense evaluation would remain — and on GPUs, where memory traffic
+dominates, that is what matters.
 
-#### Sparse Automatic Differentiation
+Making the memory scale linearly with ``N`` requires a smaller seed matrix. With
+``P`` an ``N \times c`` column coloring matrix, a binary matrix in which a 1 in
+row ``i`` and column ``j`` assigns the derivative column of ``Y_i`` to color
+``j``, the compressed product ``(\partial T_{imp} / \partial Y) P`` sums the
+columns sharing each color. Two entries ``Y_a`` and ``Y_b`` of the state can
+share a color only if ``\partial T_{imp,i} / \partial Y_a`` and
+``\partial T_{imp,i} / \partial Y_b`` are never both nonzero in the same row
+``i``; the smallest ``c`` for which this holds makes the compression lossless,
+and every entry can be recovered exactly.
 
-The `AutoDenseJacobian` can be sped up by copying its entries into the
-`ManualSparseJacobian`. This allows the matrix to be inverted using an efficient
-linear solver whose runtime scales in proportion to ``N``, rather than an LU
-factorization that scales as ``N^3``. Although this improves performance on
-CPUs, it still results in poor runtimes compared to the sparse representation.
-This is especially the case on GPUs, where performance is primarily determined
-by memory requirements. Introducing sparsity only to avoid the factorization
-does not reduce the memory requirements that scale as ``N^2``.
+The requirement can be relaxed: ``Y_a`` and ``Y_b`` may share a color if their
+derivatives never have comparable magnitudes. Summing a derivative with one that
+is negligible beside it leaves the first essentially unchanged. When the two are
+comparable, the sum approximates neither, and they need distinct colors.
 
-To make the memory requirements of automatic differentiation scale linearly
-with ``N``, ``P`` can be set to an ``N \times c`` column coloring matrix
-for the tendency derivative, so that ``c`` is the smallest value for which
-``\partial T_{imp}(Y)/\partial Y * P`` is a lossless representation of the
-nonzero entries in ``\partial T_{imp}(Y)/\partial Y``. Specifically, ``P`` is a
-binary matrix, where a 1 in row ``i`` and column ``j`` means that the tendency
-derivative column corresponding to ``Y_i`` is assigned color ``j``. Ideally,
-``P`` should be chosen so that no two values ``Y_a`` and ``Y_b`` can be assigned
-the same color if ``\partial T_{imp, i}(Y)/\partial Y_a`` and
-``\partial T_{imp, i}(Y)/\partial Y_b`` are both nonzero in any row ``i``. For
-any such matrix ``P``, ``\partial T_{imp}(Y)/\partial Y * P`` uniquely
-represents every nonzero value in the derivative matrix, so the entries of the
-derivative matrix can be extracted from it without any errors.
+Most of the derivatives the `ManualSparseJacobian` ignores are negligibly small
+and can safely be left out of the coloring sparsity pattern. Some, though, are
+ignored for a different reason and are not small. Derivatives with respect to
+`ρ` tend to be much larger than derivatives with respect to `ρe_tot` — adding a
+kilogram of air to a cubic meter does more than adding a joule of energy — but
+in a simulation, changes of `δρ = 1 kg/m^3` are correspondingly rarer than
+changes of `δρe_tot = 1 J/m^3`. The disparity in the perturbations outweighs the
+disparity in the derivatives, so those entries can be dropped from the linear
+solve even though they are large.
 
-This requirement on ``P`` can be loosened so that ``Y_a`` and ``Y_b`` can still
-be assigned the same color as long as ``\partial T_{imp, i}(Y)/\partial Y_a``
-and ``\partial T_{imp, i}(Y)/\partial Y_b`` do not have similar magnitudes.
-If the derivative with respect to ``Y_b`` is negligibly small compared to the
-derivative with respect to ``Y_a``, then assigning ``Y_b`` the same color as
-``Y_a`` might not be an issue, since this will amount to replacing the
-derivative ``\partial T_{imp, i}(Y)/\partial Y_a`` in ``T_{imp}^D`` with the sum
-``\partial T_{imp, i}(Y)/\partial Y_a + \partial T_{imp, i}(Y)/\partial Y_b``,
-which should be approximately equal to ``\partial T_{imp, i}(Y)/\partial Y_a``.
-When the derivatives with respect to ``Y_a`` and ``Y_b`` have comparable
-magnitudes, though, the sum can no longer be used to approximate either of them,
-and the only workaround is to assign them distinct colors.
+They cannot be dropped from the coloring. Every non-negligible derivative has to
+appear in the sparsity pattern used to assign colors, whether or not it is used
+in the solve; otherwise it pollutes the entries that share its color. Including
+them sometimes costs additional colors and sometimes fits within the existing
+ones.
 
-Most of the derivatives that are ignored by the `ManualSparseJacobian` are
-negligibly small, so they can safely be excluded from the sparsity pattern used
-to assign column colors. However, some of the derivatives can be ignored based
-on the inputs to the linear equation in which they are used, but they do not
-have small magnitudes. For example, derivatives with respect to `ρ` tend to be
-much larger than derivatives with respect to `ρe_tot`, since adding one
-kilogram of air to a cubic meter will typically have a more significant effect
-than adding one Joule of energy. In physical simulations, though, changes of
-`δρ = 1 kg/m^3` tend to be much less common than changes of `δρe_tot = 1 J/m^3`.
-Generally, the amount by which `δρ` is smaller than `δρe_tot` exceeds the amount
-by which derivatives with respect to `ρ` are larger than derivatives with
-respect to `ρe_tot`, which means that those derivatives can be ignored when
-solving the linear equation.
+[`ClimaAtmos.AutoSparseJacobian`](@ref) takes its sparsity structure and its
+linear solver from a `ManualSparseJacobian`, and colors that structure with
+[SparseMatrixColorings.jl](https://github.com/JuliaDiff/SparseMatrixColorings.jl).
+Its memory scales as ``N c``, which can still exceed GPU memory when ``c`` is
+large, so the ``c`` colors are split into partitions of ``n < c``. On GPUs the
+number of partitions is the smallest for which the result fits, allowing twice
+the memory currently free to leave room for garbage collection; on CPUs a single
+partition is always used.
 
-To avoid introducing errors to ``\partial T_{imp}(Y)/\partial Y``, the locations
-of all non-negligible derivatives must be included in the sparsity pattern for
-assigning column colors, even if those derivatives can be ignored when solving
-the linear equation. In many cases, this requires additional colors, but
-sometimes the coloring can be extended to include these derivatives
-without using more colors.
+To keep the entries clean, the algorithm adds "padding bands" to the coloring
+sparsity pattern, covering the large-but-ignored derivatives described above.
+The per-block defaults handle most cases, but new variables and tendencies may
+need more. When the bands that are needed are not known in advance,
+`auto_jacobian_padding_bands` adds a fixed number to every block.
 
-The memory requirements of this algorithm scale as ``N * c``, which can limit
-the range of resolutions for which the sparse representation fits in GPU memory
-when ``c`` is large. To avoid this, the [`ClimaAtmos.AutoSparseJacobian`](@ref)
-splits the ``c`` colors into partitions of length ``n < c``. Each partition sets
-``P`` to an ``N \times n`` slice of the column coloring matrix, so that
-``T_{imp}^D`` contains an ``N \times n`` slice of the tendency derivative's
-sparse representation. Computing ``T_{imp}^D`` for all partitions yields the
-full tendency derivative. On GPUs, the number of partitions is the smallest
-value for which the sparse representation fits in GPU memory (using a limit of
-twice the memory that is currently free); on CPUs, it is assumed that the sparse
-representation will always fit in memory, so only a single partition is used.
+## Debugging sparse automatic differentiation
 
-When running the `AutoSparseJacobian`, ensure that its entries are not
-polluted by non-negligible derivatives from ignored blocks (or
-from ignored bands within nonzero blocks). Whenever debugging reveals a
-difference between the nonzero values generated by sparse and dense automatic
-differentiation, ignored derivatives are almost always at fault. The default
-"padding bands" added to the coloring sparsity pattern should handle most
-non-negligible derivatives (such as the aforementioned derivatives with respect
-to `ρ`), but new variables and tendencies may require additional padding bands.
-For cases where the new padding bands that need to be added are not known in
-advance, the `AutoSparseJacobian` also has an option to add a fixed number of
-padding bands to every Jacobian block.
+Whenever the sparse and dense algorithms disagree on a nonzero entry, an ignored
+derivative is almost always the cause.
 
-##### Debugging Sparse Automatic Differentiation Errors
+Setting `debug_jacobian: true` prints block-by-block summary tables comparing
+the available algorithms in the first column of the final state. The tables come
+from `print_jacobian_summary` in
+[post_processing/jacobian_summary.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/post_processing/jacobian_summary.jl),
+which [.buildkite/ci_driver.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/.buildkite/ci_driver.jl)
+calls after the run; they are skipped when `use_dense_jacobian` is `true`, since
+the dense matrix is the reference. Magnitudes are reported per block as an RMS,
+both unnormalized and normalized to units of s⁻¹.
 
-If setting `use_auto_jacobian = true` makes a simulation unstable or leads to
-inaccurate results, set `debug_jacobian = true` and compare the different
-approximations of each Jacobian block (the block-by-block summary tables are
-printed by `print_jacobian_summary` when running a simulation,
-and are skipped when `use_dense_jacobian = true`):
+If `use_auto_jacobian: true` makes a simulation unstable or inaccurate, work
+through the tables as follows.
 
-  - When a block differs between two algorithms, check whether the difference
-    is significant (i.e., whether its normalized magnitude exceeds `1/dt`).
+  - When a block differs between two algorithms, check whether the difference is
+    significant, that is, whether its normalized magnitude exceeds ``1/\Delta t``.
   - If the `AutoSparseJacobian` and `ManualSparseJacobian` agree on a block but
-    significantly differ from the `AutoDenseJacobian`:
-      + Add bands that are missing from the sparsity pattern in this block to the
-        `ManualSparseJacobian`, which also adds them to the `AutoSparseJacobian`.
-  - If the `AutoSparseJacobian` and `AutoDenseJacobian` agree on a block but
-    significantly differ from the `ManualSparseJacobian`, and if the manual
-    approximation is more accurate than the automatic value:
-      + Determine which tendency term's derivative is responsible for the erroneous
-        automatic value.
-      + If possible, rewrite the tendency term so that it generates a more accurate
-        derivative using dual numbers.
-      + If this is not possible, add a new method for the tendency term that
-        specializes on dual numbers with the tag [`ClimaAtmos.Jacobian`](@ref),
-        overwriting the derivative automatically generated by `ForwardDiff.jl`.
-  - Otherwise, if the `AutoSparseJacobian` and `AutoDenseJacobian` significantly
-    differ for a block:
-      + Set `auto_jacobian_padding_bands` to a large number, and check whether this
-        discrepancy between the sparse and dense values disappears.
-      + If padding bands do not resolve the discrepancy:
-          * Add non-padding bands that are missing from this block to the
-            `ManualSparseJacobian`, which also adds them to the `AutoSparseJacobian`.
-      + If padding bands resolve the discrepancy:
-          * Find all differences between the sparsity patterns of the sparse and dense
-            Jacobians in the same row as this block.
-          * If any blocks (or bands within a block) are missing from this block's row
-            of the sparse Jacobian, check whether they have unnormalized magnitudes
-            that are significant in comparison to this block.
-          * Extend the default padding bands of the `AutoSparseJacobian` so they cover
-            every significant unnormalized value that could be affecting this block,
-            and reset `auto_jacobian_padding_bands` to use the default padding bands.
+    differ significantly from the `AutoDenseJacobian`, add the bands missing
+    from that block's sparsity pattern to the `ManualSparseJacobian`; the
+    `AutoSparseJacobian` inherits them.
+  - If the two automatic algorithms agree but differ significantly from the
+    `ManualSparseJacobian`, and the manual value is the more accurate one, find
+    the tendency term whose derivative is at fault. Rewrite the term so that it
+    differentiates accurately if possible; otherwise add a method for it that
+    specializes on dual numbers tagged with [`ClimaAtmos.Jacobian`](@ref),
+    overriding what `ForwardDiff.jl` generates.
+  - If only the sparse and dense automatic algorithms differ, set
+    `auto_jacobian_padding_bands` to a large number and check whether the
+    discrepancy disappears.
+      + If it does not, the block is missing non-padding bands; add them to the
+        `ManualSparseJacobian`.
+      + If it does, compare the sparse and dense sparsity patterns across the
+        whole row containing this block. Any block or band missing from the
+        sparse pattern whose unnormalized magnitude is significant beside this
+        block is a candidate. Extend the default padding bands to cover it, then
+        reset `auto_jacobian_padding_bands` to the defaults.
 
-## See also
+## Where this is implemented
 
-  - [Yatunin2026](@cite), Section 5 and Appendix F
-  - [Documentation for ClimaTimeSteppers.jl](https://clima.github.io/ClimaTimeSteppers.jl/dev/algorithm_formulations/ode_solvers/)
+| Concept                    | Source                                                                                                                                                                                                                                                                     |
+|:-------------------------- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Implicit tendency          | [src/prognostic_equations/implicit/implicit_tendency.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/implicit_tendency.jl)                                                                                                          |
+| Jacobian wrapper and types | [src/prognostic_equations/implicit/jacobian.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/jacobian.jl)                                                                                                                            |
+| Manual sparse algorithm    | [src/prognostic_equations/implicit/manual_sparse_jacobian.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/manual_sparse_jacobian.jl)                                                                                                |
+| Automatic algorithms       | [auto_dense_jacobian.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/auto_dense_jacobian.jl), [auto_sparse_jacobian.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/auto_sparse_jacobian.jl) |
+| Dual-number support        | [src/prognostic_equations/implicit/autodiff_utils.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/prognostic_equations/implicit/autodiff_utils.jl)                                                                                                                |
+| Timestepper interface      | [ClimaTimeSteppers.jl](https://clima.github.io/ClimaTimeSteppers.jl/stable/)                                                                                                                                                                                               |
+
+The tendency split itself is described in
+[Discretization and Operators](discretization.md), and the representation of
+time in [Integer Time (ITime)](itime.md). The configuration keys named above are
+listed in [Configuration Options](configuration_options.md).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ simulation in Cartesian domains to global weather and climate simulation on
 the sphere [Yatunin2026](@cite).
 
 The model can be run from the Julia REPL, with no namelists or batch scripts
-required; a first global simulation takes three lines of code (see
+required; a first simulation takes a few lines of code (see
 [Your First Simulation](first_simulation.md)).
 
 ## What the model does
@@ -32,8 +32,8 @@ required; a first global simulation takes three lines of code (see
     scheme), avoids assumptions of scale separation that become inadequate as
     resolved scales approach the scales of parameterized processes such as
     atmospheric turbulence and convection. As resolution increases, the
-    parameterized transport diminishes and hands over to the resolved flow.
-  - **Built for calibration with data.** All model parameters live in a
+    parameterized transport diminishes and the resolved flow takes over.
+  - **Built for calibration with data.** All model parameters are defined in a
     central repository, [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl),
     and CliMA's calibration tools tune parameters against data, whether those
     are output from high-resolution simulations or Earth observations from space and from the ground.
@@ -92,7 +92,7 @@ matches yours:
   - **Explanation**: the science and numerics behind the model.
 
       + [The CliMA ecosystem](ecosystem.md) -- how ClimaAtmos composes the CliMA packages
-      + Dynamics & numerics: [governing equations](equations.md), [implicit solver](implicit_solver.md), [integer time (ITime)](itime.md)
+      + Dynamics & numerics: [thermodynamics](thermodynamics.md), [governing equations](equations.md), [discretization and operators](discretization.md), [conservation properties](conservation.md), [hyperdiffusion](hyperdiffusion.md), [model top and sponge layer](sponge.md), [implicit solver](implicit_solver.md), [integer time (ITime)](itime.md)
       + Physics & parameterizations: [PROPHET](edmf_equations.md), [microphysics](microphysics.md), [radiation](radiation.md), [non-orographic gravity-wave drag](non_orographic_gravity_wave.md), [orographic gravity-wave drag](orographic_gravity_wave.md), [ocean surface albedo](surface_albedo.md), [topography](topography.md)
 
   - **Reference**: look-up material.
@@ -100,10 +100,6 @@ matches yours:
       + [API](api.md), [Configuration options](configuration_options.md), [Setups](setups.md), [Column Datasets](column_datasets_reference.md), [Grids](grids.md), [Surface conditions](surface_conditions.md), [Passive tracers](passive_tracers.md), [Trace gases](trace_gases.md), [Available diagnostics](available_diagnostics.md), [Notation](notation.md), [Glossary](glossary.md), [Bibliography](references.md)
 
   - **Developer Guide**: [contributing](contributor_guide.md) and extending the model ([setups](extending_setups.md), [diagnostics](extending_diagnostics.md), [tracers](extending_tracers.md), [column datasets](extending_column_datasets.md), [surface internals](surface_conditions_internals.md))
-
-New here? Start with [Installation](@ref) and [Your First Simulation](@ref), then pick
-the workflow that suits you in [Script vs Config Interface](@ref). For column experiments,
-see [Running Single-Column Cases](@ref).
 
 ClimaAtmos is open source under the Apache 2.0 license. Questions and bug
 reports are welcome on the

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -13,7 +13,7 @@ If you are new to Julia's package manager, the official guides on
 ClimaAtmos is a registered Julia package. To install it, open the REPL, type `]` to enter
 the package manager, and add it:
 
-```Julia-repl
+```julia-repl
 pkg> add ClimaAtmos
 ```
 
@@ -55,8 +55,12 @@ stays unchanged:
 
 ```julia
 import Pkg
-Pkg.add("CUDA")
+Pkg.add("CUDA")   # run in the default environment (plain `julia`, no --project)
+```
 
+Then, in the session that runs the model:
+
+```julia
 import ClimaComms
 ENV["CLIMACOMMS_DEVICE"] = "CUDA"
 ClimaComms.@import_required_backends   # loads CUDA.jl when CLIMACOMMS_DEVICE="CUDA"

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -2,7 +2,7 @@
 
 ClimaAtmos provides two ways to set up and run simulations. Both produce an
 `AtmosSimulation` that is run with `solve_atmos!`; they differ in where the
-configuration lives.
+configuration is written.
 
 The **script API** builds a simulation from Julia keyword arguments:
 `AtmosSimulation{FT}(; grid, model, setup, dt, t_end, ...)`. It is best for
@@ -12,7 +12,7 @@ interactive exploration, notebooks, and programmatic parameter sweeps.
 
 The **config API** reads the simulation from a YAML file:
 `AtmosSimulation(AtmosConfig("config.yml"))`. Every key overrides a default
-from `config/default_configs/default_config.yml`, which makes runs
+from [`config/default_configs/default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml), which makes runs
 reproducible and shareable; it is what the CI pipelines use. See
 [Creating custom configurations](configuration.md) for writing configuration
 files and [Configuration options](configuration_options.md) for the complete
@@ -41,17 +41,23 @@ grid constructors, `AtmosModel`, and `Setups.*`) before being handed to
 |             | `DiagnosticsConfig(; additional = ...)` | `diagnostics:` block                     |
 | Checkpoints | `checkpoint_frequency = 3600`           | `dt_save_state_to_disk: "1hours"`        |
 
-`job_id` is not in `default_config.yml`. In a script it is an
+`job_id` is not in [`default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml). In a script it is an
 `AtmosSimulation` keyword argument; with a configuration file, pass it to
 `AtmosConfig` (`AtmosConfig("f.yml"; job_id = "my_run")`) or set a `job_id:`
 key in the file itself. Given neither, it is derived from the configuration
 file names.
 
-Two caveats. First, the mapping covers each option in isolation: the shipped
+Three caveats. First, the mapping covers each option in isolation: the shipped
 YAML case configurations also set model physics keys (`turbconv`,
-`microphysics_model`, `rad`, ...), so `setup = Setups.Bomex()` alone is not
-equivalent to running `prognostic_edmfx_bomex_column.yml`; in a script, the
+`microphysics_model`, `rad`, ...), the grid and timestep, and sometimes
+parameter overrides (`toml`), so `setup = Setups.Bomex()` alone is not
+equivalent to running [`prognostic_edmfx_bomex_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_bomex_column.yml); in a script, the
 corresponding physics is chosen through `AtmosModel` (or a `CA.Presets`
-constructor). Second, `CA.AtmosSimulation(config)` and
+constructor). Second, the two entry points do not share every default: script
+defaults are the keyword defaults of
+[`AtmosSimulation`](@ref ClimaAtmos.AtmosSimulation), YAML defaults come from
+`default_config.yml`, and the two can differ (for example,
+`update_cache_every` defaults to `"stage"` in the script API and `"step"` in
+YAML). Third, `CA.AtmosSimulation(config)` and
 `CA.get_simulation(config)` are the same operation, the former being an alias
 for the latter; the documentation uses `AtmosSimulation(config)` throughout.

--- a/docs/src/itime.md
+++ b/docs/src/itime.md
@@ -1,43 +1,47 @@
-# ITime
+# Integer Time (ITime)
 
-`ITime`, or _integer time_, is a time type used by CliMA simulations to keep track
-of simulation time. For more information, refer to the
-[TimeManager section](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
-in ClimaUtilities.
+Simulation time in ClimaAtmos is counted in integers, not in floating-point
+seconds. The type that does this is `ITime`, provided by the
+[TimeManager module](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
+of ClimaUtilities and shared across CliMA components.
 
-## Why not use floating point for simulation time?
+For the timestepping scheme that advances the state over that time, see
+[Discretization and Operators](discretization.md) and
+[Implicit Solver](implicit_solver.md).
 
-Due to floating point errors, time can easily be inaccurate or stop incrementing
-(especially with Float32). For instance, consider the example below.
+## Why not floating-point time
+
+Accumulating a timestep in floating point drifts, and eventually stops
+advancing altogether.
+
+Drift appears immediately, because most decimal timesteps are not exactly
+representable in binary:
 
 ```@repl
 0.1 + 0.1 + 0.1 == 0.3
 ```
 
-If `t = 0` and `dt = 0.1`, then the simulation time is already wrong after
-three time steps. This error can accumulate over the course of a simulation.
+With `t = 0` and `dt = 0.1`, the simulation time is already wrong after three
+steps, and the error accumulates over the run.
 
-Additionally, time can stop incrementing as seen below.
+Worse, once the elapsed time is large enough that the timestep falls below the
+spacing between adjacent representable numbers, the addition has no effect at
+all:
 
 ```@repl
 Float32(16777216) + Float32(1) == Float32(16777216)
 ```
 
-In the expression above, if the number represents seconds, then time stops
-incrementing after about 194 days.
+Counting seconds in `Float32`, time stops incrementing after about 194 days.
 
-These issues propagate and lead to problems, as we cannot rely on the
-simulation time being accurate. For instance, dates will always be wrong when
-converting from simulation time to date. Since dates are wrong, the diagnostics
-are saved one timestep later than they should be.
+An inaccurate simulation time is not a cosmetic problem. Dates derived from it
+are wrong, and diagnostics keyed to those dates are written at the wrong times.
+Counting integer periods avoids both failure modes exactly.
 
-`ITime` addresses these issues.
+## How ITime represents time
 
-## Introduction to ITime
-
-`ITime` consists of three fields: `counter`, `period`, and `epoch`. The counter
-keeps track of the number of `period`s since the `epoch` if it exists. See the
-examples below of constructing an `ITime`.
+An `ITime` has three fields: a `counter`, a `period`, and an optional `epoch`.
+The counter holds the number of periods elapsed since the epoch.
 
 ```@repl example
 using ClimaUtilities.TimeManager, Dates # ITime is from ClimaUtilities
@@ -47,12 +51,9 @@ period(x)
 epoch(x)
 ```
 
-An `ITime` behaves like a number with units. Addition and subtraction work as
-expected, but multiplication between `ITime`s is not defined, and division
-results in a number rather than an `ITime`. For more
-information about what functions are available for `ITime`, see the
-[API](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/#TimeManager-API)
-at ClimaUtilities.
+An `ITime` behaves like a number carrying units. Addition and subtraction work
+as expected; multiplying two `ITime`s is undefined, and dividing them gives a
+plain number rather than an `ITime`.
 
 ```@repl example
 y = ITime(60, period = Second(1), epoch = DateTime(2010))
@@ -61,45 +62,50 @@ x - y
 x / y
 ```
 
-## How do I use ITime in my simulation?
+The [TimeManager API](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/#TimeManager-API)
+lists the full set of supported operations.
 
-In this section, we address how to use `ITime` instead of floating point for
-time in a ClimaAtmos simulation and how to write code with `ITime` in mind.
+## Using ITime in a simulation
 
-ClimaAtmos always uses `ITime` for simulation time: the time step, start time,
-and end time are converted to `ITime` when the simulation is built, regardless of
-whether they are provided as strings (e.g. `"30secs"`) or numbers.
+ClimaAtmos always uses `ITime` for simulation time. The timestep, start time,
+and end time are converted when the simulation is built, whether they are given
+as strings such as `"30secs"` or as numbers, and are then promoted to a common
+period.
 
-!!! note "Different results from rounding using `ITime`"
+Two consequences are worth knowing about.
 
-    If `a` is a floating point number and `t` is an `ITime`, then we round
-    `a * t` to the nearest integer for the `counter`, while keeping the same
-    `period` and `epoch` if it exists. As a result, the simulation will run at a
-    resolution of the period used for `ITime`. This can lead to slight
-    differences in the surface conditions and the time dependent forcing and
-    tendencies that explicitly depend on time.
+!!! note "Rounding to the period"
+
+    Multiplying an `ITime` `t` by a floating-point number `a` rounds `a * t` to
+    the nearest integer counter, keeping the same period and epoch. The
+    simulation therefore advances at the resolution of that period, which can
+    slightly change surface conditions and any forcing or tendency that depends
+    explicitly on time.
 
 !!! note "Different results from `float` on `ITime`"
 
-    Using `float` on an `ITime` returns a `Float64`. As such, a simulation
-    running Float32 and a simulation running `ITime` for time and `Float32` for
-    everything else will return different results.
+    `float` on an `ITime` returns a `Float64`. A simulation using `Float32`
+    throughout will therefore not reproduce one using `ITime` for time and
+    `Float32` for everything else.
 
 ## Developing with ITime
 
-Some helpful functions when working with `ITime`s are `float`, `date`, and
-`promote`.
-
-To convert an `ITime` `t` to a number of seconds, use the function `float` on
-`t`. To get the current date, use the function `date` on `t`. Finally, the
-types of two `ITime`s might not match (e.g. the periods are different). To
-handle this, use `promote` on the two `ITime`s. For more information about
-developing with `ITime`, see the
-`ITime` [documentation](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
-in ClimaUtilities.
+Three functions cover most needs. `float(t)` converts an `ITime` to a number of
+seconds, `date(t)` gives the corresponding date, and `promote` reconciles two
+`ITime`s whose periods differ.
 
 ```@repl example
 float(x)
 date(x)
 promote(x, y)
 ```
+
+## Where this is implemented
+
+| Concept                     | Source                                                                                                                    |
+|:--------------------------- |:------------------------------------------------------------------------------------------------------------------------- |
+| `ITime` type and operations | [ClimaUtilities.TimeManager](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)                                  |
+| Conversion at setup         | [src/simulation/AtmosSimulations.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/simulation/AtmosSimulations.jl) |
+
+The `dt`, `t_start`, and `t_end` configuration keys accept either strings or
+numbers; see [Configuration Options](configuration_options.md).

--- a/docs/src/microphysics.md
+++ b/docs/src/microphysics.md
@@ -21,10 +21,12 @@ The cloud condensate and phase partitioning are diagnosed using saturation adjus
 and the 0-moment microphysics provides a sink on total water due to precipitation.
 Precipitation is immediately removed from the computational domain.
 The nonequilibrium 1-moment option expands the state vector by four microphysics tracers:
-cloud liquid water, cloud ice, rain and snow ``(q_{liq}, q_{ice}, q_{rai}, q_{sno})``.
+cloud liquid water, cloud ice, rain and snow ``(q_{liq}, q_{ice}, q_{rai}, q_{sno})``;
+in the state vector these are `ρq_lcl`, `ρq_icl`, `ρq_rai`, and `ρq_sno`.
 The nonequilibrium 2-moment option expands the state vector by six microphysics tracers:
 cloud liquid and cloud ice mass, rain and snow mass, and cloud droplet and rain drop
-number concentrations ``(q_{liq}, q_{ice}, q_{rai}, q_{sno}, N_{liq}, N_{rai})``.
+number concentrations ``(q_{liq}, q_{ice}, q_{rai}, q_{sno}, N_{liq}, N_{rai})``,
+the last two carried as `ρn_lcl` and `ρn_rai`.
 Ice and snow are carried but their 2-moment microphysical sources are currently zero;
 only warm-rain processes are active.
 
@@ -94,7 +96,8 @@ The most common causes of these errors are:
   - spurious oscillations caused by the high order horizontal transport scheme,
   - time integration of microphysics sources at a time step longer than the stability limit,
   - use of hyperdiffusion.
-    Our strategy is to minimize the untoward effects of those errors.
+
+Our strategy is to minimize the effects of those errors.
 
 ### Implicit treatment of microphysics sinks
 
@@ -102,14 +105,14 @@ Microphysical processes can produce large negative tendencies (sinks) for tracer
 
 ### Enforcing physical constraints
 
-An additional correction is applied through the state-constraint hook
+Additional corrections are applied through the state-constraint hook
+`constrain_state!`, which runs at the cadence set by
+`update_constrain_state_every` (every step by default). Its microphysics and
+updraft part is
 
-```
+```julia
 enforce_physical_constraints!(Y, p, t, atmos)
 ```
-
-which runs at the cadence set by `update_constrain_state_every` (every step by
-default).
 
 This function applies local corrective updates to keep prognostic variables
 in a physically admissible range.
@@ -118,9 +121,9 @@ Currently, this includes:
 
   - enforcing non-negative condensate masses,
   - rescaling condensate when the total condensate exceeds total moisture,
-  - clipping non-positive updraft area fractions and negative updraft vertical
-    velocities, and relaxing the affected updraft state toward the grid mean
-    (the `edmfx_filter` option),
+  - clamping the updraft area fraction to ``[0, 1]``, clipping negative updraft
+    vertical velocities, and resetting the updraft scalars to the grid mean
+    where the updraft area is negligible (the `edmfx_filter` option),
   - ensuring subdomain consistency ``\rho a^j \chi^j \le \rho \chi``.
 
 These corrections are intended to prevent nonphysical states such as negative
@@ -135,7 +138,8 @@ at the smallest scales of the simulation without degrading the sharp features
 of the modeled tracers.
 
 Hyperdiffusion is a higher order derivative operator, and as a result does not guarantee positivity.
-Total water (`q_tot_eff = q_tot - q_rai - q_sno`) and passive tracers are
+Total water (`q_tot_eff = q_tot - q_rai - q_sno` for the 1M and 2M schemes;
+the full `q_tot` for 0M and 2MP3) and passive tracers are
 hyperdiffused at full strength; the resulting `ρq_tot` mass tendency is
 distributed proportionally to the cloud species (`ρq_lcl`, `ρq_icl`, and their
 number densities). Rain, snow, and rain number density receive no
@@ -155,7 +159,8 @@ or computed as a function that decays with height and is capped at some value ab
 Vertical diffusion can be applied implicitly when using `VerticalDiffusion`,
 `DecayWithHeightDiffusion`, or the PROPHET diffusive flux; the Smagorinsky-Lilly
 and AMD vertical tendencies are always explicit.
-With `VerticalDiffusion` or `DecayWithHeightDiffusion`, `q_tot_eff = q_tot - q_rai - q_sno` is diffused directly and the resulting mass tendency is
+With `VerticalDiffusion` or `DecayWithHeightDiffusion`, `q_tot_eff` (defined as
+for hyperdiffusion above) is diffused directly and the resulting mass tendency is
 distributed proportionally to the cloud species; precipitating species
 (`q_rai`, `q_sno`, `n_rai`) receive no diffusion. The Smagorinsky-Lilly and
 AMD models apply the full eddy diffusivity to every grid-scale tracer.
@@ -165,13 +170,16 @@ AMD models apply the full eddy diffusivity to every grid-scale tracer.
 Often, the diffusion and limiters described above are not enough to ensure positivity of the microphysics tracers.
 ClimaAtmos supports four additional constraints that can be used to enforce non-negativity of the microphysics tracers.
 This is controlled by the `tracer_nonnegativity_method` in the `AtmosWater` struct.
+Each method (except `vertical_water_borrowing`) also comes in a `_qtot` variant,
+which additionally constrains `ρq_tot` itself and then restores mass–energy
+consistency.
 The available options are:
 
   - `TracerNonnegativityElementConstraint`:
     This option enforces non-negativity while conserving the tracer mass within the element.
     It uses the `Limiters.compute_bounds!` and `Limiters.apply_limiter!` functions to redistribute the mass of the tracer within the element
     such that the tracer concentration is non-negative and bounded by the maximum value in the element.
-    Effectively, this method borrows mass from the neighboring nodes within the element to fill the negative holes.
+    This method borrows mass from the neighboring nodes within the element to fill the negative holes.
     This method is conservative and does not introduce any source/sink of total water mass.
 
   - `TracerNonnegativityVaporConstraint`:
@@ -208,11 +216,13 @@ The available options are:
     vertical mass-borrowing limiter, filling negative values from levels above
     or below. The species it applies to are set by the
     `vertical_water_borrowing_species` configuration argument; when total water
-    is limited, density and total energy are corrected for consistency.
+    is limited, density and total energy are corrected for consistency. Unlike
+    the other three options, this one acts in the timestepper's limiter stage
+    rather than in the state-constraint hook.
 
 ## Aerosol Activation for 2-Moment Microphysics
 
-Aerosol activation uses functions from the [CloudMicrophysics.jl](https://github.com/CliMA/CloudMicrophysics.jl) library, based on the Abdul-Razzak and Ghan (ARG) parameterization. ARG predicts the number of activated cloud droplets assuming a parcel of clear air rising adiabatically. This formulation is traditionally applied only at cloud base, where the maximum supersaturation typically occurs.
+Aerosol activation uses functions from the [CloudMicrophysics.jl](https://github.com/CliMA/CloudMicrophysics.jl) library, based on the Abdul-Razzak and Ghan (ARG) parameterization [AbdulRazzakGhan2000](@cite). ARG predicts the number of activated cloud droplets assuming a parcel of clear air rising adiabatically. This formulation is traditionally applied only at cloud base, where the maximum supersaturation typically occurs.
 
 To enable ARG to be used locally (i.e., without explicitly identifying cloud base), CloudMicrophysics.jl implements a modified equation for the maximum supersaturation that accounts for the presence of pre-existing liquid and ice particles. This allows activation to be applied inside clouds. To ensure that activation occurs only where physically appropriate, we apply additional clipping logic:
 

--- a/docs/src/non_orographic_gravity_wave.md
+++ b/docs/src/non_orographic_gravity_wave.md
@@ -24,14 +24,20 @@ The non-orographic gravity wave drag parameterization follows the spectra method
 The source spectrum with respect to phase speed is prescribed in Eq. (17) in [alexander1999](@cite). We adapt the equation so that the spectrum combines a wide and a narrow band:
 
 ```math
-B_0(c) = \frac{F_{S0}(c)}{\rho_0} = sgn(c-u_0) \left( Bm\_w \exp\left[ -\left( \frac{c-c_0}{c_{w\_w}} \right)^2 \ln{2} \right] + Bm\_n \exp\left[ -\left( \frac{c-c_0}{c_{w\_n}} \right)^2 \ln{2} \right] \right)
+B_0(c) = \frac{F_{S0}(c)}{\rho_0} = sgn(c-u_0) \left( B_w \exp\left[ -\left( \frac{\tilde{c}-c_0}{c_{w,w}} \right)^2 \ln{2} \right] + B_n \exp\left[ -\left( \frac{\tilde{c}-c_0}{c_{w,n}} \right)^2 \ln{2} \right] \right)
 ```
 
-where the subscript $0$ denotes values at the source level. $c_0$ is the phase speed with the maximum flux magnitude $Bm$, and $c_w$ is the half-width at half-maximum of the Gaussian.  $\_w$ and $\_n$ represent the wide and narrow bands of the spectra.
+where the subscript $0$ denotes values at the source level, and $\tilde{c} = c$
+in the extra-tropics (ground-relative frame) while $\tilde{c} = c - u_0$ in the
+tropics (wind-relative frame; see the frame discussion below). $c_0$ is the
+phase speed with the maximum flux magnitude; $B_w$ and $B_n$ are the amplitudes
+of the wide and narrow bands of the spectrum (the parameters `nogw_Bw` and
+`nogw_Bn`), and $c_{w,w}$ and $c_{w,n}$ are the corresponding half-widths at
+half-maximum.
 
 Intuitively, $B_0(c)$ is a recipe for how much momentum the wave field carries, sorted by how fast each wave travels. The two Gaussians say most waves move near a favored speed $c_0$, with waves much faster or slower being rare (a wide hump for the broad spread plus a narrow hump for the extra pile-up at the peak), and $c_w$ measures how quickly that falls off (one step of $c_w$ from the peak halves the flux). The $sgn(c-u_0)$ factor flips the sign so waves moving with the source-level wind push one way and waves moving against it push the other. The launch spectrum is therefore symmetric about the peak and carries no net momentum in the tropical (wind-relative) frame; in the extra-tropical ground-relative frame the sign flip at $c = u_0$ leaves a small net flux at launch. The atmosphere filters one side out higher up (see below).
 
-Because the background winds and convective sources differ between the tropics and the extra-tropics, the parameterization changes a few of its settings at the edge of the tropical band. The most important is the reference frame in which the phase-speed spectrum is defined: in the extra-tropics, phase speeds are measured relative to the ground, while in the tropics they are measured relative to the zonal wind at the source level. This frame, together with the narrow-band amplitude $Bm\_n$ and the wide-band width $c_w$, changes abruptly at the band edge. The overall source strength $F_{S0}$, by contrast, is blended smoothly across the transition, so the total wave drag varies continuously with latitude rather than jumping. (With the default parameters $Bm\_n$ and $c_w$ are the same inside and outside the tropics, so in practice only the reference-frame switch and the smooth amplitude blend have any effect.)
+Because the background winds and convective sources differ between the tropics and the extra-tropics, the parameterization changes a few of its settings at the edge of the tropical band. The most important is the reference frame in which the phase-speed spectrum is defined: in the extra-tropics, phase speeds are measured relative to the ground, while in the tropics they are measured relative to the zonal wind at the source level. This frame, together with the narrow-band amplitude $B_n$ and the wide-band width $c_w$, changes abruptly at the band edge. The overall source strength $F_{S0}$, by contrast, is blended smoothly across the transition, so the total wave drag varies continuously with latitude rather than jumping. (With the default parameters $B_n$ and $c_w$ are the same inside and outside the tropics, so in practice only the reference-frame switch and the smooth amplitude blend have any effect.)
 
 ### Upward propagation and wave breaking
 
@@ -71,7 +77,7 @@ X(z_{n-1/2}) = \frac{\epsilon \rho_0}{\rho(z_{n-1/2})\Delta z} \sum_j (B_0)_j
 
 where the sum is over the breaking waves and $\epsilon = F_{S0} / (\rho_0\, n_k \sum |B_0|)$ is the wave intermittency ($n_k$ is the number of horizontal wavenumber bands, one by default). Here $F_{S0}$ is the prescribed time-averaged total momentum flux, specified as a latitude-dependent quantity.
 
-Any momentum flux that propagates to the model top without breaking is re-deposited by averaging it across all levels above the damping level (defined by `nogw_damp_pressure`) to ensure momentum conservation.
+Any momentum flux that propagates to the model top without breaking is re-deposited by spreading it uniformly over the levels at and above the damping level (defined by `nogw_damp_pressure`). The divisor in the code is one larger than the number of those levels, so this recovers the escaped momentum only approximately.
 
 The drag at full levels is obtained by averaging adjacent half-levels:
 
@@ -145,7 +151,7 @@ The Beres source activates in a column only when both conditions are met:
 
 This filters out shallow or weak convection. In columns where the criteria are not met, the Beres contribution is zero and only the AD99 background source acts. Where they are met, the Beres flux is added on top of the AD99 background.
 
-**Note:** The Beres physical parameters `nogw_beres_Q0_threshold`, `nogw_beres_h_heat_min`, and the spectrum and steady-component parameters used below are ClimaParams parameters. Their defaults are in the ClimaParams `[nogw_beres_*]` / `[nogw_*]` entries. Only the toggle switches are in `default_config.yml`.
+**Note:** The Beres physical parameters `nogw_beres_Q0_threshold`, `nogw_beres_h_heat_min`, and the spectrum and steady-component parameters used below are ClimaParams parameters. Their defaults are in the ClimaParams `[nogw_beres_*]` / `[nogw_*]` entries. Only the toggle switches are in [`default_config.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/default_configs/default_config.yml).
 
 ### Source spectrum $B_0(c)$
 
@@ -206,7 +212,7 @@ Optionally, the spectrum may be computed and averaged at $n_{h,\text{avg}}$ valu
 
 ### Steady ($\nu = 0$) component
 
-The transient spectrum above starts the frequency integral at $\nu_{\min} > 0$ and therefore omits the steady ($\nu = 0$) part of the heating. This steady part is always added as a single ground-stationary wave: the time-mean convective heating acts like a fixed obstacle in the mean wind $\bar{u}_{\text{heat}}$ and radiates one mountain-wave-like mode with vertical wavenumber $m_0 = N / |\bar{u}_{\text{heat}}|$ (Beres Eq. 31, the resulting steady flux is Beres Eqs. 32–34), signed to oppose $\bar{u}_{\text{heat}}$. It is deposited entirely into the $c \approx 0$ phase-speed bin, which the transient spectrum leaves empty, so there is no double-counting. The steady source has no config switch. It is controlled implicitly by the phase-speed grid. It deposits only when an exact $c = 0$ bin exists, i.e. when `cmax`/`dc` is an integer ($c[n] = (n-1)\,dc - cmax$). On a grid without one, it silently no-ops (a warning is emitted at construction). The default grid (`nogw_cmax` $= 100$, `nogw_dc` $= 0.8 \Rightarrow 125$) has a $c = 0$ bin, so the steady source is on by default. Its amplitude carries the same half-sine response factor and the same scale factor $\alpha$ as the transient spectrum, so the two are not independently tunable. Its only additional inputs are a zero-frequency temporal weight $|Q_t(0)|^2$ set by a DC-weight knob (`nogw_beres_steady_dc_frac`) and a largest convective-system scale (`nogw_beres_L_system`) that fixes the horizontal projection.
+The transient spectrum above starts the frequency integral at $\nu_{\min} > 0$ and therefore omits the steady ($\nu = 0$) part of the heating. This steady part is always added as a single ground-stationary wave: the time-mean convective heating acts like a fixed obstacle in the mean wind $\bar{u}_{\text{heat}}$ and radiates one mountain-wave-like mode with vertical wavenumber $m_0 = N / |\bar{u}_{\text{heat}}|$ (Beres Eq. 31, the resulting steady flux is Beres Eqs. 32–34), signed to oppose $\bar{u}_{\text{heat}}$. It is deposited entirely into the $c \approx 0$ phase-speed bin, which the transient spectrum leaves empty, so there is no double-counting. The steady source has no YAML switch (the `BeresSourceParams` field `beres_steady_source` defaults to `true`); in practice it is controlled by the phase-speed grid. It deposits only when an exact $c = 0$ bin exists, i.e. when `cmax`/`dc` is an integer ($c[n] = (n-1)\,dc - cmax$). On a grid without one, it deposits nothing (a warning is emitted at construction). The default grid (`nogw_cmax` $= 100$, `nogw_dc` $= 0.8 \Rightarrow 125$) has a $c = 0$ bin, so the steady source is on by default. Its amplitude carries the same half-sine response factor and the same scale factor $\alpha$ as the transient spectrum, so the two are not independently tunable. Its only additional inputs are a zero-frequency temporal weight $|Q_t(0)|^2$ set by `nogw_beres_steady_dc_frac` and a largest convective-system scale (`nogw_beres_L_system`) that fixes the horizontal projection.
 
 ### Propagation and breaking
 

--- a/docs/src/notation.md
+++ b/docs/src/notation.md
@@ -3,7 +3,7 @@
 The [governing equations](equations.md) and the
 [PROPHET equations](edmf_equations.md) use the notation of the papers they
 follow ([Yatunin2026](@cite) for the dynamical core). The source code uses
-ASCII- and Unicode-flavored names that encode where a field lives and which
+ASCII- and Unicode-flavored names that encode where a field is defined and which
 subdomain it belongs to. This page is the bridge between the two.
 
 ## Staggered-grid prefixes
@@ -81,7 +81,7 @@ precipitation variables are added by the microphysics model, and `ρtke` by the
 turbulence-convection model. Note the code writes cloud condensate as `lcl`/
 `icl` (liquid-cloud, ice-cloud) to distinguish it from precipitating species.
 
-Draft variables live in `Y.c.sgsʲs.:(j)` and are **specific** (not
+Draft variables are stored in `Y.c.sgsʲs.:(j)` and are **specific** (not
 density-weighted), except for the effective density itself:
 
 | Paper symbol     | Code name | Description                                                 |

--- a/docs/src/orographic_gravity_wave.md
+++ b/docs/src/orographic_gravity_wave.md
@@ -18,7 +18,7 @@ The orographic gravity wave drag parameterization follows the methods described 
 
 ### Planetary Boundary Layer (PBL) top
 
-We implement the following simple criteria to find the PBL top level $k$ as the highest level that satisfies
+We implement the following criteria to find the PBL top level $k$ as the highest level that satisfies
 
 ```math
 {}^cp[k] \ge 0.5 ∗ {}^cp[1]
@@ -132,7 +132,7 @@ and given the orographic information $h_{\mathrm{max}}$ and $h_{\mathrm{min}}$, 
 \mathrm{Fr}_{\mathrm{min}} = \max(0, h_{\mathrm{min}}) \,\frac{N_{\text{pbl}}}{V_{\tau}}.
 ```
 
-The clamps to $\max(0, \cdot)$ on $h_{\mathrm{max}}$ and $h_{\mathrm{min}}$ treat negative height as zero. Here, $\mathrm{Fr}_{\mathrm{crit}} = 0.7$ is the critical Froude number for nonlinear flow. $\mathrm{Fr}_{\mathrm{crit}}$ acts as the primary tuning lever for partitioning drag between the low-level blocked flow and the upper-level wave breaking.
+The clamps to $\max(0, \cdot)$ on $h_{\mathrm{max}}$ and $h_{\mathrm{min}}$ treat negative height as zero. Here, $\mathrm{Fr}_{\mathrm{crit}} = 0.7$ (the parameter `ogw_critical_froude_number`) is the critical Froude number for nonlinear flow. $\mathrm{Fr}_{\mathrm{crit}}$ is the main parameter controlling how the drag is partitioned between the low-level blocked flow and the upper-level wave breaking.
 
 The saturation velocity is computed as
 
@@ -140,7 +140,7 @@ The saturation velocity is computed as
 U_{\mathrm{sat}} = \sqrt{\frac{\rho_{\text{pbl}}}{\rho_0} \frac{V_{\pmb{\tau}}^3}{N_{\text{pbl}}\, L_0}},
 ```
 
-where $\rho_0 = 1.2\,\mathrm{kg/m^3}$ is the arbitrary density scale, and $L_0 = 80\,000\,\mathrm{m}$ is the arbitrary horizontal length scale.
+where $\rho_0 = 1.2\,\mathrm{kg/m^3}$ is the arbitrary density scale (`ogw_density_scale_factor`), and $L_0 = 80\,000\,\mathrm{m}$ is the arbitrary horizontal length scale (`ogw_reference_mountain_width`).
 
 $U_{\mathrm{sat}}$ roughly measures the biggest wave the flow can carry before it breaks. A stronger wind ($V_\tau$) makes much bigger waves (note the cube), while stronger stratification ($N$) or a wider mountain ($L_0$) makes them break sooner and shrinks it.
 
@@ -192,7 +192,7 @@ Here, $(\gamma, \epsilon, \beta) = (0.4, 0.0, 0.5)$ are empirical shape paramete
 
 ### Saturation profiles for the propagating component
 
-Only the propagating component requires a saturation profile, as it carries a vertically propagating wave whose flux can saturate aloft. The non-propagating component remains the scalar $\tau_{np}$ from the base-flux calculation and is distributed in $z$ by pressure weighting across the blocking layer $[z_{\text{pbl}}, z_{\mathrm{ref}})$ (see [Non-propagating component](#non-propagating-component) below).
+Only the propagating component requires a saturation profile, as it carries a vertically propagating wave whose flux can saturate aloft. The non-propagating component remains the scalar $\tau_{np}$ from the base-flux calculation and is distributed in $z$ by pressure weighting across the blocking layer $[z_{\text{pbl}}, z_{\mathrm{ref}})$ (see [Non-propagating component](#Non-propagating-component) below).
 
 The vertical profile of saturated momentum flux $\tau_{\mathrm{sat}}$ is computed such that the momentum forcing follows from $d\overline{V}/dt = -\overline{\rho}^{-1}d\tau_{\mathrm{sat}}/dz$.
 
@@ -346,12 +346,18 @@ The tendencies above act on the physical horizontal wind components.
 
 The parameterization splits into an offline preprocessing step (Earth topography only) that builds an HDF5 artifact of $(h_{\mathrm{max}}, h_{\mathrm{min}}, t_{11}, t_{12}, t_{21}, t_{22})$ on the spectral element grid, and a runtime step that consumes the artifact via a `dt_ogw` callback and applies the cached forcing every integrator step.
 
+The scheme and its topographic-information source are selected with the
+`orographic_gravity_wave` configuration key: `gfdl_restart` regrids the GFDL
+`topo_drag.res.nc` artifact, `raw_topo` runs the pipeline below from raw
+elevation data, and a `linear` test path accepts user-supplied analytic drag
+coefficients.
+
 ```
 Offline (Earth topography only):
   compute_OGW_info
     ├─ calc_hpoz_latlon         → h₀ (raw 4th-moment statistic; rescaled to hmax, hmin in compute_OGW_info)
     ├─ calc_velocity_potential  → χ  (2D Hilbert transform)
-    ├─ calc_orographic_tensor   → t11, t12, t21, t22
+    ├─ calc_orographic_tensor   → t11, t21, t12, t22
     └─ regrid_OGW_info          → SpaceVaryingInput to spectral element
   write_computed_drag! → HDF5 artifact (common configs loadable via ClimaArtifacts)
 
@@ -367,7 +373,7 @@ Every dt_ogw seconds:
 
 Every dt (integrator step):
   orographic_gravity_wave_apply_tendency!
-    └─ Yₜ.c.uₕ += Covariant12Vector(ᶜuforcing, ᶜvforcing)
+    └─ Yₜ.c.uₕ += C12(UVVector(ᶜuforcing, ᶜvforcing))
 ```
 
 For analytical topographies (DCMIP200, Hughes2023, Agnesi, Schar, Cosine2d, Cosine3d), the tensor is computed on-the-fly at startup using ClimaCore horizontal gradient operators in place of the offline pipeline.

--- a/docs/src/passive_tracers.md
+++ b/docs/src/passive_tracers.md
@@ -35,7 +35,7 @@ each discovered tracer.
 
 ## SGS Tracers (PROPHET)
 
-When PROPHET (prognostic EDMF) is enabled, each updraft carries its own set of scalar
+When PROPHET is enabled, each updraft carries its own set of scalar
 fields inside `Y.c.sgsʲs.:(j)`. The utility function `sgs_tracer_names(Y)`
 discovers all scalars in the first updraft (`Y.c.sgsʲs.:(1)`) and excludes
 the core PROPHET variables `ρa`, `mse`, and `q_tot`, which receive

--- a/docs/src/radiation.md
+++ b/docs/src/radiation.md
@@ -17,13 +17,15 @@ cadence set by `dt_rad` (default `6hours`).
 
 The `rad` configuration argument selects the mode:
 
+  - `~` (default): no radiation.
   - `gray`: gray radiation, an idealized one-band model.
   - `clearsky`: RRTMGP with gases but no cloud optics.
   - `allsky`: RRTMGP with interactive cloud optics.
   - `allskywithclear`: as `allsky`, plus clear-sky diagnostic fluxes.
   - `held_suarez`: the Held–Suarez temperature relaxation (no radiative
-    transfer; applied every stage), plus idealized single-column forcings
-    (`DYCOMS`, `TRMM_LBA`, `ISDAC`).
+    transfer; applied every stage).
+  - `DYCOMS`, `TRMM_LBA`, `ISDAC`: idealized prescribed-radiation forcings for
+    the corresponding single-column cases.
 
 Clouds enter the all-sky modes either interactively from the model state or
 prescribed from ERA5 data (`prescribe_clouds_in_radiation`). Trace-gas

--- a/docs/src/restarts.md
+++ b/docs/src/restarts.md
@@ -32,18 +32,50 @@ useful for
     cloud fraction and uses it in the buoyancy gradient calculation to ensure deterministic
     behavior across restarts. We recommend disabling this option for production runs.
 
+## Checkpointing and restarting a run
+
+The minimal recipe is two configuration keys:
+
+```yaml
+# my_run.yml
+dt_save_state_to_disk: "6hours"  # write a checkpoint every 6 hours
+detect_restart_file: true        # on launch, resume from the latest checkpoint
+```
+
+Run the simulation as usual. If it is interrupted, launching the same
+configuration again finds the most recent checkpoint in the output directory
+and resumes from it; if none exists, a fresh simulation starts. To restart
+from a specific checkpoint instead, set `restart_file: <path/to/dayD.S.hdf5>`.
+
+The rest of this page explains what these options do.
+
 ## How Restarts Work
 
-`ClimaAtmos` periodically saves the simulation state to a file called a "restart
-file". This file contains all the necessary information to resume the simulation
-from that point, including the values of all prognostic variables. The frequency
-of saving restart files can be configured in the simulation settings using the
-`dt_save_state_to_disk` option.
+`ClimaAtmos` periodically saves the simulation state to a *restart file*, an
+HDF5 file holding everything needed to resume from that point: the values of all
+prognostic variables.
 
-Restart files are HDF5 files that contain the state `Y` of the simulation at the
-time of checkpoint. Then, the run is restarted by preparing a new simulation as
-specified by the new configuration, but using the state read from file. The
-values of non-prognostic variables are computed again.
+Each file is named for the elapsed simulation time, as `day$day.$sec.hdf5`. A
+checkpoint written 10 days and 3600 seconds into a run is `day10.3600.hdf5`.
+They are written to the run's output directory, which defaults to
+`output/<job_id>`. Under the default `ActiveLink` style that directory holds a
+numbered subdirectory per run — `output_0000`, `output_0001`, and so on — with an
+`output_active` symlink pointing at the current one, so a checkpoint from the
+first run lands in `output/<job_id>/output_0000/day10.3600.hdf5`.
+
+Set how often they are written with `dt_save_state_to_disk` in a YAML
+configuration, or with the `checkpoint_frequency` keyword when building an
+`AtmosSimulation` from a script. Duration strings, including `"<N>months"`,
+are accepted. The default is `Inf`, which writes no checkpoints.
+
+Inside the file the state is stored under the name `Y`, alongside two attributes:
+`time`, the simulation time in seconds, and `atmos_model_hash`, a hash of the
+model configuration that a restart checks so a checkpoint cannot be loaded
+silently into a different model.
+
+On restart, a new simulation is prepared as specified by the new configuration,
+but takes its state from the file. Non-prognostic variables are recomputed from
+that state.
 
 `ClimaAtmos` can automatically detect the latest restart file within a
 structured output directory generated using the `ActiveLinkStyle`. When
@@ -52,14 +84,14 @@ structured output directory generated using the `ActiveLinkStyle`. When
 matches the expected name for a restart file. If none is found, a new simulation
 is started.
 
-It is also possible to manually specify a restart file, which overrides any
-automatically detected file.
+It is also possible to manually specify a restart file with the `restart_file`
+configuration option, which overrides any automatically detected file.
 
 `ClimaAtmos` also provides the configuration option `t_start` to change the initial
 time of the simulation without changing the start date. This option can be
 useful when manually restarting a simulation (e.g., by overwriting the initial
-conditions). When a simulation is restarted from a checkpoint, this option
-becomes redundant.
+conditions). When a simulation is restarted from a checkpoint, the checkpoint
+supplies the time and any `t_start` given is ignored, with a warning.
 
 ## Accumulated Diagnostics
 
@@ -70,10 +102,11 @@ an example.
 Suppose you are saving 30-day averages and stop the simulation at day 45. You'll
 find output for day 30 and the checkpoint at day 45. Then, if you
 restart the simulation, you'll see that the next diagnostic output will be at
-day 75, and not day 60. In other words, the counter starts from 0 with every
-restart.
+day 75, and not day 60: the counter starts from 0 with every restart.
 
 !!! note
 
     If you care about accurate accumulated diagnostics, make sure to line up your
-    checkpoint and diagnostic frequencies.
+    checkpoint and diagnostic frequencies. ClimaAtmos checks this at setup and
+    warns when the checkpoint frequency is not a multiple of every accumulation
+    period.

--- a/docs/src/scripting_simulations.md
+++ b/docs/src/scripting_simulations.md
@@ -1,7 +1,7 @@
 # Scripting Simulations
 
 YAML configurations (see
-[Creating custom configurations](configuration.md)) suit reproducible,
+[Creating custom configurations](configuration.md)) allow reproducible,
 batch-style runs. The scripting interface builds the same simulations from
 Julia code, which fits parameter sweeps, interactive exploration in the REPL
 or in notebooks, and customization beyond what the YAML schema exposes. For a
@@ -10,7 +10,7 @@ side-by-side comparison of the two interfaces, see
 
 ## The `AtmosSimulation` object
 
-A simulation is an [`AtmosSimulation`](@ref ClimaAtmos.AtmosSimulation) value.
+A `simulation` is an [`AtmosSimulation`](@ref ClimaAtmos.AtmosSimulation) value.
 Its keyword arguments set the grid, the physics, the initial state, and the
 run parameters:
 
@@ -80,7 +80,10 @@ scripts start from one of them instead of from bare `AtmosModel` keywords.
 The model presets are `dry`, `equil_moist_0m`, `nonequil_moist_1m`,
 `prognostic_edmf`, and `prognostic_edmf_1m`; the simulation presets
 `aquaplanet`, `baroclinic_wave`, and `bomex` return a ready-to-run
-`AtmosSimulation`. Each forwards keyword arguments for further overrides:
+`AtmosSimulation`. The simulation presets and the PROPHET model presets take
+the float type as their first argument; `dry`, `equil_moist_0m`, and
+`nonequil_moist_1m` take keyword arguments only. Each forwards keyword
+arguments for further overrides:
 
 ```julia
 # PROPHET turbulence-convection with 0-moment microphysics, plus radiation
@@ -92,7 +95,10 @@ model = CA.Presets.prognostic_edmf(
 
 ## Setup (initial conditions)
 
-A setup defines the initial state and, for column cases, the case forcing:
+In the script interface, the `setup` argument sets the initial state. Case
+forcings and surface conditions that YAML configurations derive from
+`initial_condition` (subsidence, large-scale advection, column Coriolis,
+surface fluxes) are chosen through `AtmosModel` keywords or a preset instead:
 
 ```julia
 # The BOMEX shallow-cumulus case

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -1,7 +1,7 @@
 # Setups
 
-A setup defines the initial conditions for a simulation case. At its core, a
-setup is a struct that implements `center_initial_condition`, which returns a
+A setup defines the initial conditions for a simulation case. A setup is a
+struct that implements `center_initial_condition`, which returns a
 physical state NamedTuple at each grid point. The physical state describes the
 thermodynamic and kinematic state through temperature, pressure or density,
 moisture, and velocity, and is converted into prognostic variables
@@ -26,12 +26,14 @@ or `ρ` are required; all other fields default to zero.
 For example, a minimal setup:
 
 ```julia
+import ClimaAtmos as CA
+
 struct MySetup end
 
-function Setups.center_initial_condition(::MySetup, local_geometry, params)
+function CA.Setups.center_initial_condition(::MySetup, local_geometry, params)
     z = local_geometry.coordinates.z
     FT = typeof(z)
-    return physical_state(; T = FT(300), p = FT(101500))
+    return CA.Setups.physical_state(; T = FT(300), p = FT(101500))
 end
 ```
 

--- a/docs/src/single_column.md
+++ b/docs/src/single_column.md
@@ -2,7 +2,7 @@
 
 ## Idealized cases
 
-`ClimaAtmos.jl` supports several canonical test cases that are run in a single column model designed to verify how well PROPHET (an extended, prognostic EDMF scheme) reproduces each convective regime. These cases include variants of `bomex`, `dycoms`, `rico`, `soares`, `gabls`, and `trmm` and can be found in the `config/model_configs` directory. The purpose of each simulation is summarized in the following table:
+`ClimaAtmos.jl` supports several canonical test cases that are run in a single column model designed to verify how well PROPHET reproduces each convective regime. These cases include variants of `bomex`, `dycoms`, `rico`, `soares`, `gabls`, and `trmm` and can be found in the `config/model_configs` directory. The purpose of each simulation is summarized in the following table:
 
 | Abbreviation | Long Name                                            | Cloud Regime          | Reference                                                                                                                   |
 |:------------ |:---------------------------------------------------- |:--------------------- |:--------------------------------------------------------------------------------------------------------------------------- |
@@ -33,7 +33,10 @@ sol_res = CA.solve_atmos!(simulation) # run the simulation
 ```
 
 The same three lines run every case on this page; only the configuration
-file changes.
+file changes. CI runs these cases with a common diagnostics file prepended
+(e.g. `config/common_configs/diagnostics_column_progedmf_1M.yml`); see
+[Creating custom configurations](configuration.md) for combining
+configuration files.
 
 ## Externally-Driven Single Column Models
 
@@ -42,10 +45,10 @@ file changes.
 ### GCM-Driven Case
 
 For the `GCM` driven case, run the configuration file
-`config/model_configs/prognostic_edmfx_gcmdriven_column.yml`. In the config,
+[`config/model_configs/prognostic_edmfx_gcmdriven_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_gcmdriven_column.yml). In the config,
 the following settings are important:
 
-```YAML
+```yaml
 initial_condition: "GCM"
 external_forcing_file: artifact"cfsite_gcm_forcing"/HadGEM2-A_amip.2004-2008.07.nc
 cfsite_number : "site23"
@@ -56,17 +59,19 @@ Setting `initial_condition` to `GCM` selects the GCM-driven setup, which supplie
 ### ARM VARANAL Case (SGP)
 
 The ARM VARANAL setup drives a single column at the SGP Central Facility with
-time-varying profiles and tendencies from the ARM Variational Analysis product
+time-varying profiles and tendencies from the
+[ARM Variational Analysis product](https://www.arm.gov/data/science-data-products/vaps/varanal)
 (`sgp60varanarucC1.c1`). Forcing includes horizontal advection, large-scale
-subsidence (from `omega`), nudging toward observed T/q/u/v, prescribed surface
-fluxes (LH/SH), and time-varying skin temperature. Monthly files are available
+subsidence (from `omega`), nudging toward observed temperatures, humidities, and
+winds, prescribed surface latent and sensible heat fluxes, and time-varying skin
+temperature. Monthly files are available
 from the [ARM Data Center](https://adc.arm.gov/discovery/). Run the
-configuration file `config/model_configs/prognostic_edmfx_armvaranal_column.yml`.
+configuration file [`config/model_configs/prognostic_edmfx_armvaranal_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_armvaranal_column.yml).
 
 Key config entries (edit `external_forcing_file`, `start_date`, and `t_end` to
 pick a sub-period within the monthly file):
 
-```YAML
+```yaml
 initial_condition: "ARMVARANAL"
 external_forcing_file: artifact"arm_sgp_varanal_forcing"/sgp60varanarucC1.c1.20100901.000000.cdf
 start_date: "20100918"
@@ -88,7 +93,7 @@ set `external_forcing_file` to that month's VARANAL `.cdf` file.
 
 The `ReanalysisTimeVarying` case extends the `GCM` driven case to single-column simulations that resolve the diurnal cycle, can be run at any site globally, and are driven by reanalysis, allowing calibration of PROPHET to earth-system observations in the single-column setting. For example, a set of config file arguments can be:
 
-```YAML
+```yaml
 initial_condition: "ReanalysisTimeVarying"
 start_date: "20070701"
 site_latitude: 17.0
@@ -96,14 +101,14 @@ site_longitude: -149.0
 ```
 
 The case runs the configuration file
-`config/model_configs/prognostic_edmfx_tv_era5driven_column.yml`. The
+[`config/model_configs/prognostic_edmfx_tv_era5driven_column.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_tv_era5driven_column.yml). The
 `ReanalysisTimeVarying` initial condition generates a column forcing file for
 the requested site and dates (regridded from the global ERA5 archive, stored
 through `ClimaArtifacts` for reproducibility) and hands it to the generic
 `ForcingFromFile` setup, which takes the
 initial condition, external forcing, surface skin temperature, and insolation
 from that one file (surface fluxes are computed interactively by Monin–Obukhov similarity theory). Setting `external_forcing: "ReanalysisTimeVarying"` as well
-is still accepted but no longer needed. You give the site and dates directly
+is accepted but unnecessary. You give the site and dates directly
 rather than a file path because the file is generated on demand:
 `start_date` is YYYYMMDD, `site_latitude` in degrees (-90...90), and
 `site_longitude` in (-180...180). Artifact-backed ERA5 data is currently
@@ -116,9 +121,22 @@ and only on the `clima` and Caltech HPC servers.
 
 #### Monthly Averaged Forcing
 
-As the matched ERA5 trajectory is data intensive, requiring downloads for each day, we have also implemented an external forcing dispatch to repeat a specific day of data indefinitely. This setup is ideal for monthly averaged ERA5 data by hour of day and can be used to calibrate to monthly statistics. The setup is similar, except we change the flag for `external_forcing` to indicate that we want to repeat data:
+Following a matched ERA5 trajectory is data intensive, since it needs a download
+for every simulated day. A second dispatch avoids that by cycling a single day of
+forcing indefinitely.
 
-```YAML
+The day it cycles is not a calendar day. ERA5 is averaged over the month
+separately at each hour of the day, which gives one composite day carrying that
+month's mean diurnal cycle; the file stores that day, and a periodic calendar
+repeats it for as long as the simulation runs. Forcing the column with it
+therefore drives the month's mean conditions and mean diurnal cycle without
+following any particular day's weather, which is what makes it suited to
+calibrating against monthly statistics.
+
+The configuration is as above, with `external_forcing` set to request the
+composite day:
+
+```yaml
 initial_condition: "ReanalysisTimeVarying"
 external_forcing: "ReanalysisMonthlyAveragedDiurnal"
 start_date: "20070701"
@@ -127,7 +145,7 @@ site_longitude: -149.0
 ```
 
 The corresponding configuration file is
-`config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml`.
+[`config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml`](https://github.com/CliMA/ClimaAtmos.jl/blob/main/config/model_configs/prognostic_edmfx_diurnal_scm_imp.yml).
 
 Running the reanalysis-driven cases at other times and locations requires
 downloading and naming the raw ERA5 files for the processing script; see

--- a/docs/src/sponge.md
+++ b/docs/src/sponge.md
@@ -1,0 +1,126 @@
+# Model Top and Sponge Layer
+
+The model top is a rigid lid at a fixed height ``z_t``, with insulating and
+free-slip boundary conditions. A rigid lid reflects upward-propagating waves, so
+a sponge layer below it absorbs them before they can reflect and contaminate the
+solution [Yatunin2026](@cite).
+
+ClimaAtmos provides two independent sponges: a viscous sponge, which applies
+horizontal viscous damping to the velocities and most scalars, and Rayleigh
+damping, which relaxes velocities toward zero. Both are optional and both are
+confined to the upper part of the domain by the same vertical ramp.
+
+## The ramp
+
+Damping has to switch on smoothly, or the onset itself reflects waves. Both
+sponges use the ramp
+
+```math
+\beta_{\mathrm{sponge}}(z) =
+\begin{cases}
+  0 & z \le z_d, \\[1ex]
+  \sin^2 \left( \dfrac{\pi}{2} \dfrac{z - z_d}{z_t - z_d} \right) & z > z_d,
+\end{cases}
+```
+
+which rises from zero at the onset height ``z_d`` to one at the model top
+[KlempLilly1978](@cite).
+
+The layer should be roughly 1.5 times the vertical wavelength of the waves it
+aims to absorb, which is around 2–10 km in the stratosphere
+[Durran1983, Klemp2008](@cite). The default onset
+height is set by the `zd_rayleigh` and `zd_viscous` parameters.
+
+!!! warning "``z_d`` is an absolute height, unlike in Yatunin et al. (2026)"
+
+    ClimaAtmos takes ``z_d`` as an **absolute altitude**: `zd_rayleigh` and
+    `zd_viscous` are used as given, with no reference to the domain top.
+    [Yatunin2026](@cite) specifies the default as an offset below the top
+    instead.
+
+    Because ``z_d`` does not follow the domain, set it explicitly for any
+    domain whose top differs from the reference configuration.
+
+## Viscous sponge
+
+The viscous sponge applies horizontal viscous damping to the velocities
+(grid-mean and updraft vertical velocities), the total energy, and the
+grid-scale tracers, including the water species. Unlike
+[hyperdiffusion](hyperdiffusion.md), it does not exempt the precipitating
+species. Turbulence kinetic energy and the PROPHET subdomain scalars are
+exempt; they receive only the Rayleigh tracer damping described below. For a
+scalar ``\psi`` the tendency is
+
+```math
+\rho S_\psi = \dots + \kappa_{\max} \beta_{\mathrm{sponge}}
+  \nabla_h \cdot (\rho \nabla_h \psi),
+```
+
+with turbulent diffusivity ``\kappa_{\max}``, default ``10^6`` in units of m²
+s⁻¹, set by `kappa_2_sponge`. For the velocity the same coefficient multiplies
+the horizontal vector Laplacian defined in [Hyperdiffusion](hyperdiffusion.md);
+horizontal density variations are neglected there, as in the hyperdiffusion
+tendency.
+
+Viscous damping of all variables absorbs waves without applying the zonal-mean
+torque that Rayleigh damping of horizontal velocities produces
+[Shepherd1996](@cite).
+
+Energy is damped through the total specific enthalpy instead of through
+``\rho e_{tot}`` directly, which matches the
+[enthalpy-based formulation](thermodynamics.md) used elsewhere in the model.
+
+## Rayleigh damping
+
+Rayleigh damping relaxes a velocity component linearly toward zero,
+
+```math
+\boldsymbol{S}_u = \dots
+  - \alpha_{\max} \beta_{\mathrm{sponge}}
+    (\hat{\boldsymbol{k}} \cdot \boldsymbol{u}) \hat{\boldsymbol{k}} ,
+```
+
+applied to the vertical velocity with coefficient ``\alpha_{\max}``, default
+1 s⁻¹, set by `alpha_rayleigh_w`.
+
+Rayleigh damping is restricted to the vertical velocity for the same reason the
+viscous sponge handles everything else: relaxing horizontal velocities toward
+zero applies a zonal-mean torque, which distorts the upper-atmosphere
+circulation [Shepherd1996, Jablonowski2011](@cite).
+
+The implementation still offers damping of horizontal velocity and of tracers,
+for cases that want it:
+
+| Coefficient         | Parameter               | Default | Applies to                               |
+|:------------------- |:----------------------- | -------:|:---------------------------------------- |
+| ``\alpha_w``        | `alpha_rayleigh_w`      | 1.0     | Vertical velocity ``u_3``                |
+| ``\alpha_{uh}``     | `alpha_rayleigh_uh`     | 0.0     | Horizontal velocity ``\boldsymbol{u}_h`` |
+| ``\alpha_{tracer}`` | `alpha_rayleigh_tracer` | 0.0     | Tracers and TKE                          |
+
+Because the latter two default to zero, the default configuration damps only the
+vertical velocity, as described above. Some PROPHET configurations enable a
+small tracer damping; for PROPHET subdomain tracers the relaxation is toward the
+grid-mean value rather than toward zero, so only the subgrid-scale departure is
+damped.
+
+## Interaction with timestepping
+
+The Rayleigh damping of the vertical velocity is carried in the vertically
+implicit part of the tendency split, so its damping timescale does not restrict
+the timestep; this is why ``\alpha_{\max}`` of order 1 s⁻¹ works at timesteps
+far longer than 1 s. The viscous sponge, which involves horizontal operators,
+and the optional Rayleigh terms for horizontal velocity and tracers are
+treated explicitly. See
+[Discretization and Operators](discretization.md) for the split and
+[Implicit Solver](implicit_solver.md) for the solve.
+
+## Where this is implemented
+
+| Concept          | Source                                                                                                                                                            |
+|:---------------- |:----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Viscous sponge   | [src/parameterized_tendencies/sponge/viscous_sponge.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/parameterized_tendencies/sponge/viscous_sponge.jl)   |
+| Rayleigh damping | [src/parameterized_tendencies/sponge/rayleigh_sponge.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/parameterized_tendencies/sponge/rayleigh_sponge.jl) |
+| Model types      | [`ClimaAtmos.ViscousSponge`](@ref), [`ClimaAtmos.RayleighSponge`](@ref)                                                                                           |
+
+Both sponges are selected with the `viscous_sponge` and `rayleigh_sponge`
+configuration keys; see [Configuration Options](configuration_options.md).

--- a/docs/src/surface_albedo.md
+++ b/docs/src/surface_albedo.md
@@ -2,11 +2,14 @@
 
 The ocean surface albedo is the fraction of solar radiation reflected by the ocean surface. It is a function of the solar zenith angle, the sea surface roughness (which depends on wind speed), and the wavelength of the incoming radiation.
 
-Three methods are available to specify the ocean albedo:
+Three methods are available to specify the ocean albedo, selected by the
+`albedo_model` configuration argument:
 
 ## 1) `ConstantAlbedo`
 
-The default value is 0.38 (following [OGorman2008](@cite)) and is used for idealized experiments.
+A constant albedo, used for idealized experiments. In YAML configurations the
+value comes from the ClimaParams key `idealized_ocean_albedo`, default 0.38
+(following [OGorman2008](@cite)); the `AtmosModel` script-API default is 0.07.
 
 ## 2) `RegressionFunctionAlbedo`
 
@@ -21,7 +24,7 @@ where:
   - $λ$ is the wavelength (currently unused).
   - $μ$ is the cosine of the solar zenith angle.
   - $u$ is the surface wind speed.
-  - $σ(u)$ is the mean wave slope distribution width following Cox and Munk (1954), with $\sigma^2 = 0.003 + 0.00512u$.
+  - $σ(u)$ is the mean wave slope distribution width following [CoxMunk1954](@cite), with $\sigma^2 = 0.003 + 0.00512u$.
   - $r_{f}(n, μ)$ is the Fresnel reflectance (e.g., see [Warren2019](@cite)):
 
 ```math
@@ -71,6 +74,10 @@ for clear sky, and
 ```
 
 for cloudy sky. In the current implementation we assume clear skies everywhere.
+
+In the code, both the direct and the diffuse albedo are clamped to the
+interval ``[0, 1]``, since the diffuse regression can otherwise go negative,
+and both return zero at night (``μ \le 0``).
 
 ## 3) `CouplerAlbedo`
 

--- a/docs/src/surface_conditions.md
+++ b/docs/src/surface_conditions.md
@@ -13,7 +13,7 @@ extend or debug it.
 
 ## User Guide
 
-### The four knobs
+### The four fields
 
 [`AtmosSurface`](@ref ClimaAtmos.AtmosSurface) has four fields, each with one
 purpose:
@@ -128,14 +128,14 @@ either/or:
 | Prescribed heat fluxes (constant or time-varying) | [`MoninObukhov(; z0, shf, lhf)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov) or [`MoninObukhov(; z0, fluxes = (t,FT)->…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov) | [`AnalyticTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.AnalyticTemperature)   |
 | An interactive slab ocean surface                 | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                                                                                                            | [`SlabOceanTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.SlabOceanTemperature) |
 | Surface temperature from data                     | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                                                                                                            | [`ExternalTemperature(…)`](@ref ClimaAtmos.SurfaceConditions.ExternalTemperature)   |
-| Coupler owns the surface (atmos skips fluxes)     | `nothing`                                                                                                                                                                      | unused; coupler writes `sfc_conditions`                                             |
+| Coupler provides the surface (atmos skips fluxes) | `nothing`                                                                                                                                                                      | unused; coupler writes `sfc_conditions`                                             |
 | Coupler sets SST; atmos computes fluxes           | [`MoninObukhov(…)`](@ref ClimaAtmos.SurfaceConditions.MoninObukhov)                                                                                                            | [`CoupledTemperature(field)`](@ref ClimaAtmos.SurfaceConditions.CoupledTemperature) |
 
 !!! note "Prescribed fluxes do not use MOST"
 
     When you set `shf`/`lhf` (or `θ_flux`/`q_flux`), those fluxes are used **as
     prescribed**: MOST does not compute them. They appear under `MoninObukhov`
-    only because the prescribed-flux path currently lives inside that type (a
+    only because the prescribed-flux path is defined inside that type (a
     historical conflation; see the Developer Guide). The required `z0` is used
     solely for the *momentum* closure, and only when `ustar` is not also
     prescribed: when both fluxes and `ustar` are given (as in every idealized
@@ -220,7 +220,7 @@ the two patterns differ only in the `flux_scheme`/`temperature` pair:
     `"PrescribedSurface"`). `update_surface_conditions!` early-returns, so
     `temperature` is never read (leave it at its default).
     `init_sfc_conditions_zero!` pre-fills safe defaults at cache-build so RRTMGP /
-    diagnostic EDMF never see uninitialized memory, and the coupler overwrites
+    the diagnostic eddy-diffusivity mass-flux scheme never see uninitialized memory, and the coupler overwrites
     `sfc_conditions` directly.
  2. **Atmosphere computes fluxes from a coupler-supplied SST**: a real
     `flux_scheme` (e.g. `MoninObukhov(…)`) *together with*

--- a/docs/src/surface_conditions_internals.md
+++ b/docs/src/surface_conditions_internals.md
@@ -2,12 +2,12 @@
 
 Design rationale, data flow, dispatch chains, extension points, and
 debugging for the surface-conditions subsystem. For the user-facing guide —
-the four configuration knobs and how to set them, see
+the four configuration fields and how to set them, see
 [Surface Conditions](surface_conditions.md).
 
 ## Design: one source of truth
 
-Surface behavior lives entirely on `atmos.surface`. Principles:
+Surface behavior is determined entirely by `atmos.surface`. Principles:
 
   - **Orthogonality**: `flux_scheme`, `temperature`, `boundary_overrides`, and
     `surface_albedo` are independent axes. Adding an option on one shouldn't touch
@@ -179,7 +179,7 @@ ClimaAtmos.SurfaceConditions.init_sfc_conditions_zero!
   - **`sfc_conditions` NaN/uninitialized under the coupler**: `init_sfc_conditions_zero!`
     only fires when `isnothing(flux_scheme)`.
   - **`T_sfc` uniform when it should vary**: the temperature must return per-cell
-    values, or be an `AnalyticTemperature` whose `f` actually reads `coordinates`.
+    values, or be an `AnalyticTemperature` whose `f` reads `coordinates`.
   - **Space-mismatch error in `update_surface_conditions!`**: something returned a
     `Field` instead of a `DataLayout`/scalar, or a type is missing `broadcastable`.
   - **`Y.sfc` not found**: not a `SlabOceanTemperature` run; guard slab-only code.

--- a/docs/src/thermodynamics.md
+++ b/docs/src/thermodynamics.md
@@ -1,0 +1,199 @@
+# Thermodynamics and the Working Fluid
+
+The thermodynamic formulation underpins the model's conservation properties.
+ClimaAtmos prognoses the specific total energy of moist air, so the definitions
+of internal energy, enthalpy, and latent heat determine whether energy budgets
+close. This page sets out that formulation, following [Yatunin2026](@cite).
+
+The formulation is implemented in
+[Thermodynamics.jl](https://clima.github.io/Thermodynamics.jl/stable/), shared
+with the other CliMA components, and the constants are defined in
+[ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl). This page explains
+the assumptions and the reasoning; consult the Thermodynamics.jl documentation
+for the function-level interface.
+
+## The working fluid
+
+The working fluid is moist air: a mixture of dry air and water vapor, both
+treated as ideal gases, together with condensed water — suspended in clouds and
+falling as precipitation.
+
+All constituents are in **thermal** equilibrium, at the same temperature.
+Condensates may sediment or fall, but they carry the air's temperature. The
+model therefore neglects temperature differences between condensate and ambient
+air, such as those from evaporative cooling of raindrops, when computing fluid
+energetics. Microphysical process rates are unaffected.
+
+Constituents need not be in full **thermodynamic** equilibrium.
+Out-of-equilibrium phases such as supercooled liquid are therefore permitted,
+and the condensed phases can carry their own prognostic equations with
+microphysics schemes in which non-equilibrium phases coexist. Suspended
+condensate and precipitation are part of the working fluid, which suits bulk
+microphysics schemes that represent these components through moments of a
+particle size distribution.
+
+Composition is described by mass fractions: dry air ``q_d``, water vapor
+``q_v``, liquid ``q_l``, and ice ``q_i``. The condensate fraction is
+``q_c = q_l + q_i``, and the total water specific humidity is
+``q_t = q_v + q_c``. Since these account for every component, ``q_t + q_d = 1``.
+
+!!! note "No small-humidity assumption"
+
+    The formulation nowhere assumes that specific humidities are small, so the
+    same equations apply to planetary atmospheres in which a condensable species
+    is a major constituent. On Mars, for example, condensation of carbon dioxide
+    affects air mass and dynamics.
+
+Bulk microphysics schemes often split the condensate further into suspended
+cloud condensate and precipitation, ``q_l = q_l^{cl} + q_l^{pr}`` and ``q_i = q_i^{cl} + q_i^{pr}``. The equations of motion allow for that distinction; see
+[Microphysics](microphysics.md).
+
+## Equation of state
+
+The pressure of the working fluid is the sum of the partial pressures of dry air
+and water vapor. The volume — but not the mass — of the condensed phases is
+neglected, because the specific volume of condensate is smaller than that of the
+gas phases by a factor of about ``10^3``. The equation of state is then
+
+```math
+p = \rho R_m T,
+```
+
+with the specific mixture gas constant of moist air
+
+```math
+R_m(q) = R_d (1 - q_t) + R_v q_v
+       = R_d \left[ 1 + (\epsilon_{dv} - 1) q_t - \epsilon_{dv} q_c \right],
+```
+
+which depends on the specific humidities through the ratio of the gas constants
+of water vapor and dry air, ``\epsilon_{dv} = R_v / R_d \approx 1.61``.
+
+## A calorically perfect fluid
+
+The primary thermodynamic assumption is that the fluid is **calorically
+perfect**: the isochoric specific heat capacities of the constituents are
+constants. The isobaric capacities are then constant too, and the capacities of
+moist air are the mass-weighted sums of those of its constituents,
+
+```math
+c_{vm}(q) = c_{vd} + (c_{vv} - c_{vd}) q_t + (c_{vl} - c_{vv}) q_l
+          + (c_{vi} - c_{vv}) q_i,
+```
+
+with the standard relation ``c_{pm}(q) = c_{vm}(q) + R_m(q)`` carrying over from
+the constituents to the mixture. Real specific heat capacities vary slightly
+with temperature; treating them as constant introduces an error below 1% for dry
+air and at most a few percent for the water phases.
+
+The assumption has a consequence for latent heats [Ambaum2020](@cite).
+Kirchhoff's relation, ``dL/dT = \Delta c_p``, integrates under constant specific heats to a latent heat that
+is **linear** in temperature,
+
+```math
+L(T) = L_0 + \Delta c_p (T - T_0),
+```
+
+for a reference temperature ``T_0`` and the latent heat ``L_0`` at that
+temperature. This applies to vaporization, fusion, and sublimation, and the
+expected relation ``L_s(T) = L_v(T) + L_f(T)`` follows.
+
+## Energies and enthalpies
+
+Specific internal energies of the constituents are referenced to ``T_0``
+[Romps2008](@cite). Two reference values may be chosen independently, because
+dry air and water cannot be converted into one another: the reference specific
+internal energy of liquid water is set to zero and that of dry air to ``-R_d T_0``, which simplifies the later enthalpy and enthalpy-flux expressions. The
+internal energy of moist air is the mass-weighted sum,
+
+```math
+I(T, q) = c_{vm}(q) (T - T_0) + (q_t - q_c) I_{v,0} - q_i I_{i,0}
+        - (1 - q_t) R_d T_0 ,
+```
+
+which can be inverted for temperature. That inversion is how the model recovers
+temperature when specific internal energy and the specific humidities are the
+primary thermodynamic state variables.
+
+Specific enthalpies follow by adding ``p_\mu / \rho_\mu`` to each constituent's
+internal energy, neglecting the specific volumes of the condensed phases:
+
+```math
+h(T, q) = c_{pm}(q) (T - T_0) + (q_t - q_c) L_{v,0} - q_i L_{f,0}
+        = I(T, q) + R_m T .
+```
+
+Enthalpy is central to describing transport, appearing in both the grid-scale
+and the subgrid-scale flux terms of the [governing equations](equations.md).
+
+## Saturation vapor pressure
+
+The Clausius–Clapeyron relation, combined with the linear latent heat above,
+integrates to a closed-form expression for the saturation vapor pressure — the
+Rankine–Kirchhoff approximation [Duarte2014, Romps2021](@cite). For a mixture of liquid and ice out of
+thermodynamic equilibrium, as in mixed-phase clouds, a thermodynamically
+consistent saturation vapor pressure uses the liquid-fraction-weighted average
+[Pressel2015](@cite),
+``L = \lambda_f L_v + (1 - \lambda_f) L_s`` with
+``\lambda_f = q_l / q_c``.
+
+The expression is invariant to the choice of reference temperature, provided the
+reference latent heats are shifted with it. With the triple point of water as
+the reference, the saturation vapor pressure over liquid between 248 and 325 K
+lies within 0.4% of measured values, and the ratio of saturation vapor pressure
+over ice to that over liquid between 233 and 273 K within 0.6%
+[Yatunin2026](@cite).
+
+## Optional local thermodynamic equilibrium
+
+The model can optionally assume local thermodynamic equilibrium for cloudy air —
+excluding falling precipitation — as many atmosphere models do. Gibbs' phase
+rule then implies that three thermodynamic state variables suffice to determine
+the partitioning into water phases, so the suspended condensate specific
+humidities are obtained by saturation adjustment from the cloudy-air total
+humidity, density, and internal energy, while the precipitation humidities
+remain prognostic.
+
+Strict equilibrium requires the liquid fraction to be a Heaviside function of
+temperature. Supercooled liquid is out of equilibrium and exists between the
+homogeneous ice nucleation temperature and the freezing temperature; a ramp
+function between the two is often used to represent it [Kaul2015](@cite). That ramp is available
+in the code, and it remains an approximation, since out-of-equilibrium phases
+depend on the history of the air mass as well as on its thermodynamic state. By
+default the model gives the condensed phases their own prognostic equations
+instead. See [Microphysics](microphysics.md) for the available schemes.
+
+## Reference temperature invariance
+
+The reference temperature ``T_0`` is arbitrary, and the model's physics must not
+depend on it. The formulation is constructed so that it does not: a shift ``T_0 \to T_0 + \delta T_0``, with the reference latent heats shifted consistently by
+Kirchhoff's relation, offsets each constituent's specific internal energy and
+enthalpy by a constant.
+
+The offset for dry air differs from that for water, but the offsets for all
+three water phases are *identical*. The extra terms in the total energy equation
+therefore sum to zero through the total water conservation law, leaving the
+dynamics unchanged. The same holds for the surface enthalpy flux boundary
+condition. What remains of the dependence on ``T_0`` is the accuracy of the
+linear approximation to the latent heats, which is why the triple point of
+water, a value typical for the atmosphere, is the choice made here.
+
+This invariance gives a check on any new energy flux added to the model: a flux
+that breaks it is not thermodynamically consistent, and will not conserve energy
+(see [Conservation Properties](conservation.md)). The subgrid-scale enthalpy
+flux decomposition in [Hyperdiffusion](hyperdiffusion.md) and in the vertical
+diffusion scheme follows from this requirement.
+
+## Where this is implemented
+
+| Concept                                   | Source                                                                                                                                   |
+|:----------------------------------------- |:---------------------------------------------------------------------------------------------------------------------------------------- |
+| Thermodynamic state and functions         | [Thermodynamics.jl](https://clima.github.io/Thermodynamics.jl/stable/)                                                                   |
+| Constants and parameter values            | [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl)                                                                                |
+| Parameter struct and accessors            | [src/parameters/Parameters.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/parameters/Parameters.jl)                            |
+| Saturation adjustment and cloud diagnosis | [src/parameterized_tendencies/microphysics/](https://github.com/CliMA/ClimaAtmos.jl/tree/main/src/parameterized_tendencies/microphysics) |
+| Thermodynamic state construction          | [src/cache/precomputed_quantities.jl](https://github.com/CliMA/ClimaAtmos.jl/blob/main/src/cache/precomputed_quantities.jl)              |
+
+The choice between equilibrium and non-equilibrium condensate is a configuration
+option; see [Configuration Options](configuration_options.md) and
+[Microphysics](microphysics.md).

--- a/docs/src/topography.md
+++ b/docs/src/topography.md
@@ -3,7 +3,17 @@
   - Dataset source: [https://www.ncei.noaa.gov/products/etopo-global-relief-model](https://www.ncei.noaa.gov/products/etopo-global-relief-model)
   - ClimaArtifact: [https://github.com/CliMA/ClimaArtifacts/tree/main/earth_orography](https://github.com/CliMA/ClimaArtifacts/tree/main/earth_orography)
 
-We use the ClimaUtilities `SpaceVaryingInput` tool to regrid (using linear interpolation) the ETOPO2022 ice-surface elevation dataset (see ClimaArtifacts) onto the required spectral element horizontal grid. The file `examples/topography_spectra.jl` provides tools to generate such regridded fields (and their spectra) on user-defined horizontal spaces. For existing ClimaAtmos simulation data, the `orog_inst.nc` dataset from the default diagnostic outputs contains this regridded elevation. As an example, we include plots of the generated topography on a cubed sphere with 16 elements and 64 elements per panel edge, and compare `unsmoothed` and `smoothed` datasets to show the effect of our topography smoothing methods.
+We use the ClimaUtilities `SpaceVaryingInput` tool to regrid (using linear interpolation) the ETOPO2022 ice-surface elevation dataset (see ClimaArtifacts) onto the required spectral element horizontal grid. The file `examples/topography_spectra.jl` provides tools to generate such regridded fields (and their spectra) on user-defined horizontal spaces. For existing ClimaAtmos simulation data, the `orog_inst.nc` dataset from the default diagnostic outputs contains this regridded elevation.
+
+The regridded Earth elevation is always smoothed by Laplacian diffusion of the
+surface (`Hypsography.diffuse_surface_elevation!` in ClimaCore), with the
+number of diffusion iterations set by the `topography_damping_factor`
+configuration argument, and negative elevations clipped to zero. Analytic
+topographies are smoothed only when `topo_smoothing` is set. The smoothed
+surface is extended into the interior by the vertical mesh warp selected with
+`mesh_warp_type` (`SLEVE`, the default, or `Linear`).
+
+As an example, we include plots of the generated topography on a cubed sphere with 16 elements and 64 elements per panel edge, and compare `unsmoothed` and `smoothed` datasets to show the effect of this smoothing.
 
   - Elevation data (elems per panel = 16)
     ![](assets/smoothing_16elem.png)

--- a/src/types.jl
+++ b/src/types.jl
@@ -767,7 +767,9 @@ with `zmax` the domain top height, so that damping ramps up smoothly from `zd`.
 
 # Fields
 
-  - `zd`: Lower damping height; the sponge is inactive below it [m].
+  - `zd`: Lower damping height; the sponge is inactive below it [m]. This is an
+    absolute altitude, so it does not follow the domain and must be set
+    explicitly for domains whose top is not near 30 km.
   - `κ₂`: Damping coefficient [m²/s].
 
 # Examples
@@ -824,7 +826,9 @@ By default only the vertical velocity is damped (`α_uₕ = 0`, `α_w = 1`,
 
 # Fields
 
-  - `zd`: Lower damping height; the sponge is inactive below it [m].
+  - `zd`: Lower damping height; the sponge is inactive below it [m]. This is an
+    absolute altitude, so it does not follow the domain and must be set
+    explicitly for domains whose top is not near 30 km.
   - `α_uₕ`: Damping rate for the horizontal velocity, `0` by default [1/s].
   - `α_w`: Damping rate for the vertical velocity, `1` by default [1/s].
   - `α_tracer`: Damping rate for `ρtke` and the subdomain scalars, `0` by


### PR DESCRIPTION
Documents the dycore, following Yatunin et al. (2026).

New Explanation pages:
- **Thermodynamics** — working fluid, equation of state,
  the calorically perfect assumption, reference-temperature invariance.
- **Discretization and operators** — one operator glossary for the whole suite,
  plus why the scheme is hybrid and what each strong/weak/split form conserves.
- **Conservation properties** — what is conserved, the four ingredients that make
  it work, what is deliberately given up, and how to measure it in a run.
- **Hyperdiffusion** — suspended-species water partitioning, enthalpy-consistent flux.
- **Model top and sponge layer** — both sponges, with verified defaults.

The operator glossary was duplicated between `equations.md` and `edmf_equations.md`
in two different notations, and neither copy was complete. Both now point at the
single definition. Also added the coordinate-independent equation set to `equations.md`, 
changed `ρe` → `ρe_tot`, and added an equation-to-source map.