### PR TITLE
Fix climaatmos-calibrate-e2e CI

### DIFF
--- a/calibration/experiments/perfect_scm/model_interface/forward_model.jl
+++ b/calibration/experiments/perfect_scm/model_interface/forward_model.jl
@@ -21,6 +21,7 @@ function ClimaCalibrate.forward_model(interface::PerfectAtmosModelInterface, ite
 
     # Only create diagnostics that are needed for calibration
     config_dict["output_default_diagnostics"] = false
+    config_dict["debug_tendency_diagnostics"] = false
     replace_diagnostic_dicts!(config_dict, diagnostic_dicts)
 
     # Don't save state to speed up forward model

--- a/calibration/experiments/perfect_scm/model_interface/generate_observations.jl
+++ b/calibration/experiments/perfect_scm/model_interface/generate_observations.jl
@@ -49,8 +49,9 @@ function generate_perfect_model_data(interface::PerfectAtmosModelInterface; toml
     config_dict["output_dir"] = perfect_model_output_dir
     # We use all the diagnostics found in output_active to determine which
     # diagnostics to use for the observations, so we will not output the default
-    # diagnostics
+    # diagnostics or the debug tendency diagnostics
     config_dict["output_default_diagnostics"] = false
+    config_dict["debug_tendency_diagnostics"] = false
     replace_diagnostic_dicts!(config_dict, diagnostic_dicts)
 
     # Don't save state to speed up creating the observations

--- a/calibration/experiments/perfect_scm/model_interface/postprocess_data.jl
+++ b/calibration/experiments/perfect_scm/model_interface/postprocess_data.jl
@@ -11,13 +11,11 @@ observation map (in `process_member_data!`), and analyzing the iterations (in
 `plot_ensemble`).
 """
 function preprocess(var::ClimaAnalysis.OutputVar, ::PerfectAtmosModelInterface)
-    var_dates = ClimaAnalysis.dates(var)
-    start_date = last(var_dates) - Dates.Hour(6) + Dates.Minute(20)
     var = ClimaAnalysis.window(
         var,
         "time",
-        left = start_date,
-        by = ClimaAnalysis.MatchValue(),
+        left = 2, # throw away the first time point
+        by = ClimaAnalysis.Index(),
     )
     return var
 end


### PR DESCRIPTION
This PR fixes the data processing for the test calibration pipeline. It also disable the `debug_tendency_diagnostics` which are not needed for calibration.