### PR TITLE
Viscous sponge: energy split

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-402
+403
 
 # **README**
 #
@@ -32,6 +32,13 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+403
+- Viscous sponge: match hyperdiffusion and vertical diffusion. Energy is
+  diffused as a dry-static-energy + h_eff-weighted q_tot_eff split rather
+  than as total enthalpy. Water mass diffuses on q_tot_eff (rain and snow
+  excluded); the aggregate tendency is distributed to the suspended cloud
+  mass species (ρq_lcl, ρq_icl).
+
 402
 - Hyperdiffusion: subtract a hydrostatic reference state from the diffused
   scalars (dry-static-energy `sd_r(p)` and total-water `q_tot_r(p)`. Removes

--- a/src/parameterized_tendencies/sponge/viscous_sponge.jl
+++ b/src/parameterized_tendencies/sponge/viscous_sponge.jl
@@ -65,19 +65,41 @@ function viscous_sponge_tendency_u₃(u₃, s)
 end
 
 """
-    viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, s)
+    viscous_sponge_tendency_ρe_tot_dry(ᶜρ, ᶜs_d, s)
 
-Return a lazy broadcast of the viscous sponge tendency
-`β_viscous(s, z, zmax) * ∇ₕ·(ρ ∇ₕh_tot)` for total energy density, or a `NullBroadcasted`
-when `s isa Nothing`.
-
-Energy is diffused via the total specific enthalpy `ᶜh_tot` rather than `ρe_tot` itself.
+Return a lazy broadcast of the dry-static-energy piece of the viscous sponge
+tendency for total energy density,
+`β_viscous(s, z, zmax) * ∇ₕ·(ρ ∇ₕs_d)`, or a `NullBroadcasted` when
+`s isa Nothing`.
 """
-function viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, s)
+function viscous_sponge_tendency_ρe_tot_dry(ᶜρ, ᶜs_d, s)
     s isa Nothing && return NullBroadcasted()
     (; ᶜz, ᶠz) = z_coordinate_fields(axes(ᶜρ))
     zmax = Spaces.z_max(axes(ᶠz))
-    return @. lazy(β_viscous(s, ᶜz, zmax) * wdivₕ(ᶜρ * gradₕ(ᶜh_tot)))
+    return @. lazy(β_viscous(s, ᶜz, zmax) * wdivₕ(ᶜρ * gradₕ(ᶜs_d)))
+end
+
+"""
+    viscous_sponge_tendency_ρe_tot_water(ᶜρ, ᶜh_eff_plus_Φ, ᶜq_tot_eff, s)
+
+Return a lazy broadcast of the water-enthalpy piece of the viscous sponge
+tendency for total energy density,
+`β_viscous(s, z, zmax) * ∇ₕ·(ρ (h_eff + Φ) ∇ₕq_tot_eff)`, or a `NullBroadcasted`
+when `s isa Nothing`.
+"""
+function viscous_sponge_tendency_ρe_tot_water(
+    ᶜρ,
+    ᶜh_eff_plus_Φ,
+    ᶜq_tot_eff,
+    s,
+)
+    s isa Nothing && return NullBroadcasted()
+    (; ᶜz, ᶠz) = z_coordinate_fields(axes(ᶜρ))
+    zmax = Spaces.z_max(axes(ᶠz))
+    return @. lazy(
+        β_viscous(s, ᶜz, zmax) *
+        wdivₕ(ᶜρ * ᶜh_eff_plus_Φ * gradₕ(ᶜq_tot_eff)),
+    )
 end
 
 """
@@ -92,4 +114,119 @@ function viscous_sponge_tendency_tracer(ᶜρ, ᶜχ, s)
     (; ᶜz, ᶠz) = z_coordinate_fields(axes(ᶜρ))
     zmax = Spaces.z_max(axes(ᶠz))
     return @. lazy(β_viscous(s, ᶜz, zmax) * wdivₕ(ᶜρ * gradₕ(ᶜχ)))
+end
+
+"""
+    viscous_sponge_tendency!(Yₜ, Y, p)
+
+Accumulate the full viscous-sponge tendency into `Yₜ` in-place. No-op when
+`p.atmos.viscous_sponge isa Nothing`. Covers:
+
+  - Horizontal (`c.uₕ`) and vertical (`f.u₃`) velocities of the grid mean,
+    and — under `PrognosticEDMFX` — the per-updraft `sgsʲ.u₃`.
+  - `c.ρe_tot`: split-form diffusion of dry static energy plus the
+    h_eff-weighted diffusion of `q_tot_eff = q_tot - q_rai - q_sno` (rain
+    and snow excluded from both `q_tot_eff` and the enthalpy weighting),
+    matching the hyperdiffusion and vertical-diffusion energy treatments.
+  - Total-water mass: diffuse `q_tot_eff`; apply the aggregate tendency to
+    `c.ρq_tot` and `c.ρ`; distribute it proportionally to the suspended
+    cloud mass species (`ρq_lcl`, `ρq_icl`).
+  - Rain and snow are not sponge-diffused.
+  - Passive (non-microphysics) grid-scale tracers: full independent
+    diffusion.
+"""
+NVTX.@annotate function viscous_sponge_tendency!(Yₜ, Y, p)
+    (; viscous_sponge, microphysics_model, turbconv_model) = p.atmos
+    isnothing(viscous_sponge) && return nothing
+    thermo_params = CAP.thermodynamics_params(p.params)
+    (; ᶜT) = p.precomputed
+    (; ᶜΦ) = p.core
+    ᶜρ = Y.c.ρ
+
+    # Velocities (grid mean and, under EDMFX, per-updraft u₃).
+    vst_uₕ = viscous_sponge_tendency_uₕ(Y.c.uₕ, viscous_sponge)
+    vst_u₃ = viscous_sponge_tendency_u₃(Y.f.u₃, viscous_sponge)
+    @. Yₜ.c.uₕ += vst_uₕ
+    @. Yₜ.f.u₃.components.data.:1 += vst_u₃
+    if turbconv_model isa PrognosticEDMFX
+        n = n_mass_flux_subdomains(turbconv_model)
+        for j in 1:n
+            ᶠu₃ʲ = Y.f.sgsʲs.:($j).u₃
+            vst_u₃ʲ = viscous_sponge_tendency_u₃(ᶠu₃ʲ, viscous_sponge)
+            @. Yₜ.f.sgsʲs.:($$j).u₃.components.data.:1 += vst_u₃ʲ
+        end
+    end
+
+    # Energy: dry-static-energy piece (applies in all configurations).
+    ᶜs_d = @. lazy(TD.dry_static_energy(thermo_params, ᶜT, ᶜΦ))
+    vst_ρe_tot_dry =
+        viscous_sponge_tendency_ρe_tot_dry(ᶜρ, ᶜs_d, viscous_sponge)
+    @. Yₜ.c.ρe_tot += vst_ρe_tot_dry
+
+    # Water pieces: energy water-enthalpy flux + q_tot_eff mass diffusion +
+    # proportional distribution to suspended cloud species. Reuse the shared
+    # `ᶜdiffusing_water` / `ᶜsuspended_water` / `ᶜh_eff_plus_Φ!` helpers so
+    # the split matches the vertical-diffusion and hyperdiffusion tendencies.
+    if !(microphysics_model isa DryModel)
+        FT = eltype(Y)
+        ϵ_FT = eps(FT)
+        ᶜq_tot_eff = ᶜdiffusing_water(Y, p)
+        ᶜq_vap, ᶜq_lcl, ᶜq_icl = ᶜsuspended_water(Y, p)
+        ᶜh_eff_plus_Φ = ᶜh_eff_plus_Φ!(
+            p.scratch.ᶜtemp_scalar,
+            thermo_params,
+            ᶜT,
+            ᶜΦ,
+            ᶜq_vap,
+            ᶜq_lcl,
+            ᶜq_icl,
+        )
+        vst_ρe_tot_water = viscous_sponge_tendency_ρe_tot_water(
+            ᶜρ,
+            ᶜh_eff_plus_Φ,
+            ᶜq_tot_eff,
+            viscous_sponge,
+        )
+        @. Yₜ.c.ρe_tot += vst_ρe_tot_water
+
+        # Aggregate water mass tendency; reuse the generic tracer sponge on
+        # `q_tot_eff`. Applied to `ρq_tot` and `ρ`, then distributed to
+        # suspended cloud species (and matching number densities).
+        ᶜρq_tot_diff = p.scratch.ᶜtemp_scalar_2
+        vst_ρq_tot =
+            viscous_sponge_tendency_tracer(ᶜρ, ᶜq_tot_eff, viscous_sponge)
+        @. ᶜρq_tot_diff = vst_ρq_tot
+        @. Yₜ.c.ρq_tot += ᶜρq_tot_diff
+        @. Yₜ.c.ρ += ᶜρq_tot_diff
+        ᶜratio = p.scratch.ᶜtemp_scalar_3
+        for (ρq_name, ρn_name) in (
+            (@name(c.ρq_lcl), @name(c.ρn_lcl)),
+            (@name(c.ρq_icl), @name(c.ρn_icl)),
+        )
+            MatrixFields.has_field(Y, ρq_name) || continue
+            ᶜρq = MatrixFields.get_field(Y, ρq_name)
+            ᶜρqₜ = MatrixFields.get_field(Yₜ, ρq_name)
+            @. ᶜratio = max(
+                FT(0),
+                min(FT(1), specific(ᶜρq, Y.c.ρ) / max(ᶜq_tot_eff, ϵ_FT)),
+            )
+            @. ᶜρqₜ += ᶜratio * ᶜρq_tot_diff
+            if MatrixFields.has_field(Y, ρn_name)
+                ᶜρn = MatrixFields.get_field(Y, ρn_name)
+                ᶜρnₜ = MatrixFields.get_field(Yₜ, ρn_name)
+                @. ᶜρnₜ +=
+                    ᶜratio * max(FT(0), ᶜρn) / max(ᶜρq, ϵ_FT) *
+                    ᶜρq_tot_diff
+            end
+        end
+    end
+
+    # Passive (non-microphysics) grid-scale tracers.
+    foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
+        ρχ_name in microphysics_tracer_names(Y) && return
+        ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
+        vst_tracer = viscous_sponge_tendency_tracer(ᶜρ, ᶜχ, viscous_sponge)
+        @. ᶜρχₜ += vst_tracer
+    end
+    return nothing
 end

--- a/src/prognostic_equations/remaining_tendency.jl
+++ b/src/prognostic_equations/remaining_tendency.jl
@@ -116,9 +116,6 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
     (; ᶜp, ᶜK, ᶜT, ᶜh_tot, ᶜq_tot_nonneg, ᶜq_liq, ᶜq_ice) = p.precomputed
     (; sfc_conditions) = p.precomputed
 
-    vst_uₕ = viscous_sponge_tendency_uₕ(ᶜuₕ, viscous_sponge)
-    vst_u₃ = viscous_sponge_tendency_u₃(ᶠu₃, viscous_sponge)
-    vst_ρe_tot = viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, viscous_sponge)
     rst_uₕ = rayleigh_sponge_tendency_uₕ(ᶜuₕ, rayleigh_sponge)
 
     if use_prognostic_tke(turbconv_model)
@@ -166,28 +163,8 @@ NVTX.@annotate function additional_tendency!(Yₜ, Y, p, t)
 
     # TODO: fuse, once we fix
     #       https://github.com/CliMA/ClimaCore.jl/issues/2165
-    @. Yₜ.c.uₕ += vst_uₕ
     @. Yₜ.c.uₕ += rst_uₕ
-    @. Yₜ.f.u₃.components.data.:1 += vst_u₃
-    @. Yₜ.c.ρe_tot += vst_ρe_tot
-
-    foreach_gs_tracer(Yₜ, Y) do ᶜρχₜ, ᶜρχ, ρχ_name
-        ᶜχ = @. lazy(specific(ᶜρχ, Y.c.ρ))
-        vst_tracer = viscous_sponge_tendency_tracer(ᶜρ, ᶜχ, viscous_sponge)
-        @. ᶜρχₜ += vst_tracer
-        if ρχ_name == @name(ρq_tot)
-            @. Yₜ.c.ρ += vst_tracer
-        end
-    end
-
-    if turbconv_model isa PrognosticEDMFX
-        n = n_mass_flux_subdomains(turbconv_model)
-        for j in 1:n
-            ᶠu₃ʲ = Y.f.sgsʲs.:($j).u₃
-            vst_u₃ʲ = viscous_sponge_tendency_u₃(ᶠu₃ʲ, viscous_sponge)
-            @. Yₜ.f.sgsʲs.:($$j).u₃.components.data.:1 += vst_u₃ʲ
-        end
-    end
+    viscous_sponge_tendency!(Yₜ, Y, p)
 
     # Held Suarez tendencies
     @. Yₜ.c.uₕ += hs_tendency_uₕ

--- a/test/parameterized_tendencies/sponge.jl
+++ b/test/parameterized_tendencies/sponge.jl
@@ -34,7 +34,9 @@ using Base.Broadcast: materialize
     ᶠw = Fields.Field(Geometry.Covariant3Vector{FT}, ᶠspace)
     @. ᶠw = Geometry.Covariant3Vector(FT(1))
     ᶜρ = ones(ᶜspace)
-    ᶜh_tot = ones(ᶜspace)
+    ᶜs_d = ones(ᶜspace)
+    ᶜh_eff_plus_Φ = ones(ᶜspace)
+    ᶜq_tot_eff = ones(ᶜspace)
     ᶜχ = ones(ᶜspace)
     ᶜχʲ = 2 .* ones(ᶜspace)
 
@@ -153,9 +155,17 @@ using Base.Broadcast: materialize
             tendency_u₃ = CA.viscous_sponge_tendency_u₃(ᶠw, s)
             @test all(isfinite, parent(materialize(tendency_u₃)))
 
-            # Test viscous_sponge_tendency_ρe_tot returns finite values
-            tendency_ρe_tot = CA.viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, s)
-            @test all(isfinite, parent(materialize(tendency_ρe_tot)))
+            # Split-form energy tendency: dry static energy + water enthalpy
+            tendency_ρe_tot_dry =
+                CA.viscous_sponge_tendency_ρe_tot_dry(ᶜρ, ᶜs_d, s)
+            @test all(isfinite, parent(materialize(tendency_ρe_tot_dry)))
+            tendency_ρe_tot_water = CA.viscous_sponge_tendency_ρe_tot_water(
+                ᶜρ,
+                ᶜh_eff_plus_Φ,
+                ᶜq_tot_eff,
+                s,
+            )
+            @test all(isfinite, parent(materialize(tendency_ρe_tot_water)))
 
             # Test viscous_sponge_tendency_tracer returns finite values
             tendency_tracer = CA.viscous_sponge_tendency_tracer(ᶜρ, ᶜχ, s)
@@ -165,7 +175,17 @@ using Base.Broadcast: materialize
         @testset "No sponge (nothing) returns NullBroadcasted" begin
             @test CA.viscous_sponge_tendency_uₕ(ᶜuₕ, nothing) isa NullBroadcasted
             @test CA.viscous_sponge_tendency_u₃(ᶠw, nothing) isa NullBroadcasted
-            @test CA.viscous_sponge_tendency_ρe_tot(ᶜρ, ᶜh_tot, nothing) isa NullBroadcasted
+            @test CA.viscous_sponge_tendency_ρe_tot_dry(
+                ᶜρ,
+                ᶜs_d,
+                nothing,
+            ) isa NullBroadcasted
+            @test CA.viscous_sponge_tendency_ρe_tot_water(
+                ᶜρ,
+                ᶜh_eff_plus_Φ,
+                ᶜq_tot_eff,
+                nothing,
+            ) isa NullBroadcasted
             @test CA.viscous_sponge_tendency_tracer(ᶜρ, ᶜχ, nothing) isa NullBroadcasted
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Diffuse ρe_tot as a dry-static-energy + h_eff-weighted q_tot_eff split. Diffuse ρq_tot on q_tot_eff (rain/snow excluded) and distribute the aggregate tendency to suspended cloud mass species. Bundle the sponge accumulation into viscous_sponge_tendency!(Yₜ, Y, p) to keep additional_tendency! readable.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
