### PR TITLE
Make the SGS quadrature closure more self-consistent:

### DIFF
--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-404
+405
 
 # **README**
 #
@@ -32,6 +32,11 @@
 # 3) (optional) leave a link to the buildkite run that prompted this ref counter bump.
 
 #=
+405
+- SGS quadrature corrections: fit λ_lagrange to the discrete quadrature
+  measure and add a second Newton step to _compute_z; correct the 0M
+  energy sink by taking the covariance of dq_tot/dt and e_tot.
+
 404
 - SGS quadrature microphysics updates
 

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -409,7 +409,7 @@ end
 # kinked integrand max(0, ·) imperfectly (and samples the q ≥ 0 clamp).
 # The analytic inverse of C = z·Φ(z) + φ(z) therefore only *seeds*
 # `λ_lagrange`; the multiplier is then fitted to the discrete constraint
-# Σᵢ wᵢ·max(0, λ + α·S′ᵢ) = q_c  over the same sampled points the 
+# Σᵢ wᵢ·max(0, λ + α·S′ᵢ) = q_c  over the same sampled points the
 # microphysics evaluator integrates (see `_fit_discrete_lagrange`),
 # so mass conservation holds exactly under the quadrature measure.
 #
@@ -422,8 +422,8 @@ end
 # which keeps CF well-behaved in the singular limit (q_c, σ_S²) → 0.  CF is
 # always computed by solving the truncated-Gaussian closure with `σ_aug`,
 # i.e. `C_aug = q_c / σ_aug`, `z_aug = _compute_z(C_aug)`, `CF = Φ(z_aug)`;
-# it is a probability under the continuous Gaussian model. `λ_lagrange` is 
-# *not* used to recover CF (the natural shortcut `Φ(λ/σ_aug)` would be 
+# it is a probability under the continuous Gaussian model. `λ_lagrange` is
+# *not* used to recover CF (the natural shortcut `Φ(λ/σ_aug)` would be
 # inconsistent because `λ` is fitted with the equilibrium `σ_S_eff`, not `σ_aug`).
 #
 # Inverting C = z·Φ(z)+φ(z) for z uses Newton iteration on

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -319,6 +319,24 @@ end
     return (s - eval.mu_S)^2
 end
 
+"""
+    SGSExcessEvaluator(tps, ρ, mu_S)
+
+GPU-safe functor returning the centred saturation excess
+`S′ = q_tot_hat − q_sat(T_hat, ρ) − μ_S` at each quadrature point. This is the
+quantity from which the `Microphysics1MEvaluator` reconstructs condensate. It is
+used with `quadrature_point_values` to materialize the sampled S′ distribution for
+the discrete Lagrange-multiplier fit in `_compute_sgs_moments`.
+"""
+struct SGSExcessEvaluator{TPS, FT}
+    tps::TPS
+    ρ::FT
+    mu_S::FT
+end
+
+@inline (eval::SGSExcessEvaluator)(T_hat, q_tot_hat) =
+    q_tot_hat - TD.q_vap_saturation(eval.tps, T_hat, eval.ρ) - eval.mu_S
+
 
 """
     _sgs_saturation_moments(thp, ρ, T_mean, q_tot_mean,
@@ -386,6 +404,15 @@ end
 #
 # where Φ is the standard normal CDF and φ is its PDF.
 #
+# The microphysics, however, uses (*) via the N²-point quadrature
+# rule (not the continuous Gaussian), and the discrete rule represents the
+# kinked integrand max(0, ·) imperfectly (and samples the q ≥ 0 clamp).
+# The analytic inverse of C = z·Φ(z) + φ(z) therefore only *seeds*
+# `λ_lagrange`; the multiplier is then fitted to the discrete constraint
+# Σᵢ wᵢ·max(0, λ + α·S′ᵢ) = q_c  over the same sampled points the 
+# microphysics evaluator integrates (see `_fit_discrete_lagrange`),
+# so mass conservation holds exactly under the quadrature measure.
+#
 # For the *cloud fraction* we use an augmented variance with a fixed
 # non-equilibrium floor `σ_S_floor` (defined inside
 # `_compute_cloud_fraction`):
@@ -394,25 +421,24 @@ end
 #
 # which keeps CF well-behaved in the singular limit (q_c, σ_S²) → 0.  CF is
 # always computed by solving the truncated-Gaussian closure with `σ_aug`,
-# i.e. `C_aug = q_c / σ_aug`, `z_aug = _compute_z(C_aug)`, `CF = Φ(z_aug)`.
-# `λ_lagrange` is *not* used to recover CF (the natural shortcut
-# `Φ(λ/σ_aug)` would be inconsistent because `λ` is computed with the
-# equilibrium `σ_S_eff`, not `σ_aug`).  `λ_lagrange` is computed from the
-# raw `σ_S_eff` so the mass-conservation constraint (*) is preserved for
-# the microphysics tendencies.
+# i.e. `C_aug = q_c / σ_aug`, `z_aug = _compute_z(C_aug)`, `CF = Φ(z_aug)`;
+# it is a probability under the continuous Gaussian model. `λ_lagrange` is 
+# *not* used to recover CF (the natural shortcut `Φ(λ/σ_aug)` would be 
+# inconsistent because `λ` is fitted with the equilibrium `σ_S_eff`, not `σ_aug`).
 #
 # Inverting C = z·Φ(z)+φ(z) for z uses Newton iteration on
 # F(z) = z·Φ(z)+φ(z)−C with F′(z) = Φ(z):
 #
 #     z_{n+1} = (C − φ(z_n)) / Φ(z_n).
 #
-# **Algorithm** (one Newton step with a fitted initial guess):
+# **Algorithm** (two Newton steps with a fitted initial guess):
 # 1. Initial guess:  Φ(z₀) = tanh(1.35·C)  [least-squares fit to exact solution],
 #                    z₀    = Φ⁻¹(Φ(z₀))  via `normal_cdf_inv` (A&S 26.2.22).
 #    The A&S inverse correctly scales as −√(−2 ln Φ(z₀)) in the tail, avoiding
 #    the extreme underestimate of the tanh-based inverse that causes divergence.
-# 2. One Newton step:  z₁ = (C − φ(z₀)) / Φ(z₀).
-# 3. CF = Φ(z₁) via `normal_cdf` (A&S 26.2.17, max error ≈ 7.5×10⁻⁸).
+# 2. Two Newton steps:  z₁ = (C − φ(z₀)) / Φ(z₀), then likewise z₂ from z₁
+#    (skipped where Φ(z₁) ≤ ϵ_numerics; see `_compute_z`).
+# 3. CF = Φ(z₂) via `normal_cdf` (A&S 26.2.17, max error ≈ 7.5×10⁻⁸).
 
 """
     sgs_variance_fidelity(cf_steepness_coeff)
@@ -447,16 +473,23 @@ sgs_variance_fidelity(cf_steepness_coeff::FT) where {FT} = one(FT) / cf_steepnes
     _compute_z(C)
 
 Compute the normalised threshold `z` that satisfies the truncated-Gaussian
-condensate relation `C = z·Φ(z) + φ(z)` via one Newton step seeded with an
+condensate relation `C = z·Φ(z) + φ(z)` via two Newton steps seeded with an
 analytic initial guess.
 
 `C = q_c / σ_eff` is the normalised condensate; the caller is responsible
 for computing it (typically with `σ_eff = α · σ_S` or `σ_eff = σ_aug` for
 the smooth-floored CF formula) so this helper stays free of parameter-
 dependent logic.
+
+Accuracy: the residual `z·Φ(z) + φ(z) − C` after two steps is below 0.7 %
+of `C` for `C ≥ 0.05` and below 4 % for `C ≥ 0.01`; a single step leaves
+7–36 % in that range. Because the relation is convex, each Newton iterate
+overshoots `z` from above, so the (small) remaining error biases `Φ(z)`
+high.
 """
 @inline function _compute_z(C)
     FT = typeof(C)
+    inv_sqrt2π = one(FT) / sqrt(FT(2) * FT(π))
 
     # 1. Initial guess: Φ(z₀) = tanh(1.35 · C).
     Φz0 = tanh(FT(1.35) * C)
@@ -467,9 +500,18 @@ dependent logic.
     # z₀ = Φ⁻¹(Φz0) via A&S 26.2.22
     z0 = normal_cdf_inv(Φz0_safe)
 
-    # 2. One Newton step: z₁ = (C − φ(z₀)) / Φ(z₀)
-    φz0 = exp(-z0 * z0 / 2) / sqrt(FT(2) * FT(π))
-    return (C - φz0) / Φz0_safe
+    # 2. First Newton step: z₁ = (C − φ(z₀)) / Φ(z₀)
+    φz0 = exp(-z0 * z0 / 2) * inv_sqrt2π
+    z1 = (C - φz0) / Φz0_safe
+
+    # 3. Second Newton step. Applied only where Φ(z₁) is above
+    # the ϵ_numerics clamp; below that (z₁ ≲ −7 at Float32) the clamped
+    # denominator corrupts the ratio φ(z₁)/Φ(z₁), and the result is
+    # condensate- and cloud-free to machine precision either way.
+    φz1 = exp(-z1 * z1 / 2) * inv_sqrt2π
+    Φz1 = normal_cdf(z1)
+    z2 = (C - φz1) / max(Φz1, ϵ_numerics(FT))
+    return ifelse(Φz1 > ϵ_numerics(FT), z2, z1)
 end
 
 """
@@ -644,30 +686,95 @@ cloud_fraction_floor_params(params) = CloudFractionFloorParams(;
 )
 
 """
+    _fit_discrete_lagrange(λ0, q_c, α, S′s, ws)
+
+Solve the mass-conservation constraint under the discrete quadrature measure,
+
+    g(λ) = Σᵢ wᵢ · max(0, λ + α·S′ᵢ) = q_c,
+
+for the Lagrange multiplier `λ`, given the sampled centred excesses `S′s` and
+probability weights `ws` (summing to 1). `g` is convex, piecewise linear, and
+nondecreasing, with kinks at `λ = −α·S′ᵢ`; Newton with the exact one-sided
+slope solves the active segment exactly, and, by convexity, subsequent iterates
+lie on the root's side, so the iteration reaches the root within
+`length(S′s) + 2` fixed trips (GPU-safe: no data-dependent loop bound).
+
+`λ0` is the analytic truncated-Gaussian seed (see `_compute_z`); `q_c ≤ 0`
+returns the largest `λ` with `g(λ) = 0`.
+
+Fitting `λ` to the discrete rule rather than the continuous Gaussian makes
+`⟨q_c^local⟩ = q_c` hold exactly for the microphysics evaluator, which
+uses the same quadrature points.
+"""
+@inline function _fit_discrete_lagrange(λ0, q_c, α, S′s, ws)
+    FT = typeof(q_c)
+    λ_max_inactive = -α * maximum(S′s)  # largest λ with g(λ) = 0
+    q_c <= zero(FT) && return λ_max_inactive
+    λ = λ0
+    for _ in 1:(length(S′s) + 2)
+        g = zero(FT)
+        dg = zero(FT)
+        @inbounds for i in eachindex(S′s)
+            r = λ + α * S′s[i]
+            g += ifelse(r > zero(FT), ws[i] * r, zero(FT))
+            dg += ifelse(r > zero(FT), ws[i], zero(FT))
+        end
+        if dg == zero(FT)
+            # Below every kink (g = 0, slope 0): jump into the first active
+            # segment; the point with the largest S′ then has r = q_c > 0.
+            λ = λ_max_inactive + q_c
+        else
+            λ_new = λ + (q_c - g) / dg
+            λ_new == λ && return λ
+            λ = λ_new
+        end
+    end
+    return λ
+end
+
+"""
     _compute_sgs_moments(thp, ρ, T, q_tot, q_c, sgs_quad, T′T′, q′q′, corr_Tq, α)
 
 Single quadrature pass returning `(sigma_S, λ_lagrange)`:
 
-  - `sigma_S    = sqrt(E[(S − μ_S)²])`: SGS standard deviation, clipped at
-    `ϵ_numerics(FT)` (see `_sgs_saturation_moments`).
-  - `λ_lagrange = z·α·σ_S`: Lagrange multiplier satisfying
-    `E[max(0, λ + α·S′)] = q_c`.
+  - `sigma_S = sqrt(Σᵢ wᵢ·S′ᵢ²)`: SGS standard deviation of the sampled
+    centred excess, clipped at `ϵ_numerics(FT)`.
+  - `λ_lagrange`: Lagrange multiplier satisfying the mass-conservation
+    constraint `Σᵢ wᵢ·max(0, λ + α·S′ᵢ) = q_c` exactly under the discrete
+    quadrature measure — the same points and weights the microphysics
+    evaluator integrates over (see `_fit_discrete_lagrange`; the analytic
+    truncated-Gaussian inverse `_compute_z` provides the seed).
 
 The SGS mean `μ_S = q_tot − q_sat(T, ρ)` is analytic under the closure's
-linearization (see `_sgs_saturation_moments`) and is recomputed
-on demand wherever it is needed downstream.
+linearization (see `_sgs_saturation_moments`) and is recomputed on demand
+wherever it is needed downstream.
+
+Without SGS sampling (`nothing`, `GridMeanSGS`), all mass sits at the mean:
+`sigma_S = ϵ_numerics(FT)` and the constraint gives `λ_lagrange = q_c`
+directly, matching the σ_S → 0 limit of the sampled branch.
 """
 @inline function _compute_sgs_moments(
     thp, ρ, T, q_tot, q_c,
     sgs_quad, T′T′, q′q′, corr_Tq, α,
 )
-    moments =
-        _sgs_saturation_moments(thp, ρ, T, q_tot, sgs_quad, T′T′, q′q′, corr_Tq)
-    σ_S_eff = α * moments.sigma_S
-    C = q_c / σ_S_eff
-    z = _compute_z(C)
-    λ_lagrange = z * σ_S_eff
-    return (; moments.sigma_S, λ_lagrange)
+    FT = typeof(ρ)
+    not_quadrature(sgs_quad) &&
+        return (; sigma_S = ϵ_numerics(FT), λ_lagrange = q_c)
+
+    mu_S = q_tot - TD.q_vap_saturation(thp, T, ρ)
+    transform =
+        build_physical_transform(sgs_quad, q_tot, T, q′q′, T′T′, corr_Tq)
+    S′s = quadrature_point_values(
+        SGSExcessEvaluator(thp, ρ, mu_S), transform, sgs_quad,
+    )
+    ws = quadrature_prob_weights(sgs_quad)
+    sigma_S = max(sqrt(sum(ws .* S′s .* S′s)), ϵ_numerics(FT))
+
+    # Analytic truncated-Gaussian seed, then the exact discrete fit.
+    σ_S_eff = α * sigma_S
+    λ0 = _compute_z(q_c / σ_S_eff) * σ_S_eff
+    λ_lagrange = _fit_discrete_lagrange(λ0, q_c, α, S′s, ws)
+    return (; sigma_S, λ_lagrange)
 end
 
 """

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -91,9 +91,10 @@ Diagnoses the local condensate by saturation adjustment, then calls
 
 # Returns
 
-NamedTuple with `dq_tot_dt` [kg/kg/s] and `e_tot_hlpr` [J/kg]. Both are returned
-from a single call so that `integrate_over_sgs` SGS-averages the energy helper
-consistently with the water sink that carries it.
+NamedTuple with `dq_tot_dt` [kg/kg/s] and the energy-flux product
+`dq_e = dq_tot_dt · e_tot_hlpr` [W/kg]. The product is formed per point so
+that its SGS average is the true energy sink `E[dq·e]` (averaging `dq` and
+`e` separately and multiplying the means would drop their covariance).
 """
 @inline function (eval::Microphysics0MEvaluator)(T_hat, q_hat)
     # Diagnose condensate via saturation adjustment
@@ -109,12 +110,12 @@ consistently with the water sink that carries it.
         BMT.Microphysics0Moment(), eval.cm_params, eval.sat_eval.thermo_params,
         T_hat, sa.q_liq, sa.q_ice, q_vap_sat,
     )
-    # Compute energy helper at this quadrature point using the
-    # locally-diagnosed condensate, so both fields are SGS-averaged.
+    # Energy helper at this quadrature point using the locally-diagnosed
+    # condensate; returned as the product with dq_tot_dt (see docstring).
     e_tot_hlpr = e_tot_0M_precipitation_sources_helper(
         eval.sat_eval.thermo_params, T_hat, sa.q_liq, sa.q_ice, eval.Φ,
     )
-    return (; dq_tot_dt, e_tot_hlpr)
+    return (; dq_tot_dt, dq_e = dq_tot_dt * e_tot_hlpr)
 end
 
 """
@@ -150,20 +151,36 @@ via `apply_0m_tendency_limit`.
 
 # Returns
 
-NamedTuple with `dq_tot_dt` [kg/kg/s] and `e_tot_hlpr` [J/kg].
+NamedTuple with `dq_tot_dt` [kg/kg/s] and `e_tot_hlpr` [J/kg]. In the
+quadrature form, `e_tot_hlpr` is the flux-weighted helper
+`E[dq·e] / E[dq]`, so downstream products `dq_tot_dt · e_tot_hlpr`
+reconstruct the true SGS-averaged energy sink `E[dq·e]` — including after
+the limiter, which scales mass and energy by the same factor. The
+flux-weighted helper is a `dq`-weighted average of the per-point helper
+values (all `dq` share one sign), so it lies within their range.
 """
 @inline function microphysics_tendencies_0m(
     SG_quad, cmp, thp, ρ, T, q_tot_nonneg, T′T′, q′q′, corr_Tq, Φ, dt,
 )
+    FT = typeof(ρ)
     # Create GPU-safe functor (Φ is constant within a grid cell)
     # The evaluator does saturation adjustment, computes saturation vapor pressure
-    # and computes the total water sink and energy helper from 0M microphysics
+    # and computes the total water sink and energy-flux product from 0M microphysics
     evaluator = Microphysics0MEvaluator(cmp, thp, ρ, T, Φ)
-    # Integrate over quadrature points; both dq_tot_dt and e_tot_hlpr
-    # are averaged over the SGS distribution.
-    (; dq_tot_dt, e_tot_hlpr) = integrate_over_sgs(
+    # Integrate over quadrature points; dq_tot_dt and the product dq·e are
+    # averaged over the SGS distribution.
+    (; dq_tot_dt, dq_e) = integrate_over_sgs(
         evaluator, SG_quad, q_tot_nonneg, T, q′q′, T′T′, corr_Tq,
     )
+    # Flux-weighted energy helper: E[dq·e] / E[dq]. The ratio is stable for
+    # any strictly negative mean sink because numerator and denominator share
+    # the dq scale. Where no quadrature point precipitates (E[dq] = 0), fall
+    # back to the mean-state helper.
+    sa = evaluator.sat_eval(T, q_tot_nonneg)
+    e_hlpr_mean = e_tot_0M_precipitation_sources_helper(
+        thp, T, sa.q_liq, sa.q_ice, Φ,
+    )
+    e_tot_hlpr = ifelse(dq_tot_dt < zero(FT), dq_e / dq_tot_dt, e_hlpr_mean)
     # Apply limiter
     dq_tot_dt = apply_0m_tendency_limit(dq_tot_dt, q_tot_nonneg, dt)
 

--- a/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
+++ b/src/parameterized_tendencies/microphysics/microphysics_wrappers.jl
@@ -211,8 +211,9 @@ quadrature points.
   - `q_rai`, `q_sno`: Rain and snow specific humidity [kg/kg], clamped
     non-negative by the caller.
   - `λ`: Thermodynamic liquid fraction [-].
-  - `λ_lagrange`: Lagrange multiplier `z·α·σ_S` enforcing
-    `E[max(0, λ_lagrange + α·S′)] = q_c` [kg/kg].
+  - `λ_lagrange`: Lagrange multiplier enforcing
+    `E[max(0, λ_lagrange + α·S′)] = q_c` under the quadrature
+    measure (fitted in `_compute_sgs_moments`) [kg/kg].
   - `mu_S`: Linearized SGS mean saturation excess `q_tot − q_sat(T, ρ)` [kg/kg].
   - `α`: Variance fidelity parameter [-].
   - `dt`: Timestep used for the time-averaged process rates [s].
@@ -229,7 +230,7 @@ struct Microphysics1MEvaluator{S, MP, TPS, FT, Args <: Tuple}
     q_sno::FT
     # Truncated-Gaussian Lagrange multiplier, μ_S, and liquid fraction
     λ::FT              # liquid fraction (from thermodynamics, held fixed)
-    λ_lagrange::FT # Lagrange multiplier for centred S′: λ = z·α·σ_S
+    λ_lagrange::FT # Lagrange multiplier for centred S′ (discrete fit)
     mu_S::FT       # linearized SGS mean μ_S = q_tot_mean − q_sat(T_mean, ρ)
     α::FT          # variance fidelity parameter (from sgs_variance_fidelity)
     # Numerical parameters
@@ -339,8 +340,9 @@ accretion.
   - `T′T′`: Temperature variance ``\\langle T'^2 \\rangle`` [K²].
   - `q′q′`: Total-water variance ``\\langle q'^2 \\rangle`` [(kg/kg)²].
   - `corr_Tq`: Correlation coefficient corr(T′, q′) from `correlation_Tq(params)` [-].
-  - `λ_lagrange`: Lagrange multiplier `z·α·σ_S` from `ᶜsgs_moments`, precomputed to
-    enforce `E[max(0, λ_lagrange + α·S′)] = q_c` [kg/kg].
+  - `λ_lagrange`: Lagrange multiplier from `ᶜsgs_moments`, precomputed to
+    enforce `E[max(0, λ_lagrange + α·S′)] = q_c` exactly under the
+    quadrature measure [kg/kg].
   - `α`: Variance fidelity parameter from `sgs_variance_fidelity` [-].
   - `dt`: Timestep [s].
   - `nsubs`: Number of substeps for tendency averaging.

--- a/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -700,15 +700,29 @@ perturbed.
 The weighted sum ``\\approx E[f(T, q)]``, of the same type as `f(T_hat, q_hat)`.
 """
 function integrate_over_sgs(f, quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
-    σ_q, σ_T, corr = sgs_stddevs_and_correlation(q′q′, T′T′, corr_Tq)
-
     # Use functor instead of closure to avoid heap allocations.
     # Field order is (T, q) to match return order of get_physical_point.
+    transform = build_physical_transform(quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
+    return sum_over_quadrature_points(f, transform, quad)
+end
+
+"""
+    build_physical_transform(quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
+
+Build the [`AbstractPhysicalPointTransform`](@ref) for `quad` from the mean
+state and (co)variances, converting variances to standard deviations and
+clamping the correlation on the way (see `sgs_stddevs_and_correlation`).
+Factored out of [`integrate_over_sgs`](@ref) so callers that need the
+individual quadrature-point values (see [`quadrature_point_values`](@ref))
+sample from exactly the same transform.
+"""
+@inline function build_physical_transform(quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
+    σ_q, σ_T, corr = sgs_stddevs_and_correlation(q′q′, T′T′, corr_Tq)
 
     # Promote μ_T and μ_q to the widest type: with autodiff, either may
     # independently be a Dual (when ρe_tot or ρq_tot is perturbed).
     μ_T_p, μ_q_p = promote(μ_T, μ_q)
-    transform = create_physical_transform(
+    return create_physical_transform(
         quad.dist,
         μ_q_p,
         μ_T_p,
@@ -718,8 +732,46 @@ function integrate_over_sgs(f, quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
         oftype(μ_T_p, quad.T_min),
         oftype(μ_T_p, quad.q_max),
     )
+end
 
-    return sum_over_quadrature_points(f, transform, quad)
+"""
+    quadrature_point_values(f, get_x_hat, quad)
+
+Evaluate `f(T_hat, q_hat)` at each of the `N²` quadrature points and return
+the values as an `SVector{N²}`, in the same point order as
+[`quadrature_prob_weights`](@ref). Unlike [`sum_over_quadrature_points`](@ref),
+which only accumulates the weighted sum, this materializes the individual
+point values (in registers — `N` is a compile-time constant), for closures
+that need the sampled distribution itself, such as the discrete
+Lagrange-multiplier fit in `_compute_sgs_moments`.
+"""
+@inline function quadrature_point_values(
+    f,
+    get_x_hat,
+    quad::SGSQuadrature{N},
+) where {N}
+    χ = quad.a
+    return SA.SVector{N * N}(ntuple(Val(N * N)) do k
+        j, i = fldmod1(k, N)
+        f(get_x_hat(χ[i], χ[j])...)
+    end)
+end
+
+"""
+    quadrature_prob_weights(quad)
+
+Return the `N²` probability weights of the two-dimensional quadrature rule as
+an `SVector{N²}` in the same point order as [`quadrature_point_values`](@ref):
+the tensor products `wᵢ·wⱼ/π`, which sum to 1 for the Gauss-Hermite rule.
+"""
+@inline function quadrature_prob_weights(quad::SGSQuadrature{N}) where {N}
+    w = quad.w
+    FT = eltype(w)
+    inv_pi = one(FT) / FT(π)
+    return SA.SVector{N * N}(ntuple(Val(N * N)) do k
+        j, i = fldmod1(k, N)
+        w[i] * w[j] * inv_pi
+    end)
 end
 
 """

--- a/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/src/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -713,7 +713,7 @@ Build the [`AbstractPhysicalPointTransform`](@ref) for `quad` from the mean
 state and (co)variances, converting variances to standard deviations and
 clamping the correlation on the way (see `sgs_stddevs_and_correlation`).
 Factored out of [`integrate_over_sgs`](@ref) so callers that need the
-individual quadrature-point values (see [`quadrature_point_values`](@ref))
+individual quadrature-point values (see `quadrature_point_values`)
 sample from exactly the same transform.
 """
 @inline function build_physical_transform(quad, μ_q, μ_T, q′q′, T′T′, corr_Tq)
@@ -739,7 +739,7 @@ end
 
 Evaluate `f(T_hat, q_hat)` at each of the `N²` quadrature points and return
 the values as an `SVector{N²}`, in the same point order as
-[`quadrature_prob_weights`](@ref). Unlike [`sum_over_quadrature_points`](@ref),
+`quadrature_prob_weights`. Unlike `sum_over_quadrature_points`,
 which only accumulates the weighted sum, this materializes the individual
 point values (in registers — `N` is a compile-time constant), for closures
 that need the sampled distribution itself, such as the discrete
@@ -761,7 +761,7 @@ end
     quadrature_prob_weights(quad)
 
 Return the `N²` probability weights of the two-dimensional quadrature rule as
-an `SVector{N²}` in the same point order as [`quadrature_point_values`](@ref):
+an `SVector{N²}` in the same point order as `quadrature_point_values`:
 the tensor products `wᵢ·wⱼ/π`, which sum to 1 for the Gauss-Hermite rule.
 """
 @inline function quadrature_prob_weights(quad::SGSQuadrature{N}) where {N}

--- a/test/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/test/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -236,4 +236,35 @@ floor_nt(
         end
     end
 
+    @testset "`_compute_z` inversion accuracy" begin
+        # z must satisfy the truncated-Gaussian relation z·Φ(z) + φ(z) = C.
+        # Two Newton steps leave < 0.7 % residual for C ≥ 0.05 and < 4 % for
+        # C ≥ 0.01 (a single step left 14 % and 36 %). Residuals are checked
+        # with `normal_cdf` (abs. error 7.5e-8), so tolerances stay well
+        # above the CDF approximation error.
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                φ(z) = exp(-z^2 / 2) / sqrt(FT(2) * FT(π))
+                h(z) = z * CA.normal_cdf(z) + φ(z)
+                for (C, rtol) in (
+                    (FT(0.01), FT(0.05)),
+                    (FT(0.05), FT(0.01)),
+                    (FT(0.1), FT(0.005)),
+                    (FT(0.3), FT(1e-3)),
+                    (FT(1), FT(1e-3)),
+                    (FT(5), FT(1e-3)),
+                    (FT(100), FT(1e-3)),
+                )
+                    z = CA._compute_z(C)
+                    @test h(z) ≈ C rtol = rtol
+                end
+                # C = 0 (no condensate): deeply negative z, negligible CF.
+                # Regression for the second-step ϵ_numerics guard, without
+                # which Float32 returned z ≈ −2.3 (CF ≈ 1 %).
+                z0 = CA._compute_z(FT(0))
+                @test CA.normal_cdf(z0) < FT(1e-10)
+            end
+        end
+    end
+
 end

--- a/test/parameterized_tendencies/microphysics/sgs_moments.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_moments.jl
@@ -16,6 +16,22 @@ import ClimaParams as CP
 
 const CA = ClimaAtmos
 
+# Functor computing E[max(0, λ + α·S′)] over the quadrature, replicating the
+# condensate diagnosis of `Microphysics1MEvaluator` (defined at top level:
+# structs cannot be declared inside a testset).
+struct CondensateMeanProbe{TPS, FT}
+    tps::TPS
+    ρ::FT
+    mu_S::FT
+    λ_lagrange::FT
+    α::FT
+end
+function (p::CondensateMeanProbe)(T_hat, q_hat)
+    FT = typeof(p.ρ)
+    S′ = max(FT(0), q_hat) - TD.q_vap_saturation(p.tps, T_hat, p.ρ) - p.mu_S
+    return max(FT(0), p.λ_lagrange + p.α * S′)
+end
+
 @testset "SGS Moments" begin
 
     @testset "SGSVarianceEvaluator: (S − μ_S)² with linearized μ_S" begin
@@ -127,6 +143,103 @@ const CA = ClimaAtmos
                 @test isfinite(m1.sigma_S)
                 @test m1.sigma_S ≥ 0
                 @test m2.sigma_S ≈ m1.sigma_S rtol = FT(1e-6)
+            end
+        end
+    end
+
+    @testset "Discrete Lagrange-multiplier fit: exact mass constraint" begin
+        # λ_lagrange from `_compute_sgs_moments` must satisfy
+        # ⟨max(0, λ + α·S′)⟩ = q_c exactly under the quadrature measure the
+        # microphysics evaluator integrates over — including regimes where
+        # the analytic Gaussian fit errs by up to a factor ~2.5 (cold thin
+        # cloud, q_c ≪ σ_S) and where the q ≥ 0 sampling clamp shifts the
+        # sampled mean (σ_q comparable to q_tot).
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                α = FT(1)
+                corr = FT(0.6)
+                ρ = FT(1.1)
+                # (T, saturation offset, q_c, T′T′, q′q′)
+                regimes = (
+                    (FT(288), FT(2e-3), FT(3e-4), FT(1), FT(1e-6)),
+                    (FT(288), FT(-2e-3), FT(5e-5), FT(1), FT(1e-6)),
+                    (FT(233), FT(1e-4), FT(2e-5), FT(1), FT(1e-7)),
+                    (FT(288), FT(0), FT(2e-4), FT(9), FT(4e-6)),
+                )
+                for order in (1, 3, 5), (T, dq, q_c, T′T′, q′q′) in regimes
+                    quad = CA.SGSQuadrature(FT; quadrature_order = order)
+                    q_tot = TD.q_vap_saturation(thp, T, ρ) + dq
+                    m = CA._compute_sgs_moments(
+                        thp, ρ, T, q_tot, q_c, quad, T′T′, q′q′, corr, α,
+                    )
+                    mu_S = q_tot - TD.q_vap_saturation(thp, T, ρ)
+                    probe = CondensateMeanProbe(thp, ρ, mu_S, m.λ_lagrange, α)
+                    qc_mean = CA.integrate_over_sgs(
+                        probe, quad, q_tot, T, q′q′, T′T′, corr,
+                    )
+                    @test qc_mean ≈ q_c rtol = sqrt(eps(FT))
+                end
+            end
+        end
+    end
+
+    @testset "Discrete Lagrange-multiplier fit: limits and edge cases" begin
+        for FT in (Float32, Float64)
+            @testset "FT = $FT" begin
+                toml_dict = CP.create_toml_dict(FT)
+                thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+                α = FT(1)
+                corr = FT(0.6)
+                ρ = FT(1.1)
+                T = FT(288)
+                q_tot = TD.q_vap_saturation(thp, T, ρ) + FT(1e-3)
+                q_c = FT(3e-4)
+                quad = CA.SGSQuadrature(FT; quadrature_order = 3)
+
+                # No SGS sampling (nothing / GridMeanSGS): λ = q_c directly.
+                for sq in (nothing, CA.GridMeanSGS(),
+                    CA.SGSQuadrature(FT; distribution = CA.GridMeanSGS()))
+                    m = CA._compute_sgs_moments(
+                        thp, ρ, T, q_tot, q_c, sq, FT(1), FT(1e-6), corr, α,
+                    )
+                    @test m.λ_lagrange == q_c
+                end
+
+                # Zero-variance limit of the sampled branch: λ → q_c.
+                m0 = CA._compute_sgs_moments(
+                    thp, ρ, T, q_tot, q_c, quad, FT(0), FT(0), corr, α,
+                )
+                @test m0.λ_lagrange ≈ q_c rtol = sqrt(eps(FT))
+
+                # q_c = 0: every sampled point must reconstruct zero
+                # condensate (λ at or below all kinks).
+                mz = CA._compute_sgs_moments(
+                    thp, ρ, T, q_tot, FT(0), quad, FT(1), FT(1e-6), corr, α,
+                )
+                mu_S = q_tot - TD.q_vap_saturation(thp, T, ρ)
+                probe = CondensateMeanProbe(thp, ρ, mu_S, mz.λ_lagrange, α)
+                qc_mean = CA.integrate_over_sgs(
+                    probe, quad, q_tot, T, FT(1e-6), FT(1), corr,
+                )
+                @test qc_mean ≤ eps(FT)
+
+                # Seed far below all kinks (deeply subsaturated + tiny q_c):
+                # the solver must recover via the dg = 0 jump.
+                q_tot_dry = TD.q_vap_saturation(thp, T, ρ) - FT(5e-3)
+                q_c_tiny = FT(1e-8)
+                md = CA._compute_sgs_moments(
+                    thp, ρ, T, q_tot_dry, q_c_tiny, quad,
+                    FT(1), FT(1e-6), corr, α,
+                )
+                mu_S_dry = q_tot_dry - TD.q_vap_saturation(thp, T, ρ)
+                probe_dry =
+                    CondensateMeanProbe(thp, ρ, mu_S_dry, md.λ_lagrange, α)
+                qc_dry = CA.integrate_over_sgs(
+                    probe_dry, quad, q_tot_dry, T, FT(1e-6), FT(1), corr,
+                )
+                @test qc_dry ≈ q_c_tiny rtol = sqrt(eps(FT))
             end
         end
     end

--- a/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
+++ b/test/parameterized_tendencies/microphysics/sgs_quadrature.jl
@@ -824,6 +824,78 @@ using ClimaAtmos
                     @test isfinite(result_direct.e_tot_hlpr)
                 end
 
+                @testset "0M: flux-weighted energy helper" begin
+                    # The energy sink reconstructed downstream as
+                    # dq_tot_dt · e_tot_hlpr must equal the SGS average of
+                    # the per-point product E[dq·e].
+                    quad = ClimaAtmos.SGSQuadrature(FT; quadrature_order = 3)
+                    mp_0m = CMP.Microphysics0MParams(toml_dict)
+                    thp = TD.Parameters.ThermodynamicsParameters(toml_dict)
+
+                    ρ = FT(1.1)
+                    Φ = FT(5e4)
+                    dt = FT(1.0)
+                    corr = FT(0.6)
+
+                    # Mixed-phase, saturated mean with substantial variances:
+                    # e_hlpr varies strongly across points, so the covariance
+                    # term is large.
+                    T_mean = FT(263.0)
+                    q_tot_mean =
+                        TD.q_vap_saturation(thp, T_mean, ρ) + FT(5e-4)
+                    T′T′ = FT(2.0)
+                    q′q′ = FT(5e-7)
+
+                    result = ClimaAtmos.microphysics_tendencies_0m(
+                        quad, mp_0m, thp, ρ, T_mean, q_tot_mean,
+                        T′T′, q′q′, corr, Φ, dt,
+                    )
+                    # Brute-force reference from the raw evaluator averages
+                    # (dt = 1 with q_tot ≫ |dq| keeps the limiter inactive,
+                    # so the wrapper's dq matches the raw average).
+                    ev = ClimaAtmos.Microphysics0MEvaluator(
+                        mp_0m, thp, ρ, T_mean, Φ,
+                    )
+                    raw = ClimaAtmos.integrate_over_sgs(
+                        ev, quad, q_tot_mean, T_mean, q′q′, T′T′, corr,
+                    )
+                    @test raw.dq_tot_dt < FT(0)  # regime has precipitation
+                    @test result.dq_tot_dt ≈ raw.dq_tot_dt rtol = sqrt(eps(FT))
+                    @test result.dq_tot_dt * result.e_tot_hlpr ≈ raw.dq_e rtol =
+                        sqrt(eps(FT))
+                    # The flux-weighted helper is a dq-weighted mean of
+                    # per-point helper values, so it stays a physical energy.
+                    @test isfinite(result.e_tot_hlpr)
+
+                    # Zero variance: single effective point, so the helper
+                    # reduces to the mean-state saturation-adjusted helper.
+                    result0 = ClimaAtmos.microphysics_tendencies_0m(
+                        quad, mp_0m, thp, ρ, T_mean, q_tot_mean,
+                        FT(0), FT(0), FT(0), Φ, dt,
+                    )
+                    λ_mean = TD.liquid_fraction_ramp(thp, T_mean)
+                    sa = ClimaAtmos.SaturationAdjustmentEvaluator(
+                        thp, ρ, λ_mean,
+                    )(
+                        T_mean, q_tot_mean,
+                    )
+                    e_hlpr_mean =
+                        ClimaAtmos.e_tot_0M_precipitation_sources_helper(
+                            thp, T_mean, sa.q_liq, sa.q_ice, Φ,
+                        )
+                    @test result0.e_tot_hlpr ≈ e_hlpr_mean rtol = sqrt(eps(FT))
+
+                    # Subsaturated mean with zero variance: no precipitation
+                    # anywhere; the fallback helper must still be finite.
+                    q_dry = TD.q_vap_saturation(thp, T_mean, ρ) - FT(5e-3)
+                    result_dry = ClimaAtmos.microphysics_tendencies_0m(
+                        quad, mp_0m, thp, ρ, T_mean, max(q_dry, FT(0)),
+                        FT(0), FT(0), FT(0), Φ, dt,
+                    )
+                    @test result_dry.dq_tot_dt == FT(0)
+                    @test isfinite(result_dry.e_tot_hlpr)
+                end
+
                 @testset "1M: sign consistency" begin
                     quad = ClimaAtmos.SGSQuadrature(FT)
                     mp_1m = CMP.Microphysics1MParams(toml_dict;


### PR DESCRIPTION
- Fit `λ_lagrange` to the discrete quadrature constraint `Σᵢ wᵢ·max(0, λ + α·S′ᵢ) = q_c`  instead of the continuous Gaussian; the condensate mass constraint was previously violated by −15% to +160% (worst for thin clouds, q_c ≲ 0.1·σ_S); now it holds to machine precision.
- Add a second Newton step to `_compute_z`, removing a one-sided thin-cloud CF overestimate.
- 0M: return the flux-weighted energy helper E[dq_tot·e]/E[dq], so the precipitation energy sink is the true SGS average that takes covariances between `dq_tot/dt` and `e_tot` (was off by up to +56% in mixed regions, leading to warm bias near and above the melting layer).
- Adds regression tests across regimes, quadrature orders, and precisions.