### PR TITLE
Fix command-line job ID derivation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaAtmos.jl Release Notes
 main
 ----
 
+- [#4798](https://github.com/CliMA/ClimaAtmos.jl/pull/4798) ![][badge-🐛bugfix] ![][badge-🔥behavioralΔ] Made command-line runs without `--job_id` use the `job_id` from the selected configuration, or derive it from the selected config file names, instead of always using `default_config`.
+
 0.42.9
 -------
 - Update to ClimaCore.jl v0.16 (support for v0.15 is dropped). The biased

--- a/src/config/cli_options.jl
+++ b/src/config/cli_options.jl
@@ -21,7 +21,7 @@ function argparse_settings()
         "--job_id"
         help = "A unique job identifier, among all possible (parallel) running jobs. If omitted, it is taken from the `job_id` key in the configuration, or derived from the config file names."
         arg_type = String
-        default = job_id_from_config_file(default_config_file)
+        default = nothing
         #! format: on
     end
     return s

--- a/test/config.jl
+++ b/test/config.jl
@@ -14,6 +14,20 @@ import ClimaAtmos as CA
     end
 end
 
+@testset "Command-line config determines implicit job_id" begin
+    selected_config_file =
+        joinpath(CA.config_path, "model_configs", "baroclinic_wave.yml")
+    parsed_args = CA.parse_commandline(
+        ["--config_file", selected_config_file],
+        CA.argparse_settings(),
+    )
+    (; config_file, job_id) = CA.to_named_tuple(parsed_args)
+
+    config = CA.AtmosConfig(config_file; job_id)
+
+    @test config.job_id == CA.job_id_from_config_files(config_file)
+end
+
 file, io = mktemp()
 config_err = ErrorException("File $(CA.normrelpath(file)) is empty or missing.")
 @test_throws config_err CA.AtmosConfig(file)


### PR DESCRIPTION
## Purpose

Fixes #3029.

Passing `--config_file` without `--job_id` currently leaves the run named `default_config`, even when another configuration is selected. This lets `AtmosConfig` derive the implicit job ID from the selected config files, while preserving explicit CLI and YAML job IDs.

## To-do

- [x] Add a `NEWS.md` entry.
- [ ] Confirm CI.

## Content

- Changed the parser default for `--job_id` to `nothing`, allowing the existing `AtmosConfig` fallback order to apply.
- Added a regression test covering command-line selection of a config without an explicit job ID.
- Added the required bug-fix/behavioral-change release note.
- Verified the default config, explicit `--job_id`, YAML `job_id`, and filename-derived paths locally.
- Ran the pinned JuliaFormatter 2.10.1 formatter and `git diff --check`.
- Ran `julia --startup-file=no --project=. test/config.jl` successfully.
- Confirmed with a sabotage run that the regression test fails with the old parser default and passes with the fix restored.

I used Hermes Agent to help implement and verify this change.

----
- [x] I have read and checked the items on the review checklist.
