### PR TITLE
Hyperdiff; subtract ref states

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-401
+402
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+402
+- Hyperdiffusion: subtract a hydrostatic reference state from the diffused
+  scalars (dry-static-energy `sd_r(p)` and total-water `q_tot_r(p)`. Removes
+  spurious mixing across topography from the coordinate-tilt part of `gradₕ`.
+
 401
 - Distribute the aggregate q_tot_eff diffusion of
   `edmfx_sgs_diffusive_flux_tendency!` to the suspended cloud mass and

--- a/src/prognostic_equations/hyperdiffusion.jl
+++ b/src/prognostic_equations/hyperdiffusion.jl
@@ -123,26 +123,44 @@ NVTX.@annotate function prep_hyperdiffusion_tendency!(Yₜ, Y, p, t)
 
     n = n_mass_flux_subdomains(turbconv_model)
     diffuse_tke = use_prognostic_tke(turbconv_model)
-    (; ᶜu, ᶜT) = p.precomputed
+    (; ᶜu, ᶜT, ᶜp) = p.precomputed
     (; ᶜ∇²u, ᶜ∇²s_d, ᶜ∇²q_tot_eff) = p.hyperdiff
     if turbconv_model isa PrognosticEDMFX
         (; ᶜ∇²uʲs, ᶜ∇²s_dʲs, ᶜ∇²q_tot_effʲs) = p.hyperdiff
         (; ᶜuʲs, ᶜTʲs) = p.precomputed
     end
 
-    # Grid scale hyperdiffusion
+    # Grid scale hyperdiffusion. Scalars are hyperdiffused as perturbations
+    # from a smooth hydrostatic reference profile: on tilted terrain-following
+    # surfaces, `gradₕ` of a horizontally uniform `s_d(z)` or `q_tot(z)` is
+    # nonzero purely from the coordinate tilt (dominated by `Φ` for `s_d`), so
+    # `∇⁴` on the raw field would spuriously mix scalars across topography.
+    # The reference-state pair `(sd_r, q_tot_r)` cancels this leading-order
+    # geometric term, matching the split-form pressure-gradient treatment in
+    # `advection.jl`.
     @. ᶜ∇²u = C123(wgradₕ(divₕ(ᶜu))) - C123(wcurlₕ(C123(curlₕ(ᶜu))))
-    @. ᶜ∇²s_d = wdivₕ(gradₕ(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ)))
+    @. ᶜ∇²s_d = wdivₕ(
+        gradₕ(
+            TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ) -
+            sd_r(thermo_params, ᶜp),
+        ),
+    )
     if MatrixFields.has_field(Y, @name(c.ρq_tot))
         if p.atmos.microphysics_model isa Union{NonEquilibriumMicrophysics1M,
             NonEquilibriumMicrophysics2M}
             @. ᶜ∇²q_tot_eff = wdivₕ(
                 gradₕ(
-                    specific(Y.c.ρq_tot - Y.c.ρq_rai - Y.c.ρq_sno, Y.c.ρ),
+                    specific(Y.c.ρq_tot - Y.c.ρq_rai - Y.c.ρq_sno, Y.c.ρ) -
+                    q_tot_r(thermo_params, ᶜp),
                 ),
             )
         else
-            @. ᶜ∇²q_tot_eff = wdivₕ(gradₕ(specific(Y.c.ρq_tot, Y.c.ρ)))
+            @. ᶜ∇²q_tot_eff = wdivₕ(
+                gradₕ(
+                    specific(Y.c.ρq_tot, Y.c.ρ) -
+                    q_tot_r(thermo_params, ᶜp),
+                ),
+            )
         end
     end
 
@@ -166,20 +184,31 @@ NVTX.@annotate function prep_hyperdiffusion_tendency!(Yₜ, Y, p, t)
             @. ᶜ∇²uʲs.:($$j) =
                 C123(wgradₕ(divₕ(ᶜuʲs.:($$j)))) -
                 C123(wcurlₕ(C123(curlₕ(ᶜuʲs.:($$j)))))
-            @. ᶜ∇²s_dʲs.:($$j) =
-                wdivₕ(gradₕ(TD.dry_static_energy(thermo_params, ᶜTʲs.:($$j), ᶜΦ)))
+            # Same reference-state subtraction as grid mean. Updrafts share
+            # the grid-mean pressure, so `sd_r(ᶜp)` and `q_tot_r(ᶜp)` reuse the
+            # same profiles.
+            @. ᶜ∇²s_dʲs.:($$j) = wdivₕ(
+                gradₕ(
+                    TD.dry_static_energy(thermo_params, ᶜTʲs.:($$j), ᶜΦ) -
+                    sd_r(thermo_params, ᶜp),
+                ),
+            )
             if p.atmos.microphysics_model isa Union{NonEquilibriumMicrophysics1M,
                 NonEquilibriumMicrophysics2M}
                 @. ᶜ∇²q_tot_effʲs.:($$j) = wdivₕ(
                     gradₕ(
                         Y.c.sgsʲs.:($$j).q_tot -
                         Y.c.sgsʲs.:($$j).q_rai -
-                        Y.c.sgsʲs.:($$j).q_sno,
+                        Y.c.sgsʲs.:($$j).q_sno -
+                        q_tot_r(thermo_params, ᶜp),
                     ),
                 )
             else
-                @. ᶜ∇²q_tot_effʲs.:($$j) =
-                    wdivₕ(gradₕ(Y.c.sgsʲs.:($$j).q_tot))
+                @. ᶜ∇²q_tot_effʲs.:($$j) = wdivₕ(
+                    gradₕ(
+                        Y.c.sgsʲs.:($$j).q_tot - q_tot_r(thermo_params, ᶜp),
+                    ),
+                )
             end
         end
     end

--- a/src/utils/refstate_thermodynamics.jl
+++ b/src/utils/refstate_thermodynamics.jl
@@ -22,6 +22,23 @@ Exponent of the Exner function in the reference temperature profile
 const s_ref = 7
 
 """
+    RH_ref
+
+Reference relative humidity used to build a smooth `q_tot_r(p)` profile for the
+scalar hyperdiffusion split (`q_tot_r(p) = RH_ref · q_sat(T_r(p), ρ_r(p))`.
+"""
+const RH_ref = 0.5
+
+"""
+    p_q_tot_r_cutoff
+
+Pressure cutoff above which `q_tot_r(p)` is clipped to zero [Pa]. Set at
+250 hPa to keep the reference profile confined to the troposphere, avoiding
+the unphysical stratospheric growth of `RH_ref · q_sat(T_r, ρ_r)`.
+"""
+const p_q_tot_r_cutoff = 25000  # Pa (250 hPa)
+
+"""
     theta_v(thermo_params, T, p, q_tot, q_liq, q_ice)
 
 Compute the virtual potential temperature `θ_v = T_v / Π` [K].
@@ -113,16 +130,37 @@ function phi_r(thermo_params, p)
 end
 
 """
-    h_dr(thermo_params, p, Φ)
+    q_tot_r(thermo_params, p)
 
-Compute the dry static energy of the reference state, `cp_d (T_r - T_0) + Φ`
-[J/kg], where `T_r` is the reference temperature at pressure `p` and `T_0` is
-the thermodynamic reference temperature.
+Compute the reference-state total specific humidity
+`q_tot_r(p) = RH_ref · q_sat(T_r, ρ_r)` for `p ≥ p_q_tot_r_cutoff` and zero
+above [kg/kg], with the dry reference-state density `ρ_r = p / (R_d T_r)` and
+saturation over liquid.
 """
-function h_dr(thermo_params, p, Φ)
+function q_tot_r(thermo_params, p)
+    R_d = TD.TP.R_d(thermo_params)
+    T_r = air_temperature_reference(thermo_params, p)
+    ρ_r = p / (R_d * T_r)
+    return ifelse(
+        p < oftype(p, p_q_tot_r_cutoff),
+        zero(p),
+        oftype(p, RH_ref) *
+        TD.q_vap_saturation(thermo_params, T_r, ρ_r, TD.Liquid()),
+    )
+end
+
+"""
+    sd_r(thermo_params, p)
+
+Compute the dry static energy of the reference state at pressure `p`,
+`s_{d,r}(p) = cp_d (T_r(p) - T_0) + Φ_r(p)` [J/kg], where `T_r(p)` is the
+reference temperature and `Φ_r(p)` is the reference geopotential (both pure
+functions of `p`; see `air_temperature_reference` and `phi_r`).
+"""
+function sd_r(thermo_params, p)
     T_0 = TD.TP.T_0(thermo_params)
     cp_d = TD.TP.cp_d(thermo_params)
 
     T_r = air_temperature_reference(thermo_params, p)
-    return cp_d * (T_r - T_0) + Φ
+    return cp_d * (T_r - T_0) + phi_r(thermo_params, p)
 end


### PR DESCRIPTION

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Subtract the dry static energy and moisture reference states in hyperdiffusion.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
