### PR TITLE
TKE fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     if: needs.decide.outputs.skip != 'true'
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 70
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,7 +50,8 @@ makedocs(;
     # and the CI log; set LINKCHECK_STRICT=1 (e.g. in a manual or scheduled
     # run) to turn them into build failures. The check costs seconds.
     linkcheck = true,
-    warnonly = isempty(get(ENV, "LINKCHECK_STRICT", "")) ? [:linkcheck] :
+    warnonly = isempty(get(ENV, "LINKCHECK_STRICT", "")) ?
+               [:linkcheck, :external_cross_references] :
                Symbol[],
     format = Documenter.HTML(
         prettyurls = !isempty(get(ENV, "CI", "")),

--- a/reproducibility_tests/ref_counter.jl
+++ b/reproducibility_tests/ref_counter.jl
@@ -1,4 +1,4 @@
-409
+410
 
 # **README**
 #
@@ -33,13 +33,18 @@
 
 #=
 410
+- Add entr/detr shear-mixing source to the TKE budget and drop the stability-biased
+  ᶜN²_eff in favor of the unbiased ᶜbuoygrad for center l_N, Pr_t, and the Smag-Lilly
+  length scale.
+
+410
 - Update to ClimaCore 0.16
 
 409
 - Use vapor-ice timescale change, adding supercoole liquid freezing
 
 408
-- Guards against unphysical extrapolated ρa (u₃ is solved before ρa).
+- Guard against unphysical extrapolated ρa (u₃ is solved before ρa).
 
 407
 - Update dependencies: CloudMicrophysics v0.38.1 -> v0.38.3

--- a/src/cache/precomputed_quantities.jl
+++ b/src/cache/precomputed_quantities.jl
@@ -183,12 +183,6 @@ function precomputed_quantities(Y, atmos)
         # (cloud-fraction-blended) vertical gradient instead of the two-point
         # face gradient.
         ᶜbuoygrad = similar(Y.c, FT),
-        # Interface-aware effective stability N²_eff at centers; the center
-        # counterpart of `ᶠN²_eff` in `set_face_diffusivities!`, formed as the
-        # max over adjacent faces of the face-local N²_eff (including the
-        # unresolved-jump term). Feeds the mixing-length and Pr_t(Ri) closures
-        # near sharp inversions.
-        ᶜN²_eff = similar(Y.c, FT),
         # Pointwise chain-rule coefficients of the moist buoyancy gradient
         # and exact two-point face gradients of (θ_li, q_tot); filled once
         # per update by `set_buoyancy_gradient_inputs!` and shared by the
@@ -863,9 +857,9 @@ NVTX.@annotate function set_explicit_precomputed_quantities!(Y, p, t)
 
     set_covariance_cache_and_cloud_fraction!(Y, p)
 
-    # Interfacial entrainment diffusivity K_e at faces (interface-aware
-    # stability closure). Needs the final cloud fraction and ᶜN²_eff
-    # from the covariance/cloud-fraction update above.
+    # Interfacial entrainment diffusivity K_e at faces (interface-aware stability
+    # closure). Needs the final cloud fraction from the covariance/cloud-fraction
+    # update above.
     set_face_diffusivities!(Y, p)
 
     if turbconv_model isa AbstractEDMF && (

--- a/src/diagnostics/core_diagnostics.jl
+++ b/src/diagnostics/core_diagnostics.jl
@@ -223,15 +223,15 @@ function compute_lmix(state, cache, _)
         return cache.precomputed.ᶜl_mix
     end
     (; params) = cache
-    (; ᶜN²_eff, ᶜstrain_rate_norm) = cache.precomputed
+    (; ᶜbuoygrad, ᶜstrain_rate_norm) = cache.precomputed
     ᶜdz = Fields.Δz_field(axes(state.c))
     ᶜprandtl_nvec = @. lazy(turbulent_prandtl_number(
-        params, ᶜN²_eff, ᶜstrain_rate_norm,
+        params, ᶜbuoygrad, ᶜstrain_rate_norm,
     ))
     return @. lazy(
         smagorinsky_lilly_length(
             CAP.c_smag(params),
-            sqrt(max(ᶜN²_eff, 0)),   # N_eff
+            sqrt(max(ᶜbuoygrad, 0)),   # N_eff
             ᶜdz, ᶜprandtl_nvec, ᶜstrain_rate_norm,
         ),
     )

--- a/src/parameterized_tendencies/microphysics/cloud_fraction.jl
+++ b/src/parameterized_tendencies/microphysics/cloud_fraction.jl
@@ -67,12 +67,6 @@ function set_covariance_cache_and_cloud_fraction!(Y, p)
             projected_vector_data(C3, ᶜgradᵥ_θ_liq_ice, ᶜlg),
             projected_vector_data(C3, ᶜgradᵥ_q_tot, ᶜlg),
         )
-
-        # Stability-biased buoyancy gradient for the mixing-length and
-        # Pr_t(Ri) closures (max of one-sided estimates; registers
-        # unresolved inversions that the centered gradient dilutes).
-        set_stability_buoyancy_gradient!(Y, p, thermo_params)
-
         # Cache SGS covariances (no-op for dry/0M/GridScaleCloud configs).
         # For EDMF: gradients are precomputed above.
         # For non-EDMF: gradients are computed inside set_covariance_cache!.
@@ -109,7 +103,6 @@ function set_covariance_cache_and_cloud_fraction!(Y, p)
         projected_vector_data(C3, ᶜgradᵥ_θ_liq_ice, ᶜlg),
         projected_vector_data(C3, ᶜgradᵥ_q_tot, ᶜlg),
     )
-    set_stability_buoyancy_gradient!(Y, p, thermo_params)
     set_covariance_cache!(Y, p, thermo_params)
 
     # Final post-Aitken update: one quadrature pass refreshes both CF and the

--- a/src/prognostic_equations/eddy_diffusion_closures.jl
+++ b/src/prognostic_equations/eddy_diffusion_closures.jl
@@ -244,8 +244,8 @@ end
 
 """
     mixing_length_lopez_gomez_2020(
-        turbconv_params, sf_params, vkc, ustar, ᶜz, z_sfc, ᶜΔ_f, sfc_tke,
-        ᶜN²_eff, ᶜN²_prod, ᶜtke, obukhov_length, ᶜstrain_rate_norm, ᶜPr,
+        turbconv_params, sf_params, vkc, ustar, z, z_sfc, Δ_f, sfc_tke,
+        N²_eff, N²_prod, tke, obukhov_length, strain_rate_norm, Pr,
         scale_blending_method,
     ) -> MixingLength
 
@@ -260,10 +260,10 @@ Three physical scales are formed and blended by `blend_scales`:
     with `a_pd = c_m (2 |S|² - N²_prod / Pr) √e`; dropped from the blend where
     the net production `a_pd` is non-positive.
   - `l_N`: buoyancy-limited scale `√(c_b e) / N_eff`, capped by the wall
-    distance and used only where `ᶜN²_eff > 0`.
+    distance and used only where `N²_eff > 0`.
 
 The blend is then limited by the wall distance and by the resolvability filter
-scale `ᶜΔ_f`, and floored at 1 m.
+scale `Δ_f`, and floored at 1 m.
 
 The same closure is evaluated at cell centers (`ᶜmixing_length`) and at faces
 (`set_face_diffusivities!`), with the corresponding inputs.
@@ -274,25 +274,25 @@ The same closure is evaluated at cell centers (`ᶜmixing_length`) and at faces
   - `sf_params`: Surface-flux parameters (Businger universal functions).
   - `vkc`: Von Kármán constant [-].
   - `ustar`: Friction velocity [m/s].
-  - `ᶜz`: Height of the evaluation point [m].
+  - `z`: Height of the evaluation point [m].
   - `z_sfc`: Surface elevation [m].
-  - `ᶜΔ_f`: Resolvability filter scale [m] that caps the mixing length (see
+  - `Δ_f`: Resolvability filter scale [m] that caps the mixing length (see
     `resolvability_filter_scale`; `Inf` where the grid imposes no scale,
     as in single columns).
   - `sfc_tke`: TKE near the surface (first cell center) [m²/s²].
-  - `ᶜN²_eff`: Effective squared buoyancy frequency [1/s²], used for `l_N`; may
+  - `N²_eff`: Effective squared buoyancy frequency [1/s²], used for `l_N`; may
     include the unresolved-jump augmentation of
     `interface_effective_N²`.
-  - `ᶜN²_prod`: Squared buoyancy frequency entering the production-dissipation
+  - `N²_prod`: Squared buoyancy frequency entering the production-dissipation
     balance for `l_TKE` [1/s²]. Passed separately so the balance uses the same
     stability as the actual TKE buoyancy production, keeping `l_TKE`
-    stencil-consistent with the budget it parameterizes even when `ᶜN²_eff`
+    stencil-consistent with the budget it parameterizes even when `N²_eff`
     carries the interface augmentation.
-  - `ᶜtke`: Turbulent kinetic energy at the evaluation point [m²/s²].
+  - `tke`: Turbulent kinetic energy at the evaluation point [m²/s²].
   - `obukhov_length`: Surface Monin-Obukhov length [m].
-  - `ᶜstrain_rate_norm`: Squared Frobenius norm of the strain-rate tensor,
+  - `strain_rate_norm`: Squared Frobenius norm of the strain-rate tensor,
     `SᵢⱼSᵢⱼ` [1/s²].
-  - `ᶜPr`: Turbulent Prandtl number [-].
+  - `Pr`: Turbulent Prandtl number [-].
   - `scale_blending_method`: Blending method for the physical scales
     (`blend_scales`).
 
@@ -306,20 +306,20 @@ function mixing_length_lopez_gomez_2020(
     sf_params,
     vkc,
     ustar,
-    ᶜz,
+    z,
     z_sfc,
-    ᶜΔ_f,
+    Δ_f,
     sfc_tke,
-    ᶜN²_eff,
-    ᶜN²_prod,
-    ᶜtke,
+    N²_eff,
+    N²_prod,
+    tke,
     obukhov_length,
-    ᶜstrain_rate_norm,
-    ᶜPr,
+    strain_rate_norm,
+    Pr,
     scale_blending_method,
 )
 
-    FT = eltype(ᶜz)
+    FT = eltype(z)
     eps_FT = eps(FT)
 
     c_m = CAP.tke_ed_coeff(turbconv_params)
@@ -327,8 +327,8 @@ function mixing_length_lopez_gomez_2020(
     c_b = CAP.static_stab_coeff(turbconv_params)
 
     # l_z: Geometric distance from the surface
-    l_z = ᶜz - z_sfc
-    # Ensure l_z is non-negative when ᶜz is numerically smaller than z_sfc.
+    l_z = z - z_sfc
+    # Ensure l_z is non-negative when z is numerically smaller than z_sfc.
     l_z = max(l_z, FT(0))
 
     # l_W: Wall-constrained length scale (near-surface limit, to match
@@ -360,7 +360,7 @@ function mixing_length_lopez_gomez_2020(
     l_W = max(l_W, FT(0)) # Ensure non-negative
 
     # --- l_TKE: TKE production-dissipation balance scale ---
-    tke_pos = max(ᶜtke, FT(0)) # Ensure TKE is not negative
+    tke_pos = max(tke, FT(0)) # Ensure TKE is not negative
     sqrt_tke_pos = sqrt(tke_pos)
 
     # Net production of TKE from shear and buoyancy is approximated by
@@ -368,7 +368,7 @@ function mixing_length_lopez_gomez_2020(
     # where S² denotes the gradient involved in shear production and
     # N²/Pr_t denotes the gradient involved in buoyancy production.
     # The factor below corresponds to that production term normalised by l.
-    a_pd = c_m * (2 * ᶜstrain_rate_norm - ᶜN²_prod / ᶜPr) * sqrt_tke_pos
+    a_pd = c_m * (2 * strain_rate_norm - N²_prod / Pr) * sqrt_tke_pos
 
     # Dissipation is modelled as c_d · k^{3/2} / l.
     # For the quadratic expression below, c_neg ≡ c_d · k^{3/2}.
@@ -382,7 +382,7 @@ function mixing_length_lopez_gomez_2020(
     l_TKE = ifelse(tke_pos > eps_FT, sqrt(c_neg / max(a_pd, eps_FT)), FT(0))
 
     # --- l_N: Static-stability length scale (buoyancy limit), constrained by l_z ---
-    N_eff_sq = max(ᶜN²_eff, FT(0)) # Use N^2 only if stable (N^2 > 0)
+    N_eff_sq = max(N²_eff, FT(0)) # Use N^2 only if stable (N^2 > 0)
     l_N = l_z # Default to wall distance if not stably stratified or TKE is zero
     if N_eff_sq > eps_FT && tke_pos > eps_FT
         N_eff = sqrt(N_eff_sq)
@@ -411,7 +411,7 @@ function mixing_length_lopez_gomez_2020(
 
     # 2. Impose the resolvability filter scale (see
     #    resolvability_filter_scale for the rationale and regimes).
-    l_grid = ᶜΔ_f
+    l_grid = Δ_f
     l_final = min(l_limited_phys_wall, l_grid)
 
     # Final check: guarantee that the mixing length is at least a small positive
@@ -440,8 +440,8 @@ share:
     corresponding centered (interpolate-then-difference) gradients, still as
     `Covariant3Vector`s.
 
-The centered, one-sided (`set_stability_buoyancy_gradient!`), and face-native
-(`set_face_diffusivities!`) buoyancy gradients then reduce to
+The centered and face-native (`set_face_diffusivities!`) buoyancy gradients
+then reduce to
 `blended_N²` FMA broadcasts, which may be evaluated repeatedly (e.g.,
 per cloud-fraction Picard iteration, where only `cf` changes) at negligible
 cost. The coefficients depend on `(T, ρ, q)` but not on `cf`, so they are
@@ -478,83 +478,6 @@ NVTX.@annotate function set_buoyancy_gradient_inputs!(Y, p, thermo_params)
 
     @. ᶜgradᵥ_θ_liq_ice = ᶜgradᵥ(ᶠinterp(ᶜθ_li))
     @. ᶜgradᵥ_q_tot = ᶜgradᵥ(ᶠinterp(ᶜq_tot_nonneg))
-    return nothing
-end
-
-"""
-    set_stability_buoyancy_gradient!(Y, p, thermo_params)
-
-Fill `p.precomputed.ᶜN²_eff` with an interface-aware effective stability.
-
-At each cell center the buoyancy gradient is evaluated twice, with
-upward- and downward-biased one-sided vertical gradients of `θ_li` and `q_tot`
-(i.e., the exact two-point gradients of the two adjacent faces), each is
-augmented by the unresolved-jump term of `interface_effective_N²`
-(when prognostic TKE is available), and the more stable (larger) of the two
-face values is kept.
-
-Rationale: centered two-cell gradients average across unresolved, strongly
-stable interfaces such as boundary-layer capping inversions, biasing N²_eff
-low — and hence the stability mixing length `l_N` and turbulent Prandtl
-number toward too much mixing — exactly in the entrainment zone. The one-sided
-evaluation lets a single-cell jump register at both adjacent cell centers, and
-the jump term of `interface_effective_N²` additionally accounts for the limit
-in which the jump is a sheet interface thinner than the grid: eddy excursions
-are then capped by the work against the full jump `Δb`, independent of `Δz`.
-Away from sharp interfaces both one-sided gradients agree with the centered
-one and the jump term is `O((Δz/l_N)²)`, so the correction is inactive.
-
-This field feeds the mixing-length and `Pr_t(Ri)` closures only; the TKE
-buoyancy production keeps the centered `ᶜbuoygrad`, so convective
-production in unstable layers is unaffected. Without prognostic TKE
-(`Y.c.ρtke` absent) the jump term is unavailable and the pure one-sided max is
-used.
-
-Reads `ᶜbg_coeffs`, `ᶠ∂θli∂z`, `ᶠ∂qt∂z` (from
-`set_buoyancy_gradient_inputs!`) and `ᶜcloud_fraction`; mutates
-`p.precomputed.ᶜN²_eff` and returns `nothing`.
-"""
-NVTX.@annotate function set_stability_buoyancy_gradient!(Y, p, thermo_params)
-    (; ᶜN²_eff, ᶜcloud_fraction) = p.precomputed
-    (; ᶜbg_coeffs, ᶠ∂θli∂z, ᶠ∂qt∂z) = p.precomputed
-    # One-sided center gradients: the exact face gradients (see
-    # `set_buoyancy_gradient_inputs!`) brought to centers from the upper
-    # (ᶜtop_bias) and lower (ᶜbottom_bias) adjacent faces. Domain-boundary
-    # faces carry zero gradient, so the biased estimates fall back to neutral
-    # there and the max picks the interior side.
-    ᶜN²_up = @. lazy(
-        blended_N²(
-            ᶜbg_coeffs,
-            ᶜcloud_fraction,
-            ᶜtop_bias(ᶠ∂θli∂z),
-            ᶜtop_bias(ᶠ∂qt∂z),
-        ),
-    )
-    ᶜN²_dn = @. lazy(
-        blended_N²(
-            ᶜbg_coeffs,
-            ᶜcloud_fraction,
-            ᶜbottom_bias(ᶠ∂θli∂z),
-            ᶜbottom_bias(ᶠ∂qt∂z),
-        ),
-    )
-    if MatrixFields.has_field(Y, @name(c.ρtke))
-        # Interface-aware effective stability: each one-sided face gradient is
-        # augmented by the unresolved-jump term of `interface_effective_N²`
-        # before taking the max, so an inversion concentrated at a face limits
-        # eddy excursions through the work against the full jump Δb = N² Δz
-        # rather than the Δz-diluted gradient.
-        turbconv_params = CAP.turbconv_params(p.params)
-        c_b = CAP.static_stab_coeff(turbconv_params)
-        ᶜtke_pos = @. lazy(max(specific(Y.c.ρtke, Y.c.ρ), 0))
-        ᶠΔz = Fields.Δz_field(axes(Y.f))
-        @. ᶜN²_eff = max(
-            interface_effective_N²(ᶜN²_up, ᶜtop_bias(ᶠΔz), ᶜtke_pos, c_b),
-            interface_effective_N²(ᶜN²_dn, ᶜbottom_bias(ᶠΔz), ᶜtke_pos, c_b),
-        )
-    else
-        @. ᶜN²_eff = max(ᶜN²_up, ᶜN²_dn)
-    end
     return nothing
 end
 
@@ -848,12 +771,7 @@ end
 Return a lazy cell-center field of the PROPHET (`EDMFX` in code) mixing length,
 selected by `property` (`get_mixing_length_field`).
 
-Evaluates `mixing_length_lopez_gomez_2020` with center inputs: the
-stability-biased `ᶜN²_eff` (which registers unresolved inversions; see
-`set_stability_buoyancy_gradient!`) limits `l_N` and sets the turbulent
-Prandtl number, while the centered `ᶜbuoygrad` enters the
-production-dissipation balance for `l_TKE`, consistent with the TKE budget.
-
+Evaluates `mixing_length_lopez_gomez_2020` with center inputs.
 Only valid for `AbstractEDMF` configurations, which always carry `Y.c.ρtke`.
 Writes `p.scratch.ᶜtemp_scalar_5` (the Prandtl number) as a side effect.
 
@@ -869,11 +787,10 @@ function ᶜmixing_length(
 ) where {P}
     (; params) = p
     (; ustar, obukhov_length) = p.precomputed.sfc_conditions
-    # Stability-biased buoyancy gradient: registers unresolved inversions
-    # (see set_stability_buoyancy_gradient!); feeds l_N and Pr_t(Ri). The
-    # centered gradient feeds the TKE production-dissipation balance for
-    # l_TKE, consistent with the actual TKE budget.
-    (; ᶜN²_eff, ᶜbuoygrad, ᶜstrain_rate_norm) = p.precomputed
+    # Centered buoyancy gradient feeds both `l_N` and Pr_t(Ri), and the TKE
+    # production-dissipation balance for `l_TKE` (consistent with the actual
+    # TKE budget).
+    (; ᶜbuoygrad, ᶜstrain_rate_norm) = p.precomputed
     ᶜz = Fields.coordinate_field(Y.c).z
     z_sfc = Fields.level(Fields.coordinate_field(Y.f).z, Fields.half)
     ᶜΔ_f = grid_scale
@@ -885,7 +802,7 @@ function ᶜmixing_length(
 
     ᶜprandtl_nvec = p.scratch.ᶜtemp_scalar_5
     @. ᶜprandtl_nvec =
-        turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+        turbulent_prandtl_number(params, ᶜbuoygrad, ᶜstrain_rate_norm)
 
     # Extract sub-parameters before the lazy broadcast to avoid capturing
     # the full ClimaAtmosParameters struct (~4 KiB) in GPU kernel parameters.
@@ -903,7 +820,7 @@ function ᶜmixing_length(
             z_sfc,
             ᶜΔ_f,
             sfc_tke,
-            ᶜN²_eff,
+            ᶜbuoygrad,
             ᶜbuoygrad,
             ᶜtke,
             obukhov_length,
@@ -924,14 +841,14 @@ horizontal node spacing, `l_h = min(l_phys, Δx_h)`.
 """
 function set_horizontal_diffusivities!(Y, p)
     (; params) = p
-    (; ᶜK_u_h, ᶜK_h_h, ᶜN²_eff, ᶜstrain_rate_norm) = p.precomputed
+    (; ᶜK_u_h, ᶜK_h_h, ᶜbuoygrad, ᶜstrain_rate_norm) = p.precomputed
     turbconv_params = CAP.turbconv_params(params)
     Δx_h = horizontal_filter_scale(axes(Y.c))
     ᶜl_h = ᶜmixing_length(Y, p; grid_scale = Δx_h)
     ᶜtke = @. lazy(specific(Y.c.ρtke, Y.c.ρ))
     @. ᶜK_u_h = eddy_viscosity(turbconv_params, ᶜtke, ᶜl_h)
     ᶜprandtl_nvec =
-        @. lazy(turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm))
+        @. lazy(turbulent_prandtl_number(params, ᶜbuoygrad, ᶜstrain_rate_norm))
     @. ᶜK_h_h = eddy_diffusivity(ᶜK_u_h, ᶜprandtl_nvec)
     return nothing
 end
@@ -1021,17 +938,17 @@ there is no separate precipitation mass and this is `q_tot`.
     (@. lazy(specific(Y.c.ρq_tot, Y.c.ρ)))
 
 """
-    gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+    gradient_richardson_number(params, ᶜN², ᶜstrain_rate_norm)
 
 Compute the gradient Richardson number, the ratio of the buoyancy to the shear
 term in the TKE budget:
 
-    Ri = ᶜN²_eff / max(2 SᵢⱼSᵢⱼ, eps).
+    Ri = ᶜN² / max(2 SᵢⱼSᵢⱼ, eps).
 
 # Arguments
 
   - `params`: Parameter set; used only for the floating-point type.
-  - `ᶜN²_eff`: Effective squared buoyancy frequency [1/s²].
+  - `ᶜN²`: Effective squared buoyancy frequency [1/s²].
   - `ᶜstrain_rate_norm`: Squared Frobenius norm of the strain-rate tensor,
     `SᵢⱼSᵢⱼ` [1/s²].
 
@@ -1039,20 +956,20 @@ term in the TKE budget:
 
 The gradient Richardson number [-].
 """
-function gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+function gradient_richardson_number(params, ᶜN², ᶜstrain_rate_norm)
     FT = eltype(params)
 
     # Calculate the denominator term for Ri, ensuring it's not zero
     # Based on the formulation Ri = N^2 / max(2*|S|, eps)
     ᶜshear_term_safe = max(2 * ᶜstrain_rate_norm, eps(FT))
-    ᶜRi_grad = ᶜN²_eff / ᶜshear_term_safe
+    ᶜRi_grad = ᶜN² / ᶜshear_term_safe
 
     return ᶜRi_grad
 end
 
 
 """
-    turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+    turbulent_prandtl_number(params, ᶜN², ᶜstrain_rate_norm)
 
 Compute the turbulent Prandtl number as a function of the gradient Richardson
 number (`gradient_richardson_number`).
@@ -1071,7 +988,7 @@ with `X = Pr_n + ω_pr Ri`, the neutral Prandtl number `Pr_n`
 # Arguments
 
   - `params`: Parameter set.
-  - `ᶜN²_eff`: Effective squared buoyancy frequency [1/s²].
+  - `ᶜN²`: Effective squared buoyancy frequency [1/s²].
   - `ᶜstrain_rate_norm`: Squared Frobenius norm of the strain-rate tensor,
     `SᵢⱼSᵢⱼ` [1/s²].
 
@@ -1083,7 +1000,7 @@ The strong-stability limit of this closure (`Pr(Ri) → ∞`) is what closes the
 TKE dissipation coefficient; see `tke_dissipation_coefficient` for that
 derivation.
 """
-function turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+function turbulent_prandtl_number(params, ᶜN², ᶜstrain_rate_norm)
     FT = eltype(params)
     turbconv_params = CAP.turbconv_params(params)
     eps_FT = eps(FT)
@@ -1094,7 +1011,7 @@ function turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
     Pr_max = CAP.Pr_max(turbconv_params) # Maximum Prandtl number limit
 
     # Calculate the raw gradient Richardson number using the new helper function
-    ᶜRi_grad = gradient_richardson_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+    ᶜRi_grad = gradient_richardson_number(params, ᶜN², ᶜstrain_rate_norm)
 
     # --- Apply the Pr_t(Ri) formula valid for stable and unstable conditions ---
 

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -80,6 +80,8 @@ function edmfx_tke_sources!(Yₜ, Y, p)
 
     # Pressure-drag return-to-isotropy
     edmfx_pressure_drag_tke_source!(Yₜ, Y, p, p.atmos.turbconv_model)
+    # Entr/detr shear-mixing source: 0.5 δ · ρa · |Δw|² per updraft.
+    edmfx_entr_detr_tke_source!(Yₜ, Y, p, p.atmos.turbconv_model)
     return nothing
 end
 
@@ -95,10 +97,11 @@ function edmfx_pressure_drag_tke_source!(
     α_d = CAP.pressure_normalmode_drag_coeff(turbconv_params)
     a_min = CAP.min_area(turbconv_params)
     scale_height = CAP.R_d(p.params) * CAP.T_surf_ref(p.params) / CAP.grav(p.params)
-    (; ᶜρʲs, ᶠu³ʲs, ᶠu³⁰) = p.precomputed
+    (; ᶜρʲs, ᶜuʲs, ᶜu⁰) = p.precomputed
     # Environment area, shared across all updrafts.
     ᶜa⁰ = @. lazy(a⁰(Y.c.sgsʲs, ᶜρʲs, turbconv_model))
     ᶜdrag_coeff = p.scratch.ᶜtemp_scalar
+    ᶜlg = Fields.local_geometry_field(Y.c)
     for j in 1:n
         ᶜaʲ = @. lazy(draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)))
         # Same `ᶜdrag_coeff` form as the momentum equation
@@ -107,13 +110,69 @@ function edmfx_pressure_drag_tke_source!(
         @. ᶜdrag_coeff =
             α_d / (2 * scale_height) *
             (1 / sqrt(max(ᶜaʲ, a_min)) + 1 / sqrt(max(ᶜa⁰, a_min)))
-        @. Yₜ.c.ρtke += ᶜinterp(
-            ᶠinterp(Y.c.sgsʲs.:($$j).ρa * ᶜa⁰ * ᶜdrag_coeff) *
-            abs(
-                w_component(Geometry.WVector(ᶠu³ʲs.:($$j))) -
-                w_component(Geometry.WVector(ᶠu³⁰)),
-            )^3,
+        @. Yₜ.c.ρtke +=
+            Y.c.sgsʲs.:($$j).ρa * ᶜa⁰ * ᶜdrag_coeff *
+            abs(get_physical_w(ᶜuʲs.:($$j) - ᶜu⁰, ᶜlg))^3
+    end
+    return nothing
+end
+
+edmfx_entr_detr_tke_source!(Yₜ, Y, p, turbconv_model) = nothing
+function edmfx_entr_detr_tke_source!(
+    Yₜ, Y, p, turbconv_model::PrognosticEDMFX,
+)
+    n = n_mass_flux_subdomains(turbconv_model)
+    n == 0 && return nothing
+
+    (;
+        ᶜρʲs,
+        ᶜρ_diffʲs,
+        ᶜarea_bounding_entr_detrʲs,
+        ᶜuʲs,
+        ᶠu³ʲs,
+        ᶜu⁰,
+    ) = p.precomputed
+    (; ᶠgradᵥ_ᶜΦ) = p.core
+
+    turbconv_params = CAP.turbconv_params(p.params)
+    entr_detr_buoy_inv_tau_max =
+        CAP.entr_detr_buoy_inv_tau_max(turbconv_params)
+    detr_model = p.atmos.edmfx_model.detr_model
+    ᶜlg = Fields.local_geometry_field(Y.c)
+    ᶠlg = Fields.local_geometry_field(Y.f)
+    ᶠbottom_bias_zero_bot = Operators.BottomBiasedC2F(bottom = Operators.SetValue(0))
+    FT = Spaces.undertype(axes(Y.c))
+
+    for j in 1:n
+        ᶜaʲ = @. lazy(draft_area(Y.c.sgsʲs.:($$j).ρa, ᶜρʲs.:($$j)))
+        ᶜbuoy_inv_time_scale = @. lazy(
+            ᶜinterp(
+                detr_buoy_inv_time_scale(
+                    get_physical_w(ᶠu³ʲs.:($$j), ᶠlg),
+                    vertical_buoyancy_acceleration(
+                        ᶠinterp(ᶜρ_diffʲs.:($$j)),
+                        ᶠgradᵥ_ᶜΦ,
+                        ᶠlg,
+                    ),
+                    entr_detr_buoy_inv_tau_max,
+                ),
+            ),
         )
+        ᶜdetr = @. lazy(
+            compute_detrainment(
+                turbconv_params,
+                ᶜaʲ,
+                Y.c.sgsʲs.:($$j).ρa,
+                ᶜbuoy_inv_time_scale,
+                ᶜdivᵥ(ᶠbottom_bias_zero_bot(Y.c.sgsʲs.:($$j).ρa) * ᶠu³ʲs.:($$j)),
+                ᶜarea_bounding_entr_detrʲs.:($$j),
+                detr_model,
+            ),
+        )
+
+        @. Yₜ.c.ρtke +=
+            FT(0.5) * ᶜdetr * Y.c.sgsʲs.:($$j).ρa *
+            get_physical_w(ᶜuʲs.:($$j) - ᶜu⁰, ᶜlg)^2
     end
     return nothing
 end

--- a/src/prognostic_equations/gm_sgs_closures.jl
+++ b/src/prognostic_equations/gm_sgs_closures.jl
@@ -21,8 +21,7 @@ the shear production.
 # Arguments
 
   - `c_smag`: The Smagorinsky coefficient [-].
-  - `N_eff`: Effective buoyancy frequency [s⁻¹], equal to `sqrt(max(ᶜN²_eff, 0))`,
-    with `ᶜN²_eff` the interface-aware effective stability).
+  - `N_eff`: Effective buoyancy frequency [s⁻¹], equal to `sqrt(max(ᶜbuoygrad, 0))`.
   - `dz`: Vertical grid scale [m].
   - `Pr`: Turbulent Prandtl number [-].
   - `ϵ_st`: Squared Frobenius norm of the strain-rate tensor, `SᵢⱼSᵢⱼ` [s⁻²].
@@ -52,14 +51,12 @@ Used when no EDMFX model with prognostic TKE is active. Steps:
  1. Fill `p.precomputed.ᶜbuoygrad` with the cloud-fraction-blended moist
     buoyancy gradient (`blended_N²`, using the chain-rule coefficients
     and face gradients materialized by `set_buoyancy_gradient_inputs!`).
- 2. Fill `p.precomputed.ᶜN²_eff` with the stability-biased buoyancy gradient
-    (`set_stability_buoyancy_gradient!`).
- 3. Fill `p.precomputed.ᶜstrain_rate_norm` with the squared strain-rate norm
+ 2. Fill `p.precomputed.ᶜstrain_rate_norm` with the squared strain-rate norm
     of the resolved velocity.
- 4. Evaluate the turbulent Prandtl number and
+ 3. Evaluate the turbulent Prandtl number and
     `smagorinsky_lilly_length` with the vertical grid scale `ᶜdz`.
 
-Mutates `ᶜbuoygrad`, `ᶜN²_eff`, and `ᶜstrain_rate_norm` in `p.precomputed`,
+Mutates `ᶜbuoygrad` and `ᶜstrain_rate_norm` in `p.precomputed`,
 and uses `p.scratch` fields (including the returned `ᶜtemp_scalar`) for
 intermediates.
 """
@@ -91,11 +88,6 @@ NVTX.@annotate function compute_gm_mixing_length(Y, p)
         projected_vector_data(C3, p.precomputed.ᶜgradᵥ_θ_liq_ice, ᶜlg),
         projected_vector_data(C3, p.precomputed.ᶜgradᵥ_q_tot, ᶜlg),
     )
-    # Stability-biased buoyancy gradient (max of one-sided estimates) for
-    # the mixing-length and Pr_t(Ri) closures; see
-    # set_stability_buoyancy_gradient! for rationale.
-    set_stability_buoyancy_gradient!(Y, p, thermo_params)
-    (; ᶜN²_eff) = p.precomputed
 
     # TODO: move strain rate calculation to separate function
     ᶠu = p.scratch.ᶠtemp_C123
@@ -105,13 +97,13 @@ NVTX.@annotate function compute_gm_mixing_length(Y, p)
 
     ᶜprandtl_nvec = p.scratch.ᶜtemp_scalar_2
     @. ᶜprandtl_nvec =
-        turbulent_prandtl_number(params, ᶜN²_eff, ᶜstrain_rate_norm)
+        turbulent_prandtl_number(params, ᶜbuoygrad, ᶜstrain_rate_norm)
 
     # Materialize directly into scratch field to avoid lazy heap allocations
     ᶜmixing_length = p.scratch.ᶜtemp_scalar
     @. ᶜmixing_length = smagorinsky_lilly_length(
         CAP.c_smag(params),
-        sqrt(max(ᶜN²_eff, 0)),   # N_eff
+        sqrt(max(ᶜbuoygrad, 0)),   # N_eff
         ᶜdz,
         ᶜprandtl_nvec,
         ᶜstrain_rate_norm,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Add tke source due to entr/detr mixing
- Delete stability-biased buoygrad at cell centers and use unbiased buoygrad instead. The stability-biased buoygrad causes too small mixing length and too large dissipation close to the BL top.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
