### PR TITLE
fix(edmfx): apply SGS water diffusion to condensate species

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- [#4770](https://github.com/CliMA/ClimaAtmos.jl/pull/4770) ![][badge-🐛bugfix] ![][badge-🔥behavioralΔ] Distribute the aggregate `q_tot_eff` diffusion of `edmfx_sgs_diffusive_flux_tendency!` to the suspended cloud mass and number species. The distribution added in [#4753](https://github.com/CliMA/ClimaAtmos.jl/pull/4753) resolved its field names against `Y` rather than `Y.c`, so its guard was never satisfied and the block never ran: `ρq_tot` and `ρ` were tendencied while `ρq_lcl`, `ρq_icl` and their number densities were not. The hyperdiffusion and vertical-diffusion-boundary-layer paths already distributed correctly, so this removes an inconsistency between them.
 0.42.5
 -------
 - [#4762](https://github.com/CliMA/ClimaAtmos.jl/pull/4762) Include more terms in the `InvZEntrainment` closure.

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-400
+401
 
 # **README**
 #
@@ -32,6 +32,12 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+401
+- Distribute the aggregate q_tot_eff diffusion of
+  `edmfx_sgs_diffusive_flux_tendency!` to the suspended cloud mass and
+  number species. The block was present but unreachable, so the species
+  received no share of the vertical water diffusion.
+
 400
 - Update to ClimaCore 0.15.1 and Thermodynamics 1.3.0
 

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -361,9 +361,9 @@ function edmfx_sgs_diffusive_flux_tendency!(
             )
                 ρq_name = get_ρχ_name(q_name)
                 ρn_name = get_ρχ_name(n_name)
-                MatrixFields.has_field(Y, ρq_name) || continue
-                ᶜρq = MatrixFields.get_field(Y, ρq_name)
-                ᶜρqₜ = MatrixFields.get_field(Yₜ, ρq_name)
+                MatrixFields.has_field(Y.c, ρq_name) || continue
+                ᶜρq = MatrixFields.get_field(Y.c, ρq_name)
+                ᶜρqₜ = MatrixFields.get_field(Yₜ.c, ρq_name)
                 @. ᶜratio =
                     max(FT(0), min(FT(1), specific(ᶜρq, Y.c.ρ) / max(ᶜq_tot_eff, ϵ_FT)))
                 @. ᶜρqₜ -= ᶜratio * ᶜρχₜ_diffusion
@@ -375,9 +375,9 @@ function edmfx_sgs_diffusive_flux_tendency!(
                         end
                     end
                 end
-                if MatrixFields.has_field(Y, ρn_name)
-                    ᶜρn = MatrixFields.get_field(Y, ρn_name)
-                    ᶜρnₜ = MatrixFields.get_field(Yₜ, ρn_name)
+                if MatrixFields.has_field(Y.c, ρn_name)
+                    ᶜρn = MatrixFields.get_field(Y.c, ρn_name)
+                    ᶜρnₜ = MatrixFields.get_field(Yₜ.c, ρn_name)
                     @. ᶜρnₜ -= ᶜratio * max(FT(0), ᶜρn) / max(ᶜρq, ϵ_FT) * ᶜρχₜ_diffusion
                     if apply_sgs_updraft
                         for j in 1:n

--- a/test/prognostic_equations/edmfx_sgs_diffusive_flux_tests.jl
+++ b/test/prognostic_equations/edmfx_sgs_diffusive_flux_tests.jl
@@ -1,0 +1,90 @@
+#=
+Tests the water budget of the EDMFX vertical SGS diffusive flux
+(`edmfx_sgs_diffusive_flux_tendency!`). Water diffuses as a single substance on
+`q_tot_eff = q_tot - q_rai - q_sno`; the suspended cloud species have no flux of
+their own and instead take a share of the aggregate tendency scaled by the
+clipped ratio `min(q_μ / q_tot_eff, 1)`, while rain and snow get no `K_h`
+transport. The distribution is asserted directly, because a guard that never
+passes leaves it silently absent. See #4770.
+=#
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaAtmos as CA
+import ClimaCore: Fields
+
+include("../test_helpers.jl")
+
+@testset "EDMFX SGS diffusive flux water distribution (Bomex column)" begin
+    config = CA.AtmosConfig(
+        Dict{String, Any}(
+            "initial_condition" => "Bomex",
+            "FLOAT_TYPE" => "Float64",
+            "config" => "column",
+            "turbconv" => "prognostic_edmfx",
+            "edmfx_entr_model" => "Generalized",
+            "edmfx_detr_model" => "Generalized",
+            "edmfx_sgs_mass_flux" => true,
+            "edmfx_sgs_diffusive_flux" => true,
+            "edmfx_nh_pressure" => true,
+            "prognostic_tke" => true,
+            "microphysics_model" => "1M",
+            "z_max" => 3000.0,
+            "z_elem" => 30,
+            "z_stretch" => false,
+            "dt" => "1secs",
+            "t_end" => "10secs",
+            "ode_algo" => "ARS222",
+            "toml" => [joinpath(pkgdir(CA), "toml", "prognostic_edmfx.toml")],
+            "output_default_diagnostics" => false,
+        );
+        job_id = "edmfx_sgs_diffusive_flux_water_test",
+    )
+    (; Y, p, simulation) = generate_test_simulation(config)
+    t = simulation.integrator.t
+    FT = eltype(Y)
+
+    # A vertically varying water profile drives every branch of the flux.
+    ᶜz = Fields.coordinate_field(Y.c).z
+    @. Y.c.ρtke = FT(0.5) * Y.c.ρ
+    @. Y.c.ρq_lcl = Y.c.ρ * FT(2e-4) * (1 + sin(FT(2π) * ᶜz / FT(3000)))
+    @. Y.c.ρq_icl = Y.c.ρ * FT(1e-4) * (1 + sin(FT(2π) * ᶜz / FT(3000) + FT(1)))
+    @. Y.c.ρq_rai = Y.c.ρ * FT(1e-5) * (1 + sin(FT(2π) * ᶜz / FT(3000) + FT(2)))
+    @. Y.c.ρq_sno = zero(Y.c.ρ)
+    @. Y.c.ρq_tot =
+        Y.c.ρ * FT(8e-3) * (1 + FT(0.2) * sin(FT(2π) * ᶜz / FT(3000) + FT(0.5))) +
+        Y.c.ρq_rai + Y.c.ρq_sno
+    CA.set_precomputed_quantities!(Y, p, t)
+
+    Yₜ = similar(Y)
+    Yₜ .= zero(eltype(Yₜ))
+    CA.edmfx_sgs_diffusive_flux_tendency!(
+        Yₜ, Y, p, t, p.atmos.turbconv_model,
+    )
+
+    # The aggregate water tendency is nonzero, so nothing below is trivial.
+    @test maximum(abs, parent(Yₜ.c.ρq_tot)) > 0
+    # Diffusing water moves moist air mass with it.
+    @test parent(Yₜ.c.ρ) == parent(Yₜ.c.ρq_tot)
+
+    # Each suspended cloud species takes its clipped share of that tendency.
+    ᶜq_tot_eff = similar(Y.c.ρ)
+    @. ᶜq_tot_eff = (Y.c.ρq_tot - Y.c.ρq_rai - Y.c.ρq_sno) / Y.c.ρ
+    ᶜratio = similar(Y.c.ρ)
+    ᶜexpected = similar(Y.c.ρ)
+    for name in (:ρq_lcl, :ρq_icl)
+        ᶜρq = getproperty(Y.c, name)
+        @. ᶜratio = max(
+            FT(0),
+            min(FT(1), (ᶜρq / Y.c.ρ) / max(ᶜq_tot_eff, eps(FT))),
+        )
+        @test maximum(parent(ᶜratio)) > 0
+        @. ᶜexpected = ᶜratio * Yₜ.c.ρq_tot
+        @test maximum(abs, parent(ᶜexpected)) > 0
+        @test parent(getproperty(Yₜ.c, name)) ≈ parent(ᶜexpected) rtol = FT(1e-10)
+    end
+
+    # Rain and snow are excluded from the aggregate and get no K_h transport of
+    # their own, so their only tendency here is the K_e entrainment term.
+    @test maximum(abs, parent(Y.c.ρq_rai)) > 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ if TEST_GROUP in ("dynamics", "all")
     @safetestset "Tracer/mass transport consistency" begin @time include("prognostic_equations/tracer_mass_consistency_tests.jl") end
     @safetestset "Post-Newton implicit-advection correction" begin @time include("prognostic_equations/correct_implicit_advection_tests.jl") end
     @safetestset "Vertical diffusion tendency" begin @time include("prognostic_equations/vertical_diffusion_tests.jl") end
+    @safetestset "EDMFX SGS diffusive flux" begin @time include("prognostic_equations/edmfx_sgs_diffusive_flux_tests.jl") end
     @safetestset "Vertical water borrowing limiter" begin @time include("prognostic_equations/vertical_water_borrowing_tests.jl") end
     @safetestset "Enforce physical constraints" begin @time include("prognostic_equations/enforce_physical_constraints_tests.jl") end
     @safetestset "Eddy diffusion closures" begin @time include("prognostic_equations/eddy_diffusion_closures_tests.jl") end


### PR DESCRIPTION
`edmfx_sgs_diffusive_flux_tendency!` diffuses water as `q_tot_eff = q_tot - q_rai - q_sno` and gives the cloud liquid and ice a share of that tendency. The loop that applies it looked up names in `Y` instead of `Y.c`:

```julia
ρq_name = get_ρχ_name(q_name)                       # @name(q_lcl) -> @name(ρq_lcl)
MatrixFields.has_field(Y, ρq_name) || continue      # never true; the field is Y.c.ρq_lcl
```

so the code is never actually run for these species.

Added a test for the water budget of `edmfx_sgs_diffusive_flux_tendency!`. It checks that the moist air mass tendency matches the aggregate water tendency and that each cloud species receives exactly its clipped share. Also check that the ratio is nonzero.

Ref counter bumped, since the jobs that use this will change.

xref: #4753.