### PR TITLE
Initialize microphysics condensates from file-based ICs

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -632,10 +632,6 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite runscripts/rcemipii_box_CRM_1M.jl
-
-          julia --color=yes --project=.buildkite reproducibility_tests/test_reproducibility.jl
-          --job_id rcemipii_box_CRM_1M
-          --out_dir rcemipii_box_CRM_1M/output_active
         artifact_paths: "rcemipii_box_CRM_1M/output_active/*"
 
   - group: "Dry Spherical Examples"

--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -26,7 +26,7 @@ reference_job_id = Val(:les_box)  # for plotting
 output_dir = nothing  # customize if desired
 FT = Float32
 
-t_end = "4hours"
+t_end = "10mins"
 
 ##### RCE-small #####
 x_max = y_max = 96_000

--- a/src/setups/WeatherModel.jl
+++ b/src/setups/WeatherModel.jl
@@ -94,9 +94,16 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
     ᶜT = SpaceVaryingInputs.SpaceVaryingInput(
         file_path, "t", center_space; svi_kwargs...,
     )
-    ᶜq_tot = SpaceVaryingInputs.SpaceVaryingInput(
+    ᶜq_vap = SpaceVaryingInputs.SpaceVaryingInput(
         file_path, "q", center_space; svi_kwargs...,
     )
+
+    # Optional condensate species and the thermodynamic moisture partition, read
+    # before ρ / p / ρe_tot so the initial state is consistent with ρq_tot.
+    (; ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno) =
+        read_microphysics_from_file(file_path, center_space, svi_kwargs)
+    (; ᶜq_tot, ᶜq_liq, ᶜq_ice) =
+        thermodynamic_partition(Y, ᶜq_vap, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)
 
     use_p3d = NC.NCDataset(file_path) do ds
         haskey(ds, "p_3d")
@@ -122,7 +129,8 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
         end
         if has_surface_altitude
             correct_surface_pressure_for_topography!(
-                p_sfc, file_path, face_space, Y, ᶜT, ᶜq_tot,
+                p_sfc, file_path, face_space, Y, ᶜT,
+                ᶜq_tot, ᶜq_liq, ᶜq_ice,
                 thermo_params, regridder_kwargs;
                 surface_altitude_var,
             )
@@ -130,36 +138,27 @@ function overwrite_initial_state!(setup::WeatherModel, Y, thermo_params)
             @warn "Skipping topographic correction because variable " *
                   "`$surface_altitude_var` is missing from $(file_path)."
         end
-        hydrostatic_pressure(p_sfc, ᶜT, ᶜq_tot, face_space, thermo_params)
+        hydrostatic_pressure(
+            p_sfc, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, face_space,
+            thermo_params,
+        )
     end
 
     # Density
-    Y.c.ρ .= TD.air_density.(thermo_params, ᶜT, ᶜinterp.(ᶠp), ᶜq_tot)
+    Y.c.ρ .= TD.air_density.(
+        thermo_params, ᶜT, ᶜinterp.(ᶠp), ᶜq_tot, ᶜq_liq, ᶜq_ice,
+    )
 
     # Velocity and energy
     e_pot = assign_velocity_energy!(
-        Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs,
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, ᶠp, thermo_params,
+        file_path, svi_kwargs,
     )
-
-    # Microphysics fields from file (rain/snow water content)
-    has_microphysics_vars = NC.NCDataset(file_path) do ds
-        haskey(ds, "cswc") && haskey(ds, "crwc")
-    end
-    if has_microphysics_vars
-        ᶜq_rai = SpaceVaryingInputs.SpaceVaryingInput(
-            file_path, "crwc", center_space; svi_kwargs...,
-        )
-        ᶜq_sno = SpaceVaryingInputs.SpaceVaryingInput(
-            file_path, "cswc", center_space; svi_kwargs...,
-        )
-    else
-        ᶜq_rai = nothing
-        ᶜq_sno = nothing
-    end
 
     # Moisture and EDMF
     assign_moisture_edmf!(
-        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, e_pot, thermo_params,
+        ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
     )
 
     return nothing

--- a/src/setups/common/overwrite_from_file.jl
+++ b/src/setups/common/overwrite_from_file.jl
@@ -10,7 +10,7 @@
 
 """
     correct_surface_pressure_for_topography!(
-        p_sfc, file_path, face_space, Y, ᶜT, ᶜq_tot,
+        p_sfc, file_path, face_space, Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice,
         thermo_params, regridder_kwargs;
         surface_altitude_var = "z_sfc",
     )
@@ -25,6 +25,9 @@ The correction is hydrostatic over the altitude difference
 p_{sfc} ← p_{sfc} \\exp(-Δz \\, g / (R_m T_{sfc}))
 ```
 
+`R_m` uses the full moisture partition `(ᶜq_tot, ᶜq_liq, ᶜq_ice)`; see
+`thermodynamic_partition`.
+
 The caller is responsible for checking that the file carries
 `surface_altitude_var`; reading a variable the file lacks throws.
 """
@@ -35,6 +38,8 @@ function correct_surface_pressure_for_topography!(
     Y,
     ᶜT,
     ᶜq_tot,
+    ᶜq_liq,
+    ᶜq_ice,
     thermo_params,
     regridder_kwargs;
     surface_altitude_var = "z_sfc",
@@ -60,7 +65,8 @@ function correct_surface_pressure_for_topography!(
     ᶠz_model_surface = Fields.level(Fields.coordinate_field(Y.f).z, Fields.half)
     ᶠΔz = @. ᶠz_model_surface - ᶠz_surface
 
-    ᶠR_m = ᶠinterp.(TD.gas_constant_air.(thermo_params, ᶜq_tot))
+    ᶠR_m =
+        ᶠinterp.(TD.gas_constant_air.(thermo_params, ᶜq_tot, ᶜq_liq, ᶜq_ice))
     ᶠR_m_sfc = Fields.level(ᶠR_m, Fields.half)
 
     ᶠT = ᶠinterp.(ᶜT)
@@ -77,26 +83,33 @@ end
 # ============================================================================
 
 """
-    hydrostatic_pressure(p_sfc, ᶜT, ᶜq_tot, face_space, thermo_params)
+    hydrostatic_pressure(p_sfc, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, face_space, thermo_params)
 
 Compute face pressure by hydrostatic integration from surface pressure.
-Solves ∂(ln p)/∂z = -g/(Rₘ(q)T) using `column_integral_indefinite!`.
+Solves ∂(ln p)/∂z = -g/(Rₘ(q)T) using `column_integral_indefinite!`, where
+`Rₘ` uses the full moisture partition `(ᶜq_tot, ᶜq_liq, ᶜq_ice)`.
 """
-function hydrostatic_pressure(p_sfc, ᶜT, ᶜq_tot, face_space, thermo_params)
-    ᶜ∂lnp∂z = @. -thermo_params.grav /
-                 (TD.gas_constant_air(thermo_params, ᶜq_tot) * ᶜT)
+function hydrostatic_pressure(
+    p_sfc, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, face_space, thermo_params,
+)
+    ᶜ∂lnp∂z = @. -thermo_params.grav / (
+        TD.gas_constant_air(thermo_params, ᶜq_tot, ᶜq_liq, ᶜq_ice) * ᶜT
+    )
     ᶠlnp_over_psfc = zeros(face_space)
     Operators.column_integral_indefinite!(ᶠlnp_over_psfc, ᶜ∂lnp∂z)
     return p_sfc .* exp.(ᶠlnp_over_psfc)
 end
 
 """
-    assign_velocity_energy!(Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs)
+    assign_velocity_energy!(
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, ᶠp, thermo_params, file_path, svi_kwargs,
+    )
 
 Regrid velocity from file, compute kinetic and total energy, and assign to Y.
+`ρe_tot` uses the full moisture partition `(ᶜq_tot, ᶜq_liq, ᶜq_ice)`.
 """
 function assign_velocity_energy!(
-    Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs,
+    Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, ᶠp, thermo_params, file_path, svi_kwargs,
 )
     center_space = Fields.axes(Y.c)
     vel =
@@ -116,23 +129,155 @@ function assign_velocity_energy!(
     e_kin = compute_kinetic(Y.c.uₕ, Y.f.u₃)
     e_pot = geopotential.(thermo_params.grav, Fields.coordinate_field(Y.c).z)
     Y.c.ρe_tot .=
-        TD.total_energy.(thermo_params, e_kin, e_pot, ᶜT, ᶜq_tot) .* Y.c.ρ
+        TD.total_energy.(
+            thermo_params, e_kin, e_pot, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice,
+        ) .* Y.c.ρ
     return e_pot
 end
 
 """
-    assign_moisture_edmf!(Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno)
+    read_microphysics_from_file(file_path, center_space, svi_kwargs)
+
+Regrid the optional condensate fields from `file_path`, returning the named
+tuple `(; ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)` of specific humidities. Cloud
+liquid/ice come from `clwc`/`ciwc` and rain/snow from `crwc`/`cswc`. Any species
+whose file variables are absent is returned as `nothing`, which downstream code
+treats as "initialize to zero".
+"""
+function read_microphysics_from_file(file_path, center_space, svi_kwargs)
+    # Cloud liquid/ice water content (clwc/ciwc) for 1M/2M cloud condensate.
+    has_cloud_vars = NC.NCDataset(file_path) do ds
+        haskey(ds, "clwc") && haskey(ds, "ciwc")
+    end
+    if has_cloud_vars
+        @info "Initializing cloud condensate from file (clwc, ciwc)."
+        ᶜq_lcl = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "clwc", center_space; svi_kwargs...,
+        )
+        ᶜq_icl = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "ciwc", center_space; svi_kwargs...,
+        )
+    else
+        ᶜq_lcl = nothing
+        ᶜq_icl = nothing
+    end
+
+    # Rain/snow water content (crwc/cswc) for 1M/2M precipitation.
+    has_precip_vars = NC.NCDataset(file_path) do ds
+        haskey(ds, "cswc") && haskey(ds, "crwc")
+    end
+    if has_precip_vars
+        @info "Initializing precipitation from file (crwc, cswc)."
+        ᶜq_rai = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "crwc", center_space; svi_kwargs...,
+        )
+        ᶜq_sno = SpaceVaryingInputs.SpaceVaryingInput(
+            file_path, "cswc", center_space; svi_kwargs...,
+        )
+    else
+        ᶜq_rai = nothing
+        ᶜq_sno = nothing
+    end
+
+    return (; ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)
+end
+
+"""
+    thermodynamic_partition(Y, ᶜq_vap, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)
+
+Assemble the moisture partition `(; ᶜq_tot, ᶜq_liq, ᶜq_ice)` used to build the
+thermodynamic part of the initial state (density, pressure, and energy). Here
+`ᶜq_liq`/`ᶜq_ice` are the thermodynamic liquid/ice partitions (cloud grouped
+with precipitation), while `ᶜq_lcl`/`ᶜq_icl` are the file cloud-liquid/ice
+specific humidities.
+
+`ᶜq_vap` is the file water-vapor specific humidity (ERA5 `q`). ClimaAtmos carries
+*total* water `ρq_tot` prognostically and diagnoses vapor as a residual
+(`q_vap = q_tot - q_liq - q_ice`, with rain/snow grouped into the liquid/ice
+partitions). To keep the diagnosed vapor equal to the file value, each condensate
+species is added to `ᶜq_tot` only when it is both present in the file and carried
+as a prognostic variable in `Y` — exactly the species that
+`assign_moisture_edmf!` stores into `ρq_tot`. Following the runtime
+convention in the precomputed thermodynamic state, rain is grouped with the
+liquid partition and snow with the ice partition.
+
+The equilibrium (0M) scheme has no prognostic condensate fields, but any cloud
+condensate present in the file is still folded into `ᶜq_tot` (and the
+`ᶜq_liq`/`ᶜq_ice` partition) so that total water is conserved; saturation
+adjustment repartitions it at runtime. For a 0M run this includes cloud
+liquid/ice but not rain/snow, since 0M carries no precipitation. When the file
+has no condensate this reduces to `ᶜq_tot = ᶜq_vap` and `ᶜq_liq = ᶜq_ice = 0`,
+i.e. the previous vapor-only behavior.
+"""
+function thermodynamic_partition(Y, ᶜq_vap, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)
+    ᶜq_tot = copy(ᶜq_vap)
+    ᶜq_liq = zeros(axes(ᶜq_vap))
+    ᶜq_ice = zeros(axes(ᶜq_vap))
+    # In the equilibrium (0M) scheme there are no prognostic condensate tracers,
+    # so cloud condensate from the file is added to `ᶜq_tot` for total-water
+    # conservation (saturation adjustment repartitions it). In non-equilibrium
+    # schemes it is added only when the matching prognostic tracer exists, which
+    # keeps the diagnosed vapor equal to the file value.
+    equilibrium = !hasproperty(Y.c, :ρq_lcl) && !hasproperty(Y.c, :ρq_icl)
+    if !isnothing(ᶜq_lcl) && (hasproperty(Y.c, :ρq_lcl) || equilibrium)
+        @. ᶜq_tot += ᶜq_lcl
+        @. ᶜq_liq += ᶜq_lcl
+    end
+    if !isnothing(ᶜq_icl) && (hasproperty(Y.c, :ρq_icl) || equilibrium)
+        @. ᶜq_tot += ᶜq_icl
+        @. ᶜq_ice += ᶜq_icl
+    end
+    if hasproperty(Y.c, :ρq_rai) &&
+       hasproperty(Y.c, :ρq_sno) &&
+       !isnothing(ᶜq_rai)
+        @. ᶜq_tot += ᶜq_rai + ᶜq_sno
+        @. ᶜq_liq += ᶜq_rai
+        @. ᶜq_ice += ᶜq_sno
+    end
+    return (; ᶜq_tot, ᶜq_liq, ᶜq_ice)
+end
+
+"""
+    assign_moisture_edmf!(
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, e_pot, thermo_params,
+        ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
+    )
 
 Assign moisture variables and EDMF subdomain initialization.
 
-`ᶜq_rai` and `ᶜq_sno` are the rain and snow specific humidities regridded
-from file, or `nothing` when the file does not contain microphysics fields.
+`ᶜq_tot`, `ᶜq_liq`, and `ᶜq_ice` are the thermodynamic moisture partition from
+`thermodynamic_partition`; `ρq_tot` is stored directly as `ᶜq_tot * ρ` so that it
+is consistent with the density and energy already computed from the same
+partition.
+
+`ᶜq_lcl`, `ᶜq_icl`, `ᶜq_rai`, and `ᶜq_sno` are the cloud-liquid, cloud-ice,
+rain, and snow specific humidities regridded from file (see
+`read_microphysics_from_file`), or `nothing` when the file does not
+contain the corresponding field. They are written into the individual prognostic
+condensate tracers when those tracers are carried by `Y`.
+
+For the equilibrium (0M) scheme there are no prognostic condensate tracers, so
+only `ρq_tot` is set; any file cloud condensate has already been folded into
+`ᶜq_tot` by `thermodynamic_partition`, and saturation adjustment repartitions it
+at runtime.
 """
 function assign_moisture_edmf!(
-    Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
+    Y,
+    ᶜT,
+    ᶜq_tot,
+    ᶜq_liq,
+    ᶜq_ice,
+    e_pot,
+    thermo_params,
+    ᶜq_lcl,
+    ᶜq_icl,
+    ᶜq_rai,
+    ᶜq_sno,
 )
 
     if hasproperty(Y.c, :ρq_tot)
+        # Total water = file vapor + every prognostic condensate species, exactly
+        # the partition used for ρ and ρe_tot (see `thermodynamic_partition`).
         Y.c.ρq_tot .= ᶜq_tot .* Y.c.ρ
     else
         error(
@@ -141,10 +286,18 @@ function assign_moisture_edmf!(
     end
 
     if hasproperty(Y.c, :ρq_lcl)
-        fill!(Y.c.ρq_lcl, 0)
+        if !isnothing(ᶜq_lcl)
+            Y.c.ρq_lcl .= ᶜq_lcl .* Y.c.ρ
+        else
+            fill!(Y.c.ρq_lcl, 0)
+        end
     end
     if hasproperty(Y.c, :ρq_icl)
-        fill!(Y.c.ρq_icl, 0)
+        if !isnothing(ᶜq_icl)
+            Y.c.ρq_icl .= ᶜq_icl .* Y.c.ρ
+        else
+            fill!(Y.c.ρq_icl, 0)
+        end
     end
     if hasproperty(Y.c, :ρq_rai) && hasproperty(Y.c, :ρq_sno)
         if !isnothing(ᶜq_rai)
@@ -158,7 +311,10 @@ function assign_moisture_edmf!(
 
     # Initialize prognostic EDMF subdomains if present
     if hasproperty(Y.c, :sgsʲs)
-        ᶜmse = TD.enthalpy.(thermo_params, ᶜT, ᶜq_tot) .+ e_pot
+        ᶜmse =
+            TD.enthalpy.(
+                thermo_params, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice,
+            ) .+ e_pot
         for name in propertynames(Y.c.sgsʲs)
             s = getproperty(Y.c.sgsʲs, name)
             hasproperty(s, :ρa) && fill!(s.ρa, 0)
@@ -202,8 +358,10 @@ Expected variables in the file:
 
   - `p`: pressure (2D surface, broadcast in z)
   - `t`: temperature (3D)
-  - `q`: specific humidity (3D)
+  - `q`: water vapor specific humidity (3D; ERA5 `q`)
   - `u, v, w`: velocity (3D)
+  - `clwc, ciwc`: cloud liquid and ice water content (optional, initializes
+    condensate for the 1-moment / 2-moment schemes)
   - `cswc, crwc`: snow and rain water content (optional, for 1-moment microphysics)
   - `z_sfc`: surface altitude (optional, for topographic pressure correction)
 """
@@ -226,13 +384,21 @@ function overwrite_from_file!(
     center_space = Fields.axes(Y.c)
     face_space = Fields.axes(Y.f)
 
-    # Regrid temperature and humidity from file
+    # Regrid temperature and vapor specific humidity from file
     ᶜT = SpaceVaryingInputs.SpaceVaryingInput(
         file_path, "t", center_space; svi_kwargs...,
     )
-    ᶜq_tot = SpaceVaryingInputs.SpaceVaryingInput(
+    ᶜq_vap = SpaceVaryingInputs.SpaceVaryingInput(
         file_path, "q", center_space; svi_kwargs...,
     )
+
+    # Optional condensate species. These are read before ρ / p / ρe_tot so that
+    # the initial thermodynamic state is built from the same total water that is
+    # stored in ρq_tot.
+    (; ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno) =
+        read_microphysics_from_file(file_path, center_space, svi_kwargs)
+    (; ᶜq_tot, ᶜq_liq, ᶜq_ice) =
+        thermodynamic_partition(Y, ᶜq_vap, ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno)
 
     # Surface pressure with optional topographic correction
     p_sfc = Fields.level(
@@ -248,43 +414,34 @@ function overwrite_from_file!(
     end
     if has_surface_altitude
         correct_surface_pressure_for_topography!(
-            p_sfc, file_path, face_space, Y, ᶜT, ᶜq_tot,
+            p_sfc, file_path, face_space, Y, ᶜT,
+            ᶜq_tot, ᶜq_liq, ᶜq_ice,
             thermo_params, regridder_kwargs;
             surface_altitude_var,
         )
     end
 
     # Hydrostatic pressure integration
-    ᶠp = hydrostatic_pressure(p_sfc, ᶜT, ᶜq_tot, face_space, thermo_params)
+    ᶠp = hydrostatic_pressure(
+        p_sfc, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, face_space,
+        thermo_params,
+    )
 
     # Density
-    Y.c.ρ .= TD.air_density.(thermo_params, ᶜT, ᶜinterp.(ᶠp), ᶜq_tot)
+    Y.c.ρ .= TD.air_density.(
+        thermo_params, ᶜT, ᶜinterp.(ᶠp), ᶜq_tot, ᶜq_liq, ᶜq_ice,
+    )
 
     # Velocity and energy
     e_pot = assign_velocity_energy!(
-        Y, ᶜT, ᶜq_tot, ᶠp, thermo_params, file_path, svi_kwargs,
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, ᶠp, thermo_params,
+        file_path, svi_kwargs,
     )
-
-    # Microphysics fields from file (rain/snow water content)
-    center_space = Fields.axes(Y.c)
-    has_microphysics_vars = NC.NCDataset(file_path) do ds
-        haskey(ds, "cswc") && haskey(ds, "crwc")
-    end
-    if has_microphysics_vars
-        ᶜq_rai = SpaceVaryingInputs.SpaceVaryingInput(
-            file_path, "crwc", center_space; svi_kwargs...,
-        )
-        ᶜq_sno = SpaceVaryingInputs.SpaceVaryingInput(
-            file_path, "cswc", center_space; svi_kwargs...,
-        )
-    else
-        ᶜq_rai = nothing
-        ᶜq_sno = nothing
-    end
 
     # Moisture and EDMF
     assign_moisture_edmf!(
-        Y, ᶜT, ᶜq_tot, e_pot, thermo_params, ᶜq_rai, ᶜq_sno,
+        Y, ᶜT, ᶜq_tot, ᶜq_liq, ᶜq_ice, e_pot, thermo_params,
+        ᶜq_lcl, ᶜq_icl, ᶜq_rai, ᶜq_sno,
     )
 
     return nothing


### PR DESCRIPTION
Initialize cloud liquid/ice and rain/snow from clwc/ciwc/crwc/cswc when present for 1M/2M,
and assemble `ρq_tot` as vapor plus those condensates so diagnosed vapor
matches the ERA5 file.

ERA5 `q` is vapor; Atmos `ρq_tot` is total water. IC path now uses `ᶜq_vap`, seeds condensates from clwc/ciwc/crwc/cswc, and builds ρq_tot = vapor + condensates. Density/energy Thermo still vapor only (should be a very small error).

Shorten RCEMIP test, remove from reproducibility

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
