### PR TITLE
Pass ClimaComms context when loading local OGW drag files.

### DIFF
--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave.jl
@@ -1241,7 +1241,10 @@ function compute_ogw_drag(
 
         if isfile(local_path)
             @info "Loading computed drag from local file: $(local_path)"
-            topo_info = load_preprocessed_topography(local_filename)
+            topo_info = load_preprocessed_topography(
+                local_filename,
+                ClimaComms.context(Y.c),
+            )
 
             @debug begin
                 # Checkpoint 1: Validate loaded drag tensor

--- a/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
+++ b/src/parameterized_tendencies/gravity_wave_drag/orographic_gravity_wave_helper.jl
@@ -1061,14 +1061,17 @@ end
 """
     load_preprocessed_topography(; topography, topo_smoothing,
                                  topography_damping_factor, h_elem)
-    load_preprocessed_topography(filename::String)
+    load_preprocessed_topography(filename::String, comms_ctx = ClimaComms.SingletonCommsContext())
 
 Read a preprocessed orographic drag field from an HDF5 file in the package root.
+The optional `comms_ctx` must be the run's MPI context on distributed runs so the
+field is read correctly.
 
 Returns the `computed_drag` field written by `write_computed_drag!`. The keyword method
-derives the filename from the topography configuration via `generate_drag_filename`; the
-`String` method takes the extensionless filename directly. Both read on a single CPU
-context, so a GPU run has to move the result with `move_topo_info_to_gpu`.
+derives the filename from the topography configuration via `generate_drag_filename` and
+reads on a single-threaded CPU context; the `String` method takes the extensionless
+filename directly and reads with the supplied `comms_ctx`. A GPU run has to move the
+result with `move_topo_info_to_gpu`.
 """
 function load_preprocessed_topography(;
     topography,
@@ -1091,11 +1094,14 @@ function load_preprocessed_topography(;
     return computed_drag
 end
 
-function load_preprocessed_topography(filename::String)
+function load_preprocessed_topography(
+    filename::String,
+    comms_ctx = ClimaComms.SingletonCommsContext(),
+)
     @info "loading topography drag vector: $(filename)"
     reader = InputOutput.HDF5Reader(
         joinpath(@__DIR__, "../../../$(filename).hdf5"),
-        ClimaComms.SingletonCommsContext(),
+        comms_ctx,
     )
     computed_drag = InputOutput.read_field(reader, "computed_drag")
 


### PR DESCRIPTION
Pass run ClimaComms context when loading local OGW drag files. Needed for multi-rank runs with local gw files.