### PR TITLE
Shorten RCEMIP test, remove from reproducibility

### DIFF
--- a/.buildkite/full_pipeline.yml
+++ b/.buildkite/full_pipeline.yml
@@ -632,10 +632,6 @@ steps:
         retry: *retry_policy
         command: >
           julia --color=yes --project=.buildkite runscripts/rcemipii_box_CRM_1M.jl
-
-          julia --color=yes --project=.buildkite reproducibility_tests/test_reproducibility.jl
-          --job_id rcemipii_box_CRM_1M
-          --out_dir rcemipii_box_CRM_1M/output_active
         artifact_paths: "rcemipii_box_CRM_1M/output_active/*"
 
   - group: "Dry Spherical Examples"

--- a/runscripts/rcemipii_box_CRM_1M.jl
+++ b/runscripts/rcemipii_box_CRM_1M.jl
@@ -26,7 +26,7 @@ reference_job_id = Val(:les_box)  # for plotting
 output_dir = nothing  # customize if desired
 FT = Float32
 
-t_end = "4hours"
+t_end = "10mins"
 
 ##### RCE-small #####
 x_max = y_max = 96_000


### PR DESCRIPTION
Removing to shorten CI time. Will add back again later once the simulation is a bit faster.
It's not really useful until ~20 hours simulation time anyways, when convection usually starts.