### PR TITLE
Delete unused `UpwindBiasedGradient`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -324,7 +324,6 @@ Biased and upwinded reconstructions:
 
 ```@docs
 ClimaAtmos.ᶠleft_bias
-ClimaAtmos.upwind_biased_grad
 ClimaAtmos.ᶠupwind1
 ClimaAtmos.ᶠupwind3
 ClimaAtmos.ᶠlin_vanleer

--- a/src/utils/abbreviations.jl
+++ b/src/utils/abbreviations.jl
@@ -219,14 +219,6 @@ const ᶠcurlᵥ = Operators.CurlC2F(
 )
 
 """
-    upwind_biased_grad
-
-Gradient `upwind_biased_grad(v, θ)` of a field `θ`, upwinded according to the
-sign of the third contravariant component of the velocity `v`.
-"""
-const upwind_biased_grad = Operators.UpwindBiasedGradient()
-
-"""
     ᶠupwind1
 
 First-order upwind reconstruction of the product of a center scalar with a face


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

This is needed for [this](https://github.com/CliMA/ClimaCore.jl/pull/2544) climacore PR. 


## Content
- delete unused `UpwindBiasedGradient`



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.