### PR TITLE
Small fixes to speed up GHA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,6 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        with:
-          # `Pkg.test` defaults to --check-bounds=yes, which is part of Julia's
-          # precompilation cache key, so every dependency has to be recompiled.
-          # `auto` respects the packages' own `@inbounds` and lets the test
-          # process use the cache from julia-buildpkg and julia-actions/cache.
-          check_bounds: auto
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          # `Pkg.test` defaults to --check-bounds=yes, which is part of Julia's
+          # precompilation cache key, so every dependency has to be recompiled.
+          # `auto` respects the packages' own `@inbounds` and lets the test
+          # process use the cache from julia-buildpkg and julia-actions/cache.
+          check_bounds: auto
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -51,7 +51,6 @@ Aqua = "0.8.9"
 ArgParse = "1"
 Artifacts = "1"
 AtmosphericProfilesLibrary = "0.1.8"
-CairoMakie = "0.15.7"
 ClimaComms = "0.6.9"
 ClimaCore = "0.16"
 ClimaDiagnostics = "0.3.9"
@@ -95,7 +94,6 @@ julia = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
@@ -107,4 +105,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CairoMakie", "Distributions", "Downloads", "IntervalSets", "Musica", "OrderedCollections", "Pkg", "PrettyTables", "SafeTestsets", "Test"]
+test = ["Aqua", "Distributions", "Downloads", "IntervalSets", "Musica", "OrderedCollections", "Pkg", "PrettyTables", "SafeTestsets", "Test"]

--- a/src/prognostic_equations/edmfx_sgs_flux.jl
+++ b/src/prognostic_equations/edmfx_sgs_flux.jl
@@ -53,7 +53,7 @@ function edmfx_sgs_mass_flux_tendency!(
     )
     ᶜρa⁰ = @. lazy(ρa⁰(Y.c.ρ, Y.c.sgsʲs, turbconv_model))
 
-    if p.atmos.edmfx_model.sgs_mass_flux isa Val{true}
+    if p.atmos.edmfx_model.sgs_mass_flux
 
         # Enthalpy fluxes. First sum up the draft fluxes
         # TODO: Isolate assembly of flux term pattern to a function and
@@ -230,9 +230,9 @@ function edmfx_sgs_diffusive_flux_tendency!(
     # opt in/out just like the old subdomain-native diffusion did.
     apply_sgs_updraft =
         turbconv_model isa PrognosticEDMFX &&
-        p.atmos.edmfx_model.vertical_diffusion isa Val{true}
+        p.atmos.edmfx_model.vertical_diffusion
 
-    if p.atmos.edmfx_model.sgs_diffusive_flux isa Val{true}
+    if p.atmos.edmfx_model.sgs_diffusive_flux
 
         # Face-native eddy diffusivity/viscosity and interfacial entrainment
         # diffusivity, evaluated at the faces where the fluxes live (see

--- a/src/prognostic_equations/edmfx_tke.jl
+++ b/src/prognostic_equations/edmfx_tke.jl
@@ -89,7 +89,7 @@ edmfx_pressure_drag_tke_source!(Yₜ, Y, p, turbconv_model) = nothing
 function edmfx_pressure_drag_tke_source!(
     Yₜ, Y, p, turbconv_model::PrognosticEDMFX,
 )
-    p.atmos.edmfx_model.nh_pressure isa Val{true} || return nothing
+    p.atmos.edmfx_model.nh_pressure || return nothing
     n = n_mass_flux_subdomains(turbconv_model)
     n == 0 && return nothing
 

--- a/src/prognostic_equations/implicit/initialize_implicit_problem.jl
+++ b/src/prognostic_equations/implicit/initialize_implicit_problem.jl
@@ -199,7 +199,7 @@ function solve_sgs_u₃_implicit_stage_analytic!(Y, p, dtγ)
             )
 
         # Implicit NH pressure drag contributes a quadratic sink in w².
-        if p.atmos.edmfx_model.nh_pressure isa Val{true}
+        if p.atmos.edmfx_model.nh_pressure
             # Clamp a_j ∈ [0, a_max]; reuse the clamped ᶜa⁰ from above.
             ᶜaʲ = @. lazy(
                 clamp(

--- a/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
+++ b/src/prognostic_equations/implicit/manual_sparse_jacobian.jl
@@ -368,7 +368,7 @@ grid-mean scalars.
 These are the `(grid-mean tracer, updraft tracer)` blocks, the
 `(sedimenting tracer, f.u₃)` blocks, and the `ρe_tot` couplings to the updraft
 `mse` and to `ρ`. Returns `()` unless `atmos.turbconv_model` is a
-`PrognosticEDMFX` with `edmfx_model.sgs_mass_flux` set to `Val(true)`.
+`PrognosticEDMFX` with `edmfx_model.sgs_mass_flux` enabled.
 
 # Returns
 
@@ -377,7 +377,7 @@ These are the `(grid-mean tracer, updraft tracer)` blocks, the
 function sgs_massflux_jacobian_blocks(Y, atmos)
     (
         atmos.turbconv_model isa PrognosticEDMFX &&
-        atmos.edmfx_model.sgs_mass_flux isa Val{true}
+        atmos.edmfx_model.sgs_mass_flux
     ) || return ()
     FT = Spaces.undertype(axes(Y.c))
     (; TridiagonalRow, BidiagonalRow_ACT3) = jacobian_row_types(FT)
@@ -1443,7 +1443,7 @@ Update the Jacobian blocks for implicit vertical diffusion of the updraft
 scalars under the unified grid-mean tendency.
 
 No-op unless `p.atmos.turbconv_model` is a `PrognosticEDMFX`, `diffusion_flag`
-is `UseDerivative()`, and `edmfx_model.sgs_diffusive_flux` is `Val(true)` —
+is `UseDerivative()`, and `edmfx_model.sgs_diffusive_flux` is enabled —
 the same gate as the tendency being linearized. The updraft `mse`, `q_tot`,
 and passive tracer diagonals accumulate the full `ρ(K_h + K_entr)` diffusion
 matrix built by `update_diffusion_jacobian!`, while the sedimenting SGS tracers
@@ -1471,7 +1471,7 @@ function update_sgs_diffusion_jacobian!(matrix, Y, p, dtγ, diffusion_flag)
     # (`edmfx_sgs_diffusive_flux_tendency!` inside the sgs_diffusive_flux
     # branch): without it, the updraft scalar diagonals would carry
     # diffusion terms that have no tendency counterpart.
-    p.atmos.edmfx_model.sgs_diffusive_flux isa Val{true} || return nothing
+    p.atmos.edmfx_model.sgs_diffusive_flux || return nothing
     (; params) = p
     (; ᶜdiffusion_h_matrix) = p.scratch
     ᶜρ = Y.c.ρ
@@ -1655,14 +1655,14 @@ were already zeroed by `update_diffusion_jacobian!`; when diffusion is
 explicit they are zeroed here so that both can safely use `+=`.
 
 No-op unless `p.atmos.turbconv_model` is a `PrognosticEDMFX` with
-`edmfx_model.sgs_mass_flux` set to `Val(true)`. Writes
+`edmfx_model.sgs_mass_flux` enabled. Writes
 `ᶠbidiagonal_matrix_ct3` and `ᶜtridiagonal_matrix_scalar` in `p.scratch`,
 mutates `matrix`, and returns `nothing`.
 """
 function update_sgs_massflux_jacobian!(matrix, Y, p, dtγ, diffusion_flag)
     (
         p.atmos.turbconv_model isa PrognosticEDMFX &&
-        p.atmos.edmfx_model.sgs_mass_flux isa Val{true}
+        p.atmos.edmfx_model.sgs_mass_flux
     ) || return nothing
     (; params) = p
     (; ᶜΦ) = p.core

--- a/src/prognostic_equations/mass_flux_closures.jl
+++ b/src/prognostic_equations/mass_flux_closures.jl
@@ -349,7 +349,7 @@ helpers selected by the active microphysics and turbulence-convection models.
     `NonEquilibriumMicrophysics1M` and `NonEquilibriumMicrophysics2M`.
   - `enforce_edmf_updraft_constraints!` runs for `AbstractEDMF` when
     the `edmfx_filter` configuration flag is enabled
-    (`atmos.edmfx_model.filter isa Val{true}`); it is itself a no-op for models
+    (`atmos.edmfx_model.filter`); it is itself a no-op for models
     without prognostic mass-flux subdomains, such as `EDOnlyEDMFX`.
 
 Mutates `Y`; returns `nothing`. Called from `constrain_state!` after each
@@ -365,7 +365,7 @@ function enforce_physical_constraints!(Y, p, t, atmos::AtmosModel)
     # EDMF updraft constraints: only active when the filter flag is enabled.
     # Each helper is a no-op for EDOnlyEDMFX (n_prognostic_mass_flux_subdomains == 0).
     if atmos.turbconv_model isa AbstractEDMF &&
-       atmos.edmfx_model.filter isa Val{true}
+       atmos.edmfx_model.filter
         enforce_edmf_updraft_constraints!(Y, p, t, atmos.turbconv_model)
     end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1984,15 +1984,18 @@ domain so that it can be dispatched on at compile time.
 const ValTF = Union{Val{true}, Val{false}}
 
 """
-    EDMFXModel{EEM, EDM, ESMF, ESDF, ENP, EVD, EF, SBM}
+    EDMFXModel{EEM, EDM, ESDFH, EHD, SBM}
 
 Switches and closures of the EDMF scheme, kept separate from the
 turbulence-convection model itself (`PrognosticEDMFX` or `EDOnlyEDMFX`) so that
 the individual terms can be enabled independently.
 
-The boolean switches are stored as `Val{true}`/`Val{false}` (see `ValTF`) so
-that the disabled terms are compiled away; the keyword constructor below
-accepts plain `Bool`s.
+Most switches are plain `Bool` fields, so that flipping one does not create a
+new `EDMFXModel` type and force the whole EDMF stack to recompile. Two stay in
+the type domain as `Val{true}`/`Val{false}` (see `ValTF`):
+`sgs_diffusive_flux_horizontal` and `horizontal_diffusion` decide whether
+`build_cache` allocates `ᶜK_u_h`/`ᶜK_h_h`, so the cache type depends on their
+value. The keyword constructor accepts plain `Bool`s for all of them.
 
 # Fields
 
@@ -2012,32 +2015,30 @@ accepts plain `Bool`s.
     mixing-length scales (`edmfx_scale_blending`).
 """
 struct EDMFXModel{
-    EEM, EDM,
-    ESMF <: ValTF, ESDF <: ValTF, ESDFH <: ValTF, ENP <: ValTF, EVD <: ValTF,
-    EHD <: ValTF, EF <: ValTF,
+    EEM, EDM, ESDFH <: ValTF, EHD <: ValTF,
     SBM <: AbstractScaleBlendingMethod,
 }
     entr_model::EEM
     detr_model::EDM
-    sgs_mass_flux::ESMF
-    sgs_diffusive_flux::ESDF
+    sgs_mass_flux::Bool
+    sgs_diffusive_flux::Bool
     sgs_diffusive_flux_horizontal::ESDFH
-    nh_pressure::ENP
-    vertical_diffusion::EVD
+    nh_pressure::Bool
+    vertical_diffusion::Bool
     horizontal_diffusion::EHD
-    filter::EF
+    filter::Bool
     scale_blending_method::SBM
 end
 
 
-# Convenience constructor that converts booleans to Val types
-# This outer constructor allows passing booleans, which are converted to Val types
+# Convenience constructor accepting plain booleans for every switch
 """
     EDMFXModel(; entr_model = nothing, detr_model = nothing, sgs_mass_flux = false,
                sgs_diffusive_flux = false, nh_pressure = false, vertical_diffusion = false,
                filter = false, scale_blending_method, kwargs...)
 
-Create an `EDMFXModel`, lifting the boolean switches to `Val` types.
+Create an `EDMFXModel`, lifting the two cache-shaping switches to `Val` types
+and storing the rest as plain `Bool`s.
 
 # Keyword Arguments
 
@@ -2050,7 +2051,7 @@ Create an `EDMFXModel`, lifting the boolean switches to `Val` types.
   - `filter = false`: Enable relaxation of negative updraft velocities.
   - `scale_blending_method`: Required; an `AbstractScaleBlendingMethod`.
 
-Each boolean may also be given as an already-wrapped `Val{true}`/`Val{false}`.
+Each switch may also be given as an already-wrapped `Val{true}`/`Val{false}`.
 Unrecognized keyword arguments are absorbed by `kwargs...` and ignored.
 
 # Examples
@@ -2080,17 +2081,18 @@ function EDMFXModel(;
 )
     parse_val_tf(x::Bool) = Val(x)
     parse_val_tf(x::ValTF) = x
-    # Convert booleans to Val types, keep Val types as-is
+    parse_bool(x::Bool) = x
+    parse_bool(::Val{B}) where {B} = B
     return EDMFXModel(
         entr_model,
         detr_model,
-        parse_val_tf(sgs_mass_flux),
-        parse_val_tf(sgs_diffusive_flux),
+        parse_bool(sgs_mass_flux),
+        parse_bool(sgs_diffusive_flux),
         parse_val_tf(sgs_diffusive_flux_horizontal),
-        parse_val_tf(nh_pressure),
-        parse_val_tf(vertical_diffusion),
+        parse_bool(nh_pressure),
+        parse_bool(vertical_diffusion),
         parse_val_tf(horizontal_diffusion),
-        parse_val_tf(filter),
+        parse_bool(filter),
         scale_blending_method,
     )
 end

--- a/test/presets.jl
+++ b/test/presets.jl
@@ -44,11 +44,11 @@ end
     @test prog.turbconv_model isa CA.PrognosticEDMFX
     @test prog.edmfx_model.entr_model isa CA.InvZEntrainment
     @test prog.edmfx_model.detr_model isa CA.BuoyancyVelocityDetrainment
-    @test prog.edmfx_model.sgs_mass_flux === Val(true)
-    @test prog.edmfx_model.sgs_diffusive_flux === Val(true)
-    @test prog.edmfx_model.nh_pressure === Val(true)
-    @test prog.edmfx_model.vertical_diffusion === Val(true)
-    @test prog.edmfx_model.filter === Val(true)
+    @test prog.edmfx_model.sgs_mass_flux
+    @test prog.edmfx_model.sgs_diffusive_flux
+    @test prog.edmfx_model.nh_pressure
+    @test prog.edmfx_model.vertical_diffusion
+    @test prog.edmfx_model.filter
 
     # area_fraction kwarg flows through to the turbconv model
     custom = CA.Presets.prognostic_edmf(FT; area_fraction = FT(5e-5))


### PR DESCRIPTION
The GHA CI has been especially slow recently. This PR introduces two changes to improve CI runtime and efficiency:

- Remove CairoMakie from the test dependencies, it is unused and takes a long time to compile.
- Move five EDMFXModel Val types to Bools (sgs_mass_flux, sgs_diffusive_flux, nh_pressure, vertical_diffusion, filter). These were previously switched to Vals for type inference, but this is no longer needed. Every combination of Vals in the EDMFXModel struct created a distinct concrete type, causing recompilation for different settings. This change should lower compilation time for EDMF runs, particularly the Dynamics tests.