### PR TITLE
Add comparison plots back

### DIFF
--- a/.buildkite/ci_driver.jl
+++ b/.buildkite/ci_driver.jl
@@ -197,36 +197,28 @@ if ClimaComms.iamroot(config.comms_ctx)
         ),
     )
     @info "Plotting"
-    paths = latest_comparable_dirs() # __build__ path (not job path)
-    if isempty(paths)
-        make_plots(Val(Symbol(reference_job_id)), simulation.output_dir)
-    else
-        main_job_path = joinpath(first(paths), reference_job_id)
-        nc_dir = joinpath(main_job_path, "nc_files")
-        if ispath(nc_dir)
-            @info "nc_dir exists"
+    reference_dirs = latest_comparable_dirs() # __build__ paths (not job paths)
+    paths = [simulation.output_dir]
+    if !isempty(reference_dirs)
+        reference_tar =
+            joinpath(first(reference_dirs), reference_job_id, "nc_files.tar")
+        if isfile(reference_tar)
+            # Extract next to, not inside, the output directory: files left
+            # inside it would land in this job's own `nc_files.tar` below.
+            reference_nc_dir = joinpath(
+                dirname(rstrip(simulation.output_dir, '/')),
+                "reference_nc_files",
+            )
+            rm(reference_nc_dir; recursive = true, force = true)
+            Tar.extract(reference_tar, reference_nc_dir)
+            push!(paths, reference_nc_dir)
+            @info "Comparing against reference $(first(reference_dirs))"
         else
-            mkpath(nc_dir)
-            # Try to extract nc files from tarball:
-            @info "Comparing against $(readdir(nc_dir))"
+            @warn "No reference nc_files.tar found; plotting without a \
+                   comparison" reference_tar
         end
-        if isempty(readdir(nc_dir))
-            if isfile(joinpath(main_job_path, "nc_files.tar"))
-                Tar.extract(joinpath(main_job_path, "nc_files.tar"), nc_dir)
-            else
-                @warn "No nc_files found"
-            end
-        else
-            @info "Files already extracted"
-        end
-
-        paths = if isempty(readdir(nc_dir))
-            simulation.output_dir
-        else
-            [simulation.output_dir, nc_dir]
-        end
-        make_plots(Val(Symbol(reference_job_id)), paths)
     end
+    make_plots(Val(Symbol(reference_job_id)), paths)
     @info "Plotting done"
 
     if islink(simulation.output_dir)

--- a/reproducibility_tests/README.md
+++ b/reproducibility_tests/README.md
@@ -69,6 +69,16 @@ The job ID is discovered automatically from the presence of `[job_id]/output_act
 5. Test that all RMS differences are within tolerance using `test_reproducibility`.
 6. Publish the data to the central cluster as the new reference (see below).
 
+### Comparison plots
+
+Every job's plots are drawn against the newest comparable reference, when one
+exists. The plotting block of `.buildkite/ci_driver.jl` asks
+`latest_comparable_dirs` for that reference, extracts its `nc_files.tar` beside
+the job's output directory, and passes both paths to `make_plots`, so each
+figure carries the reference alongside the current run. With no comparable
+reference (a ref-counter bump, or running outside `climaatmos-ci`) only the
+current run is plotted.
+
 ### Publishing references on merge
 
 The new reference is published from data the PR already computed, immediately
@@ -90,7 +100,10 @@ upon merge. It's a two-step **stage → publish** flow:
    (`stage_output.jl` → `stage_pr_data`) copies the bundle to a per-PR staging
    directory `/resnick/scratch/esm/slurm-buildkite/climaatmos-main-staging/pr-<n>/reproducibility_bundle/`.
    Overwrites on each push, so at most one bundle is kept per open PR. Nothing is
-   published yet.
+   published yet. Each job's `nc_files.tar` is staged alongside its
+   `prog_state.hdf5`: the RMS comparison needs only the latter, but the former
+   lets a later build plot its diagnostics against the reference (see
+   "Comparison plots" below).
 2. **Publish**: on merge, `climaatmos-ci` builds `main`.
    `.buildkite/pipeline.yml` dispatches by branch inline: on `main` every job
    step is skipped (`if: build.branch != "main"`) and only the "Move

--- a/reproducibility_tests/reproducibility_utils.jl
+++ b/reproducibility_tests/reproducibility_utils.jl
@@ -553,6 +553,7 @@ end
         staging_root = STAGING_ROOT,
         ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl"),
         repro_folder = "reproducibility_bundle",
+        extra_files = ("nc_files.tar",),
     )
 
 Copy a PR build's reproducibility bundle into a per-PR staging directory,
@@ -560,9 +561,12 @@ Copy a PR build's reproducibility bundle into a per-PR staging directory,
 staging for that PR (so at most one bundle is kept per open PR). Publishes
 nothing; `publish_reference.jl` moves it into the reference store on merge.
 
-Only the bundle is staged — `prog_state.hdf5` per job plus the job-independent
-`ref_counter.jl`, which is all reference comparisons read (see
-`reproducibility_results`). See reproducibility_tests/README.md.
+What is staged is the bundle — `prog_state.hdf5` per job plus the
+job-independent `ref_counter.jl`, which is all reference *comparisons* read
+(see `reproducibility_results`) — and `extra_files`, taken from each job's
+output directory. `nc_files.tar` is staged so that a later build can plot its
+own diagnostics against the reference (see the plotting block of
+`.buildkite/ci_driver.jl`). See reproducibility_tests/README.md.
 """
 function stage_pr_data(;
     dirs_src,
@@ -570,6 +574,7 @@ function stage_pr_data(;
     staging_root = STAGING_ROOT,
     ref_counter_file_PR = joinpath(@__DIR__, "ref_counter.jl"),
     repro_folder = "reproducibility_bundle",
+    extra_files = ("nc_files.tar",),
 )
     @assert isfile(ref_counter_file_PR)
     pr_dir = pr_staging_dir(pr_number; staging_root)
@@ -578,10 +583,18 @@ function stage_pr_data(;
     ispath(pr_dir) && rm(pr_dir; recursive = true, force = true)
     for src_dir in dirs_src
         job_id = basename(src_dir)
-        bundle_dir = joinpath(src_dir, "output_active", repro_folder)
+        out_dir = joinpath(src_dir, "output_active")
+        bundle_dir = joinpath(out_dir, repro_folder)
         isdir(bundle_dir) || continue
         for src in all_files_in_dir(bundle_dir)
             dest = joinpath(dest_repro, job_id, basename(src))
+            mkpath(dirname(dest))
+            cp(src, dest; force = true)
+        end
+        for file in extra_files
+            src = joinpath(out_dir, file)
+            isfile(src) || continue
+            dest = joinpath(dest_repro, job_id, file)
             mkpath(dirname(dest))
             cp(src, dest; force = true)
         end

--- a/test/unit_reproducibility_infra.jl
+++ b/test/unit_reproducibility_infra.jl
@@ -896,13 +896,14 @@ end
         ref_counter_file_PR = joinpath(computed_dir, "ref_counter.jl")
         open(io -> println(io, 7), ref_counter_file_PR, "w")
 
-        # Each job dir holds output_active/<repro_folder>/prog_state.hdf5, as a
-        # PR build's working directory does.
+        # Each job dir holds output_active/<repro_folder>/prog_state.hdf5 and
+        # output_active/nc_files.tar, as a PR build's working directory does.
         job_ids = String[]
         for job in ("job_id_1", "job_id_2")
-            bundle =
-                mkpath(joinpath(computed_dir, job, "output_active", repro_folder))
+            out_dir = joinpath(computed_dir, job, "output_active")
+            bundle = mkpath(joinpath(out_dir, repro_folder))
             open(io -> println(io, 1), joinpath(bundle, "prog_state.hdf5"), "w")
+            open(io -> println(io, 2), joinpath(out_dir, "nc_files.tar"), "w")
             push!(job_ids, joinpath(computed_dir, job))
         end
 
@@ -919,6 +920,9 @@ end
         @test isfile(joinpath(staged, "job_id_1", "prog_state.hdf5"))
         @test isfile(joinpath(staged, "job_id_2", "prog_state.hdf5"))
         @test isfile(joinpath(staged, "ref_counter.jl"))
+        # The diagnostics tarball rides along, for the comparison plots.
+        @test isfile(joinpath(staged, "job_id_1", "nc_files.tar"))
+        @test isfile(joinpath(staged, "job_id_2", "nc_files.tar"))
 
         # A later push for the same PR overwrites: only the latest bundle is kept.
         stage_pr_data(;


### PR DESCRIPTION
This PR adds plots comparing reproducibility tests to previous reproducibility bundles. The needed files are not currently saved in reproducibility bundles, so we will need to merge this PR to generate compatible bundles for the plots.