### PR TITLE
Fixes microphysics/cloud fraction bug: erroneous subtraction of precip i

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -383,7 +383,7 @@ version = "0.5.23"
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
 path = ".."
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.42.6"
+version = "0.42.7"
 
     [deps.ClimaAtmos.extensions]
     ClimaAtmosMusica = "Musica"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAtmos"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 authors = ["Climate Modeling Alliance"]
-version = "0.42.6"
+version = "0.42.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-403
+404
 
 # **README**
 #
@@ -32,6 +32,9 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+404
+- SGS quadrature microphysics updates
+
 403
 - Viscous sponge: match hyperdiffusion and vertical diffusion. Energy is
   diffused as a dry-static-energy + h_eff-weighted q_tot_eff split rather

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -257,8 +257,16 @@ The local cloud condensate is obtained from the centred saturation excess
 `S′_hat = (q_tot_hat − q_sat(T_hat, ρ)) − mu_S`:
 
     shifted_excess = max(0, λ_lagrange + α · S′_hat)
-    q_lcl_hat      = max(0, λ · shifted_excess − q_rai)
-    q_icl_hat      = max(0, (1 − λ) · shifted_excess − q_sno)
+    q_lcl_hat      = λ · shifted_excess
+    q_icl_hat      = (1 − λ) · shifted_excess
+
+The Lagrange multiplier `λ_lagrange` is fitted (in `_compute_sgs_moments`) so
+that `E[shifted_excess] = q_c`, where `q_c = q_lcl + q_icl` is the grid-mean
+*cloud* condensate, excluding precipitation. The reconstruction therefore
+partitions `shifted_excess` into local cloud liquid and ice by the liquid
+fraction. Precipitation is held constant across quadrature points and is
+accounted for downstream, where CloudMicrophysics subtracts it from `q_tot`
+to diagnose the local vapor.
 
 `q_tot_hat` is clamped non-negative first. Subsaturated points contribute zero
 condensate but still drive rain evaporation and snow sublimation against the
@@ -273,15 +281,20 @@ with `dq_lcl_dt`, `dq_icl_dt`, `dq_rai_dt`, `dq_sno_dt` [kg/kg/s].
     FT = typeof(eval.ρ)
     q_tot_hat = max(FT(0), q_tot_hat)
 
-    # Local condensate from the Lagrange-multiplier closure.
+    # Local cloud condensate from the Lagrange-multiplier closure.
     # The mass conservation equation is E[max(0, λ + α·S′)] = q_c, so the
     # local shifted excess at each quadrature point is λ + α·S′_hat where
     # S′_hat = (q_tot_hat − q_sat_hat) − μ_S is the centred saturation excess.
+    # Precipitation in q_tot needs no special handling here: its mean level
+    # cancels in the centred S′ (the level is re-anchored by λ_lagrange, fitted
+    # to cloud-only q_c), and CloudMicrophysics subtracts q_rai/q_sno from
+    # q_tot_hat when it diagnoses the local vapor. Subtracting them from the
+    # cloud condensate as well would double-count them and break ⟨q_c^local⟩ = q_c.
     q_sat_hat = TD.q_vap_saturation(eval.tps, T_hat, eval.ρ)
     S′_hat = q_tot_hat - q_sat_hat - eval.mu_S
     shifted_excess = max(FT(0), eval.λ_lagrange + eval.α * S′_hat)
-    q_lcl_hat = max(FT(0), eval.λ * shifted_excess - eval.q_rai)
-    q_icl_hat = max(FT(0), (FT(1) - eval.λ) * shifted_excess - eval.q_sno)
+    q_lcl_hat = eval.λ * shifted_excess
+    q_icl_hat = (FT(1) - eval.λ) * shifted_excess
 
     return BMT.bulk_microphysics_tendencies(
         BMT.LinearizedAverage(),

--- a/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/test/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -285,6 +285,47 @@ import ClimaAtmos: limit_sink
                     @test result.dq_icl_dt ≈ ref.dq_icl_dt rtol = FT(1e-4)
                 end
 
+                @testset "Precipitation does not reduce reconstructed condensate" begin
+                    # λ_lagrange enforces E[shifted_excess] = q_c on *cloud*
+                    # condensate only, so at the mean point (S′_hat = 0), the
+                    # reconstruction must recover q_lcl_hat = λ·q_c and
+                    # q_icl_hat = (1−λ)·q_c regardless of q_rai / q_sno.
+                    #
+                    # Mixed-phase temperature so 0 < λ < 1 and both partitions
+                    # (liquid vs q_rai, ice vs q_sno) are exercised.
+                    T_mix = FT(263.15)
+                    q_sat_mix = TD.q_vap_saturation(thp, T_mix, ρ)
+                    q_tot_mix = q_sat_mix + FT(2e-3)
+                    mu_S_mix = q_tot_mix - q_sat_mix
+                    q_c = FT(1.5e-4)
+                    # Temperature-ramp liquid fraction (≈0.75 at 263.15 K). Used
+                    # identically below in the evaluator and the reference, so
+                    # the exact value only needs to lie strictly in (0, 1).
+                    λ_mix = TD.liquid_fraction_ramp(thp, T_mix)
+                    q_rai = FT(1e-3)
+                    q_sno = FT(5e-4)
+
+                    eval_precip = Microphysics1MEvaluator(
+                        BMT.Microphysics1Moment(), mp, thp, ρ,
+                        q_rai, q_sno,               # q_rai, q_sno
+                        λ_mix, q_c, mu_S_mix, FT(1),  # λ, λ_lagrange, mu_S, α
+                        dt, nsubs, (),
+                    )
+                    result = eval_precip(T_mix, q_tot_mix)
+                    # Reference: the condensate the closure must reconstruct at
+                    # the mean point, plus the true precipitation.
+                    ref = BMT.bulk_microphysics_tendencies(
+                        BMT.LinearizedAverage(),
+                        BMT.Microphysics1Moment(), mp, thp, ρ, T_mix,
+                        q_tot_mix, λ_mix * q_c, (1 - λ_mix) * q_c,
+                        q_rai, q_sno, dt, nsubs,
+                    )
+                    @test result.dq_lcl_dt ≈ ref.dq_lcl_dt rtol = FT(1e-4)
+                    @test result.dq_icl_dt ≈ ref.dq_icl_dt rtol = FT(1e-4)
+                    @test result.dq_rai_dt ≈ ref.dq_rai_dt rtol = FT(1e-4)
+                    @test result.dq_sno_dt ≈ ref.dq_sno_dt rtol = FT(1e-4)
+                end
+
                 @testset "Output is finite NamedTuple" begin
                     eval = Microphysics1MEvaluator(
                         BMT.Microphysics1Moment(), mp, thp, ρ,

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -375,6 +375,54 @@ using ClimaAtmos
                     @test result_quad.dq_sno_dt ≈ result_direct.dq_sno_dt rtol = FT(1e-5)
                 end
 
+                # Same exact-mean property, but with nonzero rain and
+                # snow. λ_lagrange enforces E[shifted_excess] = q_c on *cloud*
+                # condensate only, so at the mean point, the reconstruction must
+                # still recover q_lcl_hat = λ·q_c and q_icl_hat = (1−λ)·q_c,
+                # independent of q_rai / q_sno.
+                # Mixed-phase T so both the liquid (vs q_rai) and ice (vs q_sno)
+                # partitions are exercised.
+                @testset "Single Point = Grid Mean (precipitating)" begin
+                    quad_1pt = ClimaAtmos.SGSQuadrature(
+                        FT;
+                        quadrature_order = 1,
+                        distribution = ClimaAtmos.GaussianSGS(),
+                    )
+
+                    T_mix = FT(263.15)  # mixed-phase: 0 < λ < 1
+                    q_sat_mix = TD.q_vap_saturation(tps, T_mix, ρ)
+                    q_tot_mix = q_sat_mix + q_lcl_mean + q_icl_mean
+                    q_c = q_lcl_mean + q_icl_mean
+                    λ_mix = TD.liquid_fraction(tps, T_mix, q_lcl_mean, q_icl_mean)
+                    # Precipitation of the same order as (or larger than) q_c, so
+                    # the buggy subtraction would clamp the cloud water to zero.
+                    q_rai_p = FT(1e-3)
+                    q_sno_p = FT(5e-4)
+                    λ_lagrange_mix = q_c  # σ_S → 0 limit at the mean point
+
+                    result_quad = microphysics_tendencies_1m(
+                        BMT.Microphysics1Moment(),
+                        quad_1pt, mp, tps, ρ,
+                        T_mix, q_tot_mix, q_lcl_mean, q_icl_mean, q_rai_p, q_sno_p,
+                        T′T′, q′q′, corr_Tq, λ_lagrange_mix, α, dt, nsubs_quad,
+                    )
+
+                    # Reference: BMT called with the condensate the closure must
+                    # reconstruct at the mean point, plus the true precipitation.
+                    result_direct = BMT.bulk_microphysics_tendencies(
+                        BMT.LinearizedAverage(),
+                        BMT.Microphysics1Moment(),
+                        mp, tps, ρ, T_mix,
+                        q_tot_mix, λ_mix * q_c, (1 - λ_mix) * q_c,
+                        q_rai_p, q_sno_p, dt, nsubs_quad,
+                    )
+
+                    @test result_quad.dq_lcl_dt ≈ result_direct.dq_lcl_dt rtol = FT(1e-5)
+                    @test result_quad.dq_icl_dt ≈ result_direct.dq_icl_dt rtol = FT(1e-5)
+                    @test result_quad.dq_rai_dt ≈ result_direct.dq_rai_dt rtol = FT(1e-5)
+                    @test result_quad.dq_sno_dt ≈ result_direct.dq_sno_dt rtol = FT(1e-5)
+                end
+
                 # Test 2: Zero variance collapses to single-point → same as grid mean.
                 @testset "Zero Variance = Grid Mean" begin
                     quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)


### PR DESCRIPTION
Precipitation (rain/snow) was erroneously subtracted in reconstruction of SGS *cloud* condensate, violating condensate conservation in the quadratures. 

This PR fixes this and adds tests to make sure mid point equals grid mean. 